### PR TITLE
fix(plonky3): update plonky3 commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,32 +51,32 @@ openvm-stark-backend = { path = "crates/stark-backend", default-features = false
 openvm-stark-sdk = { path = "crates/stark-sdk", default-features = false }
 
 # Plonky3
-p3-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-commit = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-matrix = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
+p3-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-commit = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-matrix = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
 p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3.git", features = [
     "nightly-features",
-], rev = "88d7f05" }
-p3-util = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-challenger = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-dft = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-fri = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-goldilocks = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-keccak = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-keccak-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-blake3 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-mds = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-monty-31 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-poseidon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-uni-stark = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
+], rev = "1ba4e5c" }
+p3-util = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-challenger = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-dft = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-fri = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-goldilocks = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-keccak = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-keccak-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-blake3 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-mds = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-monty-31 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-poseidon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-uni-stark = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
 
 # Bn254 support
-p3-bn254-fr = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
+p3-bn254-fr = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2.git", rev = "bb476b9" }
 ff = { version = "0.13.0", default-features = false }
 


### PR DESCRIPTION
Update plonky3 commit to include the patch https://github.com/Plonky3/Plonky3/pull/759 fixing the Rust FRI verifier. 
Description of the security issue: https://github.com/Plonky3/Plonky3/security/advisories/GHSA-m23j-cj9m-ppg9