### PR TITLE
feat!: drop main trace earlier for lower peak memory

### DIFF
--- a/crates/stark-backend/src/interaction/mod.rs
+++ b/crates/stark-backend/src/interaction/mod.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 use p3_air::AirBuilder;
 use p3_challenger::CanObserve;
@@ -302,7 +302,7 @@ pub trait RapPhaseSeq<F, Challenge, Challenger> {
         challenger: &mut Challenger,
         constraints_per_air: &[&SymbolicConstraints<F>],
         params_per_air: &[&Self::PartialProvingKey],
-        trace_view_per_air: &[PairTraceView<F>],
+        trace_view_per_air: Vec<PairTraceView<F>>,
     ) -> Option<(Self::PartialProof, RapPhaseProverData<Challenge>)>;
 
     /// Partially verifies the challenge phases.
@@ -324,7 +324,7 @@ pub trait RapPhaseSeq<F, Challenge, Challenger> {
         Challenger: CanObserve<Commitment>;
 }
 
-type PairTraceView<'a, F> = PairView<&'a RowMajorMatrix<F>, F>;
+type PairTraceView<'a, F> = PairView<Arc<RowMajorMatrix<F>>, F>;
 
 /// Parameters to ensure sufficient soundness of the LogUp part of the protocol.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/stark-backend/src/prover/coordinator.rs
+++ b/crates/stark-backend/src/prover/coordinator.rs
@@ -19,7 +19,7 @@ use crate::{
     proof::{AirProofData, Commitments},
     prover::{
         hal::MatrixDimensions,
-        types::{PairView, SingleCommitPreimage},
+        types::{AirView, SingleCommitPreimage},
     },
     utils::metrics_span,
 };
