### PR TITLE
feat: serialize `SymbolicConstraints` as DAG 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.1.0-alpha"
+version = "0.1.2-alpha"
 edition = "2021"
 rust-version = "1.82"
 authors = ["OpenVM contributors"]

--- a/crates/stark-backend/src/air_builders/symbolic/mod.rs
+++ b/crates/stark-backend/src/air_builders/symbolic/mod.rs
@@ -36,7 +36,13 @@ pub mod symbolic_variable;
 pub struct SymbolicConstraints<F> {
     /// All constraints of the RAP, including the constraints on the logup partial sums.
     pub constraints: Vec<SymbolicExpression<F>>,
-    /// Only for debug purposes. `constraints` also contains the constraints on the logup partial sums.
+    /// Symbolic representation of chip interactions. This is used by
+    /// the prover for after challenge trace generation, and some partial
+    /// information may be used by the verifier.
+    ///
+    /// **However**, any contributions to the quotient polynomial from
+    /// logup are already included in `constraints` and do not need to
+    /// be separately calculated from `interactions`.
     pub interactions: Vec<Interaction<SymbolicExpression<F>>>,
 }
 

--- a/crates/stark-backend/src/air_builders/verifier.rs
+++ b/crates/stark-backend/src/air_builders/verifier.rs
@@ -8,7 +8,7 @@ use p3_matrix::Matrix;
 
 use super::{
     symbolic::{
-        dag::{build_symbolic_expr_dag, SymbolicExpressionNode},
+        dag::{build_symbolic_constraints_dag, SymbolicExpressionNode},
         symbolic_expression::{SymbolicEvaluator, SymbolicExpression},
         symbolic_variable::{Entry, SymbolicVariable},
     },
@@ -52,7 +52,7 @@ where
     PubVar: Into<Expr> + Copy + Send + Sync,
 {
     pub fn eval_constraints(&mut self, constraints: &[SymbolicExpression<F>]) {
-        let dag = build_symbolic_expr_dag(constraints);
+        let dag = build_symbolic_constraints_dag(constraints, &[]).constraints;
         // node_idx -> evaluation
         // We do a simple serial evaluation in topological order.
         // This can be parallelized if necessary.

--- a/crates/stark-backend/src/interaction/mod.rs
+++ b/crates/stark-backend/src/interaction/mod.rs
@@ -18,13 +18,13 @@ pub mod stark_log_up;
 pub mod trace;
 mod utils;
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum InteractionType {
     Send,
     Receive,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Interaction<Expr> {
     pub fields: Vec<Expr>,
     pub count: Expr,


### PR DESCRIPTION
Including interactions. Doing this for now to keep interfaces the same.

In the upcoming frontend-backend split, we will make a breaking
interface change to switch to using the DAG as the primary interface and
make `SymbolicExpression` and `SymbolicConstraints` private (or remove
entirely).

Closes INT-2905

I checked locally that the `openvm` book example with keccak now has instant keygen time and the vkey is `338K`.