### PR TITLE
chore: remove `Stateful` trait

### DIFF
--- a/crates/stark-backend/src/chip.rs
+++ b/crates/stark-backend/src/chip.rs
@@ -37,12 +37,6 @@ pub trait ChipUsageGetter {
     }
 }
 
-/// A chip whose state could be persisted.
-pub trait Stateful<S> {
-    fn load_state(&mut self, state: S);
-    fn store_state(&self) -> S;
-}
-
 impl<SC: StarkGenericConfig, C: Chip<SC>> Chip<SC> for RefCell<C> {
     fn air(&self) -> Arc<dyn AnyRap<SC>> {
         self.borrow().air()
@@ -144,14 +138,5 @@ impl<C: ChipUsageGetter> ChipUsageGetter for Mutex<C> {
     }
     fn trace_width(&self) -> usize {
         self.lock().unwrap().trace_width()
-    }
-}
-
-impl<S, C: Stateful<S>> Stateful<S> for RefCell<C> {
-    fn load_state(&mut self, state: S) {
-        self.borrow_mut().load_state(state)
-    }
-    fn store_state(&self) -> S {
-        self.borrow_mut().store_state()
     }
 }

--- a/crates/stark-backend/src/lib.rs
+++ b/crates/stark-backend/src/lib.rs
@@ -38,7 +38,7 @@ pub mod utils;
 /// Verifier implementation
 pub mod verifier;
 
-pub use chip::{Chip, ChipUsageGetter, Stateful};
+pub use chip::{Chip, ChipUsageGetter};
 pub use rap::AirRef;
 
 // Use jemalloc as global allocator for performance


### PR DESCRIPTION
We have found the trait not useful or flexible enough for custom state loading/storing purposes. Implementations need to be much more aware of the buffer where state needs to be deserialized from or serialized to. We remove the trait and allow users to create their own custom trait for specific use cases.