### PR TITLE
chore: move debug out of prover

### DIFF
--- a/crates/stark-backend/src/air_builders/debug/check_constraints.rs
+++ b/crates/stark-backend/src/air_builders/debug/check_constraints.rs
@@ -21,11 +21,7 @@ pub fn check_constraints<R, SC>(
     rap_name: &str,
     preprocessed: &Option<RowMajorMatrixView<Val<SC>>>,
     partitioned_main: &[RowMajorMatrixView<Val<SC>>],
-    after_challenge: &[RowMajorMatrixView<SC::Challenge>],
-    challenges: &[Vec<SC::Challenge>],
     public_values: &[Val<SC>],
-    exposed_values_after_challenge: &[Vec<SC::Challenge>],
-    rap_phase_seq_kind: RapPhaseSeqKind,
 ) where
     R: for<'a> Rap<DebugConstraintBuilder<'a, SC>>
         + BaseAir<Val<SC>>
@@ -35,7 +31,6 @@ pub fn check_constraints<R, SC>(
 {
     let height = partitioned_main[0].height();
     assert!(partitioned_main.iter().all(|mat| mat.height() == height));
-    assert!(after_challenge.iter().all(|mat| mat.height() == height));
 
     // Check that constraints are satisfied.
     (0..height).into_par_iter().for_each(|i| {
@@ -65,20 +60,6 @@ pub fn check_constraints<R, SC>(
             })
             .collect::<Vec<_>>();
 
-        let after_challenge_row_pair = after_challenge
-            .iter()
-            .map(|mat| (mat.row_slice(i), mat.row_slice(i_next)))
-            .collect::<Vec<_>>();
-        let after_challenge = after_challenge_row_pair
-            .iter()
-            .map(|(local, next)| {
-                VerticalPair::new(
-                    RowMajorMatrixView::new_row(local),
-                    RowMajorMatrixView::new_row(next),
-                )
-            })
-            .collect::<Vec<_>>();
-
         let mut builder = DebugConstraintBuilder {
             air_name: rap_name,
             row_index: i,
@@ -87,14 +68,14 @@ pub fn check_constraints<R, SC>(
                 RowMajorMatrixView::new_row(preprocessed_next.as_slice()),
             ),
             partitioned_main,
-            after_challenge,
-            challenges,
+            after_challenge: vec![], // unreachable
+            challenges: &[],         // unreachable
             public_values,
-            exposed_values_after_challenge,
+            exposed_values_after_challenge: &[], // unreachable
             is_first_row: Val::<SC>::ZERO,
             is_last_row: Val::<SC>::ZERO,
             is_transition: Val::<SC>::ONE,
-            rap_phase_seq_kind,
+            rap_phase_seq_kind: RapPhaseSeqKind::StarkLogUp, // unused
             has_common_main: rap.common_main_width() > 0,
         };
         if i == 0 {

--- a/crates/stark-backend/src/utils.rs
+++ b/crates/stark-backend/src/utils.rs
@@ -4,7 +4,7 @@ use cfg_if::cfg_if;
 use p3_field::Field;
 use tracing::instrument;
 
-use crate::prover::USE_DEBUG_BUILDER;
+use crate::air_builders::debug::USE_DEBUG_BUILDER;
 
 // Copied from valida-util
 /// Calculates and returns the multiplicative inverses of each field element, with zero

--- a/crates/stark-backend/tests/cached_lookup/mod.rs
+++ b/crates/stark-backend/tests/cached_lookup/mod.rs
@@ -1,5 +1,5 @@
 use openvm_stark_backend::{
-    config::StarkGenericConfig, engine::StarkEngine, prover::USE_DEBUG_BUILDER,
+    config::StarkGenericConfig, engine::StarkEngine, utils::disable_debug_builder,
     verifier::VerificationError, Chip,
 };
 use openvm_stark_sdk::{
@@ -114,9 +114,7 @@ fn test_interaction_cached_trace_neg() {
         (0, vec![456, 5]),
     ];
 
-    USE_DEBUG_BUILDER.with(|debug| {
-        *debug.lock().unwrap() = false;
-    });
+    disable_debug_builder();
     assert_eq!(
         prove_and_verify_indexless_lookups(sender, receiver).err(),
         Some(VerificationError::ChallengePhaseError)

--- a/crates/stark-backend/tests/interaction/mod.rs
+++ b/crates/stark-backend/tests/interaction/mod.rs
@@ -1,7 +1,5 @@
 use itertools::Itertools;
-use openvm_stark_backend::{
-    p3_field::FieldAlgebra, prover::USE_DEBUG_BUILDER, verifier::VerificationError,
-};
+use openvm_stark_backend::{p3_field::FieldAlgebra, verifier::VerificationError};
 use openvm_stark_sdk::{
     any_rap_arc_vec,
     dummy_airs::interaction::{dummy_interaction_air::DummyInteractionAir, verify_interactions},
@@ -118,9 +116,6 @@ fn test_interaction_stark_multi_rows_neg() {
         2,
     );
     let receiver_air = DummyInteractionAir::new(1, false, 0);
-    USE_DEBUG_BUILDER.with(|debug| {
-        *debug.lock().unwrap() = false;
-    });
     let res = verify_interactions(
         vec![sender_trace, receiver_trace],
         any_rap_arc_vec![sender_air, receiver_air],
@@ -216,9 +211,6 @@ fn test_interaction_stark_multi_senders_neg() {
         2,
     );
     let receiver_air = DummyInteractionAir::new(1, false, 0);
-    USE_DEBUG_BUILDER.with(|debug| {
-        *debug.lock().unwrap() = false;
-    });
     let res = verify_interactions(
         vec![sender_trace1, sender_trace2, receiver_trace],
         any_rap_arc_vec![sender_air, sender_air, receiver_air],

--- a/crates/stark-backend/tests/partitioned_sum_air/mod.rs
+++ b/crates/stark-backend/tests/partitioned_sum_air/mod.rs
@@ -3,10 +3,8 @@ use std::sync::Arc;
 use itertools::Itertools;
 use openvm_stark_backend::{
     p3_field::FieldAlgebra,
-    prover::{
-        types::{AirProofInput, AirProofRawInput, ProofInput},
-        USE_DEBUG_BUILDER,
-    },
+    prover::types::{AirProofInput, AirProofRawInput, ProofInput},
+    utils::disable_debug_builder,
     verifier::VerificationError,
 };
 use openvm_stark_sdk::{config::baby_bear_poseidon2::default_engine, engine::StarkEngine};
@@ -86,9 +84,7 @@ fn test_partitioned_sum_air_happy_neg() {
         .map(|row| row.iter().fold(Val::ZERO, |sum, x| sum + *x))
         .collect();
     x[0] = Val::ZERO;
-    USE_DEBUG_BUILDER.with(|debug| {
-        *debug.lock().unwrap() = false;
-    });
+    disable_debug_builder();
     assert_eq!(
         prove_and_verify_sum_air(x, ys),
         Err(VerificationError::OodEvaluationMismatch)


### PR DESCRIPTION
So `prove` no longer requires `AnyRap`.

I did not remove `AnyRap` from `AirProofInput` because many testing functions use it. I plan to split `AirProofInput` into `SingleKeygenCtx` and `SingleProvingCtx` for the with `AnyRap` and without `AnyRap` variants.

**Note:** this pr is into a `feat/bal` branch, not `main`.