### PR TITLE
fix: use plonky3 `Packed` types for SIMD compatibility

### DIFF
--- a/.github/workflows/tests-cuda.yml
+++ b/.github/workflows/tests-cuda.yml
@@ -15,6 +15,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Ctarget-cpu=native
 
 jobs:
   cuda-backend:

--- a/crates/cuda-backend/src/opener/mod.rs
+++ b/crates/cuda-backend/src/opener/mod.rs
@@ -31,10 +31,11 @@ use crate::{
 pub(crate) mod ops;
 
 const DIGEST_WIDTH: usize = 8;
+type PackedVal = <F as Field>::Packing;
 type Perm = Poseidon2BabyBear<16>;
 type Hash = PaddingFreeSponge<Perm, WIDTH, 8, DIGEST_WIDTH>;
 type Compress = TruncatedPermutation<Perm, 2, DIGEST_WIDTH, WIDTH>;
-type ValMmcs = MerkleTreeMmcs<F, F, Hash, Compress, DIGEST_WIDTH>;
+type ValMmcs = MerkleTreeMmcs<PackedVal, <F as Field>::Packing, Hash, Compress, DIGEST_WIDTH>;
 type ChallengeMmcs = ExtensionMmcs<F, EF, ValMmcs>;
 
 pub struct OpeningProverGpu {}


### PR DESCRIPTION
We don't use the type itself, but we need to use the correct type to avoid compile errors.

The `ValMmcs` has packed types which is phantom data and only used by the prover (which we ignore since we use the cuda prover), and the proof types only used the associated `::Value` which is SIMD-independent.

closes INT-4848