### PR TITLE
fix(cuda): bn254 prover performance

### DIFF
--- a/crates/cuda-backend/cuda/include/poseidon2_bn254.cuh
+++ b/crates/cuda-backend/cuda/include/poseidon2_bn254.cuh
@@ -6,7 +6,7 @@
 ///   - Field add / sub / neg / double / x^5 S-box
 ///   - MDS layers for WIDTH = 3 (external and internal)
 ///   - bn254_from_canonical / bn254_to_canonical conversions
-///   - reduce_32 (pack BabyBear → Bn254Fr) for both num_f_elms=7 (Merkle) and num_f_elms=3 (challenger)
+///   - reduce_32 (pack BabyBear → Bn254Fr) for both num_f_elms=8 (Merkle) and num_f_elms=3 (challenger)
 ///   - split_32 (unpack Bn254Fr → BabyBear canonical u32) for num_f_elms=3 (challenger)
 ///
 /// All functions are pure computation (no globals). The Poseidon2 permutation

--- a/crates/cuda-backend/cuda/include/poseidon2_bn254.cuh
+++ b/crates/cuda-backend/cuda/include/poseidon2_bn254.cuh
@@ -257,7 +257,7 @@ void bn254_to_canonical(uint64_t canonical[4], Bn254Fr x) {
 // ---------------------------------------------------------------------------
 // reduce_32: pack BabyBear canonical u32 values into one Bn254Fr
 //
-//   num_f_elms = 7  (Merkle hash, MultiField32PaddingFreeSponge)
+//   num_f_elms = 8  (Merkle hash, MultiField32PaddingFreeSponge)
 //   num_f_elms = 3  (Challenger, MultiField32Challenger)
 //
 // Formula: result = sum_{i=0}^{n-1} bb[i] * 2^{32*i}  (as a BN254 scalar)

--- a/crates/cuda-backend/cuda/src/bn254_poseidon2.cu
+++ b/crates/cuda-backend/cuda/src/bn254_poseidon2.cu
@@ -116,8 +116,8 @@ Bn254Fr bn254_row_hash(const Fp* matrix, int width, int height, int row) {
     for (int col = 0; col < width; col++) {
         buf[cnt++] = matrix[col * height + row].asUInt32();
         if (cnt == BN254_BABY_BEAR_RATE) {
-            state[0] = bn254_reduce_32(buf, 8);
-            state[1] = bn254_reduce_32(buf + 8, 8);
+            state[0] = bn254_reduce_32(buf, BN254_NUM_F_ELMS);
+            state[1] = bn254_reduce_32(buf + BN254_NUM_F_ELMS, BN254_NUM_F_ELMS);
             bn254_poseidon2_permute(state);
             cnt = 0;
         }
@@ -148,8 +148,8 @@ Bn254Fr bn254_row_hash_ext(const FpExt* matrix, int width, int height, int row) 
         for (int d = 0; d < 4; d++) {
             buf[cnt++] = elem.elems[d].asUInt32();
             if (cnt == BN254_BABY_BEAR_RATE) {
-                state[0] = bn254_reduce_32(buf, 8);
-                state[1] = bn254_reduce_32(buf + 8, 8);
+                state[0] = bn254_reduce_32(buf, BN254_NUM_F_ELMS);
+                state[1] = bn254_reduce_32(buf + BN254_NUM_F_ELMS, BN254_NUM_F_ELMS);
                 bn254_poseidon2_permute(state);
                 cnt = 0;
             }

--- a/crates/cuda-backend/cuda/src/bn254_poseidon2.cu
+++ b/crates/cuda-backend/cuda/src/bn254_poseidon2.cu
@@ -368,8 +368,10 @@ __device__ bool bn254_sponge_check_witness(DeviceBn254SpongeState& s,
     return (sample & ((1u << bits) - 1)) == 0;
 }
 
+static const uint32_t BN254_GRIND_BLOCK_SIZE = 32;
+
 /// Grinding kernel: find any w in [min_witness, max_witness] with check_witness(bits,w)==true.
-__launch_bounds__(32) __global__ void bn254_grind_kernel(
+__launch_bounds__(BN254_GRIND_BLOCK_SIZE) __global__ void bn254_grind_kernel(
     const DeviceBn254SpongeState* init_state,
     uint32_t bits,
     uint32_t min_witness,
@@ -475,7 +477,7 @@ extern "C" int _bn254_sponge_grind(
     uint32_t max_witness,
     uint32_t* result
 ) {
-    const size_t block_size = 32;
+    const size_t block_size = BN254_GRIND_BLOCK_SIZE;
     size_t total_threads = size_t{1} << bits;
     size_t grid_size = div_ceil(total_threads, block_size);
 

--- a/crates/cuda-backend/cuda/src/bn254_poseidon2.cu
+++ b/crates/cuda-backend/cuda/src/bn254_poseidon2.cu
@@ -92,11 +92,11 @@ Bn254Fr bn254_zero_init() {
 //
 // Matches MultiField32PaddingFreeSponge<BabyBear, Bn254Scalar, Perm, 3, 16, 1>:
 //   BABY_BEAR_RATE = 16  BabyBear values absorbed per permutation
-//   NUM_F_ELMS = 7       BabyBear values packed per Bn254Fr (floor(254/32) = 7)
+//   NUM_F_ELMS = 8       BabyBear values packed per Bn254Fr (floor(254/31) = 8)
 // ---------------------------------------------------------------------------
 
 static const int BN254_BABY_BEAR_RATE = 16;
-static const int BN254_NUM_F_ELMS    = 7;
+static const int BN254_NUM_F_ELMS    = 8;
 
 // ---------------------------------------------------------------------------
 // Row hash helpers
@@ -116,9 +116,8 @@ Bn254Fr bn254_row_hash(const Fp* matrix, int width, int height, int row) {
     for (int col = 0; col < width; col++) {
         buf[cnt++] = matrix[col * height + row].asUInt32();
         if (cnt == BN254_BABY_BEAR_RATE) {
-            state[0] = bn254_reduce_32(buf,      7);
-            state[1] = bn254_reduce_32(buf + 7,  7);
-            state[2] = bn254_reduce_32(buf + 14, 2);
+            state[0] = bn254_reduce_32(buf, 8);
+            state[1] = bn254_reduce_32(buf + 8, 8);
             bn254_poseidon2_permute(state);
             cnt = 0;
         }
@@ -128,9 +127,6 @@ Bn254Fr bn254_row_hash(const Fp* matrix, int width, int height, int row) {
         if (cnt > BN254_NUM_F_ELMS)
             state[1] = bn254_reduce_32(buf + BN254_NUM_F_ELMS,
                                        min(BN254_NUM_F_ELMS, cnt - BN254_NUM_F_ELMS));
-        if (cnt > 2 * BN254_NUM_F_ELMS)
-            state[2] = bn254_reduce_32(buf + 2 * BN254_NUM_F_ELMS,
-                                       cnt - 2 * BN254_NUM_F_ELMS);
         bn254_poseidon2_permute(state);
     }
     return state[0];
@@ -152,9 +148,8 @@ Bn254Fr bn254_row_hash_ext(const FpExt* matrix, int width, int height, int row) 
         for (int d = 0; d < 4; d++) {
             buf[cnt++] = elem.elems[d].asUInt32();
             if (cnt == BN254_BABY_BEAR_RATE) {
-                state[0] = bn254_reduce_32(buf,      7);
-                state[1] = bn254_reduce_32(buf + 7,  7);
-                state[2] = bn254_reduce_32(buf + 14, 2);
+                state[0] = bn254_reduce_32(buf, 8);
+                state[1] = bn254_reduce_32(buf + 8, 8);
                 bn254_poseidon2_permute(state);
                 cnt = 0;
             }
@@ -165,9 +160,6 @@ Bn254Fr bn254_row_hash_ext(const FpExt* matrix, int width, int height, int row) 
         if (cnt > BN254_NUM_F_ELMS)
             state[1] = bn254_reduce_32(buf + BN254_NUM_F_ELMS,
                                        min(BN254_NUM_F_ELMS, cnt - BN254_NUM_F_ELMS));
-        if (cnt > 2 * BN254_NUM_F_ELMS)
-            state[2] = bn254_reduce_32(buf + 2 * BN254_NUM_F_ELMS,
-                                       cnt - 2 * BN254_NUM_F_ELMS);
         bn254_poseidon2_permute(state);
     }
     return state[0];
@@ -376,7 +368,7 @@ __device__ bool bn254_sponge_check_witness(DeviceBn254SpongeState& s,
     return (sample & ((1u << bits) - 1)) == 0;
 }
 
-/// Grinding kernel: find smallest w in [min_witness, max_witness] with check_witness(bits,w)==true.
+/// Grinding kernel: find any w in [min_witness, max_witness] with check_witness(bits,w)==true.
 __launch_bounds__(32) __global__ void bn254_grind_kernel(
     const DeviceBn254SpongeState* init_state,
     uint32_t bits,
@@ -388,14 +380,14 @@ __launch_bounds__(32) __global__ void bn254_grind_kernel(
     const uint32_t stride = gridDim.x * blockDim.x;
     uint32_t w = min_witness + tid;
 
-    if (w > max_witness || *result < w) return;
+    if (w > max_witness || *result != UINT32_MAX) return;
 
     while (w <= max_witness) {
-        if (*result < w) return;
+        if (*result != UINT32_MAX) return;
 
         DeviceBn254SpongeState local_state = *init_state;
         if (bn254_sponge_check_witness(local_state, bits, w)) {
-            atomicMin(result, w);
+            atomicCAS(result, UINT32_MAX, w);
             return;
         }
 

--- a/crates/cuda-backend/cuda/src/sponge.cu
+++ b/crates/cuda-backend/cuda/src/sponge.cu
@@ -55,8 +55,8 @@ __device__ bool sponge_check_witness(DeviceSpongeState& sponge, uint32_t bits, F
 /**
  * Grinding kernel - finds a witness value such that check_witness(bits, witness) returns true.
  * 
- * Each thread searches a strided subset of the search space.
- * When a valid witness is found, it's atomically stored to g_grind_result.
+ * Each thread checks one witness candidate in the current chunk.
+ * When a valid witness is found, the first discovered witness is stored.
  * 
  * @param init_state Initial sponge state (before observing the witness)
  * @param bits Number of bits that must be zero in the sampled value
@@ -70,7 +70,7 @@ __global__ void grind_kernel(
     uint32_t* result
 ) {
     uint32_t w = min_witness + blockIdx.x * blockDim.x + threadIdx.x;
-    if (w > max_witness || *result < w) {
+    if (w > max_witness || *result != UINT32_MAX) {
         return;
     }
 
@@ -80,8 +80,8 @@ __global__ void grind_kernel(
     // Check if this witness value works
     Fp witness = Fp(w);
     if (sponge_check_witness(local_state, bits, witness)) {
-        // Found a valid witness - record it atomically
-        atomicMin(result, w);
+        // Found a valid witness - keep the first one discovered.
+        atomicCAS(result, UINT32_MAX, w);
         return;
     }
 }

--- a/crates/cuda-backend/src/bn254_sponge.rs
+++ b/crates/cuda-backend/src/bn254_sponge.rs
@@ -320,8 +320,7 @@ impl GpuFiatShamirTranscript<BabyBearBn254Poseidon2Config> for MultiField32Chall
 
 #[cfg(test)]
 mod tests {
-    use openvm_stark_backend::FiatShamirTranscript;
-    use openvm_stark_backend::p3_symmetric::CryptographicHasher;
+    use openvm_stark_backend::{p3_symmetric::CryptographicHasher, FiatShamirTranscript};
     use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::default_transcript;
     use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::MultiField32PaddingFreeSponge;
@@ -598,11 +597,10 @@ mod tests {
     fn test_grind_gpu_matches_cpu_after_large_commit_observes() {
         let mut gpu = MultiField32ChallengerGpu::new();
         let mut cpu = default_transcript();
-        let hash =
-            MultiField32PaddingFreeSponge::<BabyBear, Bn254Scalar, _, 3, 16, 1>::new(
-                default_babybear_bn254_poseidon2(),
-            )
-            .unwrap();
+        let hash = MultiField32PaddingFreeSponge::<BabyBear, Bn254Scalar, _, 3, 16, 1>::new(
+            default_babybear_bn254_poseidon2(),
+        )
+        .unwrap();
 
         for seed in [17u32, 113, 997] {
             let digest = hash.hash_slice(

--- a/crates/cuda-backend/src/bn254_sponge.rs
+++ b/crates/cuda-backend/src/bn254_sponge.rs
@@ -321,8 +321,10 @@ impl GpuFiatShamirTranscript<BabyBearBn254Poseidon2Config> for MultiField32Chall
 #[cfg(test)]
 mod tests {
     use openvm_stark_backend::FiatShamirTranscript;
+    use openvm_stark_backend::p3_symmetric::CryptographicHasher;
     use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::default_transcript;
     use p3_field::PrimeCharacteristicRing;
+    use p3_symmetric::MultiField32PaddingFreeSponge;
 
     use super::*;
 
@@ -590,5 +592,51 @@ mod tests {
         ];
 
         run_steps(&steps);
+    }
+
+    #[test]
+    fn test_grind_gpu_matches_cpu_after_large_commit_observes() {
+        let mut gpu = MultiField32ChallengerGpu::new();
+        let mut cpu = default_transcript();
+        let hash =
+            MultiField32PaddingFreeSponge::<BabyBear, Bn254Scalar, _, 3, 16, 1>::new(
+                default_babybear_bn254_poseidon2(),
+            )
+            .unwrap();
+
+        for seed in [17u32, 113, 997] {
+            let digest = hash.hash_slice(
+                &(0..48)
+                    .map(|i| BabyBear::from_u32(seed.wrapping_mul(i + 1).wrapping_add(i * 7)))
+                    .collect::<Vec<_>>(),
+            );
+            FiatShamirTranscript::<BabyBearBn254Poseidon2Config>::observe_commit(&mut gpu, digest);
+            FiatShamirTranscript::<BabyBearBn254Poseidon2Config>::observe_commit(&mut cpu, digest);
+        }
+
+        for i in 0..7u32 {
+            let value = BabyBear::from_u32(i.wrapping_mul(97).wrapping_add(11));
+            FiatShamirTranscript::<BabyBearBn254Poseidon2Config>::observe(&mut gpu, value);
+            FiatShamirTranscript::<BabyBearBn254Poseidon2Config>::observe(&mut cpu, value);
+        }
+
+        let witness = gpu.grind_gpu(12).expect("GPU grind should succeed");
+        FiatShamirTranscript::<BabyBearBn254Poseidon2Config>::observe(&mut cpu, witness);
+        assert!(
+            (FiatShamirTranscript::<BabyBearBn254Poseidon2Config>::sample(&mut cpu)
+                .as_canonical_u32()
+                & ((1 << 12) - 1))
+                == 0,
+            "CPU transcript rejected GPU witness"
+        );
+
+        for sample_idx in 0..12 {
+            let gpu_sample = FiatShamirTranscript::<BabyBearBn254Poseidon2Config>::sample(&mut gpu);
+            let cpu_sample = FiatShamirTranscript::<BabyBearBn254Poseidon2Config>::sample(&mut cpu);
+            assert_eq!(
+                gpu_sample, cpu_sample,
+                "post-grind sample mismatch at index {sample_idx}"
+            );
+        }
     }
 }

--- a/crates/cuda-backend/src/bn254_sponge.rs
+++ b/crates/cuda-backend/src/bn254_sponge.rs
@@ -320,10 +320,9 @@ impl GpuFiatShamirTranscript<BabyBearBn254Poseidon2Config> for MultiField32Chall
 
 #[cfg(test)]
 mod tests {
-    use openvm_stark_backend::{p3_symmetric::CryptographicHasher, FiatShamirTranscript};
+    use openvm_stark_backend::FiatShamirTranscript;
     use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::default_transcript;
     use p3_field::PrimeCharacteristicRing;
-    use p3_symmetric::MultiField32PaddingFreeSponge;
 
     use super::*;
 
@@ -591,50 +590,5 @@ mod tests {
         ];
 
         run_steps(&steps);
-    }
-
-    #[test]
-    fn test_grind_gpu_matches_cpu_after_large_commit_observes() {
-        let mut gpu = MultiField32ChallengerGpu::new();
-        let mut cpu = default_transcript();
-        let hash = MultiField32PaddingFreeSponge::<BabyBear, Bn254Scalar, _, 3, 16, 1>::new(
-            default_babybear_bn254_poseidon2(),
-        )
-        .unwrap();
-
-        for seed in [17u32, 113, 997] {
-            let digest = hash.hash_slice(
-                &(0..48)
-                    .map(|i| BabyBear::from_u32(seed.wrapping_mul(i + 1).wrapping_add(i * 7)))
-                    .collect::<Vec<_>>(),
-            );
-            FiatShamirTranscript::<BabyBearBn254Poseidon2Config>::observe_commit(&mut gpu, digest);
-            FiatShamirTranscript::<BabyBearBn254Poseidon2Config>::observe_commit(&mut cpu, digest);
-        }
-
-        for i in 0..7u32 {
-            let value = BabyBear::from_u32(i.wrapping_mul(97).wrapping_add(11));
-            FiatShamirTranscript::<BabyBearBn254Poseidon2Config>::observe(&mut gpu, value);
-            FiatShamirTranscript::<BabyBearBn254Poseidon2Config>::observe(&mut cpu, value);
-        }
-
-        let witness = gpu.grind_gpu(12).expect("GPU grind should succeed");
-        FiatShamirTranscript::<BabyBearBn254Poseidon2Config>::observe(&mut cpu, witness);
-        assert!(
-            (FiatShamirTranscript::<BabyBearBn254Poseidon2Config>::sample(&mut cpu)
-                .as_canonical_u32()
-                & ((1 << 12) - 1))
-                == 0,
-            "CPU transcript rejected GPU witness"
-        );
-
-        for sample_idx in 0..12 {
-            let gpu_sample = FiatShamirTranscript::<BabyBearBn254Poseidon2Config>::sample(&mut gpu);
-            let cpu_sample = FiatShamirTranscript::<BabyBearBn254Poseidon2Config>::sample(&mut cpu);
-            assert_eq!(
-                gpu_sample, cpu_sample,
-                "post-grind sample mismatch at index {sample_idx}"
-            );
-        }
     }
 }

--- a/crates/cuda-backend/src/merkle_tree.rs
+++ b/crates/cuda-backend/src/merkle_tree.rs
@@ -97,37 +97,6 @@ impl<F, Digest> MerkleTreeGpu<F, Digest> {
 
 // Base field merkle tree — generic constructor
 impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
-    fn batch_open_rows_host(
-        backing_matrices: &[&DeviceMatrix<F>],
-        query_indices: &[usize],
-        query_stride: usize,
-        rows_per_query: usize,
-    ) -> Result<Vec<Vec<Vec<F>>>, MerkleTreeError> {
-        backing_matrices
-            .iter()
-            .map(|matrix| {
-                let width = matrix.width();
-                let height = matrix.height();
-                let host = matrix.to_host()?;
-                let opened_rows_per_query = query_indices
-                    .iter()
-                    .map(|&query_idx| {
-                        debug_assert!(query_idx < query_stride);
-                        let mut opened = Vec::with_capacity(rows_per_query * width);
-                        for row_offset in 0..rows_per_query {
-                            let row_idx = row_offset * query_stride + query_idx;
-                            for col_idx in 0..width {
-                                opened.push(host[col_idx * height + row_idx]);
-                            }
-                        }
-                        opened
-                    })
-                    .collect_vec();
-                Ok(opened_rows_per_query)
-            })
-            .collect()
-    }
-
     /// Build a Merkle tree using the given hash scheme `MH`.
     ///
     /// This is the primary constructor; `new()` is a convenience wrapper that
@@ -217,14 +186,6 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
         >,
         MerkleTreeError,
     > {
-        if backing_matrices.len() > 1 {
-            return Self::batch_open_rows_host(
-                backing_matrices,
-                query_indices,
-                query_stride,
-                rows_per_query,
-            );
-        }
         let row_idxs = query_indices
             .iter()
             .flat_map(|&query_idx| {

--- a/crates/cuda-backend/src/merkle_tree.rs
+++ b/crates/cuda-backend/src/merkle_tree.rs
@@ -9,17 +9,6 @@ use openvm_cuda_common::{
 use openvm_stark_backend::prover::MatrixDimensions;
 use p3_util::log2_strict_usize;
 use tracing::instrument;
-#[cfg(feature = "baby-bear-bn254-poseidon2")]
-use {
-    openvm_stark_backend::{
-        hasher::{Hasher as CpuMerkleHasher, MerkleHasher},
-        p3_symmetric::{MultiField32PaddingFreeSponge, TruncatedPermutation},
-    },
-    openvm_stark_sdk::config::baby_bear_bn254_poseidon2::{
-        default_babybear_bn254_poseidon2, Bn254Scalar,
-    },
-    p3_field::PrimeCharacteristicRing,
-};
 
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 use crate::cuda::bn254_merkle_tree::Bn254Digest;
@@ -294,86 +283,13 @@ impl MerkleTreeConstructor for Poseidon2MerkleHash {
 }
 
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
-impl MerkleTreeGpu<F, Bn254Digest> {
-    fn bn254_host_hasher() -> CpuMerkleHasher<
-        F,
-        Bn254Digest,
-        MultiField32PaddingFreeSponge<F, Bn254Scalar, p3_bn254::Poseidon2Bn254<3>, 3, 16, 1>,
-        TruncatedPermutation<p3_bn254::Poseidon2Bn254<3>, 2, 1, 3>,
-    > {
-        let perm = default_babybear_bn254_poseidon2();
-        CpuMerkleHasher::new(
-            MultiField32PaddingFreeSponge::new(perm.clone()).unwrap(),
-            TruncatedPermutation::new(perm),
-        )
-    }
-
-    fn new_bn254_host(
-        matrix: DeviceMatrix<F>,
-        rows_per_query: usize,
-        cache_backing_matrix: bool,
-    ) -> Result<Self, MerkleTreeError> {
-        let height = matrix.height();
-        assert!(height.is_power_of_two());
-        assert!(
-            rows_per_query <= height,
-            "rows_per_query ({rows_per_query}) must not exceed height ({height})"
-        );
-        let query_stride = height / rows_per_query;
-        let width = matrix.width();
-        let hasher = Self::bn254_host_hasher();
-        let host = matrix.to_host()?;
-        let mut row_buf = vec![F::ZERO; width];
-        let mut leaf_hashes = Vec::with_capacity(rows_per_query);
-        let mut query_digest_layer = Vec::with_capacity(query_stride);
-        for query_idx in 0..query_stride {
-            leaf_hashes.clear();
-            for row_offset in 0..rows_per_query {
-                let row_idx = row_offset * query_stride + query_idx;
-                for col_idx in 0..width {
-                    row_buf[col_idx] = host[col_idx * height + row_idx];
-                }
-                leaf_hashes.push(hasher.hash_slice(&row_buf));
-            }
-            query_digest_layer.push(hasher.tree_compress(std::mem::take(&mut leaf_hashes)));
-        }
-
-        let mut digest_layers_host = vec![query_digest_layer];
-        while digest_layers_host.last().unwrap().len() > 1 {
-            let prev_layer = digest_layers_host.last().unwrap();
-            let layer = prev_layer
-                .chunks_exact(2)
-                .map(|pair| hasher.compress(pair[0], pair[1]))
-                .collect_vec();
-            digest_layers_host.push(layer);
-        }
-
-        let root = *digest_layers_host.last().unwrap().first().unwrap();
-        let digest_layers = digest_layers_host
-            .into_iter()
-            .map(|layer| layer.to_device())
-            .collect::<Result<Vec<_>, _>>()?;
-        let backing_matrix = cache_backing_matrix.then_some(matrix);
-
-        Ok(Self {
-            backing_matrix,
-            digest_layers,
-            rows_per_query,
-            root,
-        })
-    }
-}
-
-#[cfg(feature = "baby-bear-bn254-poseidon2")]
 impl MerkleTreeConstructor for crate::hash_scheme::Bn254Poseidon2MerkleHash {
     fn new_merkle_tree(
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
     ) -> Result<MerkleTreeGpu<F, Self::Digest>, MerkleTreeError> {
-        // BN254 Merkle leaves must match the CPU verifier byte-for-byte. Build these layers on the
-        // host and upload them to avoid CUDA leaf-hash drift on the root proving path.
-        MerkleTreeGpu::<F, Self::Digest>::new_bn254_host(
+        MerkleTreeGpu::<F, Self::Digest>::new_generic_with_hash::<Self>(
             matrix,
             rows_per_query,
             cache_backing_matrix,
@@ -427,35 +343,10 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
             .collect()
     }
 
-    /// Batch queries multiple `trees` at _the same_ `query_indices` for merkle proofs.
-    ///
-    /// # Assumptions
-    /// - All `trees` have the same depth.
-    pub fn batch_query_merkle_proofs(
+    fn batch_query_merkle_proofs_device(
         trees: &[&Self],
         query_indices: &[usize],
-    ) -> Result<
-        Vec<
-            // per tree
-            Vec<
-                // per query index
-                Vec<D>, // merkle proof
-            >,
-        >,
-        MerkleTreeError,
-    >
-    where
-        D: MerkleProofQueryDigest,
-    {
-        D::batch_query_merkle_proofs(trees, query_indices)
-    }
-}
-
-impl MerkleProofQueryDigest for Digest {
-    fn batch_query_merkle_proofs(
-        trees: &[&MerkleTreeGpu<F, Self>],
-        query_indices: &[usize],
-    ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError> {
+    ) -> Result<Vec<Vec<Vec<D>>>, MerkleTreeError> {
         // The kernel treats each layer as a separate array and does parallel accesses;
         // we lay out all the layer pointers flattened into a vec.
         let num_trees = trees.len();
@@ -523,7 +414,7 @@ impl MerkleProofQueryDigest for Digest {
                                 let base =
                                     (query_idx * num_trees * depth + tree_idx * depth + layer_idx)
                                         * DIGEST_SIZE;
-                                Self::reconstruct_from_f(&out, base)
+                                D::reconstruct_from_f(&out, base)
                             })
                             .collect_vec()
                     })
@@ -531,6 +422,38 @@ impl MerkleProofQueryDigest for Digest {
             })
             .collect_vec();
         Ok(res)
+    }
+
+    /// Batch queries multiple `trees` at _the same_ `query_indices` for merkle proofs.
+    ///
+    /// # Assumptions
+    /// - All `trees` have the same depth.
+    pub fn batch_query_merkle_proofs(
+        trees: &[&Self],
+        query_indices: &[usize],
+    ) -> Result<
+        Vec<
+            // per tree
+            Vec<
+                // per query index
+                Vec<D>, // merkle proof
+            >,
+        >,
+        MerkleTreeError,
+    >
+    where
+        D: MerkleProofQueryDigest,
+    {
+        D::batch_query_merkle_proofs(trees, query_indices)
+    }
+}
+
+impl MerkleProofQueryDigest for Digest {
+    fn batch_query_merkle_proofs(
+        trees: &[&MerkleTreeGpu<F, Self>],
+        query_indices: &[usize],
+    ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError> {
+        MerkleTreeGpu::<F, Self>::batch_query_merkle_proofs_device(trees, query_indices)
     }
 }
 
@@ -540,8 +463,6 @@ impl MerkleProofQueryDigest for Bn254Digest {
         trees: &[&MerkleTreeGpu<F, Self>],
         query_indices: &[usize],
     ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError> {
-        // BN254 digests are a raw 32-byte scalar, so host reconstruction is the safest path
-        // for Merkle proof extraction.
         MerkleTreeGpu::<F, Self>::batch_query_merkle_proofs_host(trees, query_indices)
     }
 }

--- a/crates/cuda-backend/src/merkle_tree.rs
+++ b/crates/cuda-backend/src/merkle_tree.rs
@@ -274,7 +274,7 @@ impl MerkleTreeGpu<F, Digest> {
 
 // Base field merkle tree — generic batch query (works for any BatchQueryMerkle digest)
 impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
-    fn batch_query_merkle_proofs_device(
+    fn batch_query_proofs(
         trees: &[&Self],
         query_indices: &[usize],
     ) -> Result<Vec<Vec<Vec<D>>>, MerkleTreeError> {
@@ -384,7 +384,7 @@ impl MerkleProofQueryDigest for Digest {
         trees: &[&MerkleTreeGpu<F, Self>],
         query_indices: &[usize],
     ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError> {
-        MerkleTreeGpu::<F, Self>::batch_query_merkle_proofs_device(trees, query_indices)
+        MerkleTreeGpu::<F, Self>::batch_query_proofs(trees, query_indices)
     }
 }
 
@@ -394,7 +394,7 @@ impl MerkleProofQueryDigest for Bn254Digest {
         trees: &[&MerkleTreeGpu<F, Self>],
         query_indices: &[usize],
     ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError> {
-        MerkleTreeGpu::<F, Self>::batch_query_merkle_proofs_device(trees, query_indices)
+        MerkleTreeGpu::<F, Self>::batch_query_proofs(trees, query_indices)
     }
 }
 

--- a/crates/cuda-backend/src/merkle_tree.rs
+++ b/crates/cuda-backend/src/merkle_tree.rs
@@ -313,36 +313,6 @@ impl MerkleTreeGpu<F, Digest> {
 
 // Base field merkle tree — generic batch query (works for any BatchQueryMerkle digest)
 impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
-    #[cfg(feature = "baby-bear-bn254-poseidon2")]
-    fn batch_query_merkle_proofs_host(
-        trees: &[&Self],
-        query_indices: &[usize],
-    ) -> Result<Vec<Vec<Vec<D>>>, MerkleTreeError> {
-        trees
-            .iter()
-            .map(|tree| {
-                let host_layers = tree
-                    .digest_layers
-                    .iter()
-                    .take(tree.proof_depth())
-                    .map(|layer| layer.to_host())
-                    .collect::<Result<Vec<_>, _>>()?;
-                let proofs = query_indices
-                    .iter()
-                    .map(|&index| {
-                        debug_assert!(index < tree.query_stride());
-                        host_layers
-                            .iter()
-                            .enumerate()
-                            .map(|(layer_idx, layer)| layer[(index >> layer_idx) ^ 1])
-                            .collect_vec()
-                    })
-                    .collect::<Vec<_>>();
-                Ok(proofs)
-            })
-            .collect()
-    }
-
     fn batch_query_merkle_proofs_device(
         trees: &[&Self],
         query_indices: &[usize],
@@ -463,7 +433,7 @@ impl MerkleProofQueryDigest for Bn254Digest {
         trees: &[&MerkleTreeGpu<F, Self>],
         query_indices: &[usize],
     ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError> {
-        MerkleTreeGpu::<F, Self>::batch_query_merkle_proofs_host(trees, query_indices)
+        MerkleTreeGpu::<F, Self>::batch_query_merkle_proofs_device(trees, query_indices)
     }
 }
 

--- a/crates/cuda-backend/src/tests.rs
+++ b/crates/cuda-backend/src/tests.rs
@@ -5,6 +5,7 @@
 //! GPU-specific tests (monomial vs DAG, stacked reduction) remain here.
 //! Additional GPU-specific test cases for parameterized shared tests are added below.
 
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
 use std::sync::Arc;
 
 use itertools::Itertools;
@@ -35,7 +36,9 @@ use openvm_stark_sdk::{
     },
     utils::setup_tracing_with_log_level,
 };
-use p3_field::{reduce_32, BasedVectorSpace, PrimeCharacteristicRing, TwoAdicField};
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
+use p3_field::{reduce_32, BasedVectorSpace};
+use p3_field::{PrimeCharacteristicRing, TwoAdicField};
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 use p3_symmetric::Permutation;
 use test_case::test_case;

--- a/crates/cuda-backend/src/tests.rs
+++ b/crates/cuda-backend/src/tests.rs
@@ -5,7 +5,16 @@
 //! GPU-specific tests (monomial vs DAG, stacked reduction) remain here.
 //! Additional GPU-specific test cases for parameterized shared tests are added below.
 
+use std::sync::Arc;
+
 use itertools::Itertools;
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
+use openvm_cuda_common::copy::{MemCopyD2H, MemCopyH2D};
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
+use openvm_stark_backend::{
+    hasher::{Hasher as CpuMerkleHasher, MerkleHasher},
+    p3_symmetric::{MultiField32PaddingFreeSponge, TruncatedPermutation},
+};
 use openvm_stark_backend::{
     prover::{
         stacked_pcs::stacked_commit,
@@ -22,7 +31,13 @@ use openvm_stark_sdk::{
     },
     utils::setup_tracing_with_log_level,
 };
-use p3_field::{PrimeCharacteristicRing, TwoAdicField};
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
+use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::{
+    default_babybear_bn254_poseidon2, Bn254Scalar,
+};
+use p3_field::{reduce_32, PrimeCharacteristicRing, TwoAdicField};
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
+use p3_symmetric::Permutation;
 use test_case::test_case;
 use tracing::{debug, Level};
 
@@ -31,6 +46,8 @@ use crate::{
     sponge::DuplexSpongeGpu,
     BabyBearPoseidon2GpuEngine, GpuBackend,
 };
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
+use crate::{base::DeviceMatrix, cuda::bn254_merkle_tree::Bn254Digest, merkle_tree::MerkleTreeGpu};
 
 type RefEngine = BabyBearPoseidon2RefEngine<DuplexSponge>;
 type Engine = RefEngine;
@@ -54,7 +71,9 @@ openvm_backend_tests::backend_test_suite!(Engine);
 #[test_case(2, 1   ; "log_trace_degree_1_lt_l_skip")]
 #[test_case(2, 0   ; "log_trace_degree_0_lt_l_skip")]
 fn test_bn254_fib_air_roundtrip(l_skip: usize, log_trace_degree: usize) {
-    use openvm_stark_backend::{test_utils::FibFixture, SystemParams, WhirConfig, WhirParams};
+    use openvm_stark_backend::{
+        test_utils::FibFixture, SystemParams, WhirConfig, WhirParams, WhirProximityStrategy,
+    };
     use openvm_stark_sdk::config::log_up_params::log_up_security_params_baby_bear_100_bits;
 
     setup_tracing_with_log_level(Level::DEBUG);
@@ -66,6 +85,9 @@ fn test_bn254_fib_air_roundtrip(l_skip: usize, log_trace_degree: usize) {
         k: k_whir,
         log_final_poly_len: k_whir,
         query_phase_pow_bits: 1,
+        proximity: WhirProximityStrategy::UniqueDecoding,
+        folding_pow_bits: 1,
+        mu_pow_bits: 1,
     };
     let log_blowup = 1;
     let whir = WhirConfig::new(log_blowup, l_skip + n_stack, whir_params, 80);
@@ -87,6 +109,159 @@ fn test_bn254_fib_air_roundtrip(l_skip: usize, log_trace_degree: usize) {
     engine
         .verify(&vk, &proof)
         .expect("BN254 verification failed");
+}
+
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
+fn bn254_host_merkle_layers(
+    matrix: &[F],
+    height: usize,
+    width: usize,
+    rows_per_query: usize,
+) -> Vec<Vec<Bn254Digest>> {
+    let perm = default_babybear_bn254_poseidon2();
+    let hasher = CpuMerkleHasher::new(
+        MultiField32PaddingFreeSponge::<F, Bn254Scalar, _, 3, 16, 1>::new(perm.clone()).unwrap(),
+        TruncatedPermutation::new(perm),
+    );
+
+    let query_stride = height / rows_per_query;
+    let mut row_buf = vec![F::ZERO; width];
+    let mut leaf_hashes = Vec::with_capacity(rows_per_query);
+    let mut query_digest_layer = Vec::with_capacity(query_stride);
+    for query_idx in 0..query_stride {
+        leaf_hashes.clear();
+        for row_offset in 0..rows_per_query {
+            let row_idx = row_offset * query_stride + query_idx;
+            for col_idx in 0..width {
+                row_buf[col_idx] = matrix[col_idx * height + row_idx];
+            }
+            leaf_hashes.push(hasher.hash_slice(&row_buf));
+        }
+        query_digest_layer.push(hasher.tree_compress(leaf_hashes.clone()));
+    }
+
+    let mut digest_layers = vec![query_digest_layer];
+    while digest_layers.last().unwrap().len() > 1 {
+        let prev_layer = digest_layers.last().unwrap();
+        let layer = prev_layer
+            .chunks_exact(2)
+            .map(|pair| hasher.compress(pair[0], pair[1]))
+            .collect_vec();
+        digest_layers.push(layer);
+    }
+    digest_layers
+}
+
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
+fn bn254_row_hash_emulated(vals: &[F]) -> Bn254Digest {
+    let perm = default_babybear_bn254_poseidon2();
+    let mut state = [Bn254Scalar::ZERO; 3];
+    let mut buf = [F::ZERO; 16];
+    let mut cnt = 0usize;
+
+    for &value in vals {
+        buf[cnt] = value;
+        cnt += 1;
+        if cnt == 16 {
+            state[0] = reduce_32(&buf[..8]);
+            state[1] = reduce_32(&buf[8..16]);
+            perm.permute_mut(&mut state);
+            cnt = 0;
+        }
+    }
+
+    if cnt > 0 {
+        state[0] = reduce_32(&buf[..cnt.min(8)]);
+        if cnt > 8 {
+            state[1] = reduce_32(&buf[8..cnt.min(16)]);
+        }
+        perm.permute_mut(&mut state);
+    }
+
+    [state[0]]
+}
+
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
+#[test]
+fn test_bn254_merkle_gpu_matches_host_large_matrix() {
+    let height = 1 << 16;
+    let width = 19;
+    let rows_per_query = 1 << 4;
+    let host_matrix = (0..width * height)
+        .map(|i| F::from_u32((i as u32).wrapping_mul(37).wrapping_add((i >> 7) as u32)))
+        .collect_vec();
+
+    let host_layers = bn254_host_merkle_layers(&host_matrix, height, width, rows_per_query);
+    let device_matrix = DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
+    let gpu_tree = MerkleTreeGpu::<F, Bn254Digest>::new_with_hash::<
+        crate::hash_scheme::Bn254Poseidon2MerkleHash,
+    >(device_matrix, rows_per_query, true)
+    .unwrap();
+    let gpu_layers = gpu_tree
+        .digest_layers
+        .iter()
+        .map(|layer| layer.to_host().unwrap())
+        .collect_vec();
+
+    for (layer_idx, (gpu_layer, host_layer)) in gpu_layers.iter().zip(host_layers.iter()).enumerate() {
+        assert_eq!(gpu_layer.len(), host_layer.len(), "layer {layer_idx} length mismatch");
+        if let Some((digest_idx, (gpu_digest, host_digest))) = gpu_layer
+            .iter()
+            .zip(host_layer.iter())
+            .enumerate()
+            .find(|(_, (gpu_digest, host_digest))| gpu_digest != host_digest)
+        {
+            panic!(
+                "layer {layer_idx} digest {digest_idx} mismatch: gpu={gpu_digest:?} host={host_digest:?}"
+            );
+        }
+    }
+    assert_eq!(gpu_tree.root(), *host_layers.last().unwrap().first().unwrap());
+}
+
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
+#[test]
+fn test_bn254_row_hash_gpu_matches_host_multi_block_rows() {
+    let height = 1 << 12;
+    let width = 19;
+    let rows_per_query = 1;
+    let host_matrix = (0..width * height)
+        .map(|i| F::from_u32((i as u32).wrapping_mul(53).wrapping_add((i >> 5) as u32)))
+        .collect_vec();
+
+    let host_layers = bn254_host_merkle_layers(&host_matrix, height, width, rows_per_query);
+    let device_matrix = DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
+    let gpu_tree = MerkleTreeGpu::<F, Bn254Digest>::new_with_hash::<
+        crate::hash_scheme::Bn254Poseidon2MerkleHash,
+    >(device_matrix, rows_per_query, true)
+    .unwrap();
+    let gpu_layer0 = gpu_tree.digest_layers[0].to_host().unwrap();
+
+    if let Some((digest_idx, (gpu_digest, host_digest))) = gpu_layer0
+        .iter()
+        .zip(host_layers[0].iter())
+        .enumerate()
+        .find(|(_, (gpu_digest, host_digest))| gpu_digest != host_digest)
+    {
+        panic!(
+            "row-hash digest {digest_idx} mismatch: gpu={gpu_digest:?} host={host_digest:?}"
+        );
+    }
+}
+
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
+#[test]
+fn test_bn254_row_hash_emulation_matches_host_multi_block_rows() {
+    let perm = default_babybear_bn254_poseidon2();
+    let host_hasher = CpuMerkleHasher::new(
+        MultiField32PaddingFreeSponge::<F, Bn254Scalar, _, 3, 16, 1>::new(perm).unwrap(),
+        TruncatedPermutation::new(default_babybear_bn254_poseidon2()),
+    );
+    let row = (0..19)
+        .map(|i| F::from_u32((i as u32).wrapping_mul(53).wrapping_add((i >> 1) as u32)))
+        .collect_vec();
+
+    assert_eq!(bn254_row_hash_emulated(&row), host_hasher.hash_slice(&row));
 }
 
 // ===========================================================================

--- a/crates/cuda-backend/src/tests.rs
+++ b/crates/cuda-backend/src/tests.rs
@@ -25,15 +25,15 @@ use openvm_stark_backend::{
     verifier::stacked_reduction::{verify_stacked_reduction, StackedReductionError},
     FiatShamirTranscript, StarkEngine, StarkProtocolConfig,
 };
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
+use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::{
+    default_babybear_bn254_poseidon2, Bn254Scalar,
+};
 use openvm_stark_sdk::{
     config::baby_bear_poseidon2::{
         default_duplex_sponge, BabyBearPoseidon2RefEngine, DuplexSponge,
     },
     utils::setup_tracing_with_log_level,
-};
-#[cfg(feature = "baby-bear-bn254-poseidon2")]
-use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::{
-    default_babybear_bn254_poseidon2, Bn254Scalar,
 };
 use p3_field::{reduce_32, BasedVectorSpace, PrimeCharacteristicRing, TwoAdicField};
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
@@ -41,13 +41,13 @@ use p3_symmetric::Permutation;
 use test_case::test_case;
 use tracing::{debug, Level};
 
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
+use crate::{base::DeviceMatrix, cuda::bn254_merkle_tree::Bn254Digest, merkle_tree::MerkleTreeGpu};
 use crate::{
     prelude::{EF, F, SC},
     sponge::DuplexSpongeGpu,
     BabyBearPoseidon2GpuEngine, GpuBackend,
 };
-#[cfg(feature = "baby-bear-bn254-poseidon2")]
-use crate::{base::DeviceMatrix, cuda::bn254_merkle_tree::Bn254Digest, merkle_tree::MerkleTreeGpu};
 
 type RefEngine = BabyBearPoseidon2RefEngine<DuplexSponge>;
 type Engine = RefEngine;
@@ -175,7 +175,9 @@ fn bn254_host_merkle_layers_ext(
             row_buf.clear();
             let row_idx = row_offset * query_stride + query_idx;
             for col_idx in 0..width {
-                row_buf.extend_from_slice(matrix[col_idx * height + row_idx].as_basis_coefficients_slice());
+                row_buf.extend_from_slice(
+                    matrix[col_idx * height + row_idx].as_basis_coefficients_slice(),
+                );
             }
             leaf_hashes.push(hasher.hash_slice(&row_buf));
         }
@@ -250,7 +252,8 @@ fn test_bn254_merkle_gpu_matches_host_large_matrix() {
         .collect_vec();
 
     let host_layers = bn254_host_merkle_layers(&host_matrix, height, width, rows_per_query);
-    let device_matrix = DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
+    let device_matrix =
+        DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
     let gpu_tree = MerkleTreeGpu::<F, Bn254Digest>::new_with_hash::<
         crate::hash_scheme::Bn254Poseidon2MerkleHash,
     >(device_matrix, rows_per_query, true)
@@ -261,8 +264,14 @@ fn test_bn254_merkle_gpu_matches_host_large_matrix() {
         .map(|layer| layer.to_host().unwrap())
         .collect_vec();
 
-    for (layer_idx, (gpu_layer, host_layer)) in gpu_layers.iter().zip(host_layers.iter()).enumerate() {
-        assert_eq!(gpu_layer.len(), host_layer.len(), "layer {layer_idx} length mismatch");
+    for (layer_idx, (gpu_layer, host_layer)) in
+        gpu_layers.iter().zip(host_layers.iter()).enumerate()
+    {
+        assert_eq!(
+            gpu_layer.len(),
+            host_layer.len(),
+            "layer {layer_idx} length mismatch"
+        );
         if let Some((digest_idx, (gpu_digest, host_digest))) = gpu_layer
             .iter()
             .zip(host_layer.iter())
@@ -274,7 +283,10 @@ fn test_bn254_merkle_gpu_matches_host_large_matrix() {
             );
         }
     }
-    assert_eq!(gpu_tree.root(), *host_layers.last().unwrap().first().unwrap());
+    assert_eq!(
+        gpu_tree.root(),
+        *host_layers.last().unwrap().first().unwrap()
+    );
 }
 
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
@@ -293,25 +305,37 @@ fn test_bn254_merkle_proof_queries_gpu_match_host() {
 
     let host_layers_a = bn254_host_merkle_layers(&host_matrix_a, height, width, rows_per_query);
     let host_layers_b = bn254_host_merkle_layers(&host_matrix_b, height, width, rows_per_query);
-    let tree_a = MerkleTreeGpu::<F, Bn254Digest>::new_with_hash::<crate::hash_scheme::Bn254Poseidon2MerkleHash>(
+    let tree_a = MerkleTreeGpu::<F, Bn254Digest>::new_with_hash::<
+        crate::hash_scheme::Bn254Poseidon2MerkleHash,
+    >(
         DeviceMatrix::new(Arc::new(host_matrix_a.to_device().unwrap()), height, width),
         rows_per_query,
         true,
     )
     .unwrap();
-    let tree_b = MerkleTreeGpu::<F, Bn254Digest>::new_with_hash::<crate::hash_scheme::Bn254Poseidon2MerkleHash>(
+    let tree_b = MerkleTreeGpu::<F, Bn254Digest>::new_with_hash::<
+        crate::hash_scheme::Bn254Poseidon2MerkleHash,
+    >(
         DeviceMatrix::new(Arc::new(host_matrix_b.to_device().unwrap()), height, width),
         rows_per_query,
         true,
     )
     .unwrap();
 
-    let gpu_proofs =
-        MerkleTreeGpu::<F, Bn254Digest>::batch_query_merkle_proofs(&[&tree_a, &tree_b], &query_indices)
-            .unwrap();
+    let gpu_proofs = MerkleTreeGpu::<F, Bn254Digest>::batch_query_merkle_proofs(
+        &[&tree_a, &tree_b],
+        &query_indices,
+    )
+    .unwrap();
 
-    assert_eq!(gpu_proofs[0], bn254_host_merkle_proofs(&host_layers_a, &query_indices));
-    assert_eq!(gpu_proofs[1], bn254_host_merkle_proofs(&host_layers_b, &query_indices));
+    assert_eq!(
+        gpu_proofs[0],
+        bn254_host_merkle_proofs(&host_layers_a, &query_indices)
+    );
+    assert_eq!(
+        gpu_proofs[1],
+        bn254_host_merkle_proofs(&host_layers_b, &query_indices)
+    );
 }
 
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
@@ -325,7 +349,8 @@ fn test_bn254_row_hash_gpu_matches_host_multi_block_rows() {
         .collect_vec();
 
     let host_layers = bn254_host_merkle_layers(&host_matrix, height, width, rows_per_query);
-    let device_matrix = DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
+    let device_matrix =
+        DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
     let gpu_tree = MerkleTreeGpu::<F, Bn254Digest>::new_with_hash::<
         crate::hash_scheme::Bn254Poseidon2MerkleHash,
     >(device_matrix, rows_per_query, true)
@@ -338,9 +363,7 @@ fn test_bn254_row_hash_gpu_matches_host_multi_block_rows() {
         .enumerate()
         .find(|(_, (gpu_digest, host_digest))| gpu_digest != host_digest)
     {
-        panic!(
-            "row-hash digest {digest_idx} mismatch: gpu={gpu_digest:?} host={host_digest:?}"
-        );
+        panic!("row-hash digest {digest_idx} mismatch: gpu={gpu_digest:?} host={host_digest:?}");
     }
 }
 
@@ -353,13 +376,18 @@ fn test_bn254_row_hash_ext_gpu_matches_host_multi_block_rows() {
     let host_matrix = (0..width * height)
         .map(|i| {
             EF::from_basis_coefficients_fn(|j| {
-                F::from_u32((i as u32).wrapping_mul(43).wrapping_add((j as u32) * 11 + (i >> 3) as u32))
+                F::from_u32(
+                    (i as u32)
+                        .wrapping_mul(43)
+                        .wrapping_add((j as u32) * 11 + (i >> 3) as u32),
+                )
             })
         })
         .collect_vec();
 
     let host_layers = bn254_host_merkle_layers_ext(&host_matrix, height, width, rows_per_query);
-    let device_matrix = DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
+    let device_matrix =
+        DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
     let gpu_tree = MerkleTreeGpu::<EF, Bn254Digest>::new_with_hash::<
         crate::hash_scheme::Bn254Poseidon2MerkleHash,
     >(device_matrix, rows_per_query, true)

--- a/crates/cuda-backend/src/tests.rs
+++ b/crates/cuda-backend/src/tests.rs
@@ -35,7 +35,7 @@ use openvm_stark_sdk::{
 use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::{
     default_babybear_bn254_poseidon2, Bn254Scalar,
 };
-use p3_field::{reduce_32, PrimeCharacteristicRing, TwoAdicField};
+use p3_field::{reduce_32, BasedVectorSpace, PrimeCharacteristicRing, TwoAdicField};
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 use p3_symmetric::Permutation;
 use test_case::test_case;
@@ -153,6 +153,64 @@ fn bn254_host_merkle_layers(
 }
 
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
+fn bn254_host_merkle_layers_ext(
+    matrix: &[EF],
+    height: usize,
+    width: usize,
+    rows_per_query: usize,
+) -> Vec<Vec<Bn254Digest>> {
+    let perm = default_babybear_bn254_poseidon2();
+    let hasher = CpuMerkleHasher::new(
+        MultiField32PaddingFreeSponge::<F, Bn254Scalar, _, 3, 16, 1>::new(perm.clone()).unwrap(),
+        TruncatedPermutation::new(perm),
+    );
+
+    let query_stride = height / rows_per_query;
+    let mut row_buf = Vec::with_capacity(width * 4);
+    let mut leaf_hashes = Vec::with_capacity(rows_per_query);
+    let mut query_digest_layer = Vec::with_capacity(query_stride);
+    for query_idx in 0..query_stride {
+        leaf_hashes.clear();
+        for row_offset in 0..rows_per_query {
+            row_buf.clear();
+            let row_idx = row_offset * query_stride + query_idx;
+            for col_idx in 0..width {
+                row_buf.extend_from_slice(matrix[col_idx * height + row_idx].as_basis_coefficients_slice());
+            }
+            leaf_hashes.push(hasher.hash_slice(&row_buf));
+        }
+        query_digest_layer.push(hasher.tree_compress(leaf_hashes.clone()));
+    }
+
+    let mut digest_layers = vec![query_digest_layer];
+    while digest_layers.last().unwrap().len() > 1 {
+        let prev_layer = digest_layers.last().unwrap();
+        let layer = prev_layer
+            .chunks_exact(2)
+            .map(|pair| hasher.compress(pair[0], pair[1]))
+            .collect_vec();
+        digest_layers.push(layer);
+    }
+    digest_layers
+}
+
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
+fn bn254_host_merkle_proofs(
+    host_layers: &[Vec<Bn254Digest>],
+    query_indices: &[usize],
+) -> Vec<Vec<Bn254Digest>> {
+    let proof_depth = host_layers.len() - 1;
+    query_indices
+        .iter()
+        .map(|&index| {
+            (0..proof_depth)
+                .map(|layer_idx| host_layers[layer_idx][(index >> layer_idx) ^ 1])
+                .collect_vec()
+        })
+        .collect_vec()
+}
+
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
 fn bn254_row_hash_emulated(vals: &[F]) -> Bn254Digest {
     let perm = default_babybear_bn254_poseidon2();
     let mut state = [Bn254Scalar::ZERO; 3];
@@ -221,6 +279,43 @@ fn test_bn254_merkle_gpu_matches_host_large_matrix() {
 
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 #[test]
+fn test_bn254_merkle_proof_queries_gpu_match_host() {
+    let height = 1 << 12;
+    let width = 19;
+    let rows_per_query = 1;
+    let query_indices = [0, 1, 7, 42, 255, 1023];
+    let host_matrix_a = (0..width * height)
+        .map(|i| F::from_u32((i as u32).wrapping_mul(17).wrapping_add((i >> 4) as u32)))
+        .collect_vec();
+    let host_matrix_b = (0..width * height)
+        .map(|i| F::from_u32((i as u32).wrapping_mul(29).wrapping_add((i >> 6) as u32)))
+        .collect_vec();
+
+    let host_layers_a = bn254_host_merkle_layers(&host_matrix_a, height, width, rows_per_query);
+    let host_layers_b = bn254_host_merkle_layers(&host_matrix_b, height, width, rows_per_query);
+    let tree_a = MerkleTreeGpu::<F, Bn254Digest>::new_with_hash::<crate::hash_scheme::Bn254Poseidon2MerkleHash>(
+        DeviceMatrix::new(Arc::new(host_matrix_a.to_device().unwrap()), height, width),
+        rows_per_query,
+        true,
+    )
+    .unwrap();
+    let tree_b = MerkleTreeGpu::<F, Bn254Digest>::new_with_hash::<crate::hash_scheme::Bn254Poseidon2MerkleHash>(
+        DeviceMatrix::new(Arc::new(host_matrix_b.to_device().unwrap()), height, width),
+        rows_per_query,
+        true,
+    )
+    .unwrap();
+
+    let gpu_proofs =
+        MerkleTreeGpu::<F, Bn254Digest>::batch_query_merkle_proofs(&[&tree_a, &tree_b], &query_indices)
+            .unwrap();
+
+    assert_eq!(gpu_proofs[0], bn254_host_merkle_proofs(&host_layers_a, &query_indices));
+    assert_eq!(gpu_proofs[1], bn254_host_merkle_proofs(&host_layers_b, &query_indices));
+}
+
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
+#[test]
 fn test_bn254_row_hash_gpu_matches_host_multi_block_rows() {
     let height = 1 << 12;
     let width = 19;
@@ -245,6 +340,40 @@ fn test_bn254_row_hash_gpu_matches_host_multi_block_rows() {
     {
         panic!(
             "row-hash digest {digest_idx} mismatch: gpu={gpu_digest:?} host={host_digest:?}"
+        );
+    }
+}
+
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
+#[test]
+fn test_bn254_row_hash_ext_gpu_matches_host_multi_block_rows() {
+    let height = 1 << 11;
+    let width = 5;
+    let rows_per_query = 1;
+    let host_matrix = (0..width * height)
+        .map(|i| {
+            EF::from_basis_coefficients_fn(|j| {
+                F::from_u32((i as u32).wrapping_mul(43).wrapping_add((j as u32) * 11 + (i >> 3) as u32))
+            })
+        })
+        .collect_vec();
+
+    let host_layers = bn254_host_merkle_layers_ext(&host_matrix, height, width, rows_per_query);
+    let device_matrix = DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
+    let gpu_tree = MerkleTreeGpu::<EF, Bn254Digest>::new_with_hash::<
+        crate::hash_scheme::Bn254Poseidon2MerkleHash,
+    >(device_matrix, rows_per_query, true)
+    .unwrap();
+    let gpu_layer0 = gpu_tree.digest_layers[0].to_host().unwrap();
+
+    if let Some((digest_idx, (gpu_digest, host_digest))) = gpu_layer0
+        .iter()
+        .zip(host_layers[0].iter())
+        .enumerate()
+        .find(|(_, (gpu_digest, host_digest))| gpu_digest != host_digest)
+    {
+        panic!(
+            "row-hash-ext digest {digest_idx} mismatch: gpu={gpu_digest:?} host={host_digest:?}"
         );
     }
 }


### PR DESCRIPTION
Closes INT-6989
Closes INT-7001

- Critical correctness fix (NUM_F_ELMS 7→8) is the most important change — this was the root cause of GPU/CPU Merkle hash divergence
- Clean removal of the CPU fallback (new_bn254_host) now that GPU hashing is correct
