### PR TITLE
feat: reserve capacity for perm & quotient LDE; avoid copy for quotient split

### DIFF
--- a/crates/stark-backend/src/prover/cpu/mod.rs
+++ b/crates/stark-backend/src/prover/cpu/mod.rs
@@ -373,7 +373,7 @@ impl<SC: StarkGenericConfig> hal::QuotientCommitter<CpuBackend<SC>> for CpuDevic
                 )
             })
             .unzip();
-        let qc = QuotientCommitter::new(self.pcs(), alpha);
+        let qc = QuotientCommitter::new(self.pcs(), alpha, self.log_blowup_factor);
         let quotient_values = metrics_span("quotient_poly_compute_time_ms", || {
             qc.quotient_values(&constraints, extended_views, &quotient_degrees)
         });

--- a/crates/stark-backend/src/prover/cpu/quotient/mod.rs
+++ b/crates/stark-backend/src/prover/cpu/quotient/mod.rs
@@ -43,20 +43,7 @@ impl<'pcs, SC: StarkGenericConfig> QuotientCommitter<'pcs, SC> {
     ///
     /// **Note**: This function assumes that the
     /// `quotient_domain.split_evals(quotient_degree, quotient_flat)` function from Plonky3 works
-    /// as follows (currently true for all known implementations):
-    /// The quotient polynomial will is treated as long columns of the form
-    /// ```ignore
-    /// [q_0]
-    /// [q_1]
-    /// ...
-    /// [q_{quotient_degree - 1}]
-    /// ```
-    /// where each `q_i` is column of length `trace_height` of extension field elements.
-    /// We treat them as separate base field matrices
-    /// ```ignore
-    /// [q_0], [q_1], ..., [q_{quotient_degree - 1}]
-    /// ```
-    /// Each matrix is a "chunk".
+    /// as described in [compute_single_rap_quotient_values].
     #[instrument(name = "compute quotient values", level = "info", skip_all)]
     pub fn quotient_values(
         &self,

--- a/crates/stark-backend/src/prover/cpu/quotient/mod.rs
+++ b/crates/stark-backend/src/prover/cpu/quotient/mod.rs
@@ -8,7 +8,7 @@ use p3_util::log2_strict_usize;
 use tracing::instrument;
 
 use self::single::compute_single_rap_quotient_values;
-use super::{transmute_to_base, PcsData};
+use super::PcsData;
 use crate::{
     air_builders::symbolic::SymbolicExpressionDag,
     config::{Com, Domain, PackedChallenge, StarkGenericConfig, Val},
@@ -21,11 +21,16 @@ pub(crate) mod single;
 pub struct QuotientCommitter<'pcs, SC: StarkGenericConfig> {
     pcs: &'pcs SC::Pcs,
     alpha: SC::Challenge,
+    extra_capacity_bits: usize,
 }
 
 impl<'pcs, SC: StarkGenericConfig> QuotientCommitter<'pcs, SC> {
-    pub fn new(pcs: &'pcs SC::Pcs, alpha: SC::Challenge) -> Self {
-        Self { pcs, alpha }
+    pub fn new(pcs: &'pcs SC::Pcs, alpha: SC::Challenge, extra_capacity_bits: usize) -> Self {
+        Self {
+            pcs,
+            alpha,
+            extra_capacity_bits,
+        }
     }
 
     /// Constructs quotient domains and computes the evaluation of the quotient polynomials
@@ -35,6 +40,23 @@ impl<'pcs, SC: StarkGenericConfig> QuotientCommitter<'pcs, SC> {
     /// - `constraints`, `extended_views`, `quotient_degrees` have equal lengths and the length equals number of RAPs.
     /// - `quotient_degrees` is the factor to **multiply** the trace degree by to get the degree of the quotient polynomial. This should be determined from the constraint degree of the RAP.
     /// - `extended_views` is a view of the trace polynomials evaluated on the quotient domain, with rows bit reversed to account for the fact that the quotient domain is different for each RAP.
+    ///
+    /// **Note**: This function assumes that the
+    /// `quotient_domain.split_evals(quotient_degree, quotient_flat)` function from Plonky3 works
+    /// as follows (currently true for all known implementations):
+    /// The quotient polynomial will is treated as long columns of the form
+    /// ```
+    /// [q_0]
+    /// [q_1]
+    /// ...
+    /// [q_{quotient_degree - 1}]
+    /// ```
+    /// where each `q_i` is column of length `trace_height` of extension field elements.
+    /// We treat them as separate base field matrices
+    /// ```
+    /// [q_0], [q_1], ..., [q_{quotient_degree - 1}]
+    /// ```
+    /// Each matrix is a "chunk".
     #[instrument(name = "compute quotient values", level = "info", skip_all)]
     pub fn quotient_values(
         &self,
@@ -44,12 +66,12 @@ impl<'pcs, SC: StarkGenericConfig> QuotientCommitter<'pcs, SC> {
     ) -> QuotientData<SC> {
         assert_eq!(constraints.len(), extended_views.len());
         assert_eq!(constraints.len(), quotient_degrees.len());
-        let inner = izip!(constraints, extended_views, quotient_degrees)
-            .map(|(constraints, extended_view, &quotient_degree)| {
+        let chunks = izip!(constraints, extended_views, quotient_degrees)
+            .flat_map(|(constraints, extended_view, &quotient_degree)| {
                 self.single_rap_quotient_values(constraints, extended_view, quotient_degree)
             })
             .collect();
-        QuotientData { inner }
+        QuotientData { chunks }
     }
 
     pub(super) fn single_rap_quotient_values(
@@ -57,7 +79,7 @@ impl<'pcs, SC: StarkGenericConfig> QuotientCommitter<'pcs, SC> {
         constraints: &SymbolicExpressionDag<Val<SC>>,
         view: RapView<impl Matrix<Val<SC>>, Val<SC>, SC::Challenge>,
         quotient_degree: u8,
-    ) -> SingleQuotientData<SC> {
+    ) -> impl IntoIterator<Item = QuotientChunk<SC>> {
         let log_trace_height = view.log_trace_height;
         let trace_domain = self
             .pcs
@@ -84,7 +106,7 @@ impl<'pcs, SC: StarkGenericConfig> QuotientCommitter<'pcs, SC> {
             )
         }));
 
-        let quotient_values = compute_single_rap_quotient_values::<SC, _>(
+        compute_single_rap_quotient_values::<SC, _>(
             constraints,
             trace_domain,
             quotient_domain,
@@ -95,23 +117,19 @@ impl<'pcs, SC: StarkGenericConfig> QuotientCommitter<'pcs, SC> {
             self.alpha,
             &view.public_values,
             &exposed_values_after_challenge,
-        );
-        SingleQuotientData {
-            quotient_degree: quotient_degree as usize,
-            quotient_domain,
-            quotient_values,
-        }
+            self.extra_capacity_bits,
+        )
     }
 
     #[instrument(name = "commit to quotient poly chunks", skip_all)]
     pub fn commit(&self, data: QuotientData<SC>) -> (Com<SC>, PcsData<SC>) {
         let (log_trace_heights, quotient_domains_and_chunks): (Vec<_>, Vec<_>) = data
-            .split()
+            .chunks
             .into_iter()
             .map(|q| {
                 (
                     log2_strict_usize(q.domain.size()) as u8,
-                    (q.domain, q.chunk),
+                    (q.domain, q.matrix),
                 )
             })
             .unzip();
@@ -128,45 +146,8 @@ impl<'pcs, SC: StarkGenericConfig> QuotientCommitter<'pcs, SC> {
 
 /// The quotient polynomials from multiple RAP matrices.
 pub(super) struct QuotientData<SC: StarkGenericConfig> {
-    inner: Vec<SingleQuotientData<SC>>,
-}
-
-impl<SC: StarkGenericConfig> QuotientData<SC> {
-    /// Splits the quotient polynomials from multiple AIRs into chunks of size equal to the trace domain size.
-    pub fn split(self) -> impl IntoIterator<Item = QuotientChunk<SC>> {
-        self.inner.into_iter().flat_map(|data| data.split())
-    }
-}
-
-/// The quotient polynomial from a single matrix RAP, evaluated on the quotient domain.
-pub(super) struct SingleQuotientData<SC: StarkGenericConfig> {
-    quotient_degree: usize,
-    /// Quotient domain
-    quotient_domain: Domain<SC>,
-    /// Evaluations of the quotient polynomial on the quotient domain
-    quotient_values: Vec<SC::Challenge>,
-}
-
-impl<SC: StarkGenericConfig> SingleQuotientData<SC> {
-    /// The vector of evaluations of the quotient polynomial on the quotient domain,
-    /// first flattened from vector of extension field elements to matrix of base field elements,
-    /// and then split into chunks of size equal to the trace domain size (quotient domain size
-    /// divided by `quotient_degree`).
-    pub fn split(self) -> impl IntoIterator<Item = QuotientChunk<SC>> {
-        let quotient_degree = self.quotient_degree;
-        let quotient_domain = self.quotient_domain;
-        // Flatten from extension field elements to base field elements
-        // SAFETY: `Challenge` is assumed to be extension field of `F`
-        // with memory layout `[F; Challenge::D]`
-        let quotient_flat =
-            unsafe { transmute_to_base(RowMajorMatrix::new_col(self.quotient_values)) };
-        let quotient_chunks = quotient_domain.split_evals(quotient_degree, quotient_flat);
-        let qc_domains = quotient_domain.split_domains(quotient_degree);
-        qc_domains
-            .into_iter()
-            .zip_eq(quotient_chunks)
-            .map(|(domain, chunk)| QuotientChunk { domain, chunk })
-    }
+    /// Length equals `quotient_ degree`.
+    chunks: Vec<QuotientChunk<SC>>,
 }
 
 /// The vector of evaluations of the quotient polynomial on the quotient domain,
@@ -180,5 +161,5 @@ pub struct QuotientChunk<SC: StarkGenericConfig> {
     pub domain: Domain<SC>,
     /// Matrix with number of rows equal to trace domain size,
     /// and number of columns equal to extension field degree.
-    pub chunk: RowMajorMatrix<Val<SC>>,
+    pub matrix: RowMajorMatrix<Val<SC>>,
 }

--- a/crates/stark-backend/src/prover/cpu/quotient/mod.rs
+++ b/crates/stark-backend/src/prover/cpu/quotient/mod.rs
@@ -45,7 +45,7 @@ impl<'pcs, SC: StarkGenericConfig> QuotientCommitter<'pcs, SC> {
     /// `quotient_domain.split_evals(quotient_degree, quotient_flat)` function from Plonky3 works
     /// as follows (currently true for all known implementations):
     /// The quotient polynomial will is treated as long columns of the form
-    /// ```
+    /// ```ignore
     /// [q_0]
     /// [q_1]
     /// ...
@@ -53,7 +53,7 @@ impl<'pcs, SC: StarkGenericConfig> QuotientCommitter<'pcs, SC> {
     /// ```
     /// where each `q_i` is column of length `trace_height` of extension field elements.
     /// We treat them as separate base field matrices
-    /// ```
+    /// ```ignore
     /// [q_0], [q_1], ..., [q_{quotient_degree - 1}]
     /// ```
     /// Each matrix is a "chunk".

--- a/crates/stark-backend/src/prover/cpu/quotient/single.rs
+++ b/crates/stark-backend/src/prover/cpu/quotient/single.rs
@@ -42,12 +42,12 @@ use crate::{
 /// which is "vertically strided" with stride `quotient_degree`.
 /// We regroup them into evaluations on cosets of the trace domain subgroup as separate base field matrices
 /// ```ignore
-/// [q_{0,0}], [q_{1,0}], ..., [q_{quotient_degree - 1,0}]
-/// [q_{0,1}], [q_{1,1}], ..., [q_{quotient_degree - 1,1}]
+/// [q_{0,0}               ]   [q_{1,0}               ]  ...  [q_{quotient_degree - 1,0}               ]
+/// [q_{0,1}               ]   [q_{1,1}               ]  ...  [q_{quotient_degree - 1,1}               ]
 /// ...
-/// [q_{0,trace_height - 1}], [q_{1,trace_height - 1}], ..., [q_{quotient_degree - 1,trace_height - 1}]
+/// [q_{0,trace_height - 1}]   [q_{1,trace_height - 1}]  ...  [q_{quotient_degree - 1,trace_height - 1}]
 /// ```
-/// Each matrix is a "chunk".
+/// where `q_{0,*}` and `q_{1,*}` are separate matrices. Each matrix is called a "chunk".
 #[allow(clippy::too_many_arguments)]
 #[instrument(
     name = "compute single RAP quotient polynomial",

--- a/crates/stark-backend/src/prover/cpu/quotient/single.rs
+++ b/crates/stark-backend/src/prover/cpu/quotient/single.rs
@@ -30,7 +30,7 @@ use crate::{
 /// `quotient_domain.split_evals(quotient_degree, quotient_flat)` function from Plonky3 works
 /// as follows (currently true for all known implementations):
 /// The quotient polynomial will is treated as long columns of the form
-/// ```
+/// ```ignore
 /// [q_0]
 /// [q_1]
 /// ...
@@ -38,7 +38,7 @@ use crate::{
 /// ```
 /// where each `q_i` is column of length `trace_height` of extension field elements.
 /// We treat them as separate base field matrices
-/// ```
+/// ```ignore
 /// [q_0], [q_1], ..., [q_{quotient_degree - 1}]
 /// ```
 /// Each matrix is a "chunk".
@@ -98,10 +98,13 @@ where
     // So this will be alpha^{num_constraints - 1}, ..., alpha^0
     alpha_powers.reverse();
 
-    // assert!(quotient_size >= PackedVal::<SC>::WIDTH);
-    // We take PackedVal::<SC>::WIDTH worth of values at a time from a quotient_size slice, so we need to
-    // pad with default values in the case where quotient_size is smaller than PackedVal::<SC>::WIDTH.
-    for _ in quotient_size..PackedVal::<SC>::WIDTH {
+    // We take PackedVal::<SC>::WIDTH worth of values at a time from `quotient_degree` chunks of size
+    // `trace_height`, so we need to pad with default values in the case where quotient_size is
+    // smaller than PackedVal::<SC>::WIDTH.
+    // Note: this resizes vecs but only if trace_height < PackedVal::<SC>::WIDTH, which is small
+    for _ in quotient_size
+        ..trace_height.div_ceil(PackedVal::<SC>::WIDTH) * PackedVal::<SC>::WIDTH * quotient_degree
+    {
         sels.is_first_row.push(Val::<SC>::default());
         sels.is_last_row.push(Val::<SC>::default());
         sels.is_transition.push(Val::<SC>::default());

--- a/crates/stark-backend/src/prover/cpu/quotient/single.rs
+++ b/crates/stark-backend/src/prover/cpu/quotient/single.rs
@@ -1,19 +1,23 @@
-use std::cmp::min;
+use std::cmp::max;
 
 use itertools::Itertools;
 use p3_commit::PolynomialSpace;
 use p3_field::{FieldAlgebra, FieldExtensionAlgebra, PackedValue};
-use p3_matrix::Matrix;
+use p3_matrix::{dense::RowMajorMatrix, Matrix};
 use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
 use tracing::instrument;
 
-use super::evaluator::{ProverConstraintEvaluator, ViewPair};
+use super::{
+    evaluator::{ProverConstraintEvaluator, ViewPair},
+    QuotientChunk,
+};
 use crate::{
     air_builders::symbolic::{
         symbolic_variable::Entry, SymbolicExpressionDag, SymbolicExpressionNode,
     },
     config::{Domain, PackedChallenge, PackedVal, StarkGenericConfig, Val},
+    prover::cpu::transmute_to_base,
 };
 
 // Starting reference: p3_uni_stark::prover::quotient_values
@@ -21,6 +25,23 @@ use crate::{
 /// Computes evaluation of DEEP quotient polynomial on the quotient domain for a single RAP (single trace matrix).
 ///
 /// Designed to be general enough to support RAP with multiple rounds of challenges.
+///
+/// **Note**: This function assumes that the
+/// `quotient_domain.split_evals(quotient_degree, quotient_flat)` function from Plonky3 works
+/// as follows (currently true for all known implementations):
+/// The quotient polynomial will is treated as long columns of the form
+/// ```
+/// [q_0]
+/// [q_1]
+/// ...
+/// [q_{quotient_degree - 1}]
+/// ```
+/// where each `q_i` is column of length `trace_height` of extension field elements.
+/// We treat them as separate base field matrices
+/// ```
+/// [q_0], [q_1], ..., [q_{quotient_degree - 1}]
+/// ```
+/// Each matrix is a "chunk".
 #[allow(clippy::too_many_arguments)]
 #[instrument(
     name = "compute single RAP quotient polynomial",
@@ -40,12 +61,14 @@ pub fn compute_single_rap_quotient_values<'a, SC, M>(
     public_values: &'a [Val<SC>],
     // Values exposed to verifier after challenge round i
     exposed_values_after_challenge: &'a [Vec<PackedChallenge<SC>>],
-) -> Vec<SC::Challenge>
+    extra_capacity_bits: usize,
+) -> Vec<QuotientChunk<SC>>
 where
     SC: StarkGenericConfig,
     M: Matrix<Val<SC>>,
 {
     let quotient_size = quotient_domain.size();
+    let trace_height = trace_domain.size();
     assert!(partitioned_main_lde_on_quotient_domain
         .iter()
         .all(|m| m.height() >= quotient_size));
@@ -58,8 +81,11 @@ where
         .unwrap_or(0);
     let mut sels = trace_domain.selectors_on_coset(quotient_domain);
 
-    let qdb = log2_strict_usize(quotient_size) - log2_strict_usize(trace_domain.size());
-    let next_step = 1 << qdb;
+    let qdb = log2_strict_usize(quotient_size) - log2_strict_usize(trace_height);
+    let quotient_degree = 1 << qdb;
+    debug_assert_eq!(quotient_size, trace_height * quotient_degree);
+    // The input values are evaluations on quotient domain, so the trace evaluations are spaced quotient_degree apart
+    let next_step = quotient_degree;
 
     let ext_degree = SC::Challenge::D;
 
@@ -89,7 +115,7 @@ where
         if let SymbolicExpressionNode::Variable(var) = node {
             match var.entry {
                 Entry::Preprocessed { offset } => {
-                    rotation = rotation.max(offset);
+                    rotation = max(rotation, offset);
                     assert!(var.index < preprocessed_width);
                     assert!(
                         preprocessed_trace_on_quotient_domain
@@ -100,7 +126,7 @@ where
                     );
                 }
                 Entry::Main { part_index, offset } => {
-                    rotation = rotation.max(offset);
+                    rotation = max(rotation, offset);
                     assert!(
                         var.index < partitioned_main_lde_on_quotient_domain[part_index].width()
                     );
@@ -109,7 +135,7 @@ where
                     assert!(var.index < public_values.len());
                 }
                 Entry::Permutation { offset } => {
-                    rotation = rotation.max(offset);
+                    rotation = max(rotation, offset);
                     let ext_width = after_challenge_lde_on_quotient_domain
                         .first()
                         .expect("Challenge phase not supported")
@@ -140,111 +166,136 @@ where
     }
     let needs_next = rotation > 0;
 
-    (0..quotient_size)
-        .into_par_iter()
-        .step_by(PackedVal::<SC>::WIDTH)
-        .flat_map_iter(|i_start| {
-            let wrap = |i| i % quotient_size;
-            let i_range = i_start..i_start + PackedVal::<SC>::WIDTH;
+    let qc_domains = quotient_domain.split_domains(quotient_degree);
+    qc_domains
+        .into_iter()
+        .enumerate()
+        .map(|(chunk_idx, chunk_domain)| {
+            // This will be evaluations of the quotient poly on the `chunk_domain`, where `chunk_domain.size() = trace_height`. We reserve extra capacity for the coset lde in the pcs.commit of this chunk.
+            let mut chunk = SC::Challenge::zero_vec(trace_height << extra_capacity_bits);
+            chunk.truncate(trace_height);
+            // We parallel iterate over "fat" rows, which are consecutive rows packed for SIMD.
+            // Use par_chunks instead of par_chunks_exact in case trace_height is not a multiple of PackedVal::WIDTH
+            chunk
+                .par_chunks_mut(PackedVal::<SC>::WIDTH)
+                .enumerate()
+                .for_each(|(fat_row_idx, packed_ef_mut)| {
+                    let i_start = chunk_idx * trace_height + fat_row_idx * PackedVal::<SC>::WIDTH;
+                    let wrap = |i| i % quotient_size;
+                    let i_range = i_start..i_start + PackedVal::<SC>::WIDTH;
 
-            let [row_idx_local, row_idx_next] = [0, next_step].map(|shift| {
-                (0..PackedVal::<SC>::WIDTH)
-                    .map(|offset| wrap(i_start + offset + shift))
-                    .collect::<Vec<_>>()
-            });
-            let row_idx_local = Some(row_idx_local);
-            let row_idx_next = needs_next.then_some(row_idx_next);
-
-            let is_first_row = *PackedVal::<SC>::from_slice(&sels.is_first_row[i_range.clone()]);
-            let is_last_row = *PackedVal::<SC>::from_slice(&sels.is_last_row[i_range.clone()]);
-            let is_transition = *PackedVal::<SC>::from_slice(&sels.is_transition[i_range.clone()]);
-            let inv_zeroifier = *PackedVal::<SC>::from_slice(&sels.inv_zeroifier[i_range.clone()]);
-
-            // Vertically pack rows of each matrix,
-            // skipping `next` if above scan showed no constraints need it:
-
-            let [preprocessed_local, preprocessed_next] =
-                [&row_idx_local, &row_idx_next].map(|wrapped_idx| {
-                    wrapped_idx.as_ref().map(|wrapped_idx| {
-                        (0..preprocessed_width)
-                            .map(|col| {
-                                PackedVal::<SC>::from_fn(|offset| {
-                                    preprocessed_trace_on_quotient_domain
-                                        .as_ref()
-                                        .unwrap()
-                                        .get(wrapped_idx[offset], col)
-                                })
-                            })
-                            .collect_vec()
-                    })
-                });
-            let preprocessed_pair = ViewPair::new(preprocessed_local.unwrap(), preprocessed_next);
-
-            let partitioned_main_pairs = partitioned_main_lde_on_quotient_domain
-                .iter()
-                .map(|lde| {
-                    let width = lde.width();
-                    let [local, next] = [&row_idx_local, &row_idx_next].map(|wrapped_idx| {
-                        wrapped_idx.as_ref().map(|wrapped_idx| {
-                            (0..width)
-                                .map(|col| {
-                                    PackedVal::<SC>::from_fn(|offset| {
-                                        lde.get(wrapped_idx[offset], col)
-                                    })
-                                })
-                                .collect_vec()
-                        })
+                    let [row_idx_local, row_idx_next] = [0, next_step].map(|shift| {
+                        (0..PackedVal::<SC>::WIDTH)
+                            .map(|offset| wrap(i_start + offset + shift))
+                            .collect::<Vec<_>>()
                     });
-                    ViewPair::new(local.unwrap(), next)
-                })
-                .collect_vec();
+                    let row_idx_local = Some(row_idx_local);
+                    let row_idx_next = needs_next.then_some(row_idx_next);
 
-            let after_challenge_pairs = after_challenge_lde_on_quotient_domain
-                .iter()
-                .map(|lde| {
-                    // Width in base field with extension field elements flattened
-                    let base_width = lde.width();
-                    let [local, next] = [&row_idx_local, &row_idx_next].map(|wrapped_idx| {
-                        wrapped_idx.as_ref().map(|wrapped_idx| {
-                            (0..base_width)
-                                .step_by(ext_degree)
-                                .map(|col| {
-                                    PackedChallenge::<SC>::from_base_fn(|i| {
+                    let is_first_row =
+                        *PackedVal::<SC>::from_slice(&sels.is_first_row[i_range.clone()]);
+                    let is_last_row =
+                        *PackedVal::<SC>::from_slice(&sels.is_last_row[i_range.clone()]);
+                    let is_transition =
+                        *PackedVal::<SC>::from_slice(&sels.is_transition[i_range.clone()]);
+                    let inv_zeroifier =
+                        *PackedVal::<SC>::from_slice(&sels.inv_zeroifier[i_range.clone()]);
+
+                    // Vertically pack rows of each matrix,
+                    // skipping `next` if above scan showed no constraints need it:
+
+                    let [preprocessed_local, preprocessed_next] = [&row_idx_local, &row_idx_next]
+                        .map(|wrapped_idx| {
+                            wrapped_idx.as_ref().map(|wrapped_idx| {
+                                (0..preprocessed_width)
+                                    .map(|col| {
                                         PackedVal::<SC>::from_fn(|offset| {
-                                            lde.get(wrapped_idx[offset], col + i)
+                                            preprocessed_trace_on_quotient_domain
+                                                .as_ref()
+                                                .unwrap()
+                                                .get(wrapped_idx[offset], col)
                                         })
                                     })
-                                })
-                                .collect_vec()
+                                    .collect_vec()
+                            })
+                        });
+                    let preprocessed_pair =
+                        ViewPair::new(preprocessed_local.unwrap(), preprocessed_next);
+
+                    let partitioned_main_pairs = partitioned_main_lde_on_quotient_domain
+                        .iter()
+                        .map(|lde| {
+                            let width = lde.width();
+                            let [local, next] =
+                                [&row_idx_local, &row_idx_next].map(|wrapped_idx| {
+                                    wrapped_idx.as_ref().map(|wrapped_idx| {
+                                        (0..width)
+                                            .map(|col| {
+                                                PackedVal::<SC>::from_fn(|offset| {
+                                                    lde.get(wrapped_idx[offset], col)
+                                                })
+                                            })
+                                            .collect_vec()
+                                    })
+                                });
+                            ViewPair::new(local.unwrap(), next)
                         })
-                    });
-                    ViewPair::new(local.unwrap(), next)
-                })
-                .collect_vec();
+                        .collect_vec();
 
-            let evaluator: ProverConstraintEvaluator<SC> = ProverConstraintEvaluator {
-                preprocessed: preprocessed_pair,
-                partitioned_main: partitioned_main_pairs,
-                after_challenge: after_challenge_pairs,
-                challenges,
-                is_first_row,
-                is_last_row,
-                is_transition,
-                public_values,
-                exposed_values_after_challenge,
-            };
-            let accumulator = evaluator.accumulate(constraints, &alpha_powers);
-            // quotient(x) = constraints(x) / Z_H(x)
-            let quotient: PackedChallenge<SC> = accumulator * inv_zeroifier;
+                    let after_challenge_pairs = after_challenge_lde_on_quotient_domain
+                        .iter()
+                        .map(|lde| {
+                            // Width in base field with extension field elements flattened
+                            let base_width = lde.width();
+                            let [local, next] =
+                                [&row_idx_local, &row_idx_next].map(|wrapped_idx| {
+                                    wrapped_idx.as_ref().map(|wrapped_idx| {
+                                        (0..base_width)
+                                            .step_by(ext_degree)
+                                            .map(|col| {
+                                                PackedChallenge::<SC>::from_base_fn(|i| {
+                                                    PackedVal::<SC>::from_fn(|offset| {
+                                                        lde.get(wrapped_idx[offset], col + i)
+                                                    })
+                                                })
+                                            })
+                                            .collect_vec()
+                                    })
+                                });
+                            ViewPair::new(local.unwrap(), next)
+                        })
+                        .collect_vec();
 
-            // "Transpose" D packed base coefficients into WIDTH scalar extension coefficients.
-            let width = min(PackedVal::<SC>::WIDTH, quotient_size);
-            (0..width).map(move |idx_in_packing| {
-                let quotient_value = (0..<SC::Challenge as FieldExtensionAlgebra<Val<SC>>>::D)
-                    .map(|coeff_idx| quotient.as_base_slice()[coeff_idx].as_slice()[idx_in_packing])
-                    .collect::<Vec<_>>();
-                SC::Challenge::from_base_slice(&quotient_value)
-            })
+                    let evaluator: ProverConstraintEvaluator<SC> = ProverConstraintEvaluator {
+                        preprocessed: preprocessed_pair,
+                        partitioned_main: partitioned_main_pairs,
+                        after_challenge: after_challenge_pairs,
+                        challenges,
+                        is_first_row,
+                        is_last_row,
+                        is_transition,
+                        public_values,
+                        exposed_values_after_challenge,
+                    };
+                    let accumulator = evaluator.accumulate(constraints, &alpha_powers);
+                    // quotient(x) = constraints(x) / Z_H(x)
+                    let quotient: PackedChallenge<SC> = accumulator * inv_zeroifier;
+
+                    // "Transpose" D packed base coefficients into WIDTH scalar extension coefficients.
+                    for (idx_in_packing, ef) in packed_ef_mut.iter_mut().enumerate() {
+                        *ef = SC::Challenge::from_base_fn(|coeff_idx| {
+                            quotient.as_base_slice()[coeff_idx].as_slice()[idx_in_packing]
+                        });
+                    }
+                });
+            // Flatten from extension field elements to base field elements
+            // SAFETY: `Challenge` is assumed to be extension field of `F`
+            // with memory layout `[F; Challenge::D]`
+            let matrix = unsafe { transmute_to_base(RowMajorMatrix::new_col(chunk)) };
+            QuotientChunk {
+                domain: chunk_domain,
+                matrix,
+            }
         })
         .collect()
 }

--- a/crates/stark-backend/src/prover/metrics.rs
+++ b/crates/stark-backend/src/prover/metrics.rs
@@ -26,6 +26,8 @@ pub struct SingleTraceMetrics {
     /// Omitting preprocessed trace, the total base field cells from main and after challenge
     /// traces.
     pub total_cells: usize,
+    /// Base field cells for evaluation of quotient polynomial on the quotient domain
+    pub quotient_poly_cells: usize,
 }
 
 /// Trace cells, counted in terms of number of **base field** elements.
@@ -71,6 +73,16 @@ impl Display for TraceMetrics {
                 self.per_air
                     .iter()
                     .map(|m| m.cells.after_challenge.iter().sum::<usize>())
+                    .sum::<usize>()
+            )
+        )?;
+        writeln!(
+            f,
+            "quotient_poly_cells = {}",
+            format_number_with_underscores(
+                self.per_air
+                    .iter()
+                    .map(|m| m.quotient_poly_cells)
                     .sum::<usize>()
             )
         )?;
@@ -152,6 +164,7 @@ pub fn trace_metrics<PB: ProverBackend>(
                 width,
                 cells,
                 total_cells,
+                quotient_poly_cells: height * (pk.vk.quotient_degree as usize) * ext_degree,
             }
         })
         .collect();

--- a/crates/stark-sdk/src/config/baby_bear_bytehash.rs
+++ b/crates/stark-sdk/src/config/baby_bear_bytehash.rs
@@ -130,7 +130,7 @@ where
         mmcs: challenge_mmcs,
     };
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
-    let rap_phase = FriLogUpPhase::new(log_up_params);
+    let rap_phase = FriLogUpPhase::new(log_up_params, fri_params.log_blowup);
     BabyBearByteHashConfig::new(pcs, rap_phase)
 }
 

--- a/crates/stark-sdk/src/config/baby_bear_poseidon2.rs
+++ b/crates/stark-sdk/src/config/baby_bear_poseidon2.rs
@@ -202,7 +202,7 @@ where
         mmcs: challenge_mmcs,
     };
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
-    let rap_phase = FriLogUpPhase::new(log_up_params);
+    let rap_phase = FriLogUpPhase::new(log_up_params, fri_params.log_blowup);
     BabyBearPermutationConfig::new(pcs, rap_phase)
 }
 

--- a/crates/stark-sdk/src/config/baby_bear_poseidon2_root.rs
+++ b/crates/stark-sdk/src/config/baby_bear_poseidon2_root.rs
@@ -153,7 +153,7 @@ where
         mmcs: challenge_mmcs,
     };
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
-    let rap_phase = FriLogUpPhase::new(log_up_params);
+    let rap_phase = FriLogUpPhase::new(log_up_params, fri_params.log_blowup);
     BabyBearPermutationRootConfig::new(pcs, rap_phase)
 }
 

--- a/crates/stark-sdk/src/config/goldilocks_poseidon.rs
+++ b/crates/stark-sdk/src/config/goldilocks_poseidon.rs
@@ -184,7 +184,7 @@ where
         mmcs: challenge_mmcs,
     };
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
-    let rap_phase = RapPhase::new(log_up_params);
+    let rap_phase = FriLogUpPhase::new(log_up_params, fri_params.log_blowup);
     GoldilocksPermutationConfig::new(pcs, rap_phase)
 }
 


### PR DESCRIPTION
Follow up of https://github.com/openvm-org/stark-backend/pull/68 where the main idea was that for perm and quotient PCS commitments, we generate the matrices and then immediate apply cosetLDE which does in-place DFT which resizes the matrix to `trace_height * log_blowup`. To avoid re-allocation, we allocate the right amount of space from the start.

While doing this, I noticed that we were using plonky3's `Domain::split_evals` to split the quotient poly into chunks: this does a full copy of the quotient matrix (basically a transpose) -- this is totally unnecessary since we generate the whole quotient poly using a `par_iter`! Under (what I think is) a minor assumption that we always split quotient polys in this way, I got rid of it so now there's no copy.

https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/14790290465
513s -> 500s total prove time