@@ -61,7 +61,7 @@ where
 {
     type Proof = HalProof<PB>;
     type ProvingKeyView<'a>
-        = &'a DeviceMultiStarkProvingKey<'a, PB>
+        = DeviceMultiStarkProvingKey<'a, PB>
     where
         Self: 'a;
 
@@ -93,7 +93,7 @@ where
         #[allow(clippy::type_complexity)]
         let (cached_commits_per_air, cached_views_per_air, common_main_per_air, pvs_per_air): (
             Vec<Vec<PB::Commitment>>,
-            Vec<Vec<SingleCommitPreimage<&'a PB::Matrix, &'a PB::PcsData>>>,
+            Vec<Vec<SingleCommitPreimage<PB::Matrix, PB::PcsData>>>,
             Vec<Option<PB::Matrix>>,
             Vec<Vec<PB::Val>>,
         ) = ctx
@@ -133,26 +133,31 @@ where
             .collect();
 
         // All commitments that don't require challenges have been made, so we collect them into trace views:
-        let mut common_main_idx = 0;
+        let mut common_main_traces_it = common_main_traces.into_iter();
         let mut log_trace_height_per_air: Vec<u8> = Vec::with_capacity(num_air);
-        let mut pair_trace_view_per_air = Vec::with_capacity(num_air);
-        for (pk, cached_views, pvs) in izip!(&mpk.per_air, &cached_views_per_air, &pvs_per_air) {
-            let mut main_trace_views: Vec<&PB::Matrix> =
-                cached_views.iter().map(|view| view.trace).collect_vec();
+        let mut air_trace_views_per_air = Vec::with_capacity(num_air);
+        let mut cached_pcs_datas_per_air = Vec::with_capacity(num_air);
+        for (pk, cached_views, pvs) in izip!(&mpk.per_air, cached_views_per_air, &pvs_per_air) {
+            let (mut main_trace_views, cached_pcs_datas): (Vec<PB::Matrix>, Vec<PB::PcsData>) =
+                cached_views
+                    .into_iter()
+                    .map(|view| {
+                        debug_assert_eq!(view.matrix_idx, 0);
+                        (view.trace, view.data)
+                    })
+                    .unzip();
+            cached_pcs_datas_per_air.push(cached_pcs_datas);
             if pk.vk.has_common_main() {
-                main_trace_views.push(&common_main_traces[common_main_idx]);
-                common_main_idx += 1;
+                main_trace_views.push(common_main_traces_it.next().expect("expected common main"));
             }
             let trace_height = main_trace_views.first().expect("no main trace").height();
             let log_trace_height: u8 = log2_strict_usize(trace_height).try_into().unwrap();
-            let pair_trace_view = PairView {
-                log_trace_height,
-                preprocessed: pk.preprocessed_data.as_ref().map(|d| &d.trace),
+            let air_trace_view = AirView {
                 partitioned_main: main_trace_views,
                 public_values: pvs.to_vec(),
             };
             log_trace_height_per_air.push(log_trace_height);
-            pair_trace_view_per_air.push(pair_trace_view);
+            air_trace_views_per_air.push(air_trace_view);
         }
         #[cfg(feature = "bench-metrics")]
         trace_metrics(mpk, &log_trace_height_per_air).emit();
@@ -180,7 +185,7 @@ where
         // ==================== Partially prove all RAP phases that require challenges ====================
         let (rap_partial_proof, prover_data_after) =
             self.device
-                .partially_prove(&mut self.challenger, mpk, pair_trace_view_per_air);
+                .partially_prove(&mut self.challenger, &mpk, air_trace_views_per_air);
         // Challenger observes additional commitments if any exist:
         for (commit, _) in &prover_data_after.committed_pcs_data_per_phase {
             self.challenger.observe(commit.clone());
@@ -221,7 +226,7 @@ where
             &mut self.challenger,
             &mpk.per_air,
             &pvs_per_air,
-            &cached_views_per_air,
+            &cached_pcs_datas_per_air,
             &common_main_pcs_data,
             &prover_data_after,
         );
@@ -237,18 +242,17 @@ where
             let mut quotient_degrees = Vec::with_capacity(mpk.per_air.len());
             let mut preprocessed = Vec::new();
 
-            for pk in &mpk.per_air {
+            for pk in mpk.per_air {
                 quotient_degrees.push(pk.vk.quotient_degree);
-                if let Some(data) = pk.preprocessed_data.as_ref().map(|d| &d.data) {
-                    preprocessed.push(data);
+                if let Some(preprocessed_data) = pk.preprocessed_data {
+                    preprocessed.push(preprocessed_data.data);
                 }
             }
 
-            let main = cached_views_per_air
+            let main = cached_pcs_datas_per_air
                 .into_iter()
                 .flatten()
-                .map(|cv| cv.data)
-                .chain(iter::once(&common_main_pcs_data))
+                .chain(iter::once(common_main_pcs_data))
                 .collect();
             self.device.open(
                 &mut self.challenger,

--- a/crates/stark-backend/src/prover/coordinator.rs
+++ b/crates/stark-backend/src/prover/coordinator.rs
@@ -160,7 +160,7 @@ where
             air_trace_views_per_air.push(air_trace_view);
         }
         #[cfg(feature = "bench-metrics")]
-        trace_metrics(mpk, &log_trace_height_per_air).emit();
+        trace_metrics(&mpk, &log_trace_height_per_air).emit();
 
         // ============ Challenger observations before additional RAP phases =============
         // Observe public values:
@@ -186,6 +186,8 @@ where
         let (rap_partial_proof, prover_data_after) =
             self.device
                 .partially_prove(&mut self.challenger, &mpk, air_trace_views_per_air);
+        // At this point, main trace should be dropped
+
         // Challenger observes additional commitments if any exist:
         for (commit, _) in &prover_data_after.committed_pcs_data_per_phase {
             self.challenger.observe(commit.clone());

--- a/crates/stark-backend/src/prover/cpu/quotient/mod.rs
+++ b/crates/stark-backend/src/prover/cpu/quotient/mod.rs
@@ -58,7 +58,7 @@ impl<'pcs, SC: StarkGenericConfig> QuotientCommitter<'pcs, SC> {
         view: RapView<impl Matrix<Val<SC>>, Val<SC>, SC::Challenge>,
         quotient_degree: u8,
     ) -> SingleQuotientData<SC> {
-        let log_trace_height = view.pair.log_trace_height;
+        let log_trace_height = view.log_trace_height;
         let trace_domain = self
             .pcs
             .natural_domain_for_degree(1usize << log_trace_height);
@@ -88,12 +88,12 @@ impl<'pcs, SC: StarkGenericConfig> QuotientCommitter<'pcs, SC> {
             constraints,
             trace_domain,
             quotient_domain,
-            view.pair.preprocessed,
-            view.pair.partitioned_main,
+            view.preprocessed,
+            view.partitioned_main,
             after_challenge_lde_on_quotient_domain,
             &challenges,
             self.alpha,
-            &view.pair.public_values,
+            &view.public_values,
             &exposed_values_after_challenge,
         );
         SingleQuotientData {

--- a/crates/stark-sdk/src/dummy_airs/interaction/mod.rs
+++ b/crates/stark-sdk/src/dummy_airs/interaction/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
 
 use itertools::{izip, Itertools};
 use openvm_stark_backend::{
@@ -47,6 +47,7 @@ pub fn verify_interactions(
                     cached_mains: vec![],
                     common_main: Some(Arc::new(trace)),
                     public_values: pvs,
+                    cached_lifetime: PhantomData,
                 },
             )
         })
@@ -54,7 +55,7 @@ pub fn verify_interactions(
 
     let challenger = config::baby_bear_poseidon2::Challenger::new(perm.clone());
     let mut prover = MultiTraceStarkProver::new(backend, CpuDevice::new(&config, 1), challenger);
-    let proof = prover.prove(&pk, ProvingContext::new(per_air));
+    let proof = prover.prove(pk, ProvingContext::new(per_air));
 
     // Verify the proof:
     // Start from clean challenger


### PR DESCRIPTION
Changed the traits slightly so that traces are passed without borrowing. The main reason is the realization that preprocessed and main traces are only used to generate the permutation trace, so they can be dropped immediately after this step (in `partially_prove`). Afterwards, only LDEs need to be used.

There is some improvement in how the handling of preprocessed / cached trace is done: sometimes you may want to not drop these (so they really stay in memory) and sometimes you may want to drop it to lower peak memory. Maybe some `Shared**` type may make this clearer, but for now I just opted to use owned versions of everything because in practice we are using smart pointers (`Arc`) around everything, so one can get around sharing with some cloning if necessary.

Note that right now the preprocessed trace is never dropped, because the proving key holds onto a copy until `Opening` is called. We could get around this with some extra `Option` usage, but since the size of preprocessed trace is currently small I'll leave it for later.


https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/14749714037/job/41404170207