### PR TITLE
[fix] calling run_with_metric_collection multiple times fails

### DIFF
--- a/crates/stark-sdk/src/bench/mod.rs
+++ b/crates/stark-sdk/src/bench/mod.rs
@@ -27,15 +27,13 @@ pub fn run_with_metric_collection<R>(
         .with(ForestLayer::default())
         .with(MetricsLayer::new());
     // Prepare tracing.
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+    let _ = tracing::subscriber::set_default(subscriber);
 
     // Prepare metrics.
     let recorder = DebuggingRecorder::new();
     let snapshotter = recorder.snapshotter();
     let recorder = TracingContextLayer::all().layer(recorder);
-    // Install the registry as the global recorder
-    metrics::set_global_recorder(recorder).unwrap();
-    let res = f();
+    let res = metrics::with_local_recorder(&recorder, || f());
 
     if let Ok(file) = file {
         serde_json::to_writer_pretty(&file, &serialize_metric_snapshot(snapshotter.snapshot()))

--- a/crates/stark-sdk/src/bench/mod.rs
+++ b/crates/stark-sdk/src/bench/mod.rs
@@ -33,7 +33,7 @@ pub fn run_with_metric_collection<R>(
     let recorder = DebuggingRecorder::new();
     let snapshotter = recorder.snapshotter();
     let recorder = TracingContextLayer::all().layer(recorder);
-    let res = metrics::with_local_recorder(&recorder, || f());
+    let res = metrics::with_local_recorder(&recorder, f);
 
     if let Ok(file) = file {
         serde_json::to_writer_pretty(&file, &serialize_metric_snapshot(snapshotter.snapshot()))


### PR DESCRIPTION
Currently, calling the `run_with_metric_collection` multiple times in the same thread, or even across different threads fails. This is because it sets global state by calling `tracing::subscriber::set_global_default` and `metrics::set_global_recorder`. These functions error when called more than once.

The fix is to replace them with `tracing::subscriber::set_default` and `metrics::with_local_recorder` which use local and temporary state instead.

This change allows `run_with_metric_collection` to be used in tests, since we want to be able to run multiple tests.