### PR TITLE
fix: protect against weak Fiat-Shamir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ async-trait = "0.1.83"
 getset = "0.1.3"
 rand = { version = "0.8.5", default-features = false }
 hex = { version = "0.4.3", default-features = false }
+bitcode = "0.6.5"
 
 # default-features = false for no_std
 itertools = { version = "0.14.0", default-features = false }

--- a/crates/stark-backend/Cargo.toml
+++ b/crates/stark-backend/Cargo.toml
@@ -28,8 +28,8 @@ derive-new.workspace = true
 metrics = { workspace = true, optional = true }
 cfg-if.workspace = true
 thiserror.workspace = true
-async-trait.workspace = true
 rustc-hash.workspace = true
+bitcode = { workspace = true, features = ["serde"] }
 
 [target.'cfg(unix)'.dependencies]
 tikv-jemallocator = { version = "0.6", optional = true }

--- a/crates/stark-backend/src/keygen/mod.rs
+++ b/crates/stark-backend/src/keygen/mod.rs
@@ -2,9 +2,10 @@ use std::{collections::HashMap, iter::zip, sync::Arc};
 
 use itertools::Itertools;
 use p3_commit::Pcs;
-use p3_field::{Field, FieldExtensionAlgebra};
-use p3_matrix::Matrix;
+use p3_field::{Field, FieldAlgebra, FieldExtensionAlgebra};
+use p3_matrix::{dense::RowMajorMatrix, Matrix};
 use tracing::instrument;
+use types::MultiStarkVerifyingKey0;
 
 use crate::{
     air_builders::symbolic::{get_symbolic_builder, SymbolicRapBuilder},
@@ -195,11 +196,33 @@ impl<'a, SC: StarkGenericConfig> MultiStarkKeygenBuilder<'a, SC> {
             threshold: log_up_security_params.max_interaction_count,
         });
 
+        let pre_vk: MultiStarkVerifyingKey0<SC> = MultiStarkVerifyingKey0 {
+            per_air: pk_per_air.iter().map(|pk| pk.vk.clone()).collect(),
+            trace_height_constraints: trace_height_constraints.clone(),
+            log_up_pow_bits: log_up_security_params.log_up_pow_bits,
+        };
+        // To protect against weak Fiat-Shamir, we hash the "pre"-verifying key and include it in the
+        // final verifying key. This just needs to commit to the verifying key and does not need to be
+        // verified by the verifier, so we just use bincode to serialize it.
+        let mut vk_bytes = bitcode::serialize(&pre_vk).unwrap();
+        vk_bytes.resize(vk_bytes.len().next_power_of_two(), 0u8);
+        // Purely to get type compatibility and convenience, we hash using pcs.commit
+        let vk_col = RowMajorMatrix::new_col(
+            vk_bytes
+                .into_iter()
+                .map(Val::<SC>::from_canonical_u8)
+                .collect(),
+        );
+        let pcs = self.config.pcs();
+        let vk_col_domain = pcs.natural_domain_for_degree(vk_col.height());
+        let (vk_pre_hash, _) = pcs.commit(vec![(vk_col_domain, vk_col)]);
+
         MultiStarkProvingKey {
             per_air: pk_per_air,
             trace_height_constraints,
             max_constraint_degree: self.max_constraint_degree,
             log_up_pow_bits: log_up_security_params.log_up_pow_bits,
+            vk_pre_hash,
         }
     }
 }

--- a/crates/stark-backend/src/keygen/types.rs
+++ b/crates/stark-backend/src/keygen/types.rs
@@ -87,6 +87,20 @@ pub struct MultiStarkVerifyingKey<SC: StarkGenericConfig> {
     pub per_air: Vec<StarkVerifyingKey<Val<SC>, Com<SC>>>,
     pub trace_height_constraints: Vec<LinearConstraint>,
     pub log_up_pow_bits: usize,
+    /// The hash of all other parts of the verifying key. The Fiat-Shamir hasher will
+    /// initialize by observing this hash.
+    pub pre_hash: Com<SC>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "Com<SC>: Serialize",
+    deserialize = "Com<SC>: Deserialize<'de>"
+))]
+pub(crate) struct MultiStarkVerifyingKey0<SC: StarkGenericConfig> {
+    pub per_air: Vec<StarkVerifyingKey<Val<SC>, Com<SC>>>,
+    pub trace_height_constraints: Vec<LinearConstraint>,
+    pub log_up_pow_bits: usize,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -129,6 +143,8 @@ pub struct MultiStarkProvingKey<SC: StarkGenericConfig> {
     /// Maximum degree of constraints across all AIRs
     pub max_constraint_degree: usize,
     pub log_up_pow_bits: usize,
+    /// See [MultiStarkVerifyingKey]
+    pub vk_pre_hash: Com<SC>,
 }
 
 impl<Val, Com> StarkVerifyingKey<Val, Com> {
@@ -151,6 +167,7 @@ impl<SC: StarkGenericConfig> MultiStarkProvingKey<SC> {
             per_air: self.per_air.iter().map(|pk| pk.vk.clone()).collect(),
             trace_height_constraints: self.trace_height_constraints.clone(),
             log_up_pow_bits: self.log_up_pow_bits,
+            pre_hash: self.vk_pre_hash.clone(),
         }
     }
 }

--- a/crates/stark-backend/src/keygen/view.rs
+++ b/crates/stark-backend/src/keygen/view.rs
@@ -11,6 +11,7 @@ pub(crate) struct MultiStarkVerifyingKeyView<'a, Val, Com> {
     /// Trace height constraints are *not* filtered by AIR. When computing the dot product, this
     /// will be indexed into by air_id.
     pub trace_height_constraints: &'a [LinearConstraint],
+    pub pre_hash: Com,
 }
 
 impl<SC: StarkGenericConfig> MultiStarkVerifyingKey<SC> {
@@ -22,6 +23,7 @@ impl<SC: StarkGenericConfig> MultiStarkVerifyingKey<SC> {
         MultiStarkVerifyingKeyView {
             per_air: air_ids.iter().map(|&id| &self.per_air[id]).collect(),
             trace_height_constraints: &self.trace_height_constraints,
+            pre_hash: self.pre_hash.clone(),
         }
     }
 }

--- a/crates/stark-backend/src/prover/coordinator.rs
+++ b/crates/stark-backend/src/prover/coordinator.rs
@@ -84,6 +84,7 @@ where
         #[cfg(feature = "bench-metrics")]
         let start = std::time::Instant::now();
         assert!(mpk.validate(&ctx), "Invalid proof input");
+        self.challenger.observe(mpk.vk_pre_hash.clone());
 
         let num_air = ctx.per_air.len();
         info!(num_air);
@@ -307,6 +308,7 @@ impl<'a, PB: ProverBackend> DeviceMultiStarkProvingKey<'a, PB> {
         MultiStarkVerifyingKeyView::new(
             self.per_air.iter().map(|pk| pk.vk).collect(),
             &self.trace_height_constraints,
+            self.vk_pre_hash.clone(),
         )
     }
 }

--- a/crates/stark-backend/src/prover/cpu/mod.rs
+++ b/crates/stark-backend/src/prover/cpu/mod.rs
@@ -443,7 +443,12 @@ where
                 }
             })
             .collect();
-        DeviceMultiStarkProvingKey::new(air_ids, per_air, mpk.trace_height_constraints.clone())
+        DeviceMultiStarkProvingKey::new(
+            air_ids,
+            per_air,
+            mpk.trace_height_constraints.clone(),
+            mpk.vk_pre_hash.clone(),
+        )
     }
     fn transport_matrix_to_device(
         &self,

--- a/crates/stark-backend/src/prover/types.rs
+++ b/crates/stark-backend/src/prover/types.rs
@@ -19,6 +19,7 @@ pub struct DeviceMultiStarkProvingKey<'a, PB: ProverBackend> {
     /// Each [LinearConstraint] is indexed by AIR ID.
     /// **Caution**: the linear constraints are **not** filtered for only the AIRs appearing in `per_air`.
     pub trace_height_constraints: Vec<LinearConstraint>,
+    pub vk_pre_hash: PB::Commitment,
 }
 
 impl<'a, PB: ProverBackend> DeviceMultiStarkProvingKey<'a, PB> {
@@ -26,12 +27,14 @@ impl<'a, PB: ProverBackend> DeviceMultiStarkProvingKey<'a, PB> {
         air_ids: Vec<usize>,
         per_air: Vec<DeviceStarkProvingKey<'a, PB>>,
         trace_height_constraints: Vec<LinearConstraint>,
+        vk_pre_hash: PB::Commitment,
     ) -> Self {
         assert_eq!(air_ids.len(), per_air.len());
         Self {
             air_ids,
             per_air,
             trace_height_constraints,
+            vk_pre_hash,
         }
     }
 }

--- a/crates/stark-backend/src/verifier/mod.rs
+++ b/crates/stark-backend/src/verifier/mod.rs
@@ -57,6 +57,7 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkVerifier<'c, SC> {
         mvk: &MultiStarkVerifyingKeyView<Val<SC>, Com<SC>>,
         proof: &Proof<SC>,
     ) -> Result<(), VerificationError> {
+        challenger.observe(mvk.pre_hash.clone());
         // Enforce trace height linear inequalities
         for constraint in mvk.trace_height_constraints {
             let sum = proof


### PR DESCRIPTION
**Finding Link:** https://cantina.xyz/code/c486d600-bed0-4fc6-aed1-de759fd29fa2/findings/152

### Description of Fix

To protect against weak Fiat-Shamir, the prover and verifier should both start off by having the challenger observe something that commits to the full computational statement, i.e., the constraints of the circuit. These are contained in the verifying key. Our fix is to require the honest circuit creator to generate a hash commitment to the constraints and other configuration data at keygen time. This hash commitment is observed at the start of the Fiat-Shamir transcript. Note that the verifier _does not_ need to verify that this is indeed the hash of the verifying key: this can be said to be a property of an honest vkey.

Due to the existing types and what's available in the code, the hash commitment is done by first serializing vkey to bytes via `bitcode`, converting each byte to a field element, and then considering as a 1 column matrix and using the `pcs` to commit to it. I had wanted to use `bincode v2.0.0` but there is a MSRV of 1.85. Since this hash doesn't need to be checked by the verifier, the use of `bitcode` seems acceptable. The use of `pcs` has the nice(?) side benefit that it implicitly commits to the blowup factor.

Towards INT-3564