### PR TITLE
fix: verifier should check proof shape

### DIFF
--- a/crates/stark-backend/src/verifier/error.rs
+++ b/crates/stark-backend/src/verifier/error.rs
@@ -2,6 +2,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum VerificationError {
+    #[error("all `air_id`s must be different")]
+    DuplicateAirs,
     #[error("invalid proof shape")]
     InvalidProofShape,
     /// An error occurred while verifying the claimed openings.

--- a/crates/stark-backend/src/verifier/mod.rs
+++ b/crates/stark-backend/src/verifier/mod.rs
@@ -41,7 +41,7 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkVerifier<'c, SC> {
         mvk: &MultiStarkVerifyingKey<SC>,
         proof: &Proof<SC>,
     ) -> Result<(), VerificationError> {
-        // Note: construction of view panics if any air_id exceeds num_airs
+        // Note: construction of view panics if any air_id exceeds number of AIRs in provided `MultiStarkVerifyingKey`
         let mvk = mvk.view(&proof.get_air_ids());
         self.verify_raps(challenger, &mvk, proof)?;
         Ok(())

--- a/crates/stark-backend/src/verifier/mod.rs
+++ b/crates/stark-backend/src/verifier/mod.rs
@@ -1,7 +1,9 @@
-use itertools::{izip, Itertools};
+use std::iter::zip;
+
+use itertools::{izip, zip_eq, Itertools};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
-use p3_field::FieldAlgebra;
+use p3_field::{FieldAlgebra, FieldExtensionAlgebra};
 use p3_util::log2_strict_usize;
 use tracing::instrument;
 
@@ -39,6 +41,7 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkVerifier<'c, SC> {
         mvk: &MultiStarkVerifyingKey<SC>,
         proof: &Proof<SC>,
     ) -> Result<(), VerificationError> {
+        // Note: construction of view panics if any air_id exceeds num_airs
         let mvk = mvk.view(&proof.get_air_ids());
         self.verify_raps(challenger, &mvk, proof)?;
         Ok(())
@@ -59,7 +62,8 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkVerifier<'c, SC> {
     ) -> Result<(), VerificationError> {
         challenger.observe(mvk.pre_hash.clone());
         let air_ids = proof.get_air_ids();
-        challenger.observe(Val::<SC>::from_canonical_usize(air_ids.len()));
+        let num_airs = air_ids.len();
+        challenger.observe(Val::<SC>::from_canonical_usize(num_airs));
         for &air_id in &air_ids {
             challenger.observe(Val::<SC>::from_canonical_usize(air_id));
         }
@@ -74,16 +78,27 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkVerifier<'c, SC> {
                 return Err(VerificationError::InvalidProofShape);
             }
         }
-        // Check that all `air_id`s are different
+        // (T01a): Check that all `air_id`s are different and contained in `MultiStarkVerifyingKey`
         {
             let mut air_ids = air_ids;
             air_ids.sort();
             for ids in air_ids.windows(2) {
-                assert!(ids[0] < ids[1], "all `air_id`s must be different");
+                if ids[0] >= ids[1] {
+                    return Err(VerificationError::DuplicateAirs);
+                }
             }
         }
+        // Note: (T02) is implicit in use of BTreeMap in FRI PCS verify
 
         let public_values = proof.get_public_values();
+        // (T03a): verify shape of public values
+        {
+            for (pvs_per_air, vk) in zip_eq(&public_values, &mvk.per_air) {
+                if pvs_per_air.len() != vk.params.num_public_values {
+                    return Err(VerificationError::InvalidProofShape);
+                }
+            }
+        }
         // Challenger must observe public values
         for pis in &public_values {
             challenger.observe_slice(pis);
@@ -93,6 +108,18 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkVerifier<'c, SC> {
             challenger.observe(preprocessed_commit);
         }
 
+        // (T04a): validate shapes of `main_trace_commits`:
+        {
+            let num_cached_mains = mvk
+                .per_air
+                .iter()
+                .map(|vk| vk.params.width.cached_mains.len())
+                .sum::<usize>();
+            let num_main_commits = num_cached_mains + 1; // always 1 common main
+            if proof.commitments.main_trace.len() != num_main_commits {
+                return Err(VerificationError::InvalidProofShape);
+            }
+        }
         // Observe main trace commitments
         challenger.observe_slice(&proof.commitments.main_trace);
         challenger.observe_slice(
@@ -125,10 +152,20 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkVerifier<'c, SC> {
             })
             .collect_vec();
 
