### PR TITLE
[feat] SymbolicConstraints as DAG

### DIFF
--- a/crates/stark-backend/src/air_builders/symbolic/dag.rs
+++ b/crates/stark-backend/src/air_builders/symbolic/dag.rs
@@ -1,0 +1,266 @@
+use std::sync::Arc;
+
+use p3_field::Field;
+use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
+
+use crate::air_builders::symbolic::{
+    symbolic_expression::SymbolicExpression, symbolic_variable::SymbolicVariable,
+};
+
+/// A node in symbolic expression DAG. Basically replace `Arc`s in `SymbolicExpression` with node IDs.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(bound = "F: Field")]
+enum SymbolicExpressionNode<F> {
+    Variable(SymbolicVariable<F>),
+    IsFirstRow,
+    IsLastRow,
+    IsTransition,
+    Constant(F),
+    Add {
+        x: usize,
+        y: usize,
+        degree_multiple: usize,
+    },
+    Sub {
+        x: usize,
+        y: usize,
+        degree_multiple: usize,
+    },
+    Neg {
+        x: usize,
+        degree_multiple: usize,
+    },
+    Mul {
+        x: usize,
+        y: usize,
+        degree_multiple: usize,
+    },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(bound = "F: Field")]
+pub struct SymbolicExpressionDag<F> {
+    /// Nodes in **topological** order.
+    expr_by_id: Vec<SymbolicExpressionNode<F>>,
+    /// Node ids of expressions to assert.
+    top_expr_ids: Vec<usize>,
+}
+
+pub(super) fn build_symbolic_expr_dag<F: Field>(
+    exprs: &[SymbolicExpression<F>],
+) -> SymbolicExpressionDag<F> {
+    let mut expr_to_id = FxHashMap::default();
+    let mut id_to_expr = Vec::new();
+    let top_expr_ids = exprs
+        .iter()
+        .map(|expr| topology_sort_symbolic_expr(expr, &mut expr_to_id, &mut id_to_expr))
+        .collect();
+    SymbolicExpressionDag {
+        expr_by_id: id_to_expr,
+        top_expr_ids,
+    }
+}
+
+fn topology_sort_symbolic_expr<'a, F: Field>(
+    expr: &'a SymbolicExpression<F>,
+    expr_to_id: &mut FxHashMap<&'a SymbolicExpression<F>, usize>,
+    id_to_expr: &mut Vec<SymbolicExpressionNode<F>>,
+) -> usize {
+    if let Some(&id) = expr_to_id.get(&expr) {
+        return id;
+    }
+    let exp_ser = match expr {
+        SymbolicExpression::Variable(var) => SymbolicExpressionNode::Variable(*var),
+        SymbolicExpression::IsFirstRow => SymbolicExpressionNode::IsFirstRow,
+        SymbolicExpression::IsLastRow => SymbolicExpressionNode::IsLastRow,
+        SymbolicExpression::IsTransition => SymbolicExpressionNode::IsTransition,
+        SymbolicExpression::Constant(cons) => SymbolicExpressionNode::Constant(*cons),
+        SymbolicExpression::Add {
+            x,
+            y,
+            degree_multiple,
+        } => {
+            let x_id = topology_sort_symbolic_expr(x.as_ref(), expr_to_id, id_to_expr);
+            let y_id = topology_sort_symbolic_expr(y.as_ref(), expr_to_id, id_to_expr);
+            SymbolicExpressionNode::Add {
+                x: x_id,
+                y: y_id,
+                degree_multiple: *degree_multiple,
+            }
+        }
+        SymbolicExpression::Sub {
+            x,
+            y,
+            degree_multiple,
+        } => {
+            let x_id = topology_sort_symbolic_expr(x.as_ref(), expr_to_id, id_to_expr);
+            let y_id = topology_sort_symbolic_expr(y.as_ref(), expr_to_id, id_to_expr);
+            SymbolicExpressionNode::Sub {
+                x: x_id,
+                y: y_id,
+                degree_multiple: *degree_multiple,
+            }
+        }
+        SymbolicExpression::Neg { x, degree_multiple } => {
+            let x_id = topology_sort_symbolic_expr(x.as_ref(), expr_to_id, id_to_expr);
+            SymbolicExpressionNode::Neg {
+                x: x_id,
+                degree_multiple: *degree_multiple,
+            }
+        }
+        SymbolicExpression::Mul {
+            x,
+            y,
+            degree_multiple,
+        } => {
+            let x_id = topology_sort_symbolic_expr(x.as_ref(), expr_to_id, id_to_expr);
+            let y_id = topology_sort_symbolic_expr(y.as_ref(), expr_to_id, id_to_expr);
+            SymbolicExpressionNode::Mul {
+                x: x_id,
+                y: y_id,
+                degree_multiple: *degree_multiple,
+            }
+        }
+    };
+
+    let id = id_to_expr.len();
+    id_to_expr.push(exp_ser);
+    expr_to_id.insert(expr, id);
+    id
+}
+
+impl<F: Field> SymbolicExpressionDag<F> {
+    pub fn to_symbolic_expressions(&self) -> Vec<SymbolicExpression<F>> {
+        let mut exprs: Vec<Arc<SymbolicExpression<_>>> = Vec::with_capacity(self.expr_by_id.len());
+        for expr_ser in &self.expr_by_id {
+            let expr = match expr_ser {
+                SymbolicExpressionNode::Variable(var) => SymbolicExpression::Variable(*var),
+                SymbolicExpressionNode::IsFirstRow => SymbolicExpression::IsFirstRow,
+                SymbolicExpressionNode::IsLastRow => SymbolicExpression::IsLastRow,
+                SymbolicExpressionNode::IsTransition => SymbolicExpression::IsTransition,
+                SymbolicExpressionNode::Constant(f) => SymbolicExpression::Constant(*f),
+                SymbolicExpressionNode::Add {
+                    x,
+                    y,
+                    degree_multiple,
+                } => SymbolicExpression::Add {
+                    x: exprs[*x].clone(),
+                    y: exprs[*y].clone(),
+                    degree_multiple: *degree_multiple,
+                },
+                SymbolicExpressionNode::Sub {
+                    x,
+                    y,
+                    degree_multiple,
+                } => SymbolicExpression::Sub {
+                    x: exprs[*x].clone(),
+                    y: exprs[*y].clone(),
+                    degree_multiple: *degree_multiple,
+                },
+                SymbolicExpressionNode::Neg { x, degree_multiple } => SymbolicExpression::Neg {
+                    x: exprs[*x].clone(),
+                    degree_multiple: *degree_multiple,
+                },
+                SymbolicExpressionNode::Mul {
+                    x,
+                    y,
+                    degree_multiple,
+                } => SymbolicExpression::Mul {
+                    x: exprs[*x].clone(),
+                    y: exprs[*y].clone(),
+                    degree_multiple: *degree_multiple,
+                },
+            };
+            exprs.push(Arc::new(expr));
+        }
+        self.top_expr_ids
+            .iter()
+            .map(|&id| exprs[id].as_ref().clone())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use p3_baby_bear::BabyBear;
+    use p3_field::AbstractField;
+
+    use crate::air_builders::symbolic::{
+        dag::{build_symbolic_expr_dag, SymbolicExpressionDag, SymbolicExpressionNode},
+        symbolic_expression::SymbolicExpression,
+        symbolic_variable::{Entry, SymbolicVariable},
+        SymbolicConstraints,
+    };
+
+    type F = BabyBear;
+
+    #[test]
+    fn test_symbolic_expressions_dag() {
+        let exprs = vec![
+            SymbolicExpression::IsFirstRow * SymbolicExpression::IsLastRow
+                + SymbolicExpression::Constant(F::ONE)
+                + SymbolicExpression::IsFirstRow * SymbolicExpression::IsLastRow
+                + SymbolicExpression::Constant(F::ONE)
+                    * SymbolicVariable::new(
+                        Entry::Main {
+                            part_index: 1,
+                            offset: 2,
+                        },
+                        3,
+                    ),
+            SymbolicExpression::IsFirstRow * SymbolicExpression::IsLastRow,
+        ];
+        let expr_list = build_symbolic_expr_dag(&exprs);
+        assert_eq!(
+            expr_list,
+            SymbolicExpressionDag::<F> {
+                expr_by_id: vec![
+                    SymbolicExpressionNode::IsFirstRow,
+                    SymbolicExpressionNode::IsLastRow,
+                    SymbolicExpressionNode::Mul {
+                        x: 0,
+                        y: 1,
+                        degree_multiple: 2
+                    },
+                    SymbolicExpressionNode::Constant(F::ONE),
+                    SymbolicExpressionNode::Add {
+                        x: 2,
+                        y: 3,
+                        degree_multiple: 2
+                    },
+                    SymbolicExpressionNode::Add {
+                        x: 4,
+                        y: 2,
+                        degree_multiple: 2
+                    },
+                    SymbolicExpressionNode::Variable(SymbolicVariable::new(
+                        Entry::Main {
+                            part_index: 1,
+                            offset: 2
+                        },
+                        3
+                    )),
+                    SymbolicExpressionNode::Mul {
+                        x: 3,
+                        y: 6,
+                        degree_multiple: 1
+                    },
+                    SymbolicExpressionNode::Add {
+                        x: 5,
+                        y: 7,
+                        degree_multiple: 2
+                    }
+                ],
+                top_expr_ids: vec![8, 2],
+            }
+        );
+        let sc = SymbolicConstraints {
+            constraints: exprs,
+            interactions: vec![],
+        };
+        let ser_str = serde_json::to_string(&sc).unwrap();
+        let new_sc: SymbolicConstraints<_> = serde_json::from_str(&ser_str).unwrap();
+        assert_eq!(sc.constraints, new_sc.constraints);
+    }
+}

--- a/crates/stark-backend/src/air_builders/symbolic/mod.rs
+++ b/crates/stark-backend/src/air_builders/symbolic/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     rap::{BaseAirWithPublicValues, PermutationAirBuilderWithExposedValues, Rap},
 };
 
