### PR TITLE
Feat: require `dag.constraint_idx` is sorted

### DIFF
--- a/crates/stark-backend/src/air_builders/symbolic/dag.rs
+++ b/crates/stark-backend/src/air_builders/symbolic/dag.rs
@@ -93,10 +93,11 @@ pub(crate) fn build_symbolic_constraints_dag<F: Field>(
 ) -> SymbolicConstraintsDag<F> {
     let mut expr_to_idx = FxHashMap::default();
     let mut nodes = Vec::new();
-    let constraint_idx = constraints
+    let mut constraint_idx: Vec<usize> = constraints
         .iter()
         .map(|expr| topological_sort_symbolic_expr(expr, &mut expr_to_idx, &mut nodes))
         .collect();
+    constraint_idx.sort();
     let interactions: Vec<Interaction<usize>> = interactions
         .iter()
         .map(|interaction| {

--- a/crates/stark-backend/src/verifier/folder.rs
+++ b/crates/stark-backend/src/verifier/folder.rs
@@ -55,8 +55,6 @@ where
 {
     pub fn eval_constraints(&mut self, constraints: &SymbolicExpressionDag<F>) {
         let dag = constraints;
-        // check that the constraint indices are sorted
-        assert!(dag.constraint_idx.windows(2).all(|w| w[0] < w[1]));
         // node_idx -> evaluation
         // We do a simple serial evaluation in topological order.
         // This can be parallelized if necessary.

--- a/crates/stark-backend/src/verifier/folder.rs
+++ b/crates/stark-backend/src/verifier/folder.rs
@@ -55,6 +55,8 @@ where
 {
     pub fn eval_constraints(&mut self, constraints: &SymbolicExpressionDag<F>) {
         let dag = constraints;
+        // check that the constraint indices are sorted
+        assert!(dag.constraint_idx.windows(2).all(|w| w[0] < w[1]));
         // node_idx -> evaluation
         // We do a simple serial evaluation in topological order.
         // This can be parallelized if necessary.


### PR DESCRIPTION
## Description
This pr aims to have `dag.constraint_idx` to be sorted.

## Rationale

For complex circuit like keccak, the number of nodes in the dag is very large (around 50k). However, the locality pattern still applies in this case which means each node in the dag only depends on nodes with indices that are close to its index. 

This means we can use a **small** vector for caching the intermediates (we call node like `main / preprocessed / permutation` leaf node, while we call node like `add / mul / sub / neg` as intermediate node). In the special keccak case, we can reduce it from 50k to 200.

If the `constraint_idx` is sorted, then we can free the node's memory (can be reused) after we finished accumulating them into `accumulator`.