### PR TITLE
Revert "fix: mutex poisoning in `COPY_EVENT`"

### DIFF
--- a/crates/cuda-common/src/copy.rs
+++ b/crates/cuda-common/src/copy.rs
@@ -1,4 +1,6 @@
-use std::{cell::RefCell, ffi::c_void};
+use std::{ffi::c_void, sync::Mutex};
+
+use lazy_static::lazy_static;
 
 use crate::{
     d_buffer::DeviceBuffer,
@@ -6,8 +8,8 @@ use crate::{
     stream::{cudaStreamPerThread, cudaStream_t, CudaEvent},
 };
 
-thread_local! {
-    static COPY_EVENT: RefCell<Option<CudaEvent>> = RefCell::new(Some(CudaEvent::new().unwrap()));
+lazy_static! {
+    static ref COPY_EVENT: Mutex<CudaEvent> = Mutex::new(CudaEvent::new().unwrap());
 }
 
 #[repr(i32)]
@@ -112,7 +114,9 @@ impl<T> MemCopyD2H<T> for DeviceBuffer<T> {
         })?;
         unsafe {
             COPY_EVENT
-                .with_borrow(|ce| ce.as_ref().unwrap().record_and_wait(cudaStreamPerThread))?;
+                .lock()
+                .unwrap()
+                .record_and_wait(cudaStreamPerThread)?;
 
             host_vec.set_len(self.len());
         }


### PR DESCRIPTION
Reverts openvm-org/stark-backend#238

The global mutex was in fact needed: 
If we allocate on stream 1, then copy to stream 2, then drop on stream 1, to ensure proper stream dependencies, the `COPY_EVENT` should NOT be thread-local (hence stream local).