-mod dag;
+pub mod dag;
 pub mod symbolic_expression;
 pub mod symbolic_variable;
 
@@ -35,10 +35,6 @@ pub mod symbolic_variable;
 #[serde(bound = "F: Field")]
 pub struct SymbolicConstraints<F> {
     /// All constraints of the RAP, including the constraints on the logup partial sums.
-    #[serde(
-        serialize_with = "serialize_symbolic_exprs",
-        deserialize_with = "deserialize_symbolic_exprs"
-    )]
     pub constraints: Vec<SymbolicExpression<F>>,
     /// Only for debug purposes. `constraints` also contains the constraints on the logup partial sums.
     pub interactions: Vec<Interaction<SymbolicExpression<F>>>,
@@ -472,6 +468,7 @@ fn gen_main_trace<F: Field>(
     RowMajorMatrix::new(mat_values, width)
 }
 
+#[allow(dead_code)]
 fn serialize_symbolic_exprs<F: Field, S>(
     data: &[SymbolicExpression<F>],
     serializer: S,
@@ -484,6 +481,7 @@ where
     dag.serialize(serializer)
 }
 
+#[allow(dead_code)]
 fn deserialize_symbolic_exprs<'de, F: Field, D>(
     deserializer: D,
 ) -> Result<Vec<SymbolicExpression<F>>, D::Error>

