### PR TITLE
feat: update root system params for efficient verifier

### DIFF
--- a/crates/stark-backend/src/config.rs
+++ b/crates/stark-backend/src/config.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{hasher::MerkleHasher, interaction::LogUpSecurityParameters};
 
+pub const DEFAULT_K_WHIR: usize = 4;
+
 /// Trait that holds the associated types for the SWIRL protocol. These are the types needed by the
 /// verifier and must be independent of the prover backend.
 ///
@@ -118,7 +120,7 @@ impl SystemParams {
     ) -> SystemParams {
         const WHIR_QUERY_PHASE_POW_BITS: usize = 20;
 
-        let k_whir = 4;
+        let k_whir = DEFAULT_K_WHIR;
         let max_constraint_degree = 4;
         let log_stacked_height = l_skip + n_stack;
 

--- a/crates/stark-backend/tests/soundness.rs
+++ b/crates/stark-backend/tests/soundness.rs
@@ -230,7 +230,7 @@ fn test_internal_aggregation_security() {
 #[test]
 fn test_root_aggregation_security() {
     let params = root_params();
-    let max_log_height = 19;
+    let max_log_height = 21;
     let n_logup = n_logup_bound(
         params.l_skip,
         RECURSION_NUM_AIRS,

--- a/crates/stark-backend/tests/soundness.rs
+++ b/crates/stark-backend/tests/soundness.rs
@@ -298,7 +298,7 @@ fn test_all_production_configs() {
             &root,
             RECURSION_MAX_CONSTRAINTS,
             RECURSION_NUM_AIRS,
-            19,
+            21,
             RECURSION_NUM_COLUMNS,
             RECURSION_MAX_INTERACTIONS_PER_AIR,
         ),

--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -127,7 +127,7 @@ pub fn internal_params_with_100_bits_security() -> SystemParams {
 /// - **Num AIRs**: ≤ 50
 /// - **Max interactions per AIR**: ≤ 100
 /// - **Num trace columns** (unstacked, total across all AIRs): ≤ 2,000
-/// - **`w_stack`** = 16, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
+/// - **`w_stack`** = 9, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
 ///
 /// Config: `l_skip=2, n_stack=19, log_blowup=4`.
 //
@@ -138,7 +138,7 @@ pub fn root_params_with_100_bits_security() -> SystemParams {
         DEFAULT_ROOT_LOG_BLOWUP,
         2,  // l_skip
         19, // n_stack
-        16, // w_stack
+        9,  // w_stack
         WHIR_MAX_LOG_FINAL_POLY_LEN,
         20, // folding pow
         20, // mu pow

--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -137,12 +137,12 @@ pub fn root_params_with_100_bits_security() -> SystemParams {
     SystemParams::new(
         DEFAULT_ROOT_LOG_BLOWUP,
         2,  // l_skip
-        20, // n_stack
-        64, // w_stack
+        19, // n_stack
+        16, // w_stack
         11,
-        18, // folding pow
+        20, // folding pow
         20, // mu pow
-        WhirProximityStrategy::ListDecoding { m: 1 },
+        WhirProximityStrategy::ListDecoding { m: 2 },
         SECURITY_BITS_TARGET,
         log_up_security_params_baby_bear_100_bits(),
     )

--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -122,14 +122,14 @@ pub fn internal_params_with_100_bits_security() -> SystemParams {
 /// Returns `SystemParams` targeting 100 bits of proven RBR security for root circuits.
 ///
 /// # Assumptions for 100-bit security
-/// - **Max trace height**: ≤ 2^22
+/// - **Max trace height**: ≤ 2^21
 /// - **Max constraints per AIR**: ≤ 1,000
 /// - **Num AIRs**: ≤ 50
 /// - **Max interactions per AIR**: ≤ 100
 /// - **Num trace columns** (unstacked, total across all AIRs): ≤ 2,000
-/// - **`w_stack`** = 64, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
+/// - **`w_stack`** = 16, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
 ///
-/// Config: `l_skip=2, n_stack=20, log_blowup=4`.
+/// Config: `l_skip=2, n_stack=19, log_blowup=4`.
 //
 // See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
 // full soundness analysis.
@@ -139,7 +139,7 @@ pub fn root_params_with_100_bits_security() -> SystemParams {
         2,  // l_skip
         19, // n_stack
         16, // w_stack
-        11,
+        WHIR_MAX_LOG_FINAL_POLY_LEN,
         20, // folding pow
         20, // mu pow
         WhirProximityStrategy::ListDecoding { m: 2 },

--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -24,7 +24,7 @@ pub const DEFAULT_APP_L_SKIP: usize = 4;
 pub const DEFAULT_APP_LOG_BLOWUP: usize = 1;
 pub const DEFAULT_LEAF_LOG_BLOWUP: usize = 2;
 pub const DEFAULT_INTERNAL_LOG_BLOWUP: usize = 3;
-pub const DEFAULT_ROOT_LOG_BLOWUP: usize = 3;
+pub const DEFAULT_ROOT_LOG_BLOWUP: usize = 4;
 
 pub const MAX_APP_LOG_STACKED_HEIGHT: usize = 24;
 
@@ -122,14 +122,14 @@ pub fn internal_params_with_100_bits_security() -> SystemParams {
 /// Returns `SystemParams` targeting 100 bits of proven RBR security for root circuits.
 ///
 /// # Assumptions for 100-bit security
-/// - **Max trace height**: ≤ 2^19
+/// - **Max trace height**: ≤ 2^22
 /// - **Max constraints per AIR**: ≤ 1,000
 /// - **Num AIRs**: ≤ 50
 /// - **Max interactions per AIR**: ≤ 100
 /// - **Num trace columns** (unstacked, total across all AIRs): ≤ 2,000
 /// - **`w_stack`** = 64, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
 ///
-/// Config: `l_skip=2, n_stack=17, log_blowup=3`.
+/// Config: `l_skip=2, n_stack=20, log_blowup=4`.
 //
 // See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
 // full soundness analysis.
@@ -137,12 +137,12 @@ pub fn root_params_with_100_bits_security() -> SystemParams {
     SystemParams::new(
         DEFAULT_ROOT_LOG_BLOWUP,
         2,  // l_skip
-        17, // n_stack
+        20, // n_stack
         64, // w_stack
-        WHIR_MAX_LOG_FINAL_POLY_LEN,
+        11,
         18, // folding pow
         20, // mu pow
-        WhirProximityStrategy::ListDecoding { m: 2 },
+        WhirProximityStrategy::ListDecoding { m: 1 },
         SECURITY_BITS_TARGET,
         log_up_security_params_baby_bear_100_bits(),
     )


### PR DESCRIPTION
Making the root params closer to the old compression params. We need the verifier cost to be as small as possible for the static verifier.

closes INT-6650