### PR TITLE
chore: update plonky3 commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,32 +51,32 @@ openvm-stark-backend = { path = "crates/stark-backend", default-features = false
 openvm-stark-sdk = { path = "crates/stark-sdk", default-features = false }
 
 # Plonky3
-p3-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-commit = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-matrix = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-commit = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-matrix = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
 p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3.git", features = [
     "nightly-features",
-], rev = "784b7dd" }
-p3-util = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-challenger = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-dft = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-fri = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-goldilocks = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-keccak = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-keccak-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-blake3 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-mds = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-monty-31 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-poseidon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-uni-stark = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
-p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
+], rev = "b0591e9" }
+p3-util = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-challenger = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-dft = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-fri = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-goldilocks = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-keccak = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-keccak-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-blake3 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-mds = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-monty-31 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-poseidon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-uni-stark = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
+p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
 
 # Bn254 support
-p3-bn254-fr = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-bn254-fr = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2.git", rev = "bb476b9" }
 ff = { version = "0.13.0", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,32 +51,32 @@ openvm-stark-backend = { path = "crates/stark-backend", default-features = false
 openvm-stark-sdk = { path = "crates/stark-sdk", default-features = false }
 
 # Plonky3
-p3-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-commit = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-matrix = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
+p3-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-commit = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-matrix = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
 p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3.git", features = [
     "nightly-features",
-], rev = "9b267c4" }
-p3-util = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-challenger = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-dft = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-fri = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-goldilocks = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-keccak = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-keccak-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-blake3 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-mds = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-monty-31 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-poseidon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-uni-stark = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
+], rev = "784b7dd" }
+p3-util = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-challenger = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-dft = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-fri = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-goldilocks = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-keccak = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-keccak-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-blake3 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-mds = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-monty-31 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-poseidon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-uni-stark = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
 
 # Bn254 support
