### PR TITLE
feat(v2): add nvtx annotations via a custom tracing layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ metrics-util = "0.17.0"
 metrics-exporter-prometheus = "0.15.3"
 rustls = { version = "0.23", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
+nvtx = "1.3"
 
 # default-features = false for no_std
 itertools = { version = "0.14.0", default-features = false }

--- a/crates/cuda-backend/Cargo.toml
+++ b/crates/cuda-backend/Cargo.toml
@@ -7,7 +7,7 @@ description = "OpenVM CUDA prover backend for the SWIRL proof system"
 
 [dependencies]
 openvm-stark-backend.workspace = true
-openvm-stark-sdk.workspace = true
+openvm-stark-sdk = { workspace = true, features = ["nvtx"] }
 openvm-cuda-common.workspace = true
 
 itertools.workspace = true

--- a/crates/cuda-backend/src/data_transporter.rs
+++ b/crates/cuda-backend/src/data_transporter.rs
@@ -17,7 +17,7 @@ use openvm_stark_backend::{
         MatrixView, ProvingContext,
     },
 };
-use tracing::debug;
+use tracing::{debug, info_span};
 
 use crate::{
     base::DeviceMatrix,
@@ -36,6 +36,7 @@ impl<HS: GpuHashScheme> DeviceDataTransporter<HS::SC, GenericGpuBackend<HS>> for
         &self,
         mpk: &MultiStarkProvingKey<HS::SC>,
     ) -> DeviceMultiStarkProvingKey<GenericGpuBackend<HS>> {
+        let _span = info_span!("transport_pk_to_device").entered();
         let per_air = mpk
             .per_air
             .iter()
@@ -125,6 +126,7 @@ pub fn transport_and_unstack_single_data_h2d<HS: GpuHashScheme>(
     d: &StackedPcsData<F, HS::Digest>,
     prover_config: &GpuProverConfig,
 ) -> Result<CommittedTraceData<GenericGpuBackend<HS>>, ProverError> {
+    let _span = info_span!("transport_unstack_h2d").entered();
     debug_assert!(d
         .layout
         .sorted_cols
@@ -222,6 +224,7 @@ pub fn transport_pcs_data_h2d<D: Copy + Clone + PartialEq + Send + Sync + 'stati
     pcs_data: &StackedPcsData<F, D>,
     prover_config: &GpuProverConfig,
 ) -> Result<StackedPcsDataGpu<F, D>, ProverError> {
+    let _span = info_span!("transport_pcs_data_h2d").entered();
     let StackedPcsData {
         layout,
         matrix,
@@ -245,6 +248,7 @@ pub fn transport_pcs_data_h2d<D: Copy + Clone + PartialEq + Send + Sync + 'stati
 pub fn transport_air_proving_ctx_to_device<HS: GpuHashScheme>(
     cpu_ctx: AirProvingContext<CpuColMajorBackend<SC>>,
 ) -> AirProvingContext<GenericGpuBackend<HS>> {
+    let _span = info_span!("transport_air_ctx_h2d").entered();
     assert!(
         cpu_ctx.cached_mains.is_empty(),
         "CPU to GPU transfer of cached traces not supported"

--- a/crates/cuda-backend/src/merkle_tree.rs
+++ b/crates/cuda-backend/src/merkle_tree.rs
@@ -8,7 +8,7 @@ use openvm_cuda_common::{
 };
 use openvm_stark_backend::prover::MatrixDimensions;
 use p3_util::log2_strict_usize;
-use tracing::instrument;
+use tracing::{info_span, instrument};
 
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 use crate::cuda::bn254_merkle_tree::Bn254Digest;
@@ -171,6 +171,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
         })
     }
 
+    #[instrument(name = "batch_open_rows", skip_all)]
     pub fn batch_open_rows(
         backing_matrices: &[&DeviceMatrix<F>],
         query_indices: &[usize],
@@ -218,7 +219,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                     .map_err(|error| MerkleTreeError::MatrixGetRows { error, matrix_idx })?;
                 }
                 let width = matrix.width();
-                let out = d_out.to_host()?;
+                let out = info_span!("opened_rows_d2h").in_scope(|| d_out.to_host())?;
                 let opened_rows_per_query = out
                     .chunks_exact(rows_per_query * width)
                     .map(|rows| rows.to_vec())

--- a/crates/stark-sdk/Cargo.toml
+++ b/crates/stark-sdk/Cargo.toml
@@ -39,6 +39,7 @@ eyre.workspace = true
 static_assertions.workspace = true
 derive-new.workspace = true
 num-bigint = { workspace = true, optional = true }
+nvtx = { workspace = true, optional = true }
 
 [dev-dependencies]
 p3-keccak-air.workspace = true
@@ -61,3 +62,4 @@ prometheus = [
   "dep:tokio",
   "dep:rustls",
 ]
+nvtx = ["dep:nvtx"]

--- a/crates/stark-sdk/src/bench/mod.rs
+++ b/crates/stark-sdk/src/bench/mod.rs
@@ -16,6 +16,9 @@ use {
     metrics_util::layers::Layer,
 };
 
+#[cfg(feature = "nvtx")]
+use crate::nvtx_tracing::NvtxLayer;
+
 /// Run a function with metric collection enabled. The metrics will be written to a file specified
 /// by an environment variable which name is `output_path_envar`.
 pub fn run_with_metric_collection<R>(
@@ -33,6 +36,8 @@ pub fn run_with_metric_collection<R>(
         .with(MetricsLayer::new());
     #[cfg(feature = "metrics")]
     let subscriber = subscriber.with(TimingMetricsLayer::new());
+    #[cfg(feature = "nvtx")]
+    let subscriber = subscriber.with(NvtxLayer::new(Default::default()));
     // Prepare tracing.
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
@@ -120,6 +125,8 @@ pub fn run_with_metric_exporter<R>(
         .with(MetricsLayer::new());
     #[cfg(feature = "metrics")]
     let subscriber = subscriber.with(TimingMetricsLayer::new());
+    #[cfg(feature = "nvtx")]
+    let subscriber = subscriber.with(NvtxLayer::new(Default::default()));
     // Prepare tracing.
     tracing::subscriber::set_global_default(subscriber).unwrap();
 

--- a/crates/stark-sdk/src/lib.rs
+++ b/crates/stark-sdk/src/lib.rs
@@ -7,6 +7,8 @@ pub mod bench;
 pub mod config;
 #[cfg(feature = "metrics")]
 pub mod metrics_tracing;
+#[cfg(feature = "nvtx")]
+pub mod nvtx_tracing;
 pub mod utils;
 
 // #[macro_export]

--- a/crates/stark-sdk/src/nvtx_tracing.rs
+++ b/crates/stark-sdk/src/nvtx_tracing.rs
@@ -1,0 +1,191 @@
+use std::sync::Arc;
+
+use tracing::{
+    field::{Field, Visit},
+    Id, Subscriber,
+};
+use tracing_subscriber::{registry::LookupSpan, Layer};
+
+/// A tracing layer that maps tracing spans to NVTX ranges for Nsight Systems profiling.
+///
+/// When active, each span enter/exit maps to an NVTX range_push/range_pop, making
+/// proving phases visible in `nsys profile --trace=cuda,nvtx` timelines.
+///
+/// Only spans at or above the configured level are exported.
+pub struct NvtxLayer {
+    config: NvtxConfig,
+}
+
+pub struct NvtxConfig {
+    pub max_level: tracing::Level,
+}
+
+impl Default for NvtxConfig {
+    fn default() -> Self {
+        Self {
+            max_level: tracing::Level::INFO,
+        }
+    }
+}
+
+impl NvtxLayer {
+    pub fn new(config: NvtxConfig) -> Self {
+        Self { config }
+    }
+}
+
+/// Per-span cached NVTX label, stored in span extensions.
+/// Only inserted for spans that pass the level filter.
+struct NvtxSpanData {
+    label: Arc<str>,
+}
+
+/// Visitor that collects all span fields into a compact label suffix.
+struct FieldCollector {
+    parts: Vec<String>,
+}
+
+impl FieldCollector {
+    fn new() -> Self {
+        Self { parts: Vec::new() }
+    }
+
+    fn into_suffix(self) -> Option<String> {
+        if self.parts.is_empty() {
+            None
+        } else {
+            Some(self.parts.join(","))
+        }
+    }
+}
+
+impl Visit for FieldCollector {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.parts.push(format!("{}={:?}", field.name(), value));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.parts.push(format!("{}={}", field.name(), value));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.parts.push(format!("{}={}", field.name(), value));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.parts.push(format!("{}={}", field.name(), value));
+    }
+}
+
+fn build_label(meta: &tracing::Metadata<'_>, attrs: &tracing::span::Attributes<'_>) -> Arc<str> {
+    let mut collector = FieldCollector::new();
+    attrs.record(&mut collector);
+
+    let name = meta.name();
+    match collector.into_suffix() {
+        Some(suffix) => Arc::from(format!("{name}{{{suffix}}}")),
+        None => Arc::from(name),
+    }
+}
+
+impl<S> Layer<S> for NvtxLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &Id,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let Some(span) = ctx.span(id) else { return };
+        let meta = span.metadata();
+
+        if meta.level() > &self.config.max_level {
+            return;
+        }
+
+        let label = build_label(meta, attrs);
+        span.extensions_mut().insert(NvtxSpanData { label });
+    }
+
+    fn on_record(
+        &self,
+        id: &Id,
+        values: &tracing::span::Record<'_>,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let Some(span) = ctx.span(id) else { return };
+        let mut exts = span.extensions_mut();
+        let Some(data) = exts.get_mut::<NvtxSpanData>() else {
+            return;
+        };
+        // Append newly recorded fields to the existing label.
+        // If the label already has fields ("name{a=1}"), strip the closing brace and
+        // append with a comma. If no fields yet ("name"), open a new brace group.
+        let mut collector = FieldCollector::new();
+        values.record(&mut collector);
+        if let Some(suffix) = collector.into_suffix() {
+            let base = data.label.trim_end_matches('}');
+            let sep = if base.len() < data.label.len() {
+                ","
+            } else {
+                "{"
+            };
+            data.label = Arc::from(format!("{base}{sep}{suffix}}}"));
+        }
+    }
+
+    fn on_enter(&self, id: &Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        let exts = span.extensions();
+        let Some(data) = exts.get::<NvtxSpanData>() else {
+            return;
+        };
+        nvtx::range_push!("{}", data.label);
+    }
+
+    fn on_exit(&self, id: &Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        let exts = span.extensions();
+        if exts.get::<NvtxSpanData>().is_some() {
+            nvtx::range_pop!();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tracing::info_span;
+    use tracing_subscriber::{layer::SubscriberExt, Registry};
+
+    use super::*;
+
+    #[test]
+    fn test_nvtx_layer_with_fields() {
+        let subscriber = Registry::default().with(NvtxLayer::new(NvtxConfig::default()));
+        tracing::subscriber::with_default(subscriber, || {
+            // Should produce "prove_segment{segment=42,phase=prover}"
+            let span = info_span!("prove_segment", segment = 42, phase = "prover");
+            let _guard = span.enter();
+            // No fields -> just the name
+            let inner = info_span!("stark_prove");
+            let _inner_guard = inner.enter();
+        });
+    }
+
+    #[test]
+    fn test_nvtx_layer_late_bound_fields() {
+        let subscriber = Registry::default().with(NvtxLayer::new(NvtxConfig::default()));
+        tracing::subscriber::with_default(subscriber, || {
+            // Late-bound field via span.record()
+            let span = info_span!("step", idx = tracing::field::Empty);
+            let _guard = span.enter();
+            span.record("idx", 7);
+            // Also test recording on a span that already has fields
+            let span2 = info_span!("work", phase = "init", result = tracing::field::Empty);
+            let _guard2 = span2.enter();
+            span2.record("result", 42);
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Add optional NVTX tracing support for profiling with Nsight Systems.

- New `nvtx` feature flag on `openvm-stark-sdk` with a `NvtxLayer` that maps tracing spans to NVTX `range_push`/`range_pop` calls
- Automatically enabled when building `openvm-cuda-backend` (via feature propagation)
- Wired into `run_with_metric_collection` and `run_with_metric_exporter`
- Add `info_span` instrumentation to GPU data transport functions (`data_transporter.rs`, `merkle_tree.rs`) for visibility into H2D/D2H transfers

## Usage

```bash
cargo build -p openvm-cuda-backend
nsys profile --trace=cuda,osrt,nvtx ./target/release/my_benchmark
```

<img width="1673" height="712" alt="image" src="https://github.com/user-attachments/assets/fe6ca66e-315a-422c-bc3b-10ca90240cf3" />
