### PR TITLE
chore: add KoalaBear export to stark-sdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,9 @@ p3-matrix = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
 p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3.git", features = [
     "nightly-features",
 ], rev = "1ba4e5c" }
+p3-koala-bear = { git = "https://github.com/Plonky3/Plonky3.git", features = [
+    "nightly-features",
+], rev = "1ba4e5c" }
 p3-util = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
 p3-challenger = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
 p3-dft = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }

--- a/crates/stark-sdk/Cargo.toml
+++ b/crates/stark-sdk/Cargo.toml
@@ -12,6 +12,7 @@ p3-dft = { workspace = true }
 p3-merkle-tree = { workspace = true }
 p3-fri = { workspace = true }
 p3-baby-bear = { workspace = true }
+p3-koala-bear = { workspace = true }
 p3-bn254-fr = { workspace = true }
 p3-goldilocks = { workspace = true }
 p3-poseidon2 = { workspace = true }

--- a/crates/stark-sdk/src/lib.rs
+++ b/crates/stark-sdk/src/lib.rs
@@ -4,6 +4,7 @@ pub use p3_blake3;
 pub use p3_bn254_fr;
 pub use p3_goldilocks;
 pub use p3_keccak;
+pub use p3_koala_bear;
 
 pub mod bench;
 pub mod config;


### PR DESCRIPTION
Adds Plonky3's `KoalaBear` as an export in `stark-sdk`.