-p3-bn254-fr = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
+p3-bn254-fr = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2.git", rev = "bb476b9" }
 ff = { version = "0.13.0", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.1.2-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 rust-version = "1.82"
 authors = ["OpenVM contributors"]

--- a/crates/stark-backend/src/air_builders/debug/check_constraints.rs
+++ b/crates/stark-backend/src/air_builders/debug/check_constraints.rs
@@ -1,6 +1,6 @@
 use itertools::izip;
 use p3_air::BaseAir;
-use p3_field::{AbstractField, Field};
+use p3_field::{Field, FieldAlgebra};
 use p3_matrix::{dense::RowMajorMatrixView, stack::VerticalPair, Matrix};
 use p3_maybe_rayon::prelude::*;
 

--- a/crates/stark-backend/src/air_builders/debug/mod.rs
+++ b/crates/stark-backend/src/air_builders/debug/mod.rs
@@ -1,7 +1,7 @@
 use p3_air::{
     AirBuilder, AirBuilderWithPublicValues, ExtensionBuilder, PairBuilder, PermutationAirBuilder,
 };
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 use p3_matrix::{dense::RowMajorMatrixView, stack::VerticalPair};
 
 use super::{PartitionedAirBuilder, ViewPair};

--- a/crates/stark-backend/src/air_builders/prover.rs
+++ b/crates/stark-backend/src/air_builders/prover.rs
@@ -2,7 +2,7 @@
 use p3_air::{
     AirBuilder, AirBuilderWithPublicValues, ExtensionBuilder, PairBuilder, PermutationAirBuilder,
 };
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 use p3_matrix::Matrix;
 
 use super::{

--- a/crates/stark-backend/src/air_builders/symbolic/dag.rs
+++ b/crates/stark-backend/src/air_builders/symbolic/dag.rs
@@ -283,7 +283,7 @@ impl<F: Field> From<SymbolicConstraints<F>> for SymbolicConstraintsDag<F> {
 #[cfg(test)]
 mod tests {
     use p3_baby_bear::BabyBear;
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
 
     use crate::{
         air_builders::symbolic::{

--- a/crates/stark-backend/src/air_builders/symbolic/symbolic_expression.rs
+++ b/crates/stark-backend/src/air_builders/symbolic/symbolic_expression.rs
@@ -11,7 +11,7 @@ use std::{
     sync::Arc,
 };
 
-use p3_field::{AbstractField, Field};
+use p3_field::{FieldAlgebra, Field};
 use serde::{Deserialize, Serialize};
 
 use super::symbolic_variable::SymbolicVariable;
@@ -159,7 +159,7 @@ impl<F: Field> From<F> for SymbolicExpression<F> {
     }
 }
 
-impl<F: Field> AbstractField for SymbolicExpression<F> {
+impl<F: Field> FieldAlgebra for SymbolicExpression<F> {
     type F = F;
 
     const ZERO: Self = Self::Constant(F::ZERO);
@@ -341,7 +341,7 @@ impl<F: Field> Product<F> for SymbolicExpression<F> {
     }
 }
 
-pub trait SymbolicEvaluator<F: Field, E: AbstractField + From<F>> {
+pub trait SymbolicEvaluator<F: Field, E: FieldAlgebra + From<F>> {
     fn eval_var(&self, symbolic_var: SymbolicVariable<F>) -> E;
 
     fn eval_expr(&self, symbolic_expr: &SymbolicExpression<F>) -> E {

--- a/crates/stark-backend/src/air_builders/symbolic/symbolic_expression.rs
+++ b/crates/stark-backend/src/air_builders/symbolic/symbolic_expression.rs
@@ -11,7 +11,7 @@ use std::{
     sync::Arc,
 };
 
-use p3_field::{FieldAlgebra, Field};
+use p3_field::{Field, FieldAlgebra};
 use serde::{Deserialize, Serialize};
 
 use super::symbolic_variable::SymbolicVariable;

--- a/crates/stark-backend/src/air_builders/verifier.rs
+++ b/crates/stark-backend/src/air_builders/verifier.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{AddAssign, MulAssign},
 };
 
-use p3_field::{FieldAlgebra, ExtensionField, Field};
+use p3_field::{ExtensionField, Field, FieldAlgebra};
 use p3_matrix::Matrix;
 
 use super::{

--- a/crates/stark-backend/src/air_builders/verifier.rs
+++ b/crates/stark-backend/src/air_builders/verifier.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{AddAssign, MulAssign},
 };
 
-use p3_field::{AbstractField, ExtensionField, Field};
+use p3_field::{FieldAlgebra, ExtensionField, Field};
 use p3_matrix::Matrix;
 
 use super::{
@@ -47,7 +47,7 @@ impl<F, EF, PubVar, Var, Expr> GenericVerifierConstraintFolder<'_, F, EF, PubVar
 where
     F: Field,
     EF: ExtensionField<F>,
-    Expr: AbstractField + From<F> + MulAssign<Var> + AddAssign<Var> + Send + Sync,
+    Expr: FieldAlgebra + From<F> + MulAssign<Var> + AddAssign<Var> + Send + Sync,
     Var: Into<Expr> + Copy + Send + Sync,
     PubVar: Into<Expr> + Copy + Send + Sync,
 {
@@ -100,7 +100,7 @@ impl<F, EF, PubVar, Var, Expr> SymbolicEvaluator<F, Expr>
 where
     F: Field,
     EF: ExtensionField<F>,
-    Expr: AbstractField + From<F> + Send + Sync,
+    Expr: FieldAlgebra + From<F> + Send + Sync,
     Var: Into<Expr> + Copy + Send + Sync,
     PubVar: Into<Expr> + Copy + Send + Sync,
 {

--- a/crates/stark-backend/src/gkr/prover.rs
+++ b/crates/stark-backend/src/gkr/prover.rs
@@ -512,7 +512,7 @@ pub fn correct_sum_as_poly_in_first_variable<F: Field>(
 #[cfg(test)]
 mod tests {
     use p3_baby_bear::BabyBear;
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use rand::Rng;
 
     use crate::{gkr::prover::HypercubeEqEvals, poly::multi::hypercube_eq};

--- a/crates/stark-backend/src/gkr/tests.rs
+++ b/crates/stark-backend/src/gkr/tests.rs
@@ -5,7 +5,7 @@ use openvm_stark_sdk::{
     config::baby_bear_blake3::default_engine, engine::StarkEngine, utils::create_seeded_rng,
 };
 use p3_baby_bear::BabyBear;
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 use rand::Rng;
 
 use crate::{

--- a/crates/stark-backend/src/interaction/stark_log_up.rs
+++ b/crates/stark-backend/src/interaction/stark_log_up.rs
@@ -3,7 +3,7 @@ use std::{array, borrow::Borrow, marker::PhantomData};
 use itertools::{izip, Itertools};
 use p3_air::ExtensionBuilder;
 use p3_challenger::{CanObserve, FieldChallenger};
-use p3_field::{AbstractField, ExtensionField, Field};
+use p3_field::{ExtensionField, Field, FieldAlgebra};
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
 use p3_maybe_rayon::prelude::*;
 use serde::{Deserialize, Serialize};

--- a/crates/stark-backend/src/interaction/utils.rs
+++ b/crates/stark-backend/src/interaction/utils.rs
@@ -1,10 +1,10 @@
 use p3_air::VirtualPairCol;
-use p3_field::{AbstractField, ExtensionField, Field, Powers};
+use p3_field::{FieldAlgebra, ExtensionField, Field, Powers};
 
 use super::Interaction;
 
 /// Returns [random_element, random_element^2, ..., random_element^{max_bus_index + 1}].
-pub fn generate_rlc_elements<AF: AbstractField, E>(
+pub fn generate_rlc_elements<AF: FieldAlgebra, E>(
     random_element: AF,
     all_interactions: &[Interaction<E>],
 ) -> Vec<AF> {
@@ -23,7 +23,7 @@ pub fn generate_rlc_elements<AF: AbstractField, E>(
 
 /// Returns [beta^0, beta^1, ..., beta^{max_num_fields - 1}]
 /// where max_num_fields is the maximum length of `fields` in any interaction.
-pub fn generate_betas<AF: AbstractField, E>(
+pub fn generate_betas<AF: FieldAlgebra, E>(
     beta: AF,
     all_interactions: &[Interaction<E>],
 ) -> Vec<AF> {

--- a/crates/stark-backend/src/interaction/utils.rs
+++ b/crates/stark-backend/src/interaction/utils.rs
@@ -1,5 +1,5 @@
 use p3_air::VirtualPairCol;
-use p3_field::{FieldAlgebra, ExtensionField, Field, Powers};
+use p3_field::{ExtensionField, Field, FieldAlgebra, Powers};
 
 use super::Interaction;
 

--- a/crates/stark-backend/src/keygen/mod.rs
+++ b/crates/stark-backend/src/keygen/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use itertools::Itertools;
-use p3_field::AbstractExtensionField;
+use p3_field::FieldExtensionAlgebra;
 use p3_matrix::Matrix;
 use tracing::instrument;
 
@@ -100,7 +100,7 @@ impl<'a, SC: StarkGenericConfig> MultiStarkKeygenBuilder<'a, SC> {
                 pk.vk.quotient_degree,
                 width.preprocessed.unwrap_or(0),
                 format!("{:?}",width.main_widths()),
-                format!("{:?}",width.after_challenge.iter().map(|&x| x * <SC::Challenge as AbstractExtensionField<Val<SC>>>::D).collect_vec()),
+                format!("{:?}",width.after_challenge.iter().map(|&x| x * <SC::Challenge as FieldExtensionAlgebra<Val<SC>>>::D).collect_vec()),
                 pk.vk.symbolic_constraints.constraints.len(),
                 pk.vk.symbolic_constraints.interactions.len(),
                 pk.vk

--- a/crates/stark-backend/src/poly/multi.rs
+++ b/crates/stark-backend/src/poly/multi.rs
@@ -116,7 +116,7 @@ where
 #[cfg(test)]
 mod test {
     use p3_baby_bear::BabyBear;
-    use p3_field::{AbstractField, Field};
+    use p3_field::{FieldAlgebra, Field};
 
     use super::*;
 

--- a/crates/stark-backend/src/poly/multi.rs
+++ b/crates/stark-backend/src/poly/multi.rs
@@ -116,7 +116,7 @@ where
 #[cfg(test)]
 mod test {
     use p3_baby_bear::BabyBear;
-    use p3_field::{FieldAlgebra, Field};
+    use p3_field::{Field, FieldAlgebra};
 
     use super::*;
 

--- a/crates/stark-backend/src/poly/uni.rs
+++ b/crates/stark-backend/src/poly/uni.rs
@@ -236,7 +236,7 @@ mod tests {
 
     use itertools::Itertools;
     use p3_baby_bear::BabyBear;
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
 
     use super::*;
 

--- a/crates/stark-backend/src/prover/metrics.rs
+++ b/crates/stark-backend/src/prover/metrics.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use itertools::Itertools;
-use p3_field::AbstractExtensionField;
+use p3_field::FieldExtensionAlgebra;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -75,7 +75,7 @@ pub fn trace_metrics<SC: StarkGenericConfig>(
         .map(|(pk, &height)| {
             let air_name = pk.air_name.clone();
             let mut width = pk.vk.params.width.clone();
-            let ext_degree = <SC::Challenge as AbstractExtensionField<Val<SC>>>::D;
+            let ext_degree = <SC::Challenge as FieldExtensionAlgebra<Val<SC>>>::D;
             for w in &mut width.after_challenge {
                 *w *= ext_degree;
             }

--- a/crates/stark-backend/src/prover/mod.rs
+++ b/crates/stark-backend/src/prover/mod.rs
@@ -6,7 +6,7 @@ use std::{
 use itertools::{izip, multiunzip, Itertools};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 use p3_matrix::{
     dense::{RowMajorMatrix, RowMajorMatrixView},
     Matrix,

--- a/crates/stark-backend/src/prover/quotient/mod.rs
+++ b/crates/stark-backend/src/prover/quotient/mod.rs
@@ -1,6 +1,6 @@
 use itertools::{izip, Itertools};
 use p3_commit::{Pcs, PolynomialSpace};
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
 use tracing::instrument;
 

--- a/crates/stark-backend/src/prover/quotient/single.rs
+++ b/crates/stark-backend/src/prover/quotient/single.rs
@@ -2,7 +2,7 @@ use std::cmp::min;
 
 use itertools::Itertools;
 use p3_commit::PolynomialSpace;
-use p3_field::{AbstractExtensionField, AbstractField, PackedValue};
+use p3_field::{FieldAlgebra, FieldExtensionAlgebra, PackedValue};
 use p3_matrix::{dense::RowMajorMatrixView, stack::VerticalPair, Matrix};
 use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
@@ -185,7 +185,7 @@ where
             // "Transpose" D packed base coefficients into WIDTH scalar extension coefficients.
             let width = min(PackedVal::<SC>::WIDTH, quotient_size);
             (0..width).map(move |idx_in_packing| {
-                let quotient_value = (0..<SC::Challenge as AbstractExtensionField<Val<SC>>>::D)
+                let quotient_value = (0..<SC::Challenge as FieldExtensionAlgebra<Val<SC>>>::D)
                     .map(|coeff_idx| quotient.as_base_slice()[coeff_idx].as_slice()[idx_in_packing])
                     .collect::<Vec<_>>();
                 SC::Challenge::from_base_slice(&quotient_value)

--- a/crates/stark-backend/src/sumcheck.rs
+++ b/crates/stark-backend/src/sumcheck.rs
@@ -207,7 +207,7 @@ mod tests {
         config::baby_bear_blake3::default_engine, engine::StarkEngine, utils::create_seeded_rng,
     };
     use p3_baby_bear::BabyBear;
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use rand::Rng;
 
     use super::*;

--- a/crates/stark-backend/src/verifier/constraints.rs
+++ b/crates/stark-backend/src/verifier/constraints.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use itertools::Itertools;
 use p3_commit::PolynomialSpace;
-use p3_field::{AbstractExtensionField, AbstractField, Field};
+use p3_field::{Field, FieldAlgebra, FieldExtensionAlgebra};
 use p3_matrix::{dense::RowMajorMatrixView, stack::VerticalPair};
 use tracing::instrument;
 

--- a/crates/stark-backend/src/verifier/mod.rs
+++ b/crates/stark-backend/src/verifier/mod.rs
@@ -1,7 +1,7 @@
 use itertools::{izip, Itertools};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 use p3_util::log2_strict_usize;
 use tracing::instrument;
 

--- a/crates/stark-backend/tests/fib_selector_air/air.rs
+++ b/crates/stark-backend/tests/fib_selector_air/air.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
-    p3_field::{AbstractField, Field},
+    p3_field::{Field, FieldAlgebra},
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };
 use openvm_stark_sdk::dummy_airs::fib_air::columns::{FibonacciCols, NUM_FIBONACCI_COLS};

--- a/crates/stark-backend/tests/integration_test.rs
+++ b/crates/stark-backend/tests/integration_test.rs
@@ -2,7 +2,7 @@
 #![allow(incomplete_features)]
 
 use openvm_stark_backend::{
-    config::StarkGenericConfig, p3_field::AbstractField, utils::disable_debug_builder, Chip,
+    config::StarkGenericConfig, p3_field::FieldAlgebra, utils::disable_debug_builder, Chip,
 };
 /// Test utils
 use openvm_stark_sdk::{

--- a/crates/stark-backend/tests/interaction/mod.rs
+++ b/crates/stark-backend/tests/interaction/mod.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use openvm_stark_backend::{
-    p3_field::AbstractField, prover::USE_DEBUG_BUILDER, verifier::VerificationError,
+    p3_field::FieldAlgebra, prover::USE_DEBUG_BUILDER, verifier::VerificationError,
 };
 use openvm_stark_sdk::{
     any_rap_arc_vec,

--- a/crates/stark-backend/tests/partitioned_sum_air/air.rs
+++ b/crates/stark-backend/tests/partitioned_sum_air/air.rs
@@ -5,7 +5,7 @@
 
 use openvm_stark_backend::{
     air_builders::PartitionedAirBuilder,
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };
 use p3_air::{Air, BaseAir};

--- a/crates/stark-backend/tests/partitioned_sum_air/mod.rs
+++ b/crates/stark-backend/tests/partitioned_sum_air/mod.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 use openvm_stark_backend::{
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
     prover::{
         types::{AirProofInput, AirProofRawInput, ProofInput},
         USE_DEBUG_BUILDER,

--- a/crates/stark-sdk/src/config/baby_bear_bytehash.rs
+++ b/crates/stark-sdk/src/config/baby_bear_bytehash.rs
@@ -93,6 +93,7 @@ where
     let dft = Dft::default();
     let fri_config = FriConfig {
         log_blowup: fri_params.log_blowup,
+        log_final_poly_len: fri_params.log_final_poly_len,
         num_queries: fri_params.num_queries,
         proof_of_work_bits: fri_params.proof_of_work_bits,
         mmcs: challenge_mmcs,

--- a/crates/stark-sdk/src/config/baby_bear_poseidon2.rs
+++ b/crates/stark-sdk/src/config/baby_bear_poseidon2.rs
@@ -5,7 +5,7 @@ use openvm_stark_backend::{
     interaction::stark_log_up::StarkLogUpPhase,
     p3_challenger::DuplexChallenger,
     p3_commit::ExtensionMmcs,
-    p3_field::{extension::BinomialExtensionField, AbstractField, Field},
+    p3_field::{extension::BinomialExtensionField, Field, FieldAlgebra},
 };
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_dft::Radix2DitParallel;
@@ -157,6 +157,7 @@ where
     let dft = Dft::default();
     let fri_config = FriConfig {
         log_blowup: fri_params.log_blowup,
+        log_final_poly_len: fri_params.log_final_poly_len,
         num_queries: fri_params.num_queries,
         proof_of_work_bits: fri_params.proof_of_work_bits,
         mmcs: challenge_mmcs,

--- a/crates/stark-sdk/src/config/baby_bear_poseidon2_root.rs
+++ b/crates/stark-sdk/src/config/baby_bear_poseidon2_root.rs
@@ -144,6 +144,7 @@ where
     let dft = Dft::default();
     let fri_config = FriConfig {
         log_blowup: fri_params.log_blowup,
+        log_final_poly_len: fri_params.log_final_poly_len,
         num_queries: fri_params.num_queries,
         proof_of_work_bits: fri_params.proof_of_work_bits,
         mmcs: challenge_mmcs,

--- a/crates/stark-sdk/src/config/fri_params.rs
+++ b/crates/stark-sdk/src/config/fri_params.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FriParameters {
     pub log_blowup: usize,
+    pub log_final_poly_len: usize,
     pub num_queries: usize,
     pub proof_of_work_bits: usize,
 }
@@ -39,6 +40,7 @@ pub fn standard_fri_params_with_100_bits_conjectured_security(log_blowup: usize)
     if let Ok("1") = std::env::var("OPENVM_FAST_TEST").as_deref() {
         return FriParameters {
             log_blowup,
+            log_final_poly_len: 0,
             num_queries: 2,
             proof_of_work_bits: 0,
         };
@@ -48,22 +50,26 @@ pub fn standard_fri_params_with_100_bits_conjectured_security(log_blowup: usize)
         // plonky3's default is num_queries=100, so we will use that. See https://github.com/Plonky3/Plonky3/issues/380 for related security discussion.
         1 => FriParameters {
             log_blowup,
+            log_final_poly_len: 0,
             num_queries: 100,
             proof_of_work_bits: 16,
         },
         2 => FriParameters {
             log_blowup,
+            log_final_poly_len: 0,
             num_queries: 42,
             proof_of_work_bits: 16,
         },
         // plonky2 standard recursion config: https://github.com/0xPolygonZero/plonky2/blob/41dc325e61ab8d4c0491e68e667c35a4e8173ffa/plonky2/src/plonk/circuit_data.rs#L101
         3 => FriParameters {
             log_blowup,
+            log_final_poly_len: 0,
             num_queries: 28,
             proof_of_work_bits: 16,
         },
         4 => FriParameters {
             log_blowup,
+            log_final_poly_len: 0,
             num_queries: 21,
             proof_of_work_bits: 16,
         },

--- a/crates/stark-sdk/src/config/goldilocks_poseidon.rs
+++ b/crates/stark-sdk/src/config/goldilocks_poseidon.rs
@@ -150,6 +150,7 @@ where
     let dft = Dft::default();
     let fri_config = FriConfig {
         log_blowup: fri_params.log_blowup,
+        log_final_poly_len: fri_params.log_final_poly_len,
         num_queries: fri_params.num_queries,
         proof_of_work_bits: fri_params.proof_of_work_bits,
         mmcs: challenge_mmcs,

--- a/crates/stark-sdk/src/cost_estimate.rs
+++ b/crates/stark-sdk/src/cost_estimate.rs
@@ -3,7 +3,7 @@ use std::{marker::PhantomData, ops::Add};
 use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     keygen::types::StarkVerifyingKey,
-    p3_field::AbstractExtensionField,
+    p3_field::FieldExtensionAlgebra,
 };
 
 use crate::config::FriParameters;
@@ -201,7 +201,7 @@ impl FriVerifierCostEstimate {
                 vk.params.width.common_main + vk.params.width.cached_mains.iter().sum::<usize>()
             })
             .sum();
-        let ext_degree = <SC::Challenge as AbstractExtensionField<Val<SC>>>::D;
+        let ext_degree = <SC::Challenge as FieldExtensionAlgebra<Val<SC>>>::D;
         let num_perm_columns: usize = vks
             .iter()
             .map(|vk| vk.params.width.after_challenge.iter().sum::<usize>())

--- a/crates/stark-sdk/src/dummy_airs/interaction/dummy_interaction_air.rs
+++ b/crates/stark-sdk/src/dummy_airs/interaction/dummy_interaction_air.rs
@@ -12,7 +12,7 @@ use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     interaction::{InteractionBuilder, InteractionType},
     p3_air::{Air, BaseAir},
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     prover::types::{AirProofInput, AirProofRawInput, CommittedTraceData, TraceCommitter},
     rap::{AnyRap, BaseAirWithPublicValues, PartitionedBaseAir},
@@ -141,7 +141,7 @@ pub struct DummyInteractionData {
 
 impl<'a, SC: StarkGenericConfig> DummyInteractionChip<'a, SC>
 where
-    Val<SC>: AbstractField,
+    Val<SC>: FieldAlgebra,
 {
     pub fn new_without_partition(field_width: usize, is_send: bool, bus_index: usize) -> Self {
         let air = DummyInteractionAir::new(field_width, is_send, bus_index);

--- a/crates/stark-sdk/src/dummy_airs/interaction/dummy_interaction_air.rs
+++ b/crates/stark-sdk/src/dummy_airs/interaction/dummy_interaction_air.rs
@@ -12,7 +12,7 @@ use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     interaction::{InteractionBuilder, InteractionType},
     p3_air::{Air, BaseAir},
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     prover::types::{AirProofInput, AirProofRawInput, CommittedTraceData, TraceCommitter},
     rap::{AnyRap, BaseAirWithPublicValues, PartitionedBaseAir},

--- a/crates/stark-sdk/src/utils.rs
+++ b/crates/stark-sdk/src/utils.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
 /// Deterministic seeded RNG, for testing use
@@ -16,7 +16,7 @@ pub fn create_seeded_rng_with_seed(seed: u64) -> StdRng {
 }
 
 // Returns row major matrix
-pub fn generate_random_matrix<F: AbstractField>(
+pub fn generate_random_matrix<F: FieldAlgebra>(
     mut rng: impl Rng,
     height: usize,
     width: usize,
@@ -30,7 +30,7 @@ pub fn generate_random_matrix<F: AbstractField>(
         .collect_vec()
 }
 
-pub fn to_field_vec<F: AbstractField>(v: Vec<u32>) -> Vec<F> {
+pub fn to_field_vec<F: FieldAlgebra>(v: Vec<u32>) -> Vec<F> {
     v.into_iter().map(F::from_canonical_u32).collect()
 }
 


### PR DESCRIPTION
Towards INT-2853

Main changes in the latest Plonky3 commit are
- renaming `AbstractField` -> `FieldAlgebra` and `AbstractExtensionField` -> `FieldExtensionAlgebra`
- addition of `log_final_poly_len` to `FriConfig`, which I added to `FriParameters`