### PR TITLE
perf(cuda): Opener in natural order

### DIFF
--- a/crates/cuda-backend/cuda/src/fri.cu
+++ b/crates/cuda-backend/cuda/src/fri.cu
@@ -69,10 +69,9 @@ __global__ void compute_diffs(
 }
 
 // data[i] = g^i for i in 0..N
-__global__ void powers(Fp *__restrict__ data, Fp *__restrict__ d_g, uint32_t N) {
+__global__ void powers(Fp *__restrict__ data, Fp g, uint32_t N) {
     uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     uint32_t stride = blockDim.x * gridDim.x;
-    Fp g = *d_g;
     Fp g_idx = pow(g, idx);
     Fp g_pow = pow(g, stride);
 
@@ -81,10 +80,9 @@ __global__ void powers(Fp *__restrict__ data, Fp *__restrict__ d_g, uint32_t N) 
     }
 }
 
-__global__ void powers_ext(FpExt *__restrict__ data, FpExt *__restrict__ d_g, uint32_t N) {
+__global__ void powers_ext(FpExt *__restrict__ data, FpExt g, uint32_t N) {
     uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     uint32_t stride = blockDim.x * gridDim.x;
-    FpExt g = *d_g;
     FpExt g_idx = pow(g, idx);
     FpExt g_pow = pow(g, stride);
 
@@ -422,14 +420,14 @@ extern "C" int _batch_invert(FpExt *diffs, uint32_t log_max_height, uint32_t inv
     return CHECK_KERNEL();
 }
 
-extern "C" int _powers(Fp *data, Fp *g, uint32_t N) {
+extern "C" int _powers(Fp *data, Fp g, uint32_t N) {
     auto block = FRI_MAX_THREADS;
     auto grid = get_num_sms() * 2;
     powers<<<grid, block>>>(data, g, N);
     return CHECK_KERNEL();
 }
 
-extern "C" int _powers_ext(FpExt *data, FpExt *g, uint32_t N) {
+extern "C" int _powers_ext(FpExt *data, FpExt g, uint32_t N) {
     auto block = FRI_MAX_THREADS;
     auto grid = get_num_sms() * 2;
     powers_ext<<<grid, block>>>(data, g, N);

--- a/crates/cuda-backend/src/cuda/kernels.rs
+++ b/crates/cuda-backend/src/cuda/kernels.rs
@@ -492,8 +492,6 @@ pub mod fri {
             log_max_height: u32,
         ) -> i32;
 
-        fn _fpext_bit_reverse(d_diffs: *mut std::ffi::c_void, log_max_height: u32) -> i32;
-
         fn _batch_invert(
             d_diffs: *mut std::ffi::c_void,
             log_max_height: u32,
@@ -507,9 +505,9 @@ pub mod fri {
             d_quotient_acc: *mut std::ffi::c_void,
             d_matrix: *const std::ffi::c_void,
             d_z_diff_invs: *const std::ffi::c_void,
-            d_matrix_eval: *const std::ffi::c_void,
+            matrix_eval: crate::prelude::EF,
             d_alphas: *const std::ffi::c_void,
-            d_alphas_offset: *const std::ffi::c_void,
+            alpha_offset: crate::prelude::EF,
             width: u32,
             height: u32,
             is_first: bool,
@@ -541,7 +539,6 @@ pub mod fri {
             chunk_size: u32,
             num_chunks: u32,
             matrix_height: u32,
-            inv_denoms_bitrev: bool,
         ) -> i32;
 
         fn _matrix_evaluate_finalize(
@@ -565,13 +562,6 @@ pub mod fri {
             d_domain.as_mut_raw_ptr(),
             log_max_height,
         ))
-    }
-
-    pub unsafe fn fpext_bit_rev_kernel<EF>(
-        d_diffs: &DeviceBuffer<EF>,
-        log_max_height: u32,
-    ) -> Result<(), CudaError> {
-        CudaError::from_result(_fpext_bit_reverse(d_diffs.as_mut_raw_ptr(), log_max_height))
     }
 
     pub unsafe fn batch_invert_kernel<EF>(
@@ -606,9 +596,9 @@ pub mod fri {
         d_quotient_acc: &DeviceBuffer<EF>,
         d_matrix: &DeviceBuffer<F>,
         d_z_diff_invs: &DeviceBuffer<EF>,
-        d_matrix_eval: &DeviceBuffer<EF>,
+        matrix_eval: crate::prelude::EF,
         d_alphas: &DeviceBuffer<EF>,
-        d_alphas_offset: &DeviceBuffer<EF>,
+        alpha_offset: crate::prelude::EF,
         width: u32,
         height: u32,
         is_first: bool,
@@ -617,9 +607,9 @@ pub mod fri {
             d_quotient_acc.as_mut_raw_ptr(),
             d_matrix.as_raw_ptr(),
             d_z_diff_invs.as_raw_ptr(),
-            d_matrix_eval.as_raw_ptr(),
+            matrix_eval,
             d_alphas.as_raw_ptr(),
-            d_alphas_offset.as_raw_ptr(),
+            alpha_offset,
             width,
             height,
             is_first,
@@ -668,7 +658,6 @@ pub mod fri {
         chunk_size: u32,
         num_chunks: u32,
         matrix_height: u32,
-        inv_denoms_bitrev: bool,
     ) -> Result<(), CudaError> {
         CudaError::from_result(_matrix_evaluate_chunked(
             partial_sums.as_mut_raw_ptr(),
@@ -680,7 +669,6 @@ pub mod fri {
             chunk_size,
             num_chunks,
             matrix_height,
-            inv_denoms_bitrev,
         ))
     }
 

--- a/crates/cuda-backend/src/cuda/kernels.rs
+++ b/crates/cuda-backend/src/cuda/kernels.rs
@@ -508,8 +508,9 @@ pub mod fri {
             matrix_eval: crate::prelude::EF,
             d_alphas: *const std::ffi::c_void,
             alpha_offset: crate::prelude::EF,
-            width: u32,
-            height: u32,
+            width: usize,
+            height: usize,
+            max_height: usize,
             is_first: bool,
         ) -> i32;
 
@@ -599,8 +600,9 @@ pub mod fri {
         matrix_eval: crate::prelude::EF,
         d_alphas: &DeviceBuffer<EF>,
         alpha_offset: crate::prelude::EF,
-        width: u32,
-        height: u32,
+        width: usize,
+        height: usize,
+        max_height: usize,
         is_first: bool,
     ) -> Result<(), CudaError> {
         CudaError::from_result(_reduce_matrix_quotient_acc(
@@ -612,6 +614,7 @@ pub mod fri {
             alpha_offset,
             width,
             height,
+            max_height,
             is_first,
         ))
     }

--- a/crates/cuda-backend/src/cuda/kernels.rs
+++ b/crates/cuda-backend/src/cuda/kernels.rs
@@ -500,8 +500,8 @@ pub mod fri {
             invert_task_num: u32,
         ) -> i32;
 
-        fn _powers(d_data: *mut std::ffi::c_void, d_g: *const std::ffi::c_void, N: u32) -> i32;
-        fn _powers_ext(d_data: *mut std::ffi::c_void, d_g: *const std::ffi::c_void, N: u32) -> i32;
+        fn _powers(d_data: *mut std::ffi::c_void, g: crate::prelude::F, N: u32) -> i32;
+        fn _powers_ext(d_data: *mut std::ffi::c_void, g: crate::prelude::EF, N: u32) -> i32;
 
         fn _reduce_matrix_quotient_acc(
             d_quotient_acc: *mut std::ffi::c_void,
@@ -588,18 +588,18 @@ pub mod fri {
 
     pub unsafe fn powers<F>(
         d_data: &DeviceBuffer<F>,
-        d_g: &DeviceBuffer<F>,
+        g: crate::prelude::F,
         n: u32,
     ) -> Result<(), CudaError> {
-        CudaError::from_result(_powers(d_data.as_mut_raw_ptr(), d_g.as_raw_ptr(), n))
+        CudaError::from_result(_powers(d_data.as_mut_raw_ptr(), g, n))
     }
 
     pub unsafe fn powers_ext<EF>(
         d_data: &DeviceBuffer<EF>,
-        d_g: &DeviceBuffer<EF>,
+        g: crate::prelude::EF,
         n: u32,
     ) -> Result<(), CudaError> {
-        CudaError::from_result(_powers_ext(d_data.as_mut_raw_ptr(), d_g.as_raw_ptr(), n))
+        CudaError::from_result(_powers_ext(d_data.as_mut_raw_ptr(), g, n))
     }
 
     pub unsafe fn reduce_matrix_quotient_kernel<F, EF>(

--- a/crates/cuda-backend/src/opener/mod.rs
+++ b/crates/cuda-backend/src/opener/mod.rs
@@ -187,7 +187,7 @@ impl OpeningProverGpu {
                 {
                     let log_height = log2_strict_usize(mat.height());
                     let reduced_opening = reduced_openings[log_height].get_or_insert_with(|| {
-                        DevicePoly::new(true, DeviceBuffer::<EF>::with_capacity(mat.height()))
+                        DevicePoly::new(false, DeviceBuffer::<EF>::with_capacity(mat.height()))
                     });
 
                     let mat = mat.take_lde(mat.height());
@@ -205,6 +205,7 @@ impl OpeningProverGpu {
                             num_reduced[log_height] == 0,
                         )
                         .unwrap();
+                        // println!("reduced_opening: {:?}", reduced_opening.coeff);
                         num_reduced[log_height] += mat.width();
                     }
                 }
@@ -346,7 +347,9 @@ fn commit_phase_on_gpu(
     while folded.len() > blowup * final_poly_len {
         // folded is converted to a matrix over base field with width = 8 and height =
         // folded.len()/2
+        println!("folded: {:?}", folded.coeff);
         let folded_as_matrix = fri_ext_poly_to_base_matrix(&folded).unwrap();
+        println!("folded_as_matrix: {:?}", folded_as_matrix);
         let (log_trace_heights, merkle_tree) = device.commit_trace(folded_as_matrix);
         let (commit, prover_data) = (
             merkle_tree.root(),
@@ -374,7 +377,7 @@ fn commit_phase_on_gpu(
     folded_on_host.truncate(final_poly_len);
 
     // folded was bit reversed, now convert it to non-bit reversed form
-    reverse_slice_index_bits(&mut folded_on_host);
+    // reverse_slice_index_bits(&mut folded_on_host);
 
     // TODO: For better performance, we could run the IDFT on only the first half
     //       (or less, depending on `log_blowup`) of `final_poly`.

--- a/crates/cuda-backend/src/opener/ops.rs
+++ b/crates/cuda-backend/src/opener/ops.rs
@@ -128,13 +128,13 @@ pub(crate) fn reduce_matrix_quotient_acc(
 
     // quotient poly q(x) += alpha^(matrix_offset) * m(z)-m_rlc(x) / (z-x)
     let d_alpha_powers = DeviceBuffer::<EF>::with_capacity(matrix.width());
-    let d_alpha = [alpha].to_device().unwrap();
+    // let d_alpha = [alpha].to_device().unwrap();
     let d_m_eval = [m_z].to_device().unwrap();
     let alpha_offset = alpha.exp_u64(matrix_offset as u64);
     let d_alphas_offset = [alpha_offset].to_device().unwrap();
 
     unsafe {
-        powers_ext(&d_alpha_powers, &d_alpha, matrix.width() as u32).unwrap();
+        powers_ext(&d_alpha_powers, alpha, matrix.width() as u32).unwrap();
         reduce_matrix_quotient_kernel(
             &quotient_acc.coeff,
             matrix.buffer(),
@@ -203,10 +203,10 @@ pub(crate) fn fri_fold(
 
     let half_folded_len = folded.len() / 2;
     let g_invs = DeviceBuffer::<F>::with_capacity(half_folded_len);
-    let d_g_inv = [g_inv.as_base().unwrap()].to_device().unwrap();
+    // let d_g_inv = [g_inv.as_base().unwrap()].to_device().unwrap();
     let d_result = DeviceBuffer::<EF>::with_capacity(half_folded_len);
     unsafe {
-        powers(&g_invs, &d_g_inv, half_folded_len as u32).unwrap();
+        powers(&g_invs, g_inv.as_base().unwrap(), half_folded_len as u32).unwrap();
         batch_bit_reverse(
             &g_invs,
             log2_ceil_usize(half_folded_len) as u32,

--- a/crates/cuda-backend/src/opener/ops.rs
+++ b/crates/cuda-backend/src/opener/ops.rs
@@ -37,7 +37,7 @@ pub(crate) fn compute_inverse_denominators_on_gpu(
         .into_iter()
         .map(|(z, log_height)| {
             let g = F::two_adic_generator(log_height);
-            let diff_invs = get_diff_invs(z, coset_shift, g, log_height, true).unwrap();
+            let diff_invs = get_diff_invs(z, coset_shift, g, log_height, false).unwrap();
             (z, diff_invs)
         })
         .collect()
@@ -193,7 +193,7 @@ pub(crate) fn fri_fold(
     // as we take advantage of the fact g_inv is a base field element if folded.len() <= 2^27
     assert!(log2_strict_usize(folded.len()) <= 27);
     assert!(g_inv.as_base_slice()[1..].iter().all(F::is_zero)); // g_inv.is_in_basefield()
-    assert!(folded.is_bit_reversed);
+    assert!(!folded.is_bit_reversed);
 
     let half_one = (F::ONE / F::from_canonical_usize(2)).into();
     let half_beta = beta * half_one;
@@ -207,12 +207,12 @@ pub(crate) fn fri_fold(
     let d_result = DeviceBuffer::<EF>::with_capacity(half_folded_len);
     unsafe {
         powers(&g_invs, g_inv.as_base().unwrap(), half_folded_len as u32).unwrap();
-        batch_bit_reverse(
-            &g_invs,
-            log2_ceil_usize(half_folded_len) as u32,
-            half_folded_len as u32,
-        )
-        .unwrap();
+        // batch_bit_reverse(
+        //     &g_invs,
+        //     log2_ceil_usize(half_folded_len) as u32,
+        //     half_folded_len as u32,
+        // )
+        // .unwrap();
         fri_fold_kernel(
             &d_result,
             &folded.coeff,

--- a/crates/cuda-backend/src/opener/ops.rs
+++ b/crates/cuda-backend/src/opener/ops.rs
@@ -135,8 +135,9 @@ pub(crate) fn reduce_matrix_quotient_acc(
             m_z,
             &d_alpha_powers,
             alpha_offset,
-            matrix.width().try_into().unwrap(),
-            matrix.height().try_into().unwrap(),
+            matrix.width(),
+            matrix.height(),
+            z_diff_invs.len(),
             is_first,
         )
         .unwrap();


### PR DESCRIPTION
Closes INT-4618

Making all `reduced_openings` polynomial & `z_diff_invs` in natural order.
- We still use z_diff_inv for max height only => double bit reverse required for smaller matrices
- Also I've changed some buffers with one value to just values