### PR TITLE
fix(metrics): remove `_time_ms` from span name

### DIFF
--- a/crates/stark-backend/src/interaction/fri_log_up.rs
+++ b/crates/stark-backend/src/interaction/fri_log_up.rs
@@ -119,16 +119,15 @@ where
         let challenges: [Challenge; STARK_LU_NUM_CHALLENGES] =
             array::from_fn(|_| challenger.sample_ext_element::<Challenge>());
 
-        let after_challenge_trace_per_air =
-            info_span!("generate_perm_trace_time_ms").in_scope(|| {
-                Self::generate_after_challenge_traces_per_air(
-                    &challenges,
-                    constraints_per_air,
-                    params_per_air,
-                    trace_view_per_air,
-                    self.extra_capacity_bits,
-                )
-            });
+        let after_challenge_trace_per_air = info_span!("generate_perm_trace").in_scope(|| {
+            Self::generate_after_challenge_traces_per_air(
+                &challenges,
+                constraints_per_air,
+                params_per_air,
+                trace_view_per_air,
+                self.extra_capacity_bits,
+            )
+        });
         let cumulative_sum_per_air = Self::extract_cumulative_sums(&after_challenge_trace_per_air);
 
         // Challenger needs to observe what is exposed (cumulative_sums)


### PR DESCRIPTION
The metrics layer will auto-add it.