-        assert!(
-            proof.commitments.after_challenge.len() <= 1,
-            "at most one challenge phase currently supported"
-        );
+        // (T01b): `num_phases < 2`.
+        // Assumption: valid mvk has num_phases consistent between num_challenges_to_sample and exposed_values
+        let num_phases = mvk.num_phases();
+        if num_phases != proof.commitments.after_challenge.len() || num_phases > 1 {
+            return Err(VerificationError::InvalidProofShape);
+        }
+        // (T01c): validate shape of `exposed_values_after_challenge`
+        if !zip_eq(&exposed_values_per_air_per_phase, &mvk.per_air).all(|(ev_per_phase, vk)| {
+            ev_per_phase.len() == vk.params.num_exposed_values_after_challenge.len()
+                && zip_eq(ev_per_phase, &vk.params.num_exposed_values_after_challenge)
+                    .all(|(ev, &n)| ev.len() == n)
+        }) {
+            return Err(VerificationError::InvalidProofShape);
+        }
 
         let (after_challenge_data, rap_phase_seq_result) = rap_phase.partially_verify(
             challenger,
@@ -186,6 +223,18 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkVerifier<'c, SC> {
         // Build the opening rounds
         // 1. First the preprocessed trace openings
         // Assumption: each AIR with preprocessed trace has its own commitment and opening values
+        // T05a: validate `opened_values.preprocessed` shape
+        let preprocessed_widths: Vec<usize> = mvk
+            .per_air
+            .iter()
+            .filter_map(|vk| vk.params.width.preprocessed)
+            .collect();
+        if preprocessed_widths.len() != opened_values.preprocessed.len()
+            || zip_eq(preprocessed_widths, &opened_values.preprocessed)
+                .any(|(w, ov)| w != ov.local.len() || w != ov.next.len())
+        {
+            return Err(VerificationError::InvalidProofShape);
+        }
         let mut rounds: Vec<_> = mvk
             .preprocessed_commits()
             .into_iter()
@@ -199,67 +248,108 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkVerifier<'c, SC> {
             .collect();
 
         // 2. Then the main trace openings
-
+        // T05b: validate `opened_values.main` shape inline below
         let num_main_commits = opened_values.main.len();
-        assert_eq!(num_main_commits, proof.commitments.main_trace.len());
+        if num_main_commits != proof.commitments.main_trace.len() {
+            return Err(VerificationError::InvalidProofShape);
+        }
         let mut main_commit_idx = 0;
         // All commits except the last one are cached main traces.
-        izip!(&mvk.per_air, &domains).for_each(|(vk, domain)| {
-            for _ in 0..vk.num_cached_mains() {
+        for (vk, domain) in zip_eq(&mvk.per_air, &domains) {
+            for &cached_main_width in &vk.params.width.cached_mains {
                 let commit = proof.commitments.main_trace[main_commit_idx].clone();
+                if opened_values.main[main_commit_idx].len() != 1 {
+                    return Err(VerificationError::InvalidProofShape);
+                }
                 let value = &opened_values.main[main_commit_idx][0];
+                if cached_main_width != value.local.len() || cached_main_width != value.next.len() {
+                    return Err(VerificationError::InvalidProofShape);
+                }
                 let domains_and_openings = vec![trace_domain_and_openings(*domain, zeta, value)];
                 rounds.push((commit.clone(), domains_and_openings));
                 main_commit_idx += 1;
             }
-        });
+        }
         // In the last commit, each matrix corresponds to an AIR with a common main trace.
         {
             let values_per_mat = &opened_values.main[main_commit_idx];
             let commit = proof.commitments.main_trace[main_commit_idx].clone();
-            let domains_and_openings = mvk
-                .per_air
-                .iter()
-                .zip_eq(&domains)
-                .filter_map(|(vk, domain)| vk.has_common_main().then_some(*domain))
-                .zip_eq(values_per_mat)
-                .map(|(domain, values)| trace_domain_and_openings(domain, zeta, values))
-                .collect_vec();
+            let domains_and_openings = zip(&mvk.per_air, &domains)
+                .filter(|(vk, _)| vk.has_common_main())
+                .zip(values_per_mat)
+                .map(|((vk, domain), values)| {
+                    let width = vk.params.width.common_main;
+                    if width != values.local.len() || width != values.next.len() {
+                        Err(VerificationError::InvalidProofShape)
+                    } else {
+                        Ok(trace_domain_and_openings(*domain, zeta, values))
+                    }
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            if domains_and_openings.len() != values_per_mat.len() {
+                return Err(VerificationError::InvalidProofShape);
+            }
             rounds.push((commit.clone(), domains_and_openings));
         }
 
+        let ext_degree = <SC::Challenge as FieldExtensionAlgebra<Val<SC>>>::D;
         // 3. Then after_challenge trace openings, at most 1 phase for now.
         // All AIRs with interactions should an after challenge trace.
-        let after_challenge_domain_per_air = mvk
-            .per_air
-            .iter()
-            .zip_eq(&domains)
-            .filter_map(|(vk, domain)| vk.has_interaction().then_some(*domain))
-            .collect_vec();
-        if after_challenge_domain_per_air.is_empty() {
-            assert_eq!(proof.commitments.after_challenge.len(), 0);
-            assert_eq!(opened_values.after_challenge.len(), 0);
+        let mut after_challenge_vk_domain_per_air = zip_eq(&mvk.per_air, &domains)
+            .filter(|(vk, _)| vk.has_interaction())
+            .peekable();
+        if after_challenge_vk_domain_per_air.peek().is_none() {
+            if !proof.commitments.after_challenge.is_empty()
+                || !opened_values.after_challenge.is_empty()
+            {
+                return Err(VerificationError::InvalidProofShape);
+            }
+            assert_eq!(num_phases, 0);
         } else {
+            if num_phases != 1 || opened_values.after_challenge.len() != 1 {
+                return Err(VerificationError::InvalidProofShape);
+            }
             let after_challenge_commit = proof.commitments.after_challenge[0].clone();
-            let domains_and_openings = after_challenge_domain_per_air
-                .into_iter()
-                .zip_eq(&opened_values.after_challenge[0])
-                .map(|(domain, values)| trace_domain_and_openings(domain, zeta, values))
-                .collect_vec();
+            let domains_and_openings = zip(
+                after_challenge_vk_domain_per_air,
+                &opened_values.after_challenge[0],
+            )
+            .map(|((vk, domain), values)| {
+                let width = vk.params.width.after_challenge[0] * ext_degree;
+                if width != values.local.len() || width != values.next.len() {
+                    Err(VerificationError::InvalidProofShape)
+                } else {
+                    Ok(trace_domain_and_openings(*domain, zeta, values))
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+            if domains_and_openings.len() != opened_values.after_challenge[0].len() {
+                return Err(VerificationError::InvalidProofShape);
+            }
             rounds.push((after_challenge_commit, domains_and_openings));
         }
-
-        let quotient_domains_and_openings = opened_values
-            .quotient
-            .iter()
-            .zip_eq(&quotient_chunks_domains)
-            .flat_map(|(chunk, quotient_chunks_domains_per_air)| {
-                chunk
+        if opened_values.quotient.len() != num_airs {
+            return Err(VerificationError::InvalidProofShape);
+        }
+        // All opened_values.quotient should have width D
+        if zip_eq(&opened_values.quotient, &mvk.per_air).any(|(per_air, vk)| {
+            per_air.len() != vk.quotient_degree as usize || {
+                per_air
                     .iter()
-                    .zip_eq(quotient_chunks_domains_per_air)
-                    .map(|(values, &domain)| (domain, vec![(zeta, values.clone())]))
-            })
-            .collect_vec();
+                    .any(|per_chunk| per_chunk.len() != ext_degree)
+            }
+        }) {
+            return Err(VerificationError::InvalidProofShape);
+        }
+        let quotient_domains_and_openings =
+            zip_eq(&opened_values.quotient, &quotient_chunks_domains)
+                .flat_map(|(chunk, quotient_chunks_domains_per_air)| {
+                    chunk
+                        .iter()
+                        .zip_eq(quotient_chunks_domains_per_air)
+                        .map(|(values, &domain)| (domain, vec![(zeta, values.clone())]))
+                })
+                .collect_vec();
         rounds.push((
             proof.commitments.quotient.clone(),
             quotient_domains_and_openings,
@@ -269,7 +359,6 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkVerifier<'c, SC> {
             .map_err(|e| VerificationError::InvalidOpeningArgument(format!("{:?}", e)))?;
 
         let mut preprocessed_idx = 0usize; // preprocessed commit idx
-        let num_phases = mvk.num_phases();
         let mut after_challenge_idx = vec![0usize; num_phases];
         let mut cached_main_commit_idx = 0;
         let mut common_main_matrix_idx = 0;


### PR DESCRIPTION
A good guiding principle was that `challenge.observe_slice` does not observe the length of a slice, so for every use of observe slice where we don't observe length separately, it should mean that the verifier must validate that the length matches an expected length in the vkey.