--- a/crates/stark-backend/src/air_builders/symbolic/symbolic_expression.rs
+++ b/crates/stark-backend/src/air_builders/symbolic/symbolic_expression.rs
@@ -14,7 +14,8 @@ use serde::{Deserialize, Serialize};
 use super::symbolic_variable::SymbolicVariable;
 
 /// An expression over `SymbolicVariable`s.
-#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+// Note: avoid deriving Hash because it will hash the entire sub-tree
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub enum SymbolicExpression<F> {
     Variable(SymbolicVariable<F>),

--- a/crates/stark-backend/src/air_builders/symbolic/symbolic_expression.rs
+++ b/crates/stark-backend/src/air_builders/symbolic/symbolic_expression.rs
@@ -5,10 +5,13 @@ use core::{
     iter::{Product, Sum},
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
-use std::{hash::Hash, sync::Arc};
+use std::{
+    hash::{Hash, Hasher},
+    ptr,
+    sync::Arc,
+};
 
 use p3_field::{AbstractField, Field};
-use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 use super::symbolic_variable::SymbolicVariable;
@@ -42,6 +45,36 @@ pub enum SymbolicExpression<F> {
         y: Arc<Self>,
         degree_multiple: usize,
     },
+}
+
+impl<F: Field> Hash for SymbolicExpression<F> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // First hash the discriminant of the enum
+        std::mem::discriminant(self).hash(state);
+        // Degree multiple is not necessary
+        match self {
+            Self::Variable(v) => v.hash(state),
+            Self::IsFirstRow => {}   // discriminant is enough
+            Self::IsLastRow => {}    // discriminant is enough
+            Self::IsTransition => {} // discriminant is enough
+            Self::Constant(f) => f.hash(state),
+            Self::Add { x, y, .. } => {
+                ptr::hash(&**x, state);
+                ptr::hash(&**y, state);
+            }
+            Self::Sub { x, y, .. } => {
+                ptr::hash(&**x, state);
+                ptr::hash(&**y, state);
+            }
+            Self::Neg { x, .. } => {
+                ptr::hash(&**x, state);
+            }
+            Self::Mul { x, y, .. } => {
+                ptr::hash(&**x, state);
+                ptr::hash(&**y, state);
+            }
+        }
+    }
 }
 
 impl<F: Field> SymbolicExpression<F> {
@@ -308,41 +341,18 @@ impl<F: Field> Product<F> for SymbolicExpression<F> {
     }
 }
 
