### PR TITLE
Revert "chore(cuda): Sync when release big buffer & bump version to `1.2.0-rc.8`"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.2.0-rc.8"
+version = "1.2.0-rc.7"
 edition = "2021"
 rust-version = "1.83"
 authors = ["OpenVM contributors"]

--- a/crates/cuda-common/src/common.rs
+++ b/crates/cuda-common/src/common.rs
@@ -8,7 +8,6 @@ type cudaMemPool_t = *mut c_void;
 pub const cudaMemPoolAttrReleaseThreshold: u32 = 4;
 #[allow(non_upper_case_globals)]
 pub const cudaMemPoolAttrReuseFollowEventDependencies: u32 = 1;
-pub const MEMORY_POOL_SIZE: usize = 512 * 1024 * 1024;
 
 #[link(name = "cudart")]
 extern "C" {
@@ -47,10 +46,11 @@ pub fn set_device() -> Result<(), CudaError> {
         ))?;
 
         // 2. Set release threshold to 512 MB
+        let threshold: usize = 512 * 1024 * 1024;
         check(cudaMemPoolSetAttribute(
             pool,
             cudaMemPoolAttrReleaseThreshold,
-            &MEMORY_POOL_SIZE as *const usize as *const c_void,
+            &threshold as *const usize as *const c_void,
         ))?;
 
         // 3. Optional but safe: assign pool back to device

--- a/crates/cuda-common/src/memory_manager.rs
+++ b/crates/cuda-common/src/memory_manager.rs
@@ -4,7 +4,7 @@ use bytesize::ByteSize;
 use lazy_static::lazy_static;
 
 use crate::{
-    common::{set_device, MEMORY_POOL_SIZE},
+    common::set_device,
     error::{check, MemoryError},
     stream::{cudaStreamPerThread, cudaStream_t, default_stream_sync},
 };
@@ -68,9 +68,6 @@ impl MemoryManager {
 
         if let Some(size) = self.allocated_ptrs.remove(&nn) {
             self.current_size -= size;
-            if size >= MEMORY_POOL_SIZE {
-                default_stream_sync().unwrap();
-            }
         } else {
             return Err(MemoryError::UntrackedPointer);
         }


### PR DESCRIPTION
Reverts openvm-org/stark-backend#111

Performance regression in pcs opening: https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/17335892603