### PR TITLE
perf: cpu `TraceCommitter` should reserve capacity for LDE

### DIFF
--- a/crates/stark-backend/src/engine.rs
+++ b/crates/stark-backend/src/engine.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     proof::Proof,
     prover::{
-        cpu::{CpuBackend, CpuDevice, PcsData},
+        cpu::PcsData,
         hal::{DeviceDataTransporter, TraceCommitter},
         types::{
             AirProofInput, AirProvingContext, ProofInput, ProvingContext, SingleCommitPreimage,
@@ -57,14 +57,7 @@ pub trait StarkEngine<SC: StarkGenericConfig> {
 
     fn prover<'a>(&'a self) -> MultiTraceStarkProver<'a, SC>
     where
-        Self: 'a,
-    {
-        MultiTraceStarkProver::new(
-            CpuBackend::<SC>::default(),
-            CpuDevice::new(self.config()),
-            self.new_challenger(),
-        )
-    }
+        Self: 'a;
 
     fn verifier(&self) -> MultiTraceStarkVerifier<SC> {
         MultiTraceStarkVerifier::new(self.config())

--- a/crates/stark-sdk/src/config/baby_bear_bytehash.rs
+++ b/crates/stark-sdk/src/config/baby_bear_bytehash.rs
@@ -4,6 +4,10 @@ use openvm_stark_backend::{
     p3_challenger::{HashChallenger, SerializingChallenger32},
     p3_commit::ExtensionMmcs,
     p3_field::extension::BinomialExtensionField,
+    prover::{
+        cpu::{CpuBackend, CpuDevice},
+        MultiTraceStarkProver,
+    },
 };
 use p3_baby_bear::BabyBear;
 use p3_dft::Radix2DitParallel;
@@ -54,6 +58,17 @@ where
 {
     fn config(&self) -> &BabyBearByteHashConfig<H> {
         &self.config
+    }
+
+    fn prover<'a>(&'a self) -> MultiTraceStarkProver<'a, BabyBearByteHashConfig<H>>
+    where
+        Self: 'a,
+    {
+        MultiTraceStarkProver::new(
+            CpuBackend::default(),
+            CpuDevice::new(self.config(), self.fri_params.log_blowup),
+            self.new_challenger(),
+        )
     }
 
     fn max_constraint_degree(&self) -> Option<usize> {

--- a/crates/stark-sdk/src/config/baby_bear_poseidon2.rs
+++ b/crates/stark-sdk/src/config/baby_bear_poseidon2.rs
@@ -6,6 +6,10 @@ use openvm_stark_backend::{
     p3_challenger::DuplexChallenger,
     p3_commit::ExtensionMmcs,
     p3_field::{extension::BinomialExtensionField, Field, FieldAlgebra},
+    prover::{
+        cpu::{CpuBackend, CpuDevice},
+        MultiTraceStarkProver,
+    },
 };
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_dft::Radix2DitParallel;
@@ -79,6 +83,17 @@ where
 {
     fn config(&self) -> &BabyBearPermutationConfig<P> {
         &self.config
+    }
+
+    fn prover<'a>(&'a self) -> MultiTraceStarkProver<'a, BabyBearPermutationConfig<P>>
+    where
+        Self: 'a,
+    {
+        MultiTraceStarkProver::new(
+            CpuBackend::default(),
+            CpuDevice::new(self.config(), self.fri_params.log_blowup),
+            self.new_challenger(),
+        )
     }
 
     fn max_constraint_degree(&self) -> Option<usize> {

--- a/crates/stark-sdk/src/config/baby_bear_poseidon2_root.rs
+++ b/crates/stark-sdk/src/config/baby_bear_poseidon2_root.rs
@@ -1,8 +1,14 @@
 use ff::PrimeField;
 use openvm_stark_backend::{
-    config::StarkConfig, interaction::fri_log_up::FriLogUpPhase,
-    p3_challenger::MultiField32Challenger, p3_commit::ExtensionMmcs,
+    config::StarkConfig,
+    interaction::fri_log_up::FriLogUpPhase,
+    p3_challenger::MultiField32Challenger,
+    p3_commit::ExtensionMmcs,
     p3_field::extension::BinomialExtensionField,
+    prover::{
+        cpu::{CpuBackend, CpuDevice},
+        MultiTraceStarkProver,
+    },
 };
 use p3_baby_bear::BabyBear;
 use p3_bn254_fr::{Bn254Fr, FFBn254Fr, Poseidon2Bn254};
@@ -67,6 +73,17 @@ where
 {
     fn config(&self) -> &BabyBearPermutationRootConfig<P> {
         &self.config
+    }
+
+    fn prover<'a>(&'a self) -> MultiTraceStarkProver<'a, BabyBearPermutationRootConfig<P>>
+    where
+        Self: 'a,
+    {
+        MultiTraceStarkProver::new(
+            CpuBackend::default(),
+            CpuDevice::new(self.config(), self.fri_params.log_blowup),
+            self.new_challenger(),
+        )
     }
 
     fn max_constraint_degree(&self) -> Option<usize> {

--- a/crates/stark-sdk/src/config/goldilocks_poseidon.rs
+++ b/crates/stark-sdk/src/config/goldilocks_poseidon.rs
@@ -6,6 +6,10 @@ use openvm_stark_backend::{
     p3_challenger::DuplexChallenger,
     p3_commit::ExtensionMmcs,
     p3_field::{extension::BinomialExtensionField, Field},
+    prover::{
+        cpu::{CpuBackend, CpuDevice},
+        MultiTraceStarkProver,
+    },
 };
 use p3_dft::Radix2DitParallel;
 use p3_fri::{FriConfig, TwoAdicFriPcs};
@@ -71,6 +75,17 @@ where
 {
     fn config(&self) -> &GoldilocksPermutationConfig<P> {
         &self.config
+    }
+
+    fn prover<'a>(&'a self) -> MultiTraceStarkProver<'a, GoldilocksPermutationConfig<P>>
+    where
+        Self: 'a,
+    {
+        MultiTraceStarkProver::new(
+            CpuBackend::default(),
+            CpuDevice::new(self.config(), self.security_params.fri_params.log_blowup),
+            self.new_challenger(),
+        )
     }
 
     fn max_constraint_degree(&self) -> Option<usize> {

--- a/crates/stark-sdk/src/dummy_airs/interaction/dummy_interaction_air.rs
+++ b/crates/stark-sdk/src/dummy_airs/interaction/dummy_interaction_air.rs
@@ -162,7 +162,7 @@ where
     ) -> Self {
         let air = DummyInteractionAir::new(field_width, is_send, bus_index).partition();
         Self {
-            device: Some(CpuDevice::new(config)),
+            device: Some(CpuDevice::new(config, 0)),
             data: None,
             air,
         }

--- a/crates/stark-sdk/src/dummy_airs/interaction/mod.rs
+++ b/crates/stark-sdk/src/dummy_airs/interaction/mod.rs
@@ -53,7 +53,7 @@ pub fn verify_interactions(
         .collect();
 
     let challenger = config::baby_bear_poseidon2::Challenger::new(perm.clone());
-    let mut prover = MultiTraceStarkProver::new(backend, CpuDevice::new(&config), challenger);
+    let mut prover = MultiTraceStarkProver::new(backend, CpuDevice::new(&config, 1), challenger);
     let proof = prover.prove(&pk, ProvingContext::new(per_air));
 
     // Verify the proof:


### PR DESCRIPTION
I got the idea from https://github.com/Plonky3/Plonky3/pull/634 but only realized now that since we always hang on to both the trace matrix and the LDE (assuming FRI), that the clone of trace matrix should always be in fact a memcpy into a buffer that's large enough for the cosetDFT [here](https://github.com/Plonky3/Plonky3/blob/8c8bbb4c17bd2b7ef2404338ab8f9036d5f08337/dft/src/traits.rs#L116).

This does mean you need to tell the `CpuDevice` about `log_blowup_factor`, so each `**Engine` (currently all FRI engines) needs to implement `prover()` trait independently.