-pub trait SymbolicEvaluator<F: Field, E: AbstractField + From<F>>
-where
-    SymbolicVariable<F>: Hash + PartialEq + Eq,
-{
+pub trait SymbolicEvaluator<F: Field, E: AbstractField + From<F>> {
     fn eval_var(&self, symbolic_var: SymbolicVariable<F>) -> E;
 
-    #[allow(clippy::needless_option_as_deref)]
-    fn eval_expr(
-        &self,
-        symbolic_expr: &SymbolicExpression<F>,
-        mut cache: Option<&mut FxHashMap<SymbolicExpression<F>, E>>,
-    ) -> E {
-        if let Some(ref mut cache) = cache {
-            if let Some(e) = cache.get(symbolic_expr) {
-                return e.clone();
-            }
-        }
-        let e = match symbolic_expr {
+    fn eval_expr(&self, symbolic_expr: &SymbolicExpression<F>) -> E {
+        match symbolic_expr {
             SymbolicExpression::Variable(var) => self.eval_var(*var),
             SymbolicExpression::Constant(c) => (*c).into(),
-            SymbolicExpression::Add { x, y, .. } => {
-                self.eval_expr(x, cache.as_deref_mut()) + self.eval_expr(y, cache.as_deref_mut())
-            }
-            SymbolicExpression::Sub { x, y, .. } => {
-                self.eval_expr(x, cache.as_deref_mut()) - self.eval_expr(y, cache.as_deref_mut())
-            }
-            SymbolicExpression::Neg { x, .. } => -self.eval_expr(x, cache.as_deref_mut()),
-            SymbolicExpression::Mul { x, y, .. } => {
-                self.eval_expr(x, cache.as_deref_mut()) * self.eval_expr(y, cache.as_deref_mut())
-            }
+            SymbolicExpression::Add { x, y, .. } => self.eval_expr(x) + self.eval_expr(y),
+            SymbolicExpression::Sub { x, y, .. } => self.eval_expr(x) - self.eval_expr(y),
+            SymbolicExpression::Neg { x, .. } => -self.eval_expr(x),
+            SymbolicExpression::Mul { x, y, .. } => self.eval_expr(x) * self.eval_expr(y),
             _ => unreachable!("Expression cannot be evaluated"),
-        };
-        if let Some(ref mut cache) = cache {
-            cache.insert(symbolic_expr.clone(), e.clone());
         }
-        e
     }
 }

--- a/crates/stark-backend/src/air_builders/symbolic/symbolic_variable.rs
+++ b/crates/stark-backend/src/air_builders/symbolic/symbolic_variable.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use super::symbolic_expression::SymbolicExpression;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[repr(C)]
 pub enum Entry {
     Preprocessed {
         offset: usize,

--- a/crates/stark-backend/src/air_builders/verifier.rs
+++ b/crates/stark-backend/src/air_builders/verifier.rs
@@ -61,10 +61,22 @@ where
             let expr = match *node {
                 SymbolicExpressionNode::Variable(var) => self.eval_var(var),
                 SymbolicExpressionNode::Constant(f) => Expr::from(f),
-                SymbolicExpressionNode::Add { x, y, .. } => exprs[x].clone() + exprs[y].clone(),
-                SymbolicExpressionNode::Sub { x, y, .. } => exprs[x].clone() - exprs[y].clone(),
-                SymbolicExpressionNode::Neg { x, .. } => -exprs[x].clone(),
-                SymbolicExpressionNode::Mul { x, y, .. } => exprs[x].clone() * exprs[y].clone(),
+                SymbolicExpressionNode::Add {
+                    left_idx,
+                    right_idx,
+                    ..
+                } => exprs[left_idx].clone() + exprs[right_idx].clone(),
+                SymbolicExpressionNode::Sub {
+                    left_idx,
+                    right_idx,
+                    ..
+                } => exprs[left_idx].clone() - exprs[right_idx].clone(),
+                SymbolicExpressionNode::Neg { idx, .. } => -exprs[idx].clone(),
+                SymbolicExpressionNode::Mul {
+                    left_idx,
+                    right_idx,
+                    ..
+                } => exprs[left_idx].clone() * exprs[right_idx].clone(),
                 SymbolicExpressionNode::IsFirstRow => self.is_first_row.into(),
                 SymbolicExpressionNode::IsLastRow => self.is_last_row.into(),
                 SymbolicExpressionNode::IsTransition => self.is_transition.into(),

--- a/crates/stark-backend/src/air_builders/verifier.rs
+++ b/crates/stark-backend/src/air_builders/verifier.rs
@@ -5,10 +5,10 @@ use std::{
 
 use p3_field::{AbstractField, ExtensionField, Field};
 use p3_matrix::Matrix;
-use rustc_hash::FxHashMap;
 
 use super::{
     symbolic::{
+        dag::{build_symbolic_expr_dag, SymbolicExpressionNode},
         symbolic_expression::{SymbolicEvaluator, SymbolicExpression},
         symbolic_variable::{Entry, SymbolicVariable},
     },
@@ -52,10 +52,27 @@ where
     PubVar: Into<Expr> + Copy + Send + Sync,
 {
     pub fn eval_constraints(&mut self, constraints: &[SymbolicExpression<F>]) {
-        let mut cache = FxHashMap::default();
-        for constraint in constraints {
-            let x = self.eval_expr(constraint, Some(&mut cache));
-            self.assert_zero(x);
+        let dag = build_symbolic_expr_dag(constraints);
+        // node_idx -> evaluation
+        // We do a simple serial evaluation in topological order.
+        // This can be parallelized if necessary.
+        let mut exprs: Vec<Expr> = Vec::with_capacity(dag.nodes.len());
+        for node in &dag.nodes {
+            let expr = match *node {
+                SymbolicExpressionNode::Variable(var) => self.eval_var(var),
+                SymbolicExpressionNode::Constant(f) => Expr::from(f),
+                SymbolicExpressionNode::Add { x, y, .. } => exprs[x].clone() + exprs[y].clone(),
+                SymbolicExpressionNode::Sub { x, y, .. } => exprs[x].clone() - exprs[y].clone(),
+                SymbolicExpressionNode::Neg { x, .. } => -exprs[x].clone(),
+                SymbolicExpressionNode::Mul { x, y, .. } => exprs[x].clone() * exprs[y].clone(),
+                SymbolicExpressionNode::IsFirstRow => self.is_first_row.into(),
+                SymbolicExpressionNode::IsLastRow => self.is_last_row.into(),
+                SymbolicExpressionNode::IsTransition => self.is_transition.into(),
+            };
+            exprs.push(expr);
+        }
+        for idx in dag.constraint_idx {
+            self.assert_zero(exprs[idx].clone());
         }
     }
 
@@ -101,37 +118,6 @@ where
                 .into(),
         }
     }
-    #[allow(clippy::needless_option_as_deref)]
-    fn eval_expr(
-        &self,
-        symbolic_expr: &SymbolicExpression<F>,
-        mut cache: Option<&mut FxHashMap<SymbolicExpression<F>, Expr>>,
-    ) -> Expr {
-        if let Some(ref mut cache) = cache {
-            if let Some(e) = cache.get(symbolic_expr) {
-                return e.clone();
-            }
-        }
-        let e = match symbolic_expr {
-            SymbolicExpression::Variable(var) => self.eval_var(*var),
-            SymbolicExpression::Constant(c) => (*c).into(),
-            SymbolicExpression::Add { x, y, .. } => {
-                self.eval_expr(x, cache.as_deref_mut()) + self.eval_expr(y, cache.as_deref_mut())
-            }
-            SymbolicExpression::Sub { x, y, .. } => {
-                self.eval_expr(x, cache.as_deref_mut()) - self.eval_expr(y, cache.as_deref_mut())
-            }
-            SymbolicExpression::Neg { x, .. } => -self.eval_expr(x, cache.as_deref_mut()),
-            SymbolicExpression::Mul { x, y, .. } => {
-                self.eval_expr(x, cache.as_deref_mut()) * self.eval_expr(y, cache.as_deref_mut())
-            }
-            SymbolicExpression::IsFirstRow => self.is_first_row.into(),
-            SymbolicExpression::IsLastRow => self.is_last_row.into(),
-            SymbolicExpression::IsTransition => self.is_transition.into(),
-        };
-        if let Some(ref mut cache) = cache {
-            cache.insert(symbolic_expr.clone(), e.clone());
-        }
-        e
-    }
+    // NOTE: do not use the eval_expr function as it can have exponential complexity!
+    // Instead use the `SymbolicExpressionDag`
 }

--- a/crates/stark-backend/src/interaction/debug.rs
+++ b/crates/stark-backend/src/interaction/debug.rs
@@ -42,9 +42,9 @@ pub fn generate_logical_interactions<F: Field>(
             let fields = interaction
                 .fields
                 .iter()
-                .map(|expr| evaluator.eval_expr(expr, None))
+                .map(|expr| evaluator.eval_expr(expr))
                 .collect_vec();
-            let count = evaluator.eval_expr(&interaction.count, None);
+            let count = evaluator.eval_expr(&interaction.count);
             if count.is_zero() {
                 continue;
             }

--- a/crates/stark-backend/src/interaction/stark_log_up.rs
+++ b/crates/stark-backend/src/interaction/stark_log_up.rs
@@ -342,12 +342,10 @@ where
                         debug_assert!(interaction.fields.len() <= betas.len());
                         let mut fields = interaction.fields.iter();
                         *denom = alpha
-                            + evaluator.eval_expr(
-                                fields.next().expect("fields should not be empty"),
-                                None,
-                            );
+                            + evaluator
+                                .eval_expr(fields.next().expect("fields should not be empty"));
                         for (expr, &beta) in fields.zip(betas.iter().skip(1)) {
-                            *denom += beta * evaluator.eval_expr(expr, None);
+                            *denom += beta * evaluator.eval_expr(expr);
                         }
                     }
                 }
@@ -384,7 +382,7 @@ where
                                 izip!(reciprocal_chunk, interaction_chunk)
                             {
                                 let mut interaction_val =
-                                    *reciprocal * evaluator.eval_expr(&interaction.count, None);
+                                    *reciprocal * evaluator.eval_expr(&interaction.count);
                                 if interaction.interaction_type == InteractionType::Receive {
                                     interaction_val = -interaction_val;
                                 }


### PR DESCRIPTION
To avoid exponential blowup in the evaluation of the symbolic syntax tree, we convert it into a DAG with topological sort and evaluate topologically (currently single threaded) to avoid there is not duplicate evaluations. The main note is that `Arc` should be hashed using `ptr::hash`.

This PR will not switch the serialization of vkey to DAG. This will be done in a followup where we switch the main interfaces to use the DAG, and `SymbolicExpression` should only be an internally used struct.

towards INT-2905