### PR TITLE
feat: observe AIR IDs in Fiat-Shamir transcript

### DIFF
--- a/crates/stark-backend/src/prover/coordinator.rs
+++ b/crates/stark-backend/src/prover/coordinator.rs
@@ -96,7 +96,8 @@ where
             Vec<Vec<PB::Val>>,
         ) = ctx
             .into_iter()
-            .map(|(_, ctx)| {
+            .map(|(air_id, ctx)| {
+                self.challenger.observe(Val::<SC>::from_canonical_usize(air_id));
                 let (cached_commits, cached_views): (Vec<_>, Vec<_>) =
                     ctx.cached_mains.into_iter().unzip();
                 (

--- a/crates/stark-backend/src/prover/coordinator.rs
+++ b/crates/stark-backend/src/prover/coordinator.rs
@@ -87,6 +87,8 @@ where
         self.challenger.observe(mpk.vk_pre_hash.clone());
 
         let num_air = ctx.per_air.len();
+        self.challenger
+            .observe(Val::<SC>::from_canonical_usize(num_air));
         info!(num_air);
         #[allow(clippy::type_complexity)]
         let (cached_commits_per_air, cached_views_per_air, common_main_per_air, pvs_per_air): (

--- a/crates/stark-backend/src/verifier/mod.rs
+++ b/crates/stark-backend/src/verifier/mod.rs
@@ -58,7 +58,9 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkVerifier<'c, SC> {
         proof: &Proof<SC>,
     ) -> Result<(), VerificationError> {
         challenger.observe(mvk.pre_hash.clone());
-        for air_id in proof.get_air_ids() {
+        let air_ids = proof.get_air_ids();
+        challenger.observe(Val::<SC>::from_canonical_usize(air_ids.len()));
+        for &air_id in &air_ids {
             challenger.observe(Val::<SC>::from_canonical_usize(air_id));
         }
         // Enforce trace height linear inequalities
@@ -74,7 +76,7 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkVerifier<'c, SC> {
         }
         // Check that all `air_id`s are different
         {
-            let mut air_ids: Vec<_> = proof.per_air.iter().map(|apd| apd.air_id).collect();
+            let mut air_ids = air_ids;
             air_ids.sort();
             for ids in air_ids.windows(2) {
                 assert!(ids[0] < ids[1], "all `air_id`s must be different");

--- a/crates/stark-backend/src/verifier/mod.rs
+++ b/crates/stark-backend/src/verifier/mod.rs
@@ -58,6 +58,9 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkVerifier<'c, SC> {
         proof: &Proof<SC>,
     ) -> Result<(), VerificationError> {
         challenger.observe(mvk.pre_hash.clone());
+        for air_id in proof.get_air_ids() {
+            challenger.observe(Val::<SC>::from_canonical_usize(air_id));
+        }
         // Enforce trace height linear inequalities
         for constraint in mvk.trace_height_constraints {
             let sum = proof


### PR DESCRIPTION
Fiat-Shamir says that everything in the proof should be observed. Since AIR IDs can be variable, they should also be observed.