### PR TITLE
example: profiling prove keccak-air using SDK

### DIFF
--- a/crates/stark-sdk/Cargo.toml
+++ b/crates/stark-sdk/Cargo.toml
@@ -36,6 +36,9 @@ tracing-forest = { version = "0.1.6", features = ["ansi", "smallvec"] }
 metrics-tracing-context = "0.16.0"
 metrics-util = "0.17.0"
 
+[dev-dependencies]
+p3-keccak-air = { workspace = true }
+
 [features]
 default = ["parallel"]
 parallel = ["openvm-stark-backend/parallel"]
@@ -44,3 +47,6 @@ nightly-features = [
     "p3-keccak/nightly-features",
     "p3-poseidon2/nightly-features",
 ]
+mimalloc = ["openvm-stark-backend/mimalloc"]
+jemalloc = ["openvm-stark-backend/jemalloc"]
+jemalloc-prof = ["openvm-stark-backend/jemalloc-prof"]

--- a/crates/stark-sdk/Cargo.toml
+++ b/crates/stark-sdk/Cargo.toml
@@ -50,3 +50,4 @@ nightly-features = [
 mimalloc = ["openvm-stark-backend/mimalloc"]
 jemalloc = ["openvm-stark-backend/jemalloc"]
 jemalloc-prof = ["openvm-stark-backend/jemalloc-prof"]
+bench-metrics = ["openvm-stark-backend/bench-metrics"]

--- a/crates/stark-sdk/examples/profile.sh
+++ b/crates/stark-sdk/examples/profile.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# This script profiles an example binary for STARK proving
+
+git_root=$(git rev-parse --show-toplevel)
+cd $git_root/crates/stark-sdk
+
+arch=$(uname -m)
+case $arch in
+    arm64|aarch64)
+        RUSTFLAGS="-Ctarget-cpu=native -g"
+        ;;
+    x86_64|amd64)
+        RUSTFLAGS="-Ctarget-cpu=native -C target-feature=+avx512f -g"
+        ;;
+    *)
+        echo "Unsupported architecture: $arch"
+        exit 1
+        ;;
+esac
+
+cargo build --profile=profiling --example prove_keccak_baby_bear_poseidon2 --features=parallel,nightly-features,jemalloc
+
+export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1,abort_conf:true"
+
+# Check if samply is installed
+if ! command -v samply &> /dev/null; then
+    echo "samply not found. Installing..."
+    cargo install samply
+else
+    echo "samply is already installed"
+fi
+
+samply record $git_root/target/profiling/examples/prove_keccak_baby_bear_poseidon2

--- a/crates/stark-sdk/examples/prove_keccak_baby_bear_poseidon2.rs
+++ b/crates/stark-sdk/examples/prove_keccak_baby_bear_poseidon2.rs
@@ -1,0 +1,63 @@
+//! Prove poseidon2-air over BabyBear using poseidon2 for FRI hash.
+
+use std::sync::Arc;
+
+use openvm_stark_backend::{
+    p3_air::{Air, AirBuilder, BaseAir},
+    p3_field::Field,
+    prover::types::{AirProofInput, ProofInput},
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
+use openvm_stark_sdk::{
+    config::{baby_bear_poseidon2::BabyBearPoseidon2Engine, FriParameters},
+    engine::StarkFriEngine,
+    openvm_stark_backend::engine::StarkEngine,
+    utils::create_seeded_rng,
+};
+use p3_baby_bear::BabyBear;
+use p3_keccak_air::KeccakAir;
+use rand::Rng;
+use tracing::info_span;
+
+const NUM_PERMUTATIONS: usize = 1 << 18;
+const LOG_BLOWUP: usize = 2;
+
+// Newtype to implement extended traits
+struct TestAir(KeccakAir);
+
+impl<F: Field> BaseAir<F> for TestAir {
+    fn width(&self) -> usize {
+        BaseAir::<F>::width(&self.0)
+    }
+}
+impl<F: Field> BaseAirWithPublicValues<F> for TestAir {}
+impl<F: Field> PartitionedBaseAir<F> for TestAir {}
+
+impl<AB: AirBuilder> Air<AB> for TestAir {
+    fn eval(&self, builder: &mut AB) {
+        self.0.eval(builder);
+    }
+}
+
+fn main() {
+    let mut rng = create_seeded_rng();
+    let air = TestAir(KeccakAir {});
+
+    let engine = BabyBearPoseidon2Engine::new(
+        FriParameters::standard_with_100_bits_conjectured_security(LOG_BLOWUP),
+    );
+    let mut keygen_builder = engine.keygen_builder();
+    let air_id = keygen_builder.add_air(Arc::new(air));
+    let pk = keygen_builder.generate_pk();
+
+    let inputs = (0..NUM_PERMUTATIONS).map(|_| rng.gen()).collect::<Vec<_>>();
+    let trace = info_span!("generate_trace")
+        .in_scope(|| p3_keccak_air::generate_trace_rows::<BabyBear>(inputs));
+
+    let proof = engine.prove(
+        &pk,
+        ProofInput::new(vec![(air_id, AirProofInput::simple_no_pis(trace))]),
+    );
+
+    engine.verify(&pk.get_vk(), &proof).unwrap();
+}


### PR DESCRIPTION
Example with end to end keygen, proving, verify for keccak-air from plonky3 (no interactions). 
Added a script that builds and profiles the proving using [samply](https://github.com/mstange/samply)

Closes INT-3185