### PR TITLE
chore: make device memory types owned

### DIFF
--- a/crates/stark-backend/src/interaction/mod.rs
+++ b/crates/stark-backend/src/interaction/mod.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
 
 use p3_air::AirBuilder;
 use p3_challenger::CanObserve;
@@ -186,4 +186,4 @@ pub trait RapPhaseSeq<F, Challenge, Challenger> {
         Challenger: CanObserve<Commitment>;
 }
 
-type PairTraceView<F> = PairView<Arc<RowMajorMatrix<F>>, F>;
+type PairTraceView<'a, F> = PairView<&'a RowMajorMatrix<F>, F>;

--- a/crates/stark-backend/src/prover/cpu/quotient/mod.rs
+++ b/crates/stark-backend/src/prover/cpu/quotient/mod.rs
@@ -8,7 +8,7 @@ use p3_util::log2_strict_usize;
 use tracing::instrument;
 
 use self::single::compute_single_rap_quotient_values;
-use super::{PcsDataView, RapLdeView};
+use super::{PcsData, RapMatrixView};
 use crate::{
     air_builders::symbolic::SymbolicExpressionDag,
     config::{Com, Domain, PackedChallenge, StarkGenericConfig, Val},
@@ -39,7 +39,7 @@ impl<'pcs, SC: StarkGenericConfig> QuotientCommitter<'pcs, SC> {
     pub fn quotient_values<'a>(
         &self,
         constraints: &[&SymbolicExpressionDag<Val<SC>>],
-        lde_views: Vec<RapLdeView<SC>>,
+        lde_views: Vec<RapMatrixView<SC>>,
         quotient_degrees: &[u8],
     ) -> QuotientData<SC> {
         assert_eq!(constraints.len(), lde_views.len());
@@ -55,7 +55,7 @@ impl<'pcs, SC: StarkGenericConfig> QuotientCommitter<'pcs, SC> {
     pub(super) fn single_rap_quotient_values(
         &self,
         constraints: &SymbolicExpressionDag<Val<SC>>,
-        ldes: RapLdeView<SC>,
+        ldes: RapMatrixView<SC>,
         quotient_degree: u8,
     ) -> SingleQuotientData<SC> {
         let log_trace_height = ldes.pair.log_trace_height;
@@ -110,7 +110,7 @@ impl<'pcs, SC: StarkGenericConfig> QuotientCommitter<'pcs, SC> {
     }
 
     #[instrument(name = "commit to quotient poly chunks", skip_all)]
-    pub fn commit(&self, data: QuotientData<SC>) -> (Com<SC>, PcsDataView<SC>) {
+    pub fn commit(&self, data: QuotientData<SC>) -> (Com<SC>, PcsData<SC>) {
         let (log_trace_heights, quotient_domains_and_chunks): (Vec<_>, Vec<_>) = data
             .split()
             .into_iter()
@@ -124,7 +124,7 @@ impl<'pcs, SC: StarkGenericConfig> QuotientCommitter<'pcs, SC> {
         let (commit, data) = self.pcs.commit(quotient_domains_and_chunks);
         (
             commit,
-            PcsDataView {
+            PcsData {
                 data: Arc::new(data),
                 log_trace_heights,
             },

--- a/crates/stark-backend/src/prover/metrics.rs
+++ b/crates/stark-backend/src/prover/metrics.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use super::{hal::ProverBackend, types::StarkProvingKeyView};
+use super::{hal::ProverBackend, types::DeviceStarkProvingKey};
 use crate::keygen::types::TraceWidth;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -62,8 +62,8 @@ impl Display for SingleTraceMetrics {
 }
 
 /// heights are the trace heights for each air
-pub fn trace_metrics<PB: ProverBackend, R>(
-    pk: &[StarkProvingKeyView<PB, R>],
+pub fn trace_metrics<PB: ProverBackend>(
+    pk: &[DeviceStarkProvingKey<PB>],
     log_trace_heights: &[u8],
 ) -> TraceMetrics {
     let heights = log_trace_heights

--- a/crates/stark-backend/src/prover/mod.rs
+++ b/crates/stark-backend/src/prover/mod.rs
@@ -26,14 +26,16 @@ pub trait Prover {
     type ProvingKeyView<'a>
     where
         Self: 'a;
-    type ProvingContext;
+    type ProvingContext<'a>
+    where
+        Self: 'a;
     type Proof;
 
     /// The prover should own the challenger, whose state mutates during proving.
     fn prove<'a>(
         &'a mut self,
         pk: Self::ProvingKeyView<'a>,
-        ctx: Self::ProvingContext,
+        ctx: Self::ProvingContext<'a>,
     ) -> Self::Proof;
 }
 

--- a/crates/stark-sdk/src/dummy_airs/interaction/mod.rs
+++ b/crates/stark-sdk/src/dummy_airs/interaction/mod.rs
@@ -54,7 +54,7 @@ pub fn verify_interactions(
 
     let challenger = config::baby_bear_poseidon2::Challenger::new(perm.clone());
     let mut prover = MultiTraceStarkProver::new(backend, CpuDevice::new(&config), challenger);
-    let proof = prover.prove(pk, ProvingContext::new(per_air));
+    let proof = prover.prove(&pk, ProvingContext::new(per_air));
 
     // Verify the proof:
     // Start from clean challenger


### PR DESCRIPTION
Even if they are buffers, make them owned types (no Clone) so that when they are dropped, the device memory is automatically deallocated.

CpuDevice types still use `Arc` because lifetimes and ownership is extremely annoying.

There is also a distinction that main trace is owned, but preprocessed / cached trace is borrowed. The rationale is that any cached data could live on the device and outlive the lifetime of a single proof. Any deallocation should be manually done.

Closes INT-3042