### PR TITLE
chore(cuda): stream migration refactoring

### DIFF
--- a/benchmarks/fields/cuda/src/ext_field_bench.cu
+++ b/benchmarks/fields/cuda/src/ext_field_bench.cu
@@ -138,33 +138,33 @@ __global__ void bench_inv_kernel(T* out, const T* a, size_t n, int reps) {
 // Extern "C" Wrappers for Fp (base field)
 // ============================================================================
 
-extern "C" int init_fp(void* out, const uint32_t* raw_data, size_t n) {
+extern "C" int init_fp(void* out, const uint32_t* raw_data, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_init_kernel<Fp, Fp, 1><<<grid_size, block>>>(static_cast<Fp*>(out), raw_data, n);
+    bench_init_kernel<Fp, Fp, 1><<<grid_size, block, 0, stream>>>(static_cast<Fp*>(out), raw_data, n);
     return cudaGetLastError();
 }
 
-extern "C" int add_fp(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int add_fp(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_add_kernel<Fp><<<grid_size, block>>>(
+    bench_add_kernel<Fp><<<grid_size, block, 0, stream>>>(
         static_cast<Fp*>(out), static_cast<const Fp*>(a), static_cast<const Fp*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int mul_fp(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int mul_fp(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_mul_kernel<Fp><<<grid_size, block>>>(
+    bench_mul_kernel<Fp><<<grid_size, block, 0, stream>>>(
         static_cast<Fp*>(out), static_cast<const Fp*>(a), static_cast<const Fp*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int inv_fp(void* out, const void* a, size_t n, int reps) {
+extern "C" int inv_fp(void* out, const void* a, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_inv_kernel<Fp><<<grid_size, block>>>(static_cast<Fp*>(out), static_cast<const Fp*>(a), n, reps);
+    bench_inv_kernel<Fp><<<grid_size, block, 0, stream>>>(static_cast<Fp*>(out), static_cast<const Fp*>(a), n, reps);
     return cudaGetLastError();
 }
 
@@ -172,33 +172,33 @@ extern "C" int inv_fp(void* out, const void* a, size_t n, int reps) {
 // Extern "C" Wrappers for Fp4 (quartic extension - simple implementation)
 // ============================================================================
 
-extern "C" int init_fp4(void* out, const uint32_t* raw_data, size_t n) {
+extern "C" int init_fp4(void* out, const uint32_t* raw_data, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_init_kernel<Fp4, Fp, 4><<<grid_size, block>>>(static_cast<Fp4*>(out), raw_data, n);
+    bench_init_kernel<Fp4, Fp, 4><<<grid_size, block, 0, stream>>>(static_cast<Fp4*>(out), raw_data, n);
     return cudaGetLastError();
 }
 
-extern "C" int add_fp4(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int add_fp4(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_add_kernel<Fp4><<<grid_size, block>>>(
+    bench_add_kernel<Fp4><<<grid_size, block, 0, stream>>>(
         static_cast<Fp4*>(out), static_cast<const Fp4*>(a), static_cast<const Fp4*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int mul_fp4(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int mul_fp4(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_mul_kernel<Fp4><<<grid_size, block>>>(
+    bench_mul_kernel<Fp4><<<grid_size, block, 0, stream>>>(
         static_cast<Fp4*>(out), static_cast<const Fp4*>(a), static_cast<const Fp4*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int inv_fp4(void* out, const void* a, size_t n, int reps) {
+extern "C" int inv_fp4(void* out, const void* a, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_inv_kernel<Fp4><<<grid_size, block>>>(static_cast<Fp4*>(out), static_cast<const Fp4*>(a), n, reps);
+    bench_inv_kernel<Fp4><<<grid_size, block, 0, stream>>>(static_cast<Fp4*>(out), static_cast<const Fp4*>(a), n, reps);
     return cudaGetLastError();
 }
 
@@ -206,33 +206,33 @@ extern "C" int inv_fp4(void* out, const void* a, size_t n, int reps) {
 // Extern "C" Wrappers for FpExt (quartic extension - optimized bb31_4_t)
 // ============================================================================
 
-extern "C" int init_fpext(void* out, const uint32_t* raw_data, size_t n) {
+extern "C" int init_fpext(void* out, const uint32_t* raw_data, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_init_kernel<FpExt, Fp, 4><<<grid_size, block>>>(static_cast<FpExt*>(out), raw_data, n);
+    bench_init_kernel<FpExt, Fp, 4><<<grid_size, block, 0, stream>>>(static_cast<FpExt*>(out), raw_data, n);
     return cudaGetLastError();
 }
 
-extern "C" int add_fpext(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int add_fpext(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_add_kernel<FpExt><<<grid_size, block>>>(
+    bench_add_kernel<FpExt><<<grid_size, block, 0, stream>>>(
         static_cast<FpExt*>(out), static_cast<const FpExt*>(a), static_cast<const FpExt*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int mul_fpext(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int mul_fpext(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_mul_kernel<FpExt><<<grid_size, block>>>(
+    bench_mul_kernel<FpExt><<<grid_size, block, 0, stream>>>(
         static_cast<FpExt*>(out), static_cast<const FpExt*>(a), static_cast<const FpExt*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int inv_fpext(void* out, const void* a, size_t n, int reps) {
+extern "C" int inv_fpext(void* out, const void* a, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_inv_kernel<FpExt><<<grid_size, block>>>(static_cast<FpExt*>(out), static_cast<const FpExt*>(a), n, reps);
+    bench_inv_kernel<FpExt><<<grid_size, block, 0, stream>>>(static_cast<FpExt*>(out), static_cast<const FpExt*>(a), n, reps);
     return cudaGetLastError();
 }
 
@@ -240,33 +240,33 @@ extern "C" int inv_fpext(void* out, const void* a, size_t n, int reps) {
 // Extern "C" Wrappers for Fp5 (quintic extension)
 // ============================================================================
 
-extern "C" int init_fp5(void* out, const uint32_t* raw_data, size_t n) {
+extern "C" int init_fp5(void* out, const uint32_t* raw_data, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_init_kernel<Fp5, Fp, 5><<<grid_size, block>>>(static_cast<Fp5*>(out), raw_data, n);
+    bench_init_kernel<Fp5, Fp, 5><<<grid_size, block, 0, stream>>>(static_cast<Fp5*>(out), raw_data, n);
     return cudaGetLastError();
 }
 
-extern "C" int add_fp5(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int add_fp5(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_add_kernel<Fp5><<<grid_size, block>>>(
+    bench_add_kernel<Fp5><<<grid_size, block, 0, stream>>>(
         static_cast<Fp5*>(out), static_cast<const Fp5*>(a), static_cast<const Fp5*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int mul_fp5(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int mul_fp5(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_mul_kernel<Fp5><<<grid_size, block>>>(
+    bench_mul_kernel<Fp5><<<grid_size, block, 0, stream>>>(
         static_cast<Fp5*>(out), static_cast<const Fp5*>(a), static_cast<const Fp5*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int inv_fp5(void* out, const void* a, size_t n, int reps) {
+extern "C" int inv_fp5(void* out, const void* a, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_inv_kernel<Fp5><<<grid_size, block>>>(static_cast<Fp5*>(out), static_cast<const Fp5*>(a), n, reps);
+    bench_inv_kernel<Fp5><<<grid_size, block, 0, stream>>>(static_cast<Fp5*>(out), static_cast<const Fp5*>(a), n, reps);
     return cudaGetLastError();
 }
 
@@ -275,33 +275,33 @@ extern "C" int inv_fp5(void* out, const void* a, size_t n, int reps) {
 // Extern "C" Wrappers for Fp6 (sextic extension)
 // ============================================================================
 
-extern "C" int init_fp6(void* out, const uint32_t* raw_data, size_t n) {
+extern "C" int init_fp6(void* out, const uint32_t* raw_data, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_init_kernel<Fp6, Fp, 6><<<grid_size, block>>>(static_cast<Fp6*>(out), raw_data, n);
+    bench_init_kernel<Fp6, Fp, 6><<<grid_size, block, 0, stream>>>(static_cast<Fp6*>(out), raw_data, n);
     return cudaGetLastError();
 }
 
-extern "C" int add_fp6(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int add_fp6(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_add_kernel<Fp6><<<grid_size, block>>>(
+    bench_add_kernel<Fp6><<<grid_size, block, 0, stream>>>(
         static_cast<Fp6*>(out), static_cast<const Fp6*>(a), static_cast<const Fp6*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int mul_fp6(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int mul_fp6(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_mul_kernel<Fp6><<<grid_size, block>>>(
+    bench_mul_kernel<Fp6><<<grid_size, block, 0, stream>>>(
         static_cast<Fp6*>(out), static_cast<const Fp6*>(a), static_cast<const Fp6*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int inv_fp6(void* out, const void* a, size_t n, int reps) {
+extern "C" int inv_fp6(void* out, const void* a, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_inv_kernel<Fp6><<<grid_size, block>>>(static_cast<Fp6*>(out), static_cast<const Fp6*>(a), n, reps);
+    bench_inv_kernel<Fp6><<<grid_size, block, 0, stream>>>(static_cast<Fp6*>(out), static_cast<const Fp6*>(a), n, reps);
     return cudaGetLastError();
 }
 
@@ -309,33 +309,33 @@ extern "C" int inv_fp6(void* out, const void* a, size_t n, int reps) {
 // Extern "C" Wrappers for Fp2x3 (2×3 tower: Fp → Fp2 → Fp6)
 // ============================================================================
 
-extern "C" int init_fp2x3(void* out, const uint32_t* raw_data, size_t n) {
+extern "C" int init_fp2x3(void* out, const uint32_t* raw_data, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_init_kernel<Fp2x3, Fp, 6><<<grid_size, block>>>(static_cast<Fp2x3*>(out), raw_data, n);
+    bench_init_kernel<Fp2x3, Fp, 6><<<grid_size, block, 0, stream>>>(static_cast<Fp2x3*>(out), raw_data, n);
     return cudaGetLastError();
 }
 
-extern "C" int add_fp2x3(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int add_fp2x3(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_add_kernel<Fp2x3><<<grid_size, block>>>(
+    bench_add_kernel<Fp2x3><<<grid_size, block, 0, stream>>>(
         static_cast<Fp2x3*>(out), static_cast<const Fp2x3*>(a), static_cast<const Fp2x3*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int mul_fp2x3(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int mul_fp2x3(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_mul_kernel<Fp2x3><<<grid_size, block>>>(
+    bench_mul_kernel<Fp2x3><<<grid_size, block, 0, stream>>>(
         static_cast<Fp2x3*>(out), static_cast<const Fp2x3*>(a), static_cast<const Fp2x3*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int inv_fp2x3(void* out, const void* a, size_t n, int reps) {
+extern "C" int inv_fp2x3(void* out, const void* a, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_inv_kernel<Fp2x3><<<grid_size, block>>>(static_cast<Fp2x3*>(out), static_cast<const Fp2x3*>(a), n, reps);
+    bench_inv_kernel<Fp2x3><<<grid_size, block, 0, stream>>>(static_cast<Fp2x3*>(out), static_cast<const Fp2x3*>(a), n, reps);
     return cudaGetLastError();
 }
 
@@ -343,33 +343,33 @@ extern "C" int inv_fp2x3(void* out, const void* a, size_t n, int reps) {
 // Extern "C" Wrappers for Fp3x2 (3×2 tower: Fp → Fp3 → Fp6)
 // ============================================================================
 
-extern "C" int init_fp3x2(void* out, const uint32_t* raw_data, size_t n) {
+extern "C" int init_fp3x2(void* out, const uint32_t* raw_data, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_init_kernel<Fp3x2, Fp, 6><<<grid_size, block>>>(static_cast<Fp3x2*>(out), raw_data, n);
+    bench_init_kernel<Fp3x2, Fp, 6><<<grid_size, block, 0, stream>>>(static_cast<Fp3x2*>(out), raw_data, n);
     return cudaGetLastError();
 }
 
-extern "C" int add_fp3x2(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int add_fp3x2(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_add_kernel<Fp3x2><<<grid_size, block>>>(
+    bench_add_kernel<Fp3x2><<<grid_size, block, 0, stream>>>(
         static_cast<Fp3x2*>(out), static_cast<const Fp3x2*>(a), static_cast<const Fp3x2*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int mul_fp3x2(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int mul_fp3x2(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_mul_kernel<Fp3x2><<<grid_size, block>>>(
+    bench_mul_kernel<Fp3x2><<<grid_size, block, 0, stream>>>(
         static_cast<Fp3x2*>(out), static_cast<const Fp3x2*>(a), static_cast<const Fp3x2*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int inv_fp3x2(void* out, const void* a, size_t n, int reps) {
+extern "C" int inv_fp3x2(void* out, const void* a, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_inv_kernel<Fp3x2><<<grid_size, block>>>(static_cast<Fp3x2*>(out), static_cast<const Fp3x2*>(a), n, reps);
+    bench_inv_kernel<Fp3x2><<<grid_size, block, 0, stream>>>(static_cast<Fp3x2*>(out), static_cast<const Fp3x2*>(a), n, reps);
     return cudaGetLastError();
 }
 
@@ -377,33 +377,33 @@ extern "C" int inv_fp3x2(void* out, const void* a, size_t n, int reps) {
 // Extern "C" Wrappers for Kb (KoalaBear base field)
 // ============================================================================
 
-extern "C" int init_kb(void* out, const uint32_t* raw_data, size_t n) {
+extern "C" int init_kb(void* out, const uint32_t* raw_data, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_init_kernel<Kb, Kb, 1><<<grid_size, block>>>(static_cast<Kb*>(out), raw_data, n);
+    bench_init_kernel<Kb, Kb, 1><<<grid_size, block, 0, stream>>>(static_cast<Kb*>(out), raw_data, n);
     return cudaGetLastError();
 }
 
-extern "C" int add_kb(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int add_kb(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_add_kernel<Kb><<<grid_size, block>>>(
+    bench_add_kernel<Kb><<<grid_size, block, 0, stream>>>(
         static_cast<Kb*>(out), static_cast<const Kb*>(a), static_cast<const Kb*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int mul_kb(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int mul_kb(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_mul_kernel<Kb><<<grid_size, block>>>(
+    bench_mul_kernel<Kb><<<grid_size, block, 0, stream>>>(
         static_cast<Kb*>(out), static_cast<const Kb*>(a), static_cast<const Kb*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int inv_kb(void* out, const void* a, size_t n, int reps) {
+extern "C" int inv_kb(void* out, const void* a, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_inv_kernel<Kb><<<grid_size, block>>>(static_cast<Kb*>(out), static_cast<const Kb*>(a), n, reps);
+    bench_inv_kernel<Kb><<<grid_size, block, 0, stream>>>(static_cast<Kb*>(out), static_cast<const Kb*>(a), n, reps);
     return cudaGetLastError();
 }
 
@@ -411,33 +411,33 @@ extern "C" int inv_kb(void* out, const void* a, size_t n, int reps) {
 // Extern "C" Wrappers for Kb5 (KoalaBear quintic extension)
 // ============================================================================
 
-extern "C" int init_kb5(void* out, const uint32_t* raw_data, size_t n) {
+extern "C" int init_kb5(void* out, const uint32_t* raw_data, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_init_kernel<Kb5, Kb, 5><<<grid_size, block>>>(static_cast<Kb5*>(out), raw_data, n);
+    bench_init_kernel<Kb5, Kb, 5><<<grid_size, block, 0, stream>>>(static_cast<Kb5*>(out), raw_data, n);
     return cudaGetLastError();
 }
 
-extern "C" int add_kb5(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int add_kb5(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_add_kernel<Kb5><<<grid_size, block>>>(
+    bench_add_kernel<Kb5><<<grid_size, block, 0, stream>>>(
         static_cast<Kb5*>(out), static_cast<const Kb5*>(a), static_cast<const Kb5*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int mul_kb5(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int mul_kb5(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_mul_kernel<Kb5><<<grid_size, block>>>(
+    bench_mul_kernel<Kb5><<<grid_size, block, 0, stream>>>(
         static_cast<Kb5*>(out), static_cast<const Kb5*>(a), static_cast<const Kb5*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int inv_kb5(void* out, const void* a, size_t n, int reps) {
+extern "C" int inv_kb5(void* out, const void* a, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_inv_kernel<Kb5><<<grid_size, block>>>(static_cast<Kb5*>(out), static_cast<const Kb5*>(a), n, reps);
+    bench_inv_kernel<Kb5><<<grid_size, block, 0, stream>>>(static_cast<Kb5*>(out), static_cast<const Kb5*>(a), n, reps);
     return cudaGetLastError();
 }
 
@@ -445,33 +445,33 @@ extern "C" int inv_kb5(void* out, const void* a, size_t n, int reps) {
 // Extern "C" Wrappers for Kb6 (KoalaBear sextic extension)
 // ============================================================================
 
-extern "C" int init_kb6(void* out, const uint32_t* raw_data, size_t n) {
+extern "C" int init_kb6(void* out, const uint32_t* raw_data, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_init_kernel<Kb6, Kb, 6><<<grid_size, block>>>(static_cast<Kb6*>(out), raw_data, n);
+    bench_init_kernel<Kb6, Kb, 6><<<grid_size, block, 0, stream>>>(static_cast<Kb6*>(out), raw_data, n);
     return cudaGetLastError();
 }
 
-extern "C" int add_kb6(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int add_kb6(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_add_kernel<Kb6><<<grid_size, block>>>(
+    bench_add_kernel<Kb6><<<grid_size, block, 0, stream>>>(
         static_cast<Kb6*>(out), static_cast<const Kb6*>(a), static_cast<const Kb6*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int mul_kb6(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int mul_kb6(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_mul_kernel<Kb6><<<grid_size, block>>>(
+    bench_mul_kernel<Kb6><<<grid_size, block, 0, stream>>>(
         static_cast<Kb6*>(out), static_cast<const Kb6*>(a), static_cast<const Kb6*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int inv_kb6(void* out, const void* a, size_t n, int reps) {
+extern "C" int inv_kb6(void* out, const void* a, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_inv_kernel<Kb6><<<grid_size, block>>>(static_cast<Kb6*>(out), static_cast<const Kb6*>(a), n, reps);
+    bench_inv_kernel<Kb6><<<grid_size, block, 0, stream>>>(static_cast<Kb6*>(out), static_cast<const Kb6*>(a), n, reps);
     return cudaGetLastError();
 }
 
@@ -479,33 +479,33 @@ extern "C" int inv_kb6(void* out, const void* a, size_t n, int reps) {
 // Extern "C" Wrappers for Kb2x3 (KoalaBear 2×3 tower)
 // ============================================================================
 
-extern "C" int init_kb2x3(void* out, const uint32_t* raw_data, size_t n) {
+extern "C" int init_kb2x3(void* out, const uint32_t* raw_data, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_init_kernel<Kb2x3, Kb, 6><<<grid_size, block>>>(static_cast<Kb2x3*>(out), raw_data, n);
+    bench_init_kernel<Kb2x3, Kb, 6><<<grid_size, block, 0, stream>>>(static_cast<Kb2x3*>(out), raw_data, n);
     return cudaGetLastError();
 }
 
-extern "C" int add_kb2x3(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int add_kb2x3(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_add_kernel<Kb2x3><<<grid_size, block>>>(
+    bench_add_kernel<Kb2x3><<<grid_size, block, 0, stream>>>(
         static_cast<Kb2x3*>(out), static_cast<const Kb2x3*>(a), static_cast<const Kb2x3*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int mul_kb2x3(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int mul_kb2x3(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_mul_kernel<Kb2x3><<<grid_size, block>>>(
+    bench_mul_kernel<Kb2x3><<<grid_size, block, 0, stream>>>(
         static_cast<Kb2x3*>(out), static_cast<const Kb2x3*>(a), static_cast<const Kb2x3*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int inv_kb2x3(void* out, const void* a, size_t n, int reps) {
+extern "C" int inv_kb2x3(void* out, const void* a, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_inv_kernel<Kb2x3><<<grid_size, block>>>(static_cast<Kb2x3*>(out), static_cast<const Kb2x3*>(a), n, reps);
+    bench_inv_kernel<Kb2x3><<<grid_size, block, 0, stream>>>(static_cast<Kb2x3*>(out), static_cast<const Kb2x3*>(a), n, reps);
     return cudaGetLastError();
 }
 
@@ -513,33 +513,33 @@ extern "C" int inv_kb2x3(void* out, const void* a, size_t n, int reps) {
 // Extern "C" Wrappers for Kb3x2 (KoalaBear 3×2 tower)
 // ============================================================================
 
-extern "C" int init_kb3x2(void* out, const uint32_t* raw_data, size_t n) {
+extern "C" int init_kb3x2(void* out, const uint32_t* raw_data, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_init_kernel<Kb3x2, Kb, 6><<<grid_size, block>>>(static_cast<Kb3x2*>(out), raw_data, n);
+    bench_init_kernel<Kb3x2, Kb, 6><<<grid_size, block, 0, stream>>>(static_cast<Kb3x2*>(out), raw_data, n);
     return cudaGetLastError();
 }
 
-extern "C" int add_kb3x2(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int add_kb3x2(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_add_kernel<Kb3x2><<<grid_size, block>>>(
+    bench_add_kernel<Kb3x2><<<grid_size, block, 0, stream>>>(
         static_cast<Kb3x2*>(out), static_cast<const Kb3x2*>(a), static_cast<const Kb3x2*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int mul_kb3x2(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int mul_kb3x2(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_mul_kernel<Kb3x2><<<grid_size, block>>>(
+    bench_mul_kernel<Kb3x2><<<grid_size, block, 0, stream>>>(
         static_cast<Kb3x2*>(out), static_cast<const Kb3x2*>(a), static_cast<const Kb3x2*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int inv_kb3x2(void* out, const void* a, size_t n, int reps) {
+extern "C" int inv_kb3x2(void* out, const void* a, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_inv_kernel<Kb3x2><<<grid_size, block>>>(static_cast<Kb3x2*>(out), static_cast<const Kb3x2*>(a), n, reps);
+    bench_inv_kernel<Kb3x2><<<grid_size, block, 0, stream>>>(static_cast<Kb3x2*>(out), static_cast<const Kb3x2*>(a), n, reps);
     return cudaGetLastError();
 }
 
@@ -547,33 +547,33 @@ extern "C" int inv_kb3x2(void* out, const void* a, size_t n, int reps) {
 // Extern "C" Wrappers for Gl (Goldilocks base field)
 // ============================================================================
 
-extern "C" int init_gl(void* out, const uint64_t* raw_data, size_t n) {
+extern "C" int init_gl(void* out, const uint64_t* raw_data, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_init_gl_kernel<<<grid_size, block>>>(static_cast<Gl*>(out), raw_data, n);
+    bench_init_gl_kernel<<<grid_size, block, 0, stream>>>(static_cast<Gl*>(out), raw_data, n);
     return cudaGetLastError();
 }
 
-extern "C" int add_gl(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int add_gl(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_add_kernel<Gl><<<grid_size, block>>>(
+    bench_add_kernel<Gl><<<grid_size, block, 0, stream>>>(
         static_cast<Gl*>(out), static_cast<const Gl*>(a), static_cast<const Gl*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int mul_gl(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int mul_gl(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_mul_kernel<Gl><<<grid_size, block>>>(
+    bench_mul_kernel<Gl><<<grid_size, block, 0, stream>>>(
         static_cast<Gl*>(out), static_cast<const Gl*>(a), static_cast<const Gl*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int inv_gl(void* out, const void* a, size_t n, int reps) {
+extern "C" int inv_gl(void* out, const void* a, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_inv_kernel<Gl><<<grid_size, block>>>(static_cast<Gl*>(out), static_cast<const Gl*>(a), n, reps);
+    bench_inv_kernel<Gl><<<grid_size, block, 0, stream>>>(static_cast<Gl*>(out), static_cast<const Gl*>(a), n, reps);
     return cudaGetLastError();
 }
 
@@ -581,32 +581,32 @@ extern "C" int inv_gl(void* out, const void* a, size_t n, int reps) {
 // Extern "C" Wrappers for Gl3 (Goldilocks cubic extension)
 // ============================================================================
 
-extern "C" int init_gl3(void* out, const uint64_t* raw_data, size_t n) {
+extern "C" int init_gl3(void* out, const uint64_t* raw_data, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_init_gl3_kernel<<<grid_size, block>>>(static_cast<Gl3*>(out), raw_data, n);
+    bench_init_gl3_kernel<<<grid_size, block, 0, stream>>>(static_cast<Gl3*>(out), raw_data, n);
     return cudaGetLastError();
 }
 
-extern "C" int add_gl3(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int add_gl3(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_add_kernel<Gl3><<<grid_size, block>>>(
+    bench_add_kernel<Gl3><<<grid_size, block, 0, stream>>>(
         static_cast<Gl3*>(out), static_cast<const Gl3*>(a), static_cast<const Gl3*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int mul_gl3(void* out, const void* a, const void* b, size_t n, int reps) {
+extern "C" int mul_gl3(void* out, const void* a, const void* b, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_mul_kernel<Gl3><<<grid_size, block>>>(
+    bench_mul_kernel<Gl3><<<grid_size, block, 0, stream>>>(
         static_cast<Gl3*>(out), static_cast<const Gl3*>(a), static_cast<const Gl3*>(b), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int inv_gl3(void* out, const void* a, size_t n, int reps) {
+extern "C" int inv_gl3(void* out, const void* a, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_launch_config(n, grid_size);
-    bench_inv_kernel<Gl3><<<grid_size, block>>>(static_cast<Gl3*>(out), static_cast<const Gl3*>(a), n, reps);
+    bench_inv_kernel<Gl3><<<grid_size, block, 0, stream>>>(static_cast<Gl3*>(out), static_cast<const Gl3*>(a), n, reps);
     return cudaGetLastError();
 }

--- a/benchmarks/fields/cuda/src/poseidon2_bench.cu
+++ b/benchmarks/fields/cuda/src/poseidon2_bench.cu
@@ -63,30 +63,30 @@ __global__ void poseidon2_bench_kernel(T* states, size_t n, int reps) {
 // Extern "C" Wrappers
 // ============================================================================
 
-extern "C" int init_poseidon2_bb(void* out, const uint32_t* raw_data, size_t n) {
+extern "C" int init_poseidon2_bb(void* out, const uint32_t* raw_data, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_p2_launch_config(n, grid_size);
-    poseidon2_init_kernel<Fp><<<grid_size, block>>>(static_cast<Fp*>(out), raw_data, n);
+    poseidon2_init_kernel<Fp><<<grid_size, block, 0, stream>>>(static_cast<Fp*>(out), raw_data, n);
     return cudaGetLastError();
 }
 
-extern "C" int run_poseidon2_bb(void* states, size_t n, int reps) {
+extern "C" int run_poseidon2_bb(void* states, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_p2_launch_config(n, grid_size);
-    poseidon2_bench_kernel<Fp, poseidon2::poseidon2_mix><<<grid_size, block>>>(static_cast<Fp*>(states), n, reps);
+    poseidon2_bench_kernel<Fp, poseidon2::poseidon2_mix><<<grid_size, block, 0, stream>>>(static_cast<Fp*>(states), n, reps);
     return cudaGetLastError();
 }
 
-extern "C" int init_poseidon2_kb(void* out, const uint32_t* raw_data, size_t n) {
+extern "C" int init_poseidon2_kb(void* out, const uint32_t* raw_data, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_p2_launch_config(n, grid_size);
-    poseidon2_init_kernel<Kb><<<grid_size, block>>>(static_cast<Kb*>(out), raw_data, n);
+    poseidon2_init_kernel<Kb><<<grid_size, block, 0, stream>>>(static_cast<Kb*>(out), raw_data, n);
     return cudaGetLastError();
 }
 
-extern "C" int run_poseidon2_kb(void* states, size_t n, int reps) {
+extern "C" int run_poseidon2_kb(void* states, size_t n, int reps, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_p2_launch_config(n, grid_size);
-    poseidon2_bench_kernel<Kb, kb_poseidon2::poseidon2_mix><<<grid_size, block>>>(static_cast<Kb*>(states), n, reps);
+    poseidon2_bench_kernel<Kb, kb_poseidon2::poseidon2_mix><<<grid_size, block, 0, stream>>>(static_cast<Kb*>(states), n, reps);
     return cudaGetLastError();
 }

--- a/benchmarks/fields/cuda/src/verification.cu
+++ b/benchmarks/fields/cuda/src/verification.cu
@@ -79,17 +79,17 @@ __global__ void verify_distrib_kernel(uint32_t* failures, const T* a, const T* b
 // Fp4 Verification (simple implementation)
 // ============================================================================
 
-extern "C" int verify_inv_fp4(uint32_t* failures, const void* a, size_t n) {
+extern "C" int verify_inv_fp4(uint32_t* failures, const void* a, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_inv_kernel<Fp4><<<grid_size, block>>>(failures, static_cast<const Fp4*>(a), n);
+    verify_inv_kernel<Fp4><<<grid_size, block, 0, stream>>>(failures, static_cast<const Fp4*>(a), n);
     return cudaGetLastError();
 }
 
-extern "C" int verify_distrib_fp4(uint32_t* failures, const void* a, const void* b, const void* c, size_t n) {
+extern "C" int verify_distrib_fp4(uint32_t* failures, const void* a, const void* b, const void* c, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_distrib_kernel<Fp4><<<grid_size, block>>>(
+    verify_distrib_kernel<Fp4><<<grid_size, block, 0, stream>>>(
         failures, static_cast<const Fp4*>(a), static_cast<const Fp4*>(b), static_cast<const Fp4*>(c), n);
     return cudaGetLastError();
 }
@@ -98,17 +98,17 @@ extern "C" int verify_distrib_fp4(uint32_t* failures, const void* a, const void*
 // Fp5 Verification
 // ============================================================================
 
-extern "C" int verify_inv_fp5(uint32_t* failures, const void* a, size_t n) {
+extern "C" int verify_inv_fp5(uint32_t* failures, const void* a, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_inv_kernel<Fp5><<<grid_size, block>>>(failures, static_cast<const Fp5*>(a), n);
+    verify_inv_kernel<Fp5><<<grid_size, block, 0, stream>>>(failures, static_cast<const Fp5*>(a), n);
     return cudaGetLastError();
 }
 
-extern "C" int verify_distrib_fp5(uint32_t* failures, const void* a, const void* b, const void* c, size_t n) {
+extern "C" int verify_distrib_fp5(uint32_t* failures, const void* a, const void* b, const void* c, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_distrib_kernel<Fp5><<<grid_size, block>>>(
+    verify_distrib_kernel<Fp5><<<grid_size, block, 0, stream>>>(
         failures, static_cast<const Fp5*>(a), static_cast<const Fp5*>(b), static_cast<const Fp5*>(c), n);
     return cudaGetLastError();
 }
@@ -117,17 +117,17 @@ extern "C" int verify_distrib_fp5(uint32_t* failures, const void* a, const void*
 // Fp6 Verification
 // ============================================================================
 
-extern "C" int verify_inv_fp6(uint32_t* failures, const void* a, size_t n) {
+extern "C" int verify_inv_fp6(uint32_t* failures, const void* a, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_inv_kernel<Fp6><<<grid_size, block>>>(failures, static_cast<const Fp6*>(a), n);
+    verify_inv_kernel<Fp6><<<grid_size, block, 0, stream>>>(failures, static_cast<const Fp6*>(a), n);
     return cudaGetLastError();
 }
 
-extern "C" int verify_distrib_fp6(uint32_t* failures, const void* a, const void* b, const void* c, size_t n) {
+extern "C" int verify_distrib_fp6(uint32_t* failures, const void* a, const void* b, const void* c, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_distrib_kernel<Fp6><<<grid_size, block>>>(
+    verify_distrib_kernel<Fp6><<<grid_size, block, 0, stream>>>(
         failures, static_cast<const Fp6*>(a), static_cast<const Fp6*>(b), static_cast<const Fp6*>(c), n);
     return cudaGetLastError();
 }
@@ -136,17 +136,17 @@ extern "C" int verify_distrib_fp6(uint32_t* failures, const void* a, const void*
 // Fp2x3 Verification (2×3 tower)
 // ============================================================================
 
-extern "C" int verify_inv_fp2x3(uint32_t* failures, const void* a, size_t n) {
+extern "C" int verify_inv_fp2x3(uint32_t* failures, const void* a, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_inv_kernel<Fp2x3><<<grid_size, block>>>(failures, static_cast<const Fp2x3*>(a), n);
+    verify_inv_kernel<Fp2x3><<<grid_size, block, 0, stream>>>(failures, static_cast<const Fp2x3*>(a), n);
     return cudaGetLastError();
 }
 
-extern "C" int verify_distrib_fp2x3(uint32_t* failures, const void* a, const void* b, const void* c, size_t n) {
+extern "C" int verify_distrib_fp2x3(uint32_t* failures, const void* a, const void* b, const void* c, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_distrib_kernel<Fp2x3><<<grid_size, block>>>(
+    verify_distrib_kernel<Fp2x3><<<grid_size, block, 0, stream>>>(
         failures, static_cast<const Fp2x3*>(a), static_cast<const Fp2x3*>(b), static_cast<const Fp2x3*>(c), n);
     return cudaGetLastError();
 }
@@ -155,17 +155,17 @@ extern "C" int verify_distrib_fp2x3(uint32_t* failures, const void* a, const voi
 // Fp3x2 Verification (3×2 tower)
 // ============================================================================
 
-extern "C" int verify_inv_fp3x2(uint32_t* failures, const void* a, size_t n) {
+extern "C" int verify_inv_fp3x2(uint32_t* failures, const void* a, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_inv_kernel<Fp3x2><<<grid_size, block>>>(failures, static_cast<const Fp3x2*>(a), n);
+    verify_inv_kernel<Fp3x2><<<grid_size, block, 0, stream>>>(failures, static_cast<const Fp3x2*>(a), n);
     return cudaGetLastError();
 }
 
-extern "C" int verify_distrib_fp3x2(uint32_t* failures, const void* a, const void* b, const void* c, size_t n) {
+extern "C" int verify_distrib_fp3x2(uint32_t* failures, const void* a, const void* b, const void* c, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_distrib_kernel<Fp3x2><<<grid_size, block>>>(
+    verify_distrib_kernel<Fp3x2><<<grid_size, block, 0, stream>>>(
         failures, static_cast<const Fp3x2*>(a), static_cast<const Fp3x2*>(b), static_cast<const Fp3x2*>(c), n);
     return cudaGetLastError();
 }
@@ -174,17 +174,17 @@ extern "C" int verify_distrib_fp3x2(uint32_t* failures, const void* a, const voi
 // Kb Verification (KoalaBear base)
 // ============================================================================
 
-extern "C" int verify_inv_kb(uint32_t* failures, const void* a, size_t n) {
+extern "C" int verify_inv_kb(uint32_t* failures, const void* a, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_inv_kernel<Kb><<<grid_size, block>>>(failures, static_cast<const Kb*>(a), n);
+    verify_inv_kernel<Kb><<<grid_size, block, 0, stream>>>(failures, static_cast<const Kb*>(a), n);
     return cudaGetLastError();
 }
 
-extern "C" int verify_distrib_kb(uint32_t* failures, const void* a, const void* b, const void* c, size_t n) {
+extern "C" int verify_distrib_kb(uint32_t* failures, const void* a, const void* b, const void* c, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_distrib_kernel<Kb><<<grid_size, block>>>(
+    verify_distrib_kernel<Kb><<<grid_size, block, 0, stream>>>(
         failures, static_cast<const Kb*>(a), static_cast<const Kb*>(b), static_cast<const Kb*>(c), n);
     return cudaGetLastError();
 }
@@ -193,17 +193,17 @@ extern "C" int verify_distrib_kb(uint32_t* failures, const void* a, const void* 
 // Kb5 Verification (KoalaBear quintic)
 // ============================================================================
 
-extern "C" int verify_inv_kb5(uint32_t* failures, const void* a, size_t n) {
+extern "C" int verify_inv_kb5(uint32_t* failures, const void* a, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_inv_kernel<Kb5><<<grid_size, block>>>(failures, static_cast<const Kb5*>(a), n);
+    verify_inv_kernel<Kb5><<<grid_size, block, 0, stream>>>(failures, static_cast<const Kb5*>(a), n);
     return cudaGetLastError();
 }
 
-extern "C" int verify_distrib_kb5(uint32_t* failures, const void* a, const void* b, const void* c, size_t n) {
+extern "C" int verify_distrib_kb5(uint32_t* failures, const void* a, const void* b, const void* c, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_distrib_kernel<Kb5><<<grid_size, block>>>(
+    verify_distrib_kernel<Kb5><<<grid_size, block, 0, stream>>>(
         failures, static_cast<const Kb5*>(a), static_cast<const Kb5*>(b), static_cast<const Kb5*>(c), n);
     return cudaGetLastError();
 }
@@ -212,17 +212,17 @@ extern "C" int verify_distrib_kb5(uint32_t* failures, const void* a, const void*
 // Kb6 Verification (KoalaBear sextic)
 // ============================================================================
 
-extern "C" int verify_inv_kb6(uint32_t* failures, const void* a, size_t n) {
+extern "C" int verify_inv_kb6(uint32_t* failures, const void* a, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_inv_kernel<Kb6><<<grid_size, block>>>(failures, static_cast<const Kb6*>(a), n);
+    verify_inv_kernel<Kb6><<<grid_size, block, 0, stream>>>(failures, static_cast<const Kb6*>(a), n);
     return cudaGetLastError();
 }
 
-extern "C" int verify_distrib_kb6(uint32_t* failures, const void* a, const void* b, const void* c, size_t n) {
+extern "C" int verify_distrib_kb6(uint32_t* failures, const void* a, const void* b, const void* c, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_distrib_kernel<Kb6><<<grid_size, block>>>(
+    verify_distrib_kernel<Kb6><<<grid_size, block, 0, stream>>>(
         failures, static_cast<const Kb6*>(a), static_cast<const Kb6*>(b), static_cast<const Kb6*>(c), n);
     return cudaGetLastError();
 }
@@ -231,17 +231,17 @@ extern "C" int verify_distrib_kb6(uint32_t* failures, const void* a, const void*
 // Kb2x3 Verification (KoalaBear 2×3 tower)
 // ============================================================================
 
-extern "C" int verify_inv_kb2x3(uint32_t* failures, const void* a, size_t n) {
+extern "C" int verify_inv_kb2x3(uint32_t* failures, const void* a, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_inv_kernel<Kb2x3><<<grid_size, block>>>(failures, static_cast<const Kb2x3*>(a), n);
+    verify_inv_kernel<Kb2x3><<<grid_size, block, 0, stream>>>(failures, static_cast<const Kb2x3*>(a), n);
     return cudaGetLastError();
 }
 
-extern "C" int verify_distrib_kb2x3(uint32_t* failures, const void* a, const void* b, const void* c, size_t n) {
+extern "C" int verify_distrib_kb2x3(uint32_t* failures, const void* a, const void* b, const void* c, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_distrib_kernel<Kb2x3><<<grid_size, block>>>(
+    verify_distrib_kernel<Kb2x3><<<grid_size, block, 0, stream>>>(
         failures, static_cast<const Kb2x3*>(a), static_cast<const Kb2x3*>(b), static_cast<const Kb2x3*>(c), n);
     return cudaGetLastError();
 }
@@ -250,17 +250,17 @@ extern "C" int verify_distrib_kb2x3(uint32_t* failures, const void* a, const voi
 // Kb3x2 Verification (KoalaBear 3×2 tower)
 // ============================================================================
 
-extern "C" int verify_inv_kb3x2(uint32_t* failures, const void* a, size_t n) {
+extern "C" int verify_inv_kb3x2(uint32_t* failures, const void* a, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_inv_kernel<Kb3x2><<<grid_size, block>>>(failures, static_cast<const Kb3x2*>(a), n);
+    verify_inv_kernel<Kb3x2><<<grid_size, block, 0, stream>>>(failures, static_cast<const Kb3x2*>(a), n);
     return cudaGetLastError();
 }
 
-extern "C" int verify_distrib_kb3x2(uint32_t* failures, const void* a, const void* b, const void* c, size_t n) {
+extern "C" int verify_distrib_kb3x2(uint32_t* failures, const void* a, const void* b, const void* c, size_t n, cudaStream_t stream) {
     int grid_size;
     dim3 block = get_verify_config(n, grid_size);
-    verify_distrib_kernel<Kb3x2><<<grid_size, block>>>(
+    verify_distrib_kernel<Kb3x2><<<grid_size, block, 0, stream>>>(
         failures, static_cast<const Kb3x2*>(a), static_cast<const Kb3x2*>(b), static_cast<const Kb3x2*>(c), n);
     return cudaGetLastError();
 }

--- a/benchmarks/fields/src/lib.rs
+++ b/benchmarks/fields/src/lib.rs
@@ -10,7 +10,7 @@ use std::{ffi::c_void, time::Instant};
 use openvm_cuda_common::{
     copy::MemCopyH2D,
     d_buffer::DeviceBuffer,
-    stream::{cudaStream_t, current_stream_sync},
+    stream::{cudaStreamPerThread, cudaStream_t, CudaStream},
 };
 
 // ============================================================================
@@ -18,390 +18,605 @@ use openvm_cuda_common::{
 // ============================================================================
 
 // Benchmark kernels
-#[link(name = "ext_field_bench")]
-extern "C" {
-    fn init_fp(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_fp(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn mul_fp(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn inv_fp(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t)
-        -> i32;
+mod ffi {
+    use super::*;
 
-    // BabyBear quartic extension (simple implementation)
-    pub fn init_fp4(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_fp4(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn mul_fp4(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn inv_fp4(
-        out: *mut c_void,
-        a: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
+    #[link(name = "ext_field_bench")]
+    extern "C" {
+        pub(crate) fn init_fp(
+            out: *mut c_void,
+            raw_data: *const u32,
+            n: usize,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn add_fp(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn mul_fp(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn inv_fp(
+            out: *mut c_void,
+            a: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
 
-    // BabyBear quartic extension (optimized bb31_4_t)
-    fn init_fpext(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_fpext(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn mul_fpext(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn inv_fpext(
-        out: *mut c_void,
-        a: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
+        // BabyBear quartic extension (simple implementation)
+        pub fn init_fp4(
+            out: *mut c_void,
+            raw_data: *const u32,
+            n: usize,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn add_fp4(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn mul_fp4(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn inv_fp4(
+            out: *mut c_void,
+            a: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
 
-    pub fn init_fp5(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_fp5(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn mul_fp5(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn inv_fp5(
-        out: *mut c_void,
-        a: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
+        // BabyBear quartic extension (optimized bb31_4_t)
+        pub(crate) fn init_fpext(
+            out: *mut c_void,
+            raw_data: *const u32,
+            n: usize,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn add_fpext(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn mul_fpext(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn inv_fpext(
+            out: *mut c_void,
+            a: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
 
-    pub fn init_fp6(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_fp6(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn mul_fp6(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn inv_fp6(
-        out: *mut c_void,
-        a: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
+        pub fn init_fp5(
+            out: *mut c_void,
+            raw_data: *const u32,
+            n: usize,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn add_fp5(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn mul_fp5(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn inv_fp5(
+            out: *mut c_void,
+            a: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
 
-    pub fn init_fp2x3(
-        out: *mut c_void,
-        raw_data: *const u32,
-        n: usize,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn add_fp2x3(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn mul_fp2x3(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn inv_fp2x3(
-        out: *mut c_void,
-        a: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
+        pub fn init_fp6(
+            out: *mut c_void,
+            raw_data: *const u32,
+            n: usize,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn add_fp6(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn mul_fp6(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn inv_fp6(
+            out: *mut c_void,
+            a: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
 
-    pub fn init_fp3x2(
-        out: *mut c_void,
-        raw_data: *const u32,
-        n: usize,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn add_fp3x2(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn mul_fp3x2(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn inv_fp3x2(
-        out: *mut c_void,
-        a: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
+        pub fn init_fp2x3(
+            out: *mut c_void,
+            raw_data: *const u32,
+            n: usize,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn add_fp2x3(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn mul_fp2x3(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn inv_fp2x3(
+            out: *mut c_void,
+            a: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
 
-    // KoalaBear base field
-    pub fn init_kb(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_kb(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn mul_kb(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn inv_kb(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t)
-        -> i32;
+        pub fn init_fp3x2(
+            out: *mut c_void,
+            raw_data: *const u32,
+            n: usize,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn add_fp3x2(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn mul_fp3x2(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn inv_fp3x2(
+            out: *mut c_void,
+            a: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
 
-    // KoalaBear quintic extension (x^5 + x + 4)
-    pub fn init_kb5(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_kb5(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn mul_kb5(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn inv_kb5(
-        out: *mut c_void,
-        a: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
+        // KoalaBear base field
+        pub fn init_kb(
+            out: *mut c_void,
+            raw_data: *const u32,
+            n: usize,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn add_kb(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn mul_kb(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn inv_kb(
+            out: *mut c_void,
+            a: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
 
-    // KoalaBear sextic extension (x^6 + x^3 + 1)
-    pub fn init_kb6(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_kb6(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn mul_kb6(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn inv_kb6(
-        out: *mut c_void,
-        a: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
+        // KoalaBear quintic extension (x^5 + x + 4)
+        pub fn init_kb5(
+            out: *mut c_void,
+            raw_data: *const u32,
+            n: usize,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn add_kb5(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn mul_kb5(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn inv_kb5(
+            out: *mut c_void,
+            a: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
 
-    // KoalaBear 2×3 tower (u²=3, v³=1+u)
-    pub fn init_kb2x3(
-        out: *mut c_void,
-        raw_data: *const u32,
-        n: usize,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn add_kb2x3(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn mul_kb2x3(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn inv_kb2x3(
-        out: *mut c_void,
-        a: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
+        // KoalaBear sextic extension (x^6 + x^3 + 1)
+        pub fn init_kb6(
+            out: *mut c_void,
+            raw_data: *const u32,
+            n: usize,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn add_kb6(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn mul_kb6(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn inv_kb6(
+            out: *mut c_void,
+            a: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
 
-    // KoalaBear 3×2 tower (w³=-w-4, z²=3)
-    pub fn init_kb3x2(
-        out: *mut c_void,
-        raw_data: *const u32,
-        n: usize,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn add_kb3x2(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn mul_kb3x2(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn inv_kb3x2(
-        out: *mut c_void,
-        a: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
+        // KoalaBear 2×3 tower (u²=3, v³=1+u)
+        pub fn init_kb2x3(
+            out: *mut c_void,
+            raw_data: *const u32,
+            n: usize,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn add_kb2x3(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn mul_kb2x3(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn inv_kb2x3(
+            out: *mut c_void,
+            a: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
 
-    // Goldilocks base field (64-bit prime: 2^64 - 2^32 + 1)
-    fn init_gl(out: *mut c_void, raw_data: *const u64, n: usize, stream: cudaStream_t) -> i32;
-    fn add_gl(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn mul_gl(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn inv_gl(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t)
-        -> i32;
+        // KoalaBear 3×2 tower (w³=-w-4, z²=3)
+        pub fn init_kb3x2(
+            out: *mut c_void,
+            raw_data: *const u32,
+            n: usize,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn add_kb3x2(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn mul_kb3x2(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn inv_kb3x2(
+            out: *mut c_void,
+            a: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
 
-    // Goldilocks cubic extension (X³ - X - 1)
-    fn init_gl3(out: *mut c_void, raw_data: *const u64, n: usize, stream: cudaStream_t) -> i32;
-    fn add_gl3(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn mul_gl3(
-        out: *mut c_void,
-        a: *const c_void,
-        b: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn inv_gl3(
-        out: *mut c_void,
-        a: *const c_void,
-        n: usize,
-        reps: i32,
-        stream: cudaStream_t,
-    ) -> i32;
+        // Goldilocks base field (64-bit prime: 2^64 - 2^32 + 1)
+        pub(crate) fn init_gl(
+            out: *mut c_void,
+            raw_data: *const u64,
+            n: usize,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn add_gl(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn mul_gl(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn inv_gl(
+            out: *mut c_void,
+            a: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+
+        // Goldilocks cubic extension (X³ - X - 1)
+        pub(crate) fn init_gl3(
+            out: *mut c_void,
+            raw_data: *const u64,
+            n: usize,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn add_gl3(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn mul_gl3(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn inv_gl3(
+            out: *mut c_void,
+            a: *const c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+    }
+
+    // Poseidon2 benchmark kernels
+    #[link(name = "ext_field_bench")]
+    extern "C" {
+        pub(crate) fn init_poseidon2_bb(
+            out: *mut c_void,
+            raw_data: *const u32,
+            n: usize,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn run_poseidon2_bb(
+            states: *mut c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn init_poseidon2_kb(
+            out: *mut c_void,
+            raw_data: *const u32,
+            n: usize,
+            stream: cudaStream_t,
+        ) -> i32;
+        pub(crate) fn run_poseidon2_kb(
+            states: *mut c_void,
+            n: usize,
+            reps: i32,
+            stream: cudaStream_t,
+        ) -> i32;
+    }
 }
 
-// Poseidon2 benchmark kernels
-#[link(name = "ext_field_bench")]
-extern "C" {
-    fn init_poseidon2_bb(
-        out: *mut c_void,
-        raw_data: *const u32,
-        n: usize,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn run_poseidon2_bb(states: *mut c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn init_poseidon2_kb(
-        out: *mut c_void,
-        raw_data: *const u32,
-        n: usize,
-        stream: cudaStream_t,
-    ) -> i32;
-    fn run_poseidon2_kb(states: *mut c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+macro_rules! wrap_init_u32 {
+    ($vis:vis $name:ident) => {
+        /// Launches the benchmark init kernel on the PTDS benchmark stream.
+        ///
+        /// # Safety
+        /// The caller must provide valid device pointers for `out` and `raw_data`,
+        /// and `out` must have capacity for `n` field elements of the target type.
+        #[inline]
+        $vis unsafe extern "C" fn $name(out: *mut c_void, raw_data: *const u32, n: usize) -> i32 {
+            ffi::$name(out, raw_data, n, cudaStreamPerThread)
+        }
+    };
+}
+
+macro_rules! wrap_init_u64 {
+    ($vis:vis $name:ident) => {
+        /// Launches the benchmark init kernel on the PTDS benchmark stream.
+        ///
+        /// # Safety
+        /// The caller must provide valid device pointers for `out` and `raw_data`,
+        /// and `out` must have capacity for `n` field elements of the target type.
+        #[inline]
+        $vis unsafe extern "C" fn $name(out: *mut c_void, raw_data: *const u64, n: usize) -> i32 {
+            ffi::$name(out, raw_data, n, cudaStreamPerThread)
+        }
+    };
+}
+
+macro_rules! wrap_binary {
+    ($name:ident) => {
+        #[inline]
+        unsafe extern "C" fn $name(
+            out: *mut c_void,
+            a: *const c_void,
+            b: *const c_void,
+            n: usize,
+            reps: i32,
+        ) -> i32 {
+            ffi::$name(out, a, b, n, reps, cudaStreamPerThread)
+        }
+    };
+}
+
+macro_rules! wrap_unary {
+    ($name:ident) => {
+        #[inline]
+        unsafe extern "C" fn $name(out: *mut c_void, a: *const c_void, n: usize, reps: i32) -> i32 {
+            ffi::$name(out, a, n, reps, cudaStreamPerThread)
+        }
+    };
+}
+
+wrap_init_u32!(pub init_fp);
+wrap_binary!(add_fp);
+wrap_binary!(mul_fp);
+wrap_unary!(inv_fp);
+
+wrap_init_u32!(pub init_fp4);
+wrap_binary!(add_fp4);
+wrap_binary!(mul_fp4);
+wrap_unary!(inv_fp4);
+
+wrap_init_u32!(init_fpext);
+wrap_binary!(add_fpext);
+wrap_binary!(mul_fpext);
+wrap_unary!(inv_fpext);
+
+wrap_init_u32!(pub init_fp5);
+wrap_binary!(add_fp5);
+wrap_binary!(mul_fp5);
+wrap_unary!(inv_fp5);
+
+wrap_init_u32!(pub init_fp6);
+wrap_binary!(add_fp6);
+wrap_binary!(mul_fp6);
+wrap_unary!(inv_fp6);
+
+wrap_init_u32!(pub init_fp2x3);
+wrap_binary!(add_fp2x3);
+wrap_binary!(mul_fp2x3);
+wrap_unary!(inv_fp2x3);
+
+wrap_init_u32!(pub init_fp3x2);
+wrap_binary!(add_fp3x2);
+wrap_binary!(mul_fp3x2);
+wrap_unary!(inv_fp3x2);
+
+wrap_init_u32!(pub init_kb);
+wrap_binary!(add_kb);
+wrap_binary!(mul_kb);
+wrap_unary!(inv_kb);
+
+wrap_init_u32!(pub init_kb5);
+wrap_binary!(add_kb5);
+wrap_binary!(mul_kb5);
+wrap_unary!(inv_kb5);
+
+wrap_init_u32!(pub init_kb6);
+wrap_binary!(add_kb6);
+wrap_binary!(mul_kb6);
+wrap_unary!(inv_kb6);
+
+wrap_init_u32!(pub init_kb2x3);
+wrap_binary!(add_kb2x3);
+wrap_binary!(mul_kb2x3);
+wrap_unary!(inv_kb2x3);
+
+wrap_init_u32!(pub init_kb3x2);
+wrap_binary!(add_kb3x2);
+wrap_binary!(mul_kb3x2);
+wrap_unary!(inv_kb3x2);
+
+wrap_init_u64!(init_gl);
+wrap_binary!(add_gl);
+wrap_binary!(mul_gl);
+wrap_unary!(inv_gl);
+
+wrap_init_u64!(init_gl3);
+wrap_binary!(add_gl3);
+wrap_binary!(mul_gl3);
+wrap_unary!(inv_gl3);
+
+wrap_init_u32!(init_poseidon2_bb);
+
+#[inline]
+unsafe extern "C" fn run_poseidon2_bb(states: *mut c_void, n: usize, reps: i32) -> i32 {
+    ffi::run_poseidon2_bb(states, n, reps, cudaStreamPerThread)
+}
+
+wrap_init_u32!(init_poseidon2_kb);
+
+#[inline]
+unsafe extern "C" fn run_poseidon2_kb(states: *mut c_void, n: usize, reps: i32) -> i32 {
+    ffi::run_poseidon2_kb(states, n, reps, cudaStreamPerThread)
 }
 
 /// Check CUDA return code, panic on error
@@ -411,7 +626,8 @@ pub fn cuda_check(code: i32) {
 
 /// Sync and check
 pub fn sync() {
-    current_stream_sync().expect("sync failed");
+    let stream = CudaStream::ptds();
+    stream.synchronize().expect("sync failed");
 }
 
 // ============================================================================

--- a/benchmarks/fields/src/lib.rs
+++ b/benchmarks/fields/src/lib.rs
@@ -7,7 +7,11 @@
 
 use std::{ffi::c_void, time::Instant};
 
-use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer, stream::current_stream_sync};
+use openvm_cuda_common::{
+    copy::MemCopyH2D,
+    d_buffer::DeviceBuffer,
+    stream::{cudaStream_t, current_stream_sync},
+};
 
 // ============================================================================
 // FFI Bindings
@@ -16,93 +20,93 @@ use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer, stream::curre
 // Benchmark kernels
 #[link(name = "ext_field_bench")]
 extern "C" {
-    fn init_fp(out: *mut c_void, raw_data: *const u32, n: usize) -> i32;
-    fn add_fp(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn mul_fp(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn inv_fp(out: *mut c_void, a: *const c_void, n: usize, reps: i32) -> i32;
+    fn init_fp(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
+    fn add_fp(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn mul_fp(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn inv_fp(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
 
     // BabyBear quartic extension (simple implementation)
-    pub fn init_fp4(out: *mut c_void, raw_data: *const u32, n: usize) -> i32;
-    fn add_fp4(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn mul_fp4(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn inv_fp4(out: *mut c_void, a: *const c_void, n: usize, reps: i32) -> i32;
+    pub fn init_fp4(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
+    fn add_fp4(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn mul_fp4(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn inv_fp4(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
 
     // BabyBear quartic extension (optimized bb31_4_t)
-    fn init_fpext(out: *mut c_void, raw_data: *const u32, n: usize) -> i32;
-    fn add_fpext(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn mul_fpext(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn inv_fpext(out: *mut c_void, a: *const c_void, n: usize, reps: i32) -> i32;
+    fn init_fpext(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
+    fn add_fpext(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn mul_fpext(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn inv_fpext(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
 
-    pub fn init_fp5(out: *mut c_void, raw_data: *const u32, n: usize) -> i32;
-    fn add_fp5(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn mul_fp5(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn inv_fp5(out: *mut c_void, a: *const c_void, n: usize, reps: i32) -> i32;
+    pub fn init_fp5(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
+    fn add_fp5(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn mul_fp5(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn inv_fp5(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
 
-    pub fn init_fp6(out: *mut c_void, raw_data: *const u32, n: usize) -> i32;
-    fn add_fp6(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn mul_fp6(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn inv_fp6(out: *mut c_void, a: *const c_void, n: usize, reps: i32) -> i32;
+    pub fn init_fp6(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
+    fn add_fp6(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn mul_fp6(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn inv_fp6(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
 
-    pub fn init_fp2x3(out: *mut c_void, raw_data: *const u32, n: usize) -> i32;
-    fn add_fp2x3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn mul_fp2x3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn inv_fp2x3(out: *mut c_void, a: *const c_void, n: usize, reps: i32) -> i32;
+    pub fn init_fp2x3(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
+    fn add_fp2x3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn mul_fp2x3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn inv_fp2x3(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
 
-    pub fn init_fp3x2(out: *mut c_void, raw_data: *const u32, n: usize) -> i32;
-    fn add_fp3x2(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn mul_fp3x2(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn inv_fp3x2(out: *mut c_void, a: *const c_void, n: usize, reps: i32) -> i32;
+    pub fn init_fp3x2(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
+    fn add_fp3x2(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn mul_fp3x2(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn inv_fp3x2(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
 
     // KoalaBear base field
-    pub fn init_kb(out: *mut c_void, raw_data: *const u32, n: usize) -> i32;
-    fn add_kb(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn mul_kb(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn inv_kb(out: *mut c_void, a: *const c_void, n: usize, reps: i32) -> i32;
+    pub fn init_kb(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
+    fn add_kb(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn mul_kb(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn inv_kb(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
 
     // KoalaBear quintic extension (x^5 + x + 4)
-    pub fn init_kb5(out: *mut c_void, raw_data: *const u32, n: usize) -> i32;
-    fn add_kb5(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn mul_kb5(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn inv_kb5(out: *mut c_void, a: *const c_void, n: usize, reps: i32) -> i32;
+    pub fn init_kb5(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
+    fn add_kb5(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn mul_kb5(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn inv_kb5(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
 
     // KoalaBear sextic extension (x^6 + x^3 + 1)
-    pub fn init_kb6(out: *mut c_void, raw_data: *const u32, n: usize) -> i32;
-    fn add_kb6(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn mul_kb6(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn inv_kb6(out: *mut c_void, a: *const c_void, n: usize, reps: i32) -> i32;
+    pub fn init_kb6(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
+    fn add_kb6(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn mul_kb6(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn inv_kb6(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
 
     // KoalaBear 2×3 tower (u²=3, v³=1+u)
-    pub fn init_kb2x3(out: *mut c_void, raw_data: *const u32, n: usize) -> i32;
-    fn add_kb2x3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn mul_kb2x3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn inv_kb2x3(out: *mut c_void, a: *const c_void, n: usize, reps: i32) -> i32;
+    pub fn init_kb2x3(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
+    fn add_kb2x3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn mul_kb2x3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn inv_kb2x3(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
 
     // KoalaBear 3×2 tower (w³=-w-4, z²=3)
-    pub fn init_kb3x2(out: *mut c_void, raw_data: *const u32, n: usize) -> i32;
-    fn add_kb3x2(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn mul_kb3x2(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn inv_kb3x2(out: *mut c_void, a: *const c_void, n: usize, reps: i32) -> i32;
+    pub fn init_kb3x2(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
+    fn add_kb3x2(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn mul_kb3x2(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn inv_kb3x2(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
 
     // Goldilocks base field (64-bit prime: 2^64 - 2^32 + 1)
-    fn init_gl(out: *mut c_void, raw_data: *const u64, n: usize) -> i32;
-    fn add_gl(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn mul_gl(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn inv_gl(out: *mut c_void, a: *const c_void, n: usize, reps: i32) -> i32;
+    fn init_gl(out: *mut c_void, raw_data: *const u64, n: usize, stream: cudaStream_t) -> i32;
+    fn add_gl(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn mul_gl(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn inv_gl(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
 
     // Goldilocks cubic extension (X³ - X - 1)
-    fn init_gl3(out: *mut c_void, raw_data: *const u64, n: usize) -> i32;
-    fn add_gl3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn mul_gl3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32) -> i32;
-    fn inv_gl3(out: *mut c_void, a: *const c_void, n: usize, reps: i32) -> i32;
+    fn init_gl3(out: *mut c_void, raw_data: *const u64, n: usize, stream: cudaStream_t) -> i32;
+    fn add_gl3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn mul_gl3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn inv_gl3(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
 }
 
 // Poseidon2 benchmark kernels
 #[link(name = "ext_field_bench")]
 extern "C" {
-    fn init_poseidon2_bb(out: *mut c_void, raw_data: *const u32, n: usize) -> i32;
-    fn run_poseidon2_bb(states: *mut c_void, n: usize, reps: i32) -> i32;
-    fn init_poseidon2_kb(out: *mut c_void, raw_data: *const u32, n: usize) -> i32;
-    fn run_poseidon2_kb(states: *mut c_void, n: usize, reps: i32) -> i32;
+    fn init_poseidon2_bb(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
+    fn run_poseidon2_bb(states: *mut c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn init_poseidon2_kb(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
+    fn run_poseidon2_kb(states: *mut c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
 }
 
 /// Check CUDA return code, panic on error

--- a/benchmarks/fields/src/lib.rs
+++ b/benchmarks/fields/src/lib.rs
@@ -5,13 +5,18 @@
 //!
 //! Throughput is reported in Gops/s (Giga-operations per second = billion ops/sec).
 
-use std::{ffi::c_void, time::Instant};
+use std::{ffi::c_void, sync::OnceLock, time::Instant};
 
 use openvm_cuda_common::{
     copy::MemCopyH2D,
     d_buffer::DeviceBuffer,
-    stream::{cudaStreamPerThread, cudaStream_t, CudaStream},
+    stream::{cudaStream_t, DeviceContext},
 };
+
+pub fn bench_ctx() -> &'static DeviceContext {
+    static CTX: OnceLock<DeviceContext> = OnceLock::new();
+    CTX.get_or_init(|| DeviceContext::for_current_device().expect("benchmark CUDA context"))
+}
 
 // ============================================================================
 // FFI Bindings
@@ -485,28 +490,28 @@ mod ffi {
 
 macro_rules! wrap_init_u32 {
     ($vis:vis $name:ident) => {
-        /// Launches the benchmark init kernel on the PTDS benchmark stream.
+        /// Launches the benchmark init kernel on the benchmark stream.
         ///
         /// # Safety
         /// The caller must provide valid device pointers for `out` and `raw_data`,
         /// and `out` must have capacity for `n` field elements of the target type.
         #[inline]
         $vis unsafe extern "C" fn $name(out: *mut c_void, raw_data: *const u32, n: usize) -> i32 {
-            ffi::$name(out, raw_data, n, cudaStreamPerThread)
+            ffi::$name(out, raw_data, n, bench_ctx().stream.as_raw())
         }
     };
 }
 
 macro_rules! wrap_init_u64 {
     ($vis:vis $name:ident) => {
-        /// Launches the benchmark init kernel on the PTDS benchmark stream.
+        /// Launches the benchmark init kernel on the benchmark stream.
         ///
         /// # Safety
         /// The caller must provide valid device pointers for `out` and `raw_data`,
         /// and `out` must have capacity for `n` field elements of the target type.
         #[inline]
         $vis unsafe extern "C" fn $name(out: *mut c_void, raw_data: *const u64, n: usize) -> i32 {
-            ffi::$name(out, raw_data, n, cudaStreamPerThread)
+            ffi::$name(out, raw_data, n, bench_ctx().stream.as_raw())
         }
     };
 }
@@ -521,7 +526,7 @@ macro_rules! wrap_binary {
             n: usize,
             reps: i32,
         ) -> i32 {
-            ffi::$name(out, a, b, n, reps, cudaStreamPerThread)
+            ffi::$name(out, a, b, n, reps, bench_ctx().stream.as_raw())
         }
     };
 }
@@ -530,7 +535,7 @@ macro_rules! wrap_unary {
     ($name:ident) => {
         #[inline]
         unsafe extern "C" fn $name(out: *mut c_void, a: *const c_void, n: usize, reps: i32) -> i32 {
-            ffi::$name(out, a, n, reps, cudaStreamPerThread)
+            ffi::$name(out, a, n, reps, bench_ctx().stream.as_raw())
         }
     };
 }
@@ -609,14 +614,14 @@ wrap_init_u32!(init_poseidon2_bb);
 
 #[inline]
 unsafe extern "C" fn run_poseidon2_bb(states: *mut c_void, n: usize, reps: i32) -> i32 {
-    ffi::run_poseidon2_bb(states, n, reps, cudaStreamPerThread)
+    ffi::run_poseidon2_bb(states, n, reps, bench_ctx().stream.as_raw())
 }
 
 wrap_init_u32!(init_poseidon2_kb);
 
 #[inline]
 unsafe extern "C" fn run_poseidon2_kb(states: *mut c_void, n: usize, reps: i32) -> i32 {
-    ffi::run_poseidon2_kb(states, n, reps, cudaStreamPerThread)
+    ffi::run_poseidon2_kb(states, n, reps, bench_ctx().stream.as_raw())
 }
 
 /// Check CUDA return code, panic on error
@@ -626,8 +631,7 @@ pub fn cuda_check(code: i32) {
 
 /// Sync and check
 pub fn sync() {
-    let stream = CudaStream::ptds();
-    stream.synchronize().expect("sync failed");
+    bench_ctx().stream.synchronize().expect("sync failed");
 }
 
 // ============================================================================
@@ -808,9 +812,9 @@ pub fn bench_fp(config: &BenchConfig) -> FieldBenchResult {
     let reps = config.ops_per_element;
 
     // Only 3 device buffers: a, b, out (init works in-place)
-    let d_a = random_u32s(n, 12345).to_device().unwrap();
-    let d_b = random_u32s(n, 67890).to_device().unwrap();
-    let d_out = DeviceBuffer::<u32>::with_capacity(n);
+    let d_a = random_u32s(n, 12345).to_device_on(bench_ctx()).unwrap();
+    let d_b = random_u32s(n, 67890).to_device_on(bench_ctx()).unwrap();
+    let d_out = DeviceBuffer::<u32>::with_capacity_on(n, bench_ctx());
 
     // Benchmark init (in-place: raw u32 -> Fp) - also initializes d_a
     let init = measure(config, n as u64, || {
@@ -864,9 +868,9 @@ pub fn bench_fp4(config: &BenchConfig) -> FieldBenchResult {
     let n = config.num_elements;
     let reps = config.ops_per_element;
 
-    let d_a = random_u32s(n * 4, 11111).to_device().unwrap();
-    let d_b = random_u32s(n * 4, 22222).to_device().unwrap();
-    let d_out = DeviceBuffer::<u32>::with_capacity(n * 4);
+    let d_a = random_u32s(n * 4, 11111).to_device_on(bench_ctx()).unwrap();
+    let d_b = random_u32s(n * 4, 22222).to_device_on(bench_ctx()).unwrap();
+    let d_out = DeviceBuffer::<u32>::with_capacity_on(n * 4, bench_ctx());
 
     let init = measure(config, n as u64, || {
         cuda_check(unsafe { init_fp4(d_a.as_mut_raw_ptr(), d_a.as_ptr(), n) });
@@ -920,9 +924,9 @@ pub fn bench_fpext(config: &BenchConfig) -> FieldBenchResult {
     let reps = config.ops_per_element;
 
     // Only 3 device buffers: a, b, out (init works in-place)
-    let d_a = random_u32s(n * 4, 12345).to_device().unwrap();
-    let d_b = random_u32s(n * 4, 67890).to_device().unwrap();
-    let d_out = DeviceBuffer::<u32>::with_capacity(n * 4);
+    let d_a = random_u32s(n * 4, 12345).to_device_on(bench_ctx()).unwrap();
+    let d_b = random_u32s(n * 4, 67890).to_device_on(bench_ctx()).unwrap();
+    let d_out = DeviceBuffer::<u32>::with_capacity_on(n * 4, bench_ctx());
 
     // Benchmark init (in-place: raw u32s -> FpExt) - also initializes d_a
     let init = measure(config, n as u64, || {
@@ -977,9 +981,9 @@ pub fn bench_fp5(config: &BenchConfig) -> FieldBenchResult {
     let reps = config.ops_per_element;
 
     // Only 3 device buffers: a, b, out (init works in-place)
-    let d_a = random_u32s(n * 5, 12345).to_device().unwrap();
-    let d_b = random_u32s(n * 5, 67890).to_device().unwrap();
-    let d_out = DeviceBuffer::<u32>::with_capacity(n * 5);
+    let d_a = random_u32s(n * 5, 12345).to_device_on(bench_ctx()).unwrap();
+    let d_b = random_u32s(n * 5, 67890).to_device_on(bench_ctx()).unwrap();
+    let d_out = DeviceBuffer::<u32>::with_capacity_on(n * 5, bench_ctx());
 
     // Benchmark init (in-place: raw u32s -> Fp5) - also initializes d_a
     let init = measure(config, n as u64, || {
@@ -1034,9 +1038,9 @@ pub fn bench_fp6(config: &BenchConfig) -> FieldBenchResult {
     let reps = config.ops_per_element;
 
     // Only 3 device buffers: a, b, out (init works in-place)
-    let d_a = random_u32s(n * 6, 12345).to_device().unwrap();
-    let d_b = random_u32s(n * 6, 67890).to_device().unwrap();
-    let d_out = DeviceBuffer::<u32>::with_capacity(n * 6);
+    let d_a = random_u32s(n * 6, 12345).to_device_on(bench_ctx()).unwrap();
+    let d_b = random_u32s(n * 6, 67890).to_device_on(bench_ctx()).unwrap();
+    let d_out = DeviceBuffer::<u32>::with_capacity_on(n * 6, bench_ctx());
 
     // Benchmark init (in-place: raw u32s -> Fp6) - also initializes d_a
     let init = measure(config, n as u64, || {
@@ -1090,9 +1094,9 @@ pub fn bench_fp2x3(config: &BenchConfig) -> FieldBenchResult {
     let n = config.num_elements;
     let reps = config.ops_per_element;
 
-    let d_a = random_u32s(n * 6, 12345).to_device().unwrap();
-    let d_b = random_u32s(n * 6, 67890).to_device().unwrap();
-    let d_out = DeviceBuffer::<u32>::with_capacity(n * 6);
+    let d_a = random_u32s(n * 6, 12345).to_device_on(bench_ctx()).unwrap();
+    let d_b = random_u32s(n * 6, 67890).to_device_on(bench_ctx()).unwrap();
+    let d_out = DeviceBuffer::<u32>::with_capacity_on(n * 6, bench_ctx());
 
     let init = measure(config, n as u64, || {
         cuda_check(unsafe { init_fp2x3(d_a.as_mut_raw_ptr(), d_a.as_ptr(), n) });
@@ -1145,9 +1149,9 @@ pub fn bench_fp3x2(config: &BenchConfig) -> FieldBenchResult {
     let n = config.num_elements;
     let reps = config.ops_per_element;
 
-    let d_a = random_u32s(n * 6, 12345).to_device().unwrap();
-    let d_b = random_u32s(n * 6, 67890).to_device().unwrap();
-    let d_out = DeviceBuffer::<u32>::with_capacity(n * 6);
+    let d_a = random_u32s(n * 6, 12345).to_device_on(bench_ctx()).unwrap();
+    let d_b = random_u32s(n * 6, 67890).to_device_on(bench_ctx()).unwrap();
+    let d_out = DeviceBuffer::<u32>::with_capacity_on(n * 6, bench_ctx());
 
     let init = measure(config, n as u64, || {
         cuda_check(unsafe { init_fp3x2(d_a.as_mut_raw_ptr(), d_a.as_ptr(), n) });
@@ -1201,9 +1205,9 @@ pub fn bench_kb(config: &BenchConfig) -> FieldBenchResult {
     let reps = config.ops_per_element;
 
     // Only 3 device buffers: a, b, out (init works in-place)
-    let d_a = random_u32s(n, 12345).to_device().unwrap();
-    let d_b = random_u32s(n, 67890).to_device().unwrap();
-    let d_out = DeviceBuffer::<u32>::with_capacity(n);
+    let d_a = random_u32s(n, 12345).to_device_on(bench_ctx()).unwrap();
+    let d_b = random_u32s(n, 67890).to_device_on(bench_ctx()).unwrap();
+    let d_out = DeviceBuffer::<u32>::with_capacity_on(n, bench_ctx());
 
     // Benchmark init (in-place: raw u32 -> Kb) - also initializes d_a
     let init = measure(config, n as u64, || {
@@ -1258,9 +1262,9 @@ pub fn bench_kb5(config: &BenchConfig) -> FieldBenchResult {
     let reps = config.ops_per_element;
 
     // Kb5 has 5 u32s per element
-    let d_a = random_u32s(n * 5, 11111).to_device().unwrap();
-    let d_b = random_u32s(n * 5, 22222).to_device().unwrap();
-    let d_out = DeviceBuffer::<u32>::with_capacity(n * 5);
+    let d_a = random_u32s(n * 5, 11111).to_device_on(bench_ctx()).unwrap();
+    let d_b = random_u32s(n * 5, 22222).to_device_on(bench_ctx()).unwrap();
+    let d_out = DeviceBuffer::<u32>::with_capacity_on(n * 5, bench_ctx());
 
     let init = measure(config, n as u64, || {
         cuda_check(unsafe { init_kb5(d_a.as_mut_raw_ptr(), d_a.as_ptr(), n) });
@@ -1314,9 +1318,9 @@ pub fn bench_kb6(config: &BenchConfig) -> FieldBenchResult {
     let reps = config.ops_per_element;
 
     // Kb6 has 6 u32s per element
-    let d_a = random_u32s(n * 6, 33333).to_device().unwrap();
-    let d_b = random_u32s(n * 6, 44444).to_device().unwrap();
-    let d_out = DeviceBuffer::<u32>::with_capacity(n * 6);
+    let d_a = random_u32s(n * 6, 33333).to_device_on(bench_ctx()).unwrap();
+    let d_b = random_u32s(n * 6, 44444).to_device_on(bench_ctx()).unwrap();
+    let d_out = DeviceBuffer::<u32>::with_capacity_on(n * 6, bench_ctx());
 
     let init = measure(config, n as u64, || {
         cuda_check(unsafe { init_kb6(d_a.as_mut_raw_ptr(), d_a.as_ptr(), n) });
@@ -1370,9 +1374,9 @@ pub fn bench_kb2x3(config: &BenchConfig) -> FieldBenchResult {
     let reps = config.ops_per_element;
 
     // Kb2x3 has 6 u32s per element
-    let d_a = random_u32s(n * 6, 55555).to_device().unwrap();
-    let d_b = random_u32s(n * 6, 66666).to_device().unwrap();
-    let d_out = DeviceBuffer::<u32>::with_capacity(n * 6);
+    let d_a = random_u32s(n * 6, 55555).to_device_on(bench_ctx()).unwrap();
+    let d_b = random_u32s(n * 6, 66666).to_device_on(bench_ctx()).unwrap();
+    let d_out = DeviceBuffer::<u32>::with_capacity_on(n * 6, bench_ctx());
 
     let init = measure(config, n as u64, || {
         cuda_check(unsafe { init_kb2x3(d_a.as_mut_raw_ptr(), d_a.as_ptr(), n) });
@@ -1426,9 +1430,9 @@ pub fn bench_kb3x2(config: &BenchConfig) -> FieldBenchResult {
     let reps = config.ops_per_element;
 
     // Kb3x2 has 6 u32s per element
-    let d_a = random_u32s(n * 6, 77777).to_device().unwrap();
-    let d_b = random_u32s(n * 6, 88888).to_device().unwrap();
-    let d_out = DeviceBuffer::<u32>::with_capacity(n * 6);
+    let d_a = random_u32s(n * 6, 77777).to_device_on(bench_ctx()).unwrap();
+    let d_b = random_u32s(n * 6, 88888).to_device_on(bench_ctx()).unwrap();
+    let d_out = DeviceBuffer::<u32>::with_capacity_on(n * 6, bench_ctx());
 
     let init = measure(config, n as u64, || {
         cuda_check(unsafe { init_kb3x2(d_a.as_mut_raw_ptr(), d_a.as_ptr(), n) });
@@ -1485,9 +1489,9 @@ pub fn bench_gl(config: &BenchConfig) -> FieldBenchResult {
     let h_a = random_u64s(n, 99999);
     let h_b = random_u64s(n, 88888);
 
-    let d_a = h_a.to_device().unwrap();
-    let d_b = h_b.to_device().unwrap();
-    let d_out = DeviceBuffer::<u64>::with_capacity(n);
+    let d_a = h_a.to_device_on(bench_ctx()).unwrap();
+    let d_b = h_b.to_device_on(bench_ctx()).unwrap();
+    let d_out = DeviceBuffer::<u64>::with_capacity_on(n, bench_ctx());
 
     let init = measure(config, n as u64, || {
         cuda_check(unsafe { init_gl(d_a.as_mut_raw_ptr(), d_a.as_ptr(), n) });
@@ -1545,9 +1549,9 @@ pub fn bench_gl3(config: &BenchConfig) -> FieldBenchResult {
     let h_a = random_u64s(n * 3, 77777);
     let h_b = random_u64s(n * 3, 66666);
 
-    let d_a = h_a.to_device().unwrap();
-    let d_b = h_b.to_device().unwrap();
-    let d_out = DeviceBuffer::<u64>::with_capacity(n * 3);
+    let d_a = h_a.to_device_on(bench_ctx()).unwrap();
+    let d_b = h_b.to_device_on(bench_ctx()).unwrap();
+    let d_out = DeviceBuffer::<u64>::with_capacity_on(n * 3, bench_ctx());
 
     let init = measure(config, n as u64, || {
         cuda_check(unsafe { init_gl3(d_a.as_mut_raw_ptr(), d_a.as_ptr(), n) });
@@ -1613,7 +1617,9 @@ pub fn bench_poseidon2_bb(config: &BenchConfig) -> Poseidon2BenchResult {
     let reps = config.ops_per_element;
 
     // 16 u32s per poseidon2 state
-    let d_states = random_u32s(n * 16, 55555).to_device().unwrap();
+    let d_states = random_u32s(n * 16, 55555)
+        .to_device_on(bench_ctx())
+        .unwrap();
 
     // Initialize: raw u32 -> Fp field elements
     cuda_check(unsafe { init_poseidon2_bb(d_states.as_mut_raw_ptr(), d_states.as_ptr(), n) });
@@ -1636,7 +1642,9 @@ pub fn bench_poseidon2_kb(config: &BenchConfig) -> Poseidon2BenchResult {
     let reps = config.ops_per_element;
 
     // 16 u32s per poseidon2 state
-    let d_states = random_u32s(n * 16, 66666).to_device().unwrap();
+    let d_states = random_u32s(n * 16, 66666)
+        .to_device_on(bench_ctx())
+        .unwrap();
 
     // Initialize: raw u32 -> Kb field elements
     cuda_check(unsafe { init_poseidon2_kb(d_states.as_mut_raw_ptr(), d_states.as_ptr(), n) });

--- a/benchmarks/fields/src/lib.rs
+++ b/benchmarks/fields/src/lib.rs
@@ -10,12 +10,12 @@ use std::{ffi::c_void, sync::OnceLock, time::Instant};
 use openvm_cuda_common::{
     copy::MemCopyH2D,
     d_buffer::DeviceBuffer,
-    stream::{cudaStream_t, DeviceContext},
+    stream::{cudaStream_t, GpuDeviceCtx},
 };
 
-pub fn bench_ctx() -> &'static DeviceContext {
-    static CTX: OnceLock<DeviceContext> = OnceLock::new();
-    CTX.get_or_init(|| DeviceContext::for_current_device().expect("benchmark CUDA context"))
+pub fn bench_ctx() -> &'static GpuDeviceCtx {
+    static CTX: OnceLock<GpuDeviceCtx> = OnceLock::new();
+    CTX.get_or_init(|| GpuDeviceCtx::for_current_device().expect("benchmark CUDA context"))
 }
 
 // ============================================================================

--- a/benchmarks/fields/src/lib.rs
+++ b/benchmarks/fields/src/lib.rs
@@ -21,91 +21,386 @@ use openvm_cuda_common::{
 #[link(name = "ext_field_bench")]
 extern "C" {
     fn init_fp(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_fp(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn mul_fp(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn inv_fp(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn add_fp(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn mul_fp(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn inv_fp(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t)
+        -> i32;
 
     // BabyBear quartic extension (simple implementation)
     pub fn init_fp4(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_fp4(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn mul_fp4(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn inv_fp4(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn add_fp4(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn mul_fp4(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn inv_fp4(
+        out: *mut c_void,
+        a: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
 
     // BabyBear quartic extension (optimized bb31_4_t)
     fn init_fpext(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_fpext(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn mul_fpext(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn inv_fpext(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn add_fpext(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn mul_fpext(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn inv_fpext(
+        out: *mut c_void,
+        a: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
 
     pub fn init_fp5(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_fp5(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn mul_fp5(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn inv_fp5(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn add_fp5(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn mul_fp5(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn inv_fp5(
+        out: *mut c_void,
+        a: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
 
     pub fn init_fp6(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_fp6(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn mul_fp6(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn inv_fp6(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn add_fp6(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn mul_fp6(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn inv_fp6(
+        out: *mut c_void,
+        a: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
 
-    pub fn init_fp2x3(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_fp2x3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn mul_fp2x3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn inv_fp2x3(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    pub fn init_fp2x3(
+        out: *mut c_void,
+        raw_data: *const u32,
+        n: usize,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn add_fp2x3(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn mul_fp2x3(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn inv_fp2x3(
+        out: *mut c_void,
+        a: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
 
-    pub fn init_fp3x2(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_fp3x2(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn mul_fp3x2(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn inv_fp3x2(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    pub fn init_fp3x2(
+        out: *mut c_void,
+        raw_data: *const u32,
+        n: usize,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn add_fp3x2(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn mul_fp3x2(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn inv_fp3x2(
+        out: *mut c_void,
+        a: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
 
     // KoalaBear base field
     pub fn init_kb(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_kb(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn mul_kb(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn inv_kb(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn add_kb(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn mul_kb(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn inv_kb(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t)
+        -> i32;
 
     // KoalaBear quintic extension (x^5 + x + 4)
     pub fn init_kb5(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_kb5(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn mul_kb5(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn inv_kb5(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn add_kb5(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn mul_kb5(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn inv_kb5(
+        out: *mut c_void,
+        a: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
 
     // KoalaBear sextic extension (x^6 + x^3 + 1)
     pub fn init_kb6(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_kb6(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn mul_kb6(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn inv_kb6(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn add_kb6(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn mul_kb6(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn inv_kb6(
+        out: *mut c_void,
+        a: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
 
     // KoalaBear 2×3 tower (u²=3, v³=1+u)
-    pub fn init_kb2x3(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_kb2x3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn mul_kb2x3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn inv_kb2x3(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    pub fn init_kb2x3(
+        out: *mut c_void,
+        raw_data: *const u32,
+        n: usize,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn add_kb2x3(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn mul_kb2x3(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn inv_kb2x3(
+        out: *mut c_void,
+        a: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
 
     // KoalaBear 3×2 tower (w³=-w-4, z²=3)
-    pub fn init_kb3x2(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
-    fn add_kb3x2(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn mul_kb3x2(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn inv_kb3x2(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    pub fn init_kb3x2(
+        out: *mut c_void,
+        raw_data: *const u32,
+        n: usize,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn add_kb3x2(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn mul_kb3x2(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn inv_kb3x2(
+        out: *mut c_void,
+        a: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
 
     // Goldilocks base field (64-bit prime: 2^64 - 2^32 + 1)
     fn init_gl(out: *mut c_void, raw_data: *const u64, n: usize, stream: cudaStream_t) -> i32;
-    fn add_gl(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn mul_gl(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn inv_gl(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn add_gl(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn mul_gl(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn inv_gl(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t)
+        -> i32;
 
     // Goldilocks cubic extension (X³ - X - 1)
     fn init_gl3(out: *mut c_void, raw_data: *const u64, n: usize, stream: cudaStream_t) -> i32;
-    fn add_gl3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn mul_gl3(out: *mut c_void, a: *const c_void, b: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn inv_gl3(out: *mut c_void, a: *const c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
+    fn add_gl3(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn mul_gl3(
+        out: *mut c_void,
+        a: *const c_void,
+        b: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn inv_gl3(
+        out: *mut c_void,
+        a: *const c_void,
+        n: usize,
+        reps: i32,
+        stream: cudaStream_t,
+    ) -> i32;
 }
 
 // Poseidon2 benchmark kernels
 #[link(name = "ext_field_bench")]
 extern "C" {
-    fn init_poseidon2_bb(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
+    fn init_poseidon2_bb(
+        out: *mut c_void,
+        raw_data: *const u32,
+        n: usize,
+        stream: cudaStream_t,
+    ) -> i32;
     fn run_poseidon2_bb(states: *mut c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
-    fn init_poseidon2_kb(out: *mut c_void, raw_data: *const u32, n: usize, stream: cudaStream_t) -> i32;
+    fn init_poseidon2_kb(
+        out: *mut c_void,
+        raw_data: *const u32,
+        n: usize,
+        stream: cudaStream_t,
+    ) -> i32;
     fn run_poseidon2_kb(states: *mut c_void, n: usize, reps: i32, stream: cudaStream_t) -> i32;
 }
 

--- a/benchmarks/fields/tests/verification.rs
+++ b/benchmarks/fields/tests/verification.rs
@@ -126,9 +126,15 @@ fn verify_field(
     ) -> i32,
 ) -> Result<(), String> {
     // Create test data
-    let d_a = random_u32s(n * elems_per_field, 11111).to_device().unwrap();
-    let d_b = random_u32s(n * elems_per_field, 22222).to_device().unwrap();
-    let d_c = random_u32s(n * elems_per_field, 33333).to_device().unwrap();
+    let d_a = random_u32s(n * elems_per_field, 11111)
+        .to_device_on(bench_ctx())
+        .unwrap();
+    let d_b = random_u32s(n * elems_per_field, 22222)
+        .to_device_on(bench_ctx())
+        .unwrap();
+    let d_c = random_u32s(n * elems_per_field, 33333)
+        .to_device_on(bench_ctx())
+        .unwrap();
 
     // Initialize
     cuda_check(unsafe { init_fn(d_a.as_mut_raw_ptr(), d_a.as_ptr(), n) });
@@ -136,14 +142,14 @@ fn verify_field(
     cuda_check(unsafe { init_fn(d_c.as_mut_raw_ptr(), d_c.as_ptr(), n) });
 
     // Test 1: a * inv(a) = 1
-    let d_failures = DeviceBuffer::<u32>::with_capacity(1);
-    d_failures.fill_zero().unwrap();
+    let d_failures = DeviceBuffer::<u32>::with_capacity_on(1, bench_ctx());
+    d_failures.fill_zero_on(bench_ctx()).unwrap();
     cuda_check(unsafe { inv_fn(d_failures.as_mut_raw_ptr() as *mut u32, d_a.as_raw_ptr(), n) });
-    let inv_failures = d_failures.to_host().unwrap();
+    let inv_failures = d_failures.to_host_on(bench_ctx()).unwrap();
 
     // Test 2: Distributivity
-    let d_failures2 = DeviceBuffer::<u32>::with_capacity(1);
-    d_failures2.fill_zero().unwrap();
+    let d_failures2 = DeviceBuffer::<u32>::with_capacity_on(1, bench_ctx());
+    d_failures2.fill_zero_on(bench_ctx()).unwrap();
     cuda_check(unsafe {
         distrib_fn(
             d_failures2.as_mut_raw_ptr() as *mut u32,
@@ -153,7 +159,7 @@ fn verify_field(
             n,
         )
     });
-    let distrib_failures = d_failures2.to_host().unwrap();
+    let distrib_failures = d_failures2.to_host_on(bench_ctx()).unwrap();
 
     if inv_failures[0] != 0 {
         return Err(format!(

--- a/crates/cpu-backend/src/device.rs
+++ b/crates/cpu-backend/src/device.rs
@@ -52,6 +52,11 @@ where
     TS: FiatShamirTranscript<SC>,
 {
     type Error = CpuProverError;
+    type DeviceCtx = ();
+
+    fn device_ctx(&self) -> &() {
+        &()
+    }
 }
 
 impl<SC: StarkProtocolConfig> TraceCommitter<CpuBackend<SC>> for CpuDevice<SC>

--- a/crates/cuda-backend/cuda/src/batch_ntt_small.cu
+++ b/crates/cuda-backend/cuda/src/batch_ntt_small.cu
@@ -50,11 +50,10 @@ __global__ void generate_device_ntt_twiddles_kernel(Fp *d_twiddles) {
 // Generate twiddles into the provided device buffer and copy to constant memory.
 // `d_twiddles` must have capacity for DEVICE_NTT_TWIDDLES_SIZE elements.
 // Returns 0 on success, non-zero on error.
-extern "C" int _generate_device_ntt_twiddles(Fp *d_twiddles) {
+extern "C" int _generate_device_ntt_twiddles(Fp *d_twiddles, cudaStream_t stream) {
     // Generate twiddles on GPU
     constexpr uint32_t BLOCK_SIZE = 256;
     uint32_t num_blocks = div_ceil(DEVICE_NTT_TWIDDLES_SIZE, BLOCK_SIZE);
-    cudaStream_t stream = cudaStreamPerThread;
     generate_device_ntt_twiddles_kernel<<<num_blocks, BLOCK_SIZE, 0, stream>>>(d_twiddles);
 
     // Generate and publish on the same explicit stream so the copy cannot race the kernel.
@@ -68,7 +67,7 @@ extern "C" int _generate_device_ntt_twiddles(Fp *d_twiddles) {
     );
     cudaStreamSynchronize(stream);
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 // ============================================================================
@@ -115,7 +114,9 @@ __global__ void batch_ntt_kernel(
 }
 
 template <bool intt, bool needs_shmem>
-int launch_batch_ntt_small(Fp *buffer, size_t const l_skip, size_t const cnt_blocks) {
+int launch_batch_ntt_small(
+    Fp *buffer, size_t const l_skip, size_t const cnt_blocks, cudaStream_t stream
+) {
     uint32_t const threads_per_block = 1024;
     uint32_t const threads_x = 1 << l_skip;
     assert(threads_per_block >> l_skip);
@@ -123,18 +124,19 @@ int launch_batch_ntt_small(Fp *buffer, size_t const l_skip, size_t const cnt_blo
     size_t const smem_size = needs_shmem ? (sizeof(Fp) * threads_per_block) : 0;
 
     batch_ntt_kernel<intt, needs_shmem>
-        <<<div_ceil(cnt_blocks, threads_y), dim3{threads_x, threads_y, 1}, smem_size>>>(
+        <<<div_ceil(cnt_blocks, threads_y), dim3{threads_x, threads_y, 1}, smem_size, stream>>>(
             buffer, l_skip, cnt_blocks
         );
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _batch_ntt_small(
     Fp *buffer,
     size_t const l_skip,
     size_t const cnt_blocks,
-    bool const is_intt
+    bool const is_intt,
+    cudaStream_t stream
 ) {
     if (l_skip == 0 || cnt_blocks == 0) {
         return 0;
@@ -146,6 +148,6 @@ extern "C" int _batch_ntt_small(
     bool const needs_shmem = l_skip > LOG_WARP_SIZE;
     assert((1 << l_skip) <= 1024);
     return DISPATCH_BOOL_PAIR(
-        launch_batch_ntt_small, is_intt, needs_shmem, buffer, l_skip, cnt_blocks
+        launch_batch_ntt_small, is_intt, needs_shmem, buffer, l_skip, cnt_blocks, stream
     );
 }

--- a/crates/cuda-backend/cuda/src/batch_ntt_small.cu
+++ b/crates/cuda-backend/cuda/src/batch_ntt_small.cu
@@ -67,7 +67,7 @@ extern "C" int _generate_device_ntt_twiddles(Fp *d_twiddles, cudaStream_t stream
     );
     cudaStreamSynchronize(stream);
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 // ============================================================================
@@ -128,7 +128,7 @@ int launch_batch_ntt_small(
             buffer, l_skip, cnt_blocks
         );
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _batch_ntt_small(

--- a/crates/cuda-backend/cuda/src/batch_ntt_small.cu
+++ b/crates/cuda-backend/cuda/src/batch_ntt_small.cu
@@ -82,7 +82,7 @@ __global__ void batch_ntt_kernel(
 ) {
     uint32_t const block_idx = blockIdx.x * blockDim.y + threadIdx.y;
     bool const active_thread = (block_idx < cnt_blocks);
-    buffer += block_idx << l_skip;
+    buffer += static_cast<size_t>(block_idx) << l_skip;
 
 #ifdef CUDA_DEBUG
     assert(blockDim.x <= (1 << l_skip));

--- a/crates/cuda-backend/cuda/src/bn254_poseidon2.cu
+++ b/crates/cuda-backend/cuda/src/bn254_poseidon2.cu
@@ -455,8 +455,7 @@ __launch_bounds__(BN254_GRIND_BLOCK_SIZE) __global__ void bn254_grind_kernel(
 extern "C" int _init_bn254_poseidon2_rc(
     const uint64_t* initial_rc,
     const uint64_t* partial_rc,
-    const uint64_t* terminal_rc
-) {
+    const uint64_t* terminal_rc, cudaStream_t stream) {
     cudaError_t err;
     err = cudaMemcpyToSymbol(g_initial_rc,  initial_rc,  4 * 3 * 4 * sizeof(uint64_t));
     if (err != cudaSuccess) return (int)err;
@@ -475,8 +474,7 @@ extern "C" int _init_bn254_poseidon2_rc(
 extern "C" int _init_bn254_poseidon2_rc_w2(
     const uint64_t* initial_rc,
     const uint64_t* partial_rc,
-    const uint64_t* terminal_rc
-) {
+    const uint64_t* terminal_rc, cudaStream_t stream) {
     cudaError_t err;
     err = cudaMemcpyToSymbol(g_initial_rc_w2,  initial_rc,  3 * 2 * 4 * sizeof(uint64_t));
     if (err != cudaSuccess) return (int)err;
@@ -492,8 +490,7 @@ extern "C" int _bn254_poseidon2_compressing_row_hashes(
     const Fp*       matrix,
     size_t          width,
     size_t          query_stride,
-    size_t          log_rows_per_query
-) {
+    size_t          log_rows_per_query, cudaStream_t stream) {
     if (log_rows_per_query > 10) {
         return cudaErrorInvalidValue;
     }
@@ -505,10 +502,10 @@ extern "C" int _bn254_poseidon2_compressing_row_hashes(
     size_t shmem_bytes   = shared_stride * sizeof(Bn254Fr);
     auto   height        = query_stride << log_rows_per_query;
 
-    bn254_compressing_row_hashes_kernel<<<grid, block, shmem_bytes>>>(
+    bn254_compressing_row_hashes_kernel<<<grid, block, shmem_bytes, stream>>>(
         out, matrix, width, height, query_stride, log_rows_per_query
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _bn254_poseidon2_compressing_row_hashes_ext(
@@ -516,8 +513,7 @@ extern "C" int _bn254_poseidon2_compressing_row_hashes_ext(
     const FpExt*    matrix,
     size_t          width,
     size_t          query_stride,
-    size_t          log_rows_per_query
-) {
+    size_t          log_rows_per_query, cudaStream_t stream) {
     if (log_rows_per_query > 10) {
         return cudaErrorInvalidValue;
     }
@@ -529,20 +525,19 @@ extern "C" int _bn254_poseidon2_compressing_row_hashes_ext(
     size_t shmem_bytes   = shared_stride * sizeof(Bn254Fr);
     auto   height        = query_stride << log_rows_per_query;
 
-    bn254_compressing_row_hashes_ext_kernel<<<grid, block, shmem_bytes>>>(
+    bn254_compressing_row_hashes_ext_kernel<<<grid, block, shmem_bytes, stream>>>(
         out, matrix, width, height, query_stride, log_rows_per_query
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _bn254_poseidon2_adjacent_compress_layer(
     bn254_digest_t*       output,
     const bn254_digest_t* prev_layer,
-    size_t                output_size
-) {
+    size_t                output_size, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(output_size);
-    bn254_adjacent_compress_layer_kernel<<<grid, block>>>(output, prev_layer, output_size);
-    return CHECK_KERNEL();
+    bn254_adjacent_compress_layer_kernel<<<grid, block, 0, stream>>>(output, prev_layer, output_size);
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _bn254_sponge_grind(
@@ -550,8 +545,7 @@ extern "C" int _bn254_sponge_grind(
     uint32_t bits,
     uint32_t min_witness,
     uint32_t max_witness,
-    uint32_t* result
-) {
+    uint32_t* result, cudaStream_t stream) {
     if (bits >= 32 || (uint64_t{1} << bits) >= Fp::P) {
         return cudaErrorInvalidValue;
     }
@@ -559,13 +553,13 @@ extern "C" int _bn254_sponge_grind(
     size_t total_threads = size_t{1} << bits;
     size_t grid_size = div_ceil(total_threads, block_size);
 
-    bn254_grind_kernel<<<grid_size, block_size>>>(init_state, bits, min_witness, max_witness, result);
+    bn254_grind_kernel<<<grid_size, block_size, 0, stream>>>(init_state, bits, min_witness, max_witness, result);
 
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess) return (int)err;
 
-    err = cudaDeviceSynchronize();
+    err = cudaStreamSynchronize(stream);
     if (err != cudaSuccess) return (int)err;
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }

--- a/crates/cuda-backend/cuda/src/bn254_poseidon2.cu
+++ b/crates/cuda-backend/cuda/src/bn254_poseidon2.cu
@@ -137,7 +137,7 @@ static const int BN254_NUM_F_ELMS    = 8;
 
 /// Row hash for a base-field (Fp / BabyBear) matrix row.
 static __device__ __forceinline__
-Bn254Fr bn254_row_hash(const Fp* matrix, int width, int height, int row) {
+Bn254Fr bn254_row_hash(const Fp* matrix, size_t width, size_t height, size_t row) {
     Bn254Fr state[3];
     state[0] = bn254_zero_init();
     state[1] = bn254_zero_init();
@@ -146,7 +146,7 @@ Bn254Fr bn254_row_hash(const Fp* matrix, int width, int height, int row) {
     uint32_t buf[BN254_BABY_BEAR_RATE];
     int cnt = 0;
 
-    for (int col = 0; col < width; col++) {
+    for (size_t col = 0; col < width; col++) {
         buf[cnt++] = matrix[col * height + row].asUInt32();
         if (cnt == BN254_BABY_BEAR_RATE) {
             state[0] = bn254_pack_base_2_31(buf, BN254_NUM_F_ELMS);
@@ -167,7 +167,7 @@ Bn254Fr bn254_row_hash(const Fp* matrix, int width, int height, int row) {
 
 /// Row hash for an extension-field (FpExt / BinomialExtensionField<BabyBear,4>) matrix row.
 static __device__ __forceinline__
-Bn254Fr bn254_row_hash_ext(const FpExt* matrix, int width, int height, int row) {
+Bn254Fr bn254_row_hash_ext(const FpExt* matrix, size_t width, size_t height, size_t row) {
     Bn254Fr state[3];
     state[0] = bn254_zero_init();
     state[1] = bn254_zero_init();
@@ -176,7 +176,7 @@ Bn254Fr bn254_row_hash_ext(const FpExt* matrix, int width, int height, int row) 
     uint32_t buf[BN254_BABY_BEAR_RATE];
     int cnt = 0;
 
-    for (int col = 0; col < width; col++) {
+    for (size_t col = 0; col < width; col++) {
         FpExt elem = matrix[col * height + row];
         for (int d = 0; d < 4; d++) {
             buf[cnt++] = elem.elems[d].asUInt32();
@@ -225,12 +225,12 @@ __global__ void bn254_compressing_row_hashes_kernel(
 
     const uint32_t stride_idx = blockDim.x * blockIdx.x + threadIdx.x;
     uint32_t       leaf_idx   = threadIdx.y;
-    const uint32_t row        = leaf_idx * query_stride + stride_idx;
+    const size_t   row        = leaf_idx * query_stride + stride_idx;
 
     Bn254Fr digest = bn254_zero_init();
 
     if (stride_idx < query_stride) {
-        digest = bn254_row_hash(matrix, (int)width, (int)height, (int)row);
+        digest = bn254_row_hash(matrix, width, height, row);
     }
 
     // Tree reduction (same structure as the BabyBear kernel)
@@ -271,12 +271,12 @@ __global__ void bn254_compressing_row_hashes_ext_kernel(
 
     const uint32_t stride_idx = blockDim.x * blockIdx.x + threadIdx.x;
     uint32_t       leaf_idx   = threadIdx.y;
-    const uint32_t row        = leaf_idx * query_stride + stride_idx;
+    const size_t   row        = leaf_idx * query_stride + stride_idx;
 
     Bn254Fr digest = bn254_zero_init();
 
     if (stride_idx < query_stride) {
-        digest = bn254_row_hash_ext(matrix, (int)width, (int)height, (int)row);
+        digest = bn254_row_hash_ext(matrix, width, height, row);
     }
 
     for (int layer = 0; layer < (int)log_rows_per_query; ++layer) {

--- a/crates/cuda-backend/cuda/src/bn254_poseidon2.cu
+++ b/crates/cuda-backend/cuda/src/bn254_poseidon2.cu
@@ -505,7 +505,7 @@ extern "C" int _bn254_poseidon2_compressing_row_hashes(
     bn254_compressing_row_hashes_kernel<<<grid, block, shmem_bytes, stream>>>(
         out, matrix, width, height, query_stride, log_rows_per_query
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _bn254_poseidon2_compressing_row_hashes_ext(
@@ -528,7 +528,7 @@ extern "C" int _bn254_poseidon2_compressing_row_hashes_ext(
     bn254_compressing_row_hashes_ext_kernel<<<grid, block, shmem_bytes, stream>>>(
         out, matrix, width, height, query_stride, log_rows_per_query
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _bn254_poseidon2_adjacent_compress_layer(
@@ -537,7 +537,7 @@ extern "C" int _bn254_poseidon2_adjacent_compress_layer(
     size_t                output_size, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(output_size);
     bn254_adjacent_compress_layer_kernel<<<grid, block, 0, stream>>>(output, prev_layer, output_size);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _bn254_sponge_grind(
@@ -561,5 +561,5 @@ extern "C" int _bn254_sponge_grind(
     err = cudaStreamSynchronize(stream);
     if (err != cudaSuccess) return (int)err;
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }

--- a/crates/cuda-backend/cuda/src/device_info.cu
+++ b/crates/cuda-backend/cuda/src/device_info.cu
@@ -3,7 +3,7 @@
 #include <cuda_runtime_api.h>
 #include <driver_types.h>
 
-extern "C" int _cuda_get_sm_count(uint32_t device_id, uint32_t *out_sm_count) {
+extern "C" int _cuda_get_sm_count(uint32_t device_id, uint32_t *out_sm_count, cudaStream_t stream) {
     int sm_count = 0;
     cudaError_t err = cudaDeviceGetAttribute(
         &sm_count, cudaDevAttrMultiProcessorCount, static_cast<int>(device_id)

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/batch_mle.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/batch_mle.cu
@@ -396,7 +396,7 @@ extern "C" int _zerocheck_batch_eval_mle(
     zerocheck_batch_mle_kernel<<<grid, block, shmem_bytes, stream>>>(
         tmp_sums_buffer, block_ctxs, zc_ctxs, lambda_pows, lambda_len
     );
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0)
         return err;
 
@@ -410,7 +410,7 @@ extern "C" int _zerocheck_batch_eval_mle(
         tmp_sums_buffer, output, air_block_offsets, num_x
     );
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _logup_batch_eval_mle(
@@ -431,7 +431,7 @@ extern "C" int _logup_batch_eval_mle(
     size_t shmem_bytes = div_ceil(block.x, WARP_SIZE) * sizeof(FpExt);
 
     logup_batch_mle_kernel<<<grid, block, shmem_bytes, stream>>>(tmp_sums_buffer, block_ctxs, logup_ctxs);
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0)
         return err;
 
@@ -449,7 +449,7 @@ extern "C" int _logup_batch_eval_mle(
         2 * num_x
     );
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 } // namespace logup_zerocheck_mle

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/batch_mle.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/batch_mle.cu
@@ -385,8 +385,7 @@ extern "C" int _zerocheck_batch_eval_mle(
     uint32_t num_blocks,
     uint32_t num_x,
     uint32_t num_airs,
-    uint32_t threads_per_block
-) {
+    uint32_t threads_per_block, cudaStream_t stream) {
     if (!valid_grid_y_dim(num_x)) {
         return cudaErrorInvalidValue;
     }
@@ -394,10 +393,10 @@ extern "C" int _zerocheck_batch_eval_mle(
     dim3 block(threads_per_block);
     size_t shmem_bytes = div_ceil(block.x, WARP_SIZE) * sizeof(FpExt);
 
-    zerocheck_batch_mle_kernel<<<grid, block, shmem_bytes>>>(
+    zerocheck_batch_mle_kernel<<<grid, block, shmem_bytes, stream>>>(
         tmp_sums_buffer, block_ctxs, zc_ctxs, lambda_pows, lambda_len
     );
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0)
         return err;
 
@@ -407,11 +406,11 @@ extern "C" int _zerocheck_batch_eval_mle(
     size_t reduce_shmem = std::max(1u, reduce_warps) * sizeof(FpExt);
 
     dim3 reduce_grid(num_airs, num_x);
-    sumcheck::batched_final_reduce_block_sums<<<reduce_grid, reduce_block, reduce_shmem>>>(
+    sumcheck::batched_final_reduce_block_sums<<<reduce_grid, reduce_block, reduce_shmem, stream>>>(
         tmp_sums_buffer, output, air_block_offsets, num_x
     );
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _logup_batch_eval_mle(
@@ -423,8 +422,7 @@ extern "C" int _logup_batch_eval_mle(
     uint32_t num_blocks,
     uint32_t num_x,
     uint32_t num_airs,
-    uint32_t threads_per_block
-) {
+    uint32_t threads_per_block, cudaStream_t stream) {
     if (!valid_frac_grid_y_dim(num_x)) {
         return cudaErrorInvalidValue;
     }
@@ -432,8 +430,8 @@ extern "C" int _logup_batch_eval_mle(
     dim3 block(threads_per_block);
     size_t shmem_bytes = div_ceil(block.x, WARP_SIZE) * sizeof(FpExt);
 
-    logup_batch_mle_kernel<<<grid, block, shmem_bytes>>>(tmp_sums_buffer, block_ctxs, logup_ctxs);
-    int err = CHECK_KERNEL();
+    logup_batch_mle_kernel<<<grid, block, shmem_bytes, stream>>>(tmp_sums_buffer, block_ctxs, logup_ctxs);
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0)
         return err;
 
@@ -444,14 +442,14 @@ extern "C" int _logup_batch_eval_mle(
     size_t reduce_shmem = std::max(1u, reduce_warps) * sizeof(FpExt);
 
     dim3 reduce_grid(num_airs, 2 * num_x);
-    sumcheck::batched_final_reduce_block_sums<<<reduce_grid, reduce_block, reduce_shmem>>>(
+    sumcheck::batched_final_reduce_block_sums<<<reduce_grid, reduce_block, reduce_shmem, stream>>>(
         reinterpret_cast<FpExt *>(tmp_sums_buffer),
         reinterpret_cast<FpExt *>(output),
         air_block_offsets,
         2 * num_x
     );
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 } // namespace logup_zerocheck_mle

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/batch_mle.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/batch_mle.cu
@@ -358,7 +358,8 @@ __global__ void logup_batch_mle_kernel(
 extern "C" size_t _zerocheck_batch_mle_intermediates_buffer_size(
     uint32_t buffer_size,
     uint32_t num_x,
-    uint32_t num_y
+    uint32_t num_y,
+    cudaStream_t stream
 ) {
     size_t height = static_cast<size_t>(num_x) * num_y;
     return height * buffer_size;
@@ -368,7 +369,8 @@ extern "C" size_t _zerocheck_batch_mle_intermediates_buffer_size(
 extern "C" size_t _logup_batch_mle_intermediates_buffer_size(
     uint32_t buffer_size,
     uint32_t num_x,
-    uint32_t num_y
+    uint32_t num_y,
+    cudaStream_t stream
 ) {
     size_t height = static_cast<size_t>(num_x) * num_y;
     return height * buffer_size;

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/batch_mle.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/batch_mle.cu
@@ -387,7 +387,9 @@ extern "C" int _zerocheck_batch_eval_mle(
     uint32_t num_blocks,
     uint32_t num_x,
     uint32_t num_airs,
-    uint32_t threads_per_block, cudaStream_t stream) {
+    uint32_t threads_per_block,
+    cudaStream_t stream
+) {
     if (!valid_grid_y_dim(num_x)) {
         return cudaErrorInvalidValue;
     }
@@ -424,7 +426,9 @@ extern "C" int _logup_batch_eval_mle(
     uint32_t num_blocks,
     uint32_t num_x,
     uint32_t num_airs,
-    uint32_t threads_per_block, cudaStream_t stream) {
+    uint32_t threads_per_block,
+    cudaStream_t stream
+) {
     if (!valid_frac_grid_y_dim(num_x)) {
         return cudaErrorInvalidValue;
     }

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/batch_mle_monomial.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/batch_mle_monomial.cu
@@ -92,7 +92,7 @@ extern "C" int _precompute_lambda_combinations(
     precompute_lambda_combinations_kernel<<<blocks, threads, 0, stream>>>(
         out, headers, lambda_terms, lambda_pows, num_monomials
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 // ============================================================================
@@ -175,7 +175,7 @@ extern "C" int _zerocheck_monomial_batched(
     zerocheck_monomial_kernel<<<grid, block, shmem, stream>>>(
         tmp_sums, block_ctxs, air_ctxs, threads_per_block
     );
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0)
         return err;
 
@@ -190,7 +190,7 @@ extern "C" int _zerocheck_monomial_batched(
         tmp_sums, output, air_block_offsets, num_x
     );
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 // ============================================================================
@@ -283,7 +283,7 @@ extern "C" int _zerocheck_monomial_par_y_batched(
     zerocheck_monomial_par_y_kernel<<<grid, block, shmem, stream>>>(
         tmp_sums, block_ctxs, air_ctxs, threads_per_block, chunk_size
     );
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0)
         return err;
 
@@ -297,7 +297,7 @@ extern "C" int _zerocheck_monomial_par_y_batched(
         tmp_sums, output, air_block_offsets, num_x
     );
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 // ============================================================================
@@ -344,7 +344,7 @@ extern "C" int _precompute_logup_numer_combinations(
     precompute_logup_combinations_kernel<false><<<blocks, threads, 0, stream>>>(
         out, headers, terms, nullptr, eq_3bs, num_monomials
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _precompute_logup_denom_combinations(
@@ -362,7 +362,7 @@ extern "C" int _precompute_logup_denom_combinations(
     precompute_logup_combinations_kernel<true><<<blocks, threads, 0, stream>>>(
         out, headers, terms, beta_pows, eq_3bs, num_monomials
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 // AIR context for logup monomial MLE evaluation
@@ -469,7 +469,7 @@ extern "C" int _logup_monomial_batched(
     logup_monomial_kernel<false><<<grid, block, shmem, stream>>>(
         tmp_sums, block_ctxs, common_ctxs, numer_ctxs
     );
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0)
         return err;
 
@@ -477,7 +477,7 @@ extern "C" int _logup_monomial_batched(
     logup_monomial_kernel<true><<<grid, block, shmem, stream>>>(
         tmp_sums, block_ctxs, common_ctxs, denom_ctxs
     );
-    err = CHECK_KERNEL_ON(stream);
+    err = CHECK_KERNEL();
     if (err != 0)
         return err;
 
@@ -495,7 +495,7 @@ extern "C" int _logup_monomial_batched(
         2 * num_x
     );
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 } // namespace logup_zerocheck_mle

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/batch_mle_monomial.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/batch_mle_monomial.cu
@@ -83,17 +83,16 @@ extern "C" int _precompute_lambda_combinations(
     const MonomialHeader *headers,
     const LambdaTerm *lambda_terms,
     const FpExt *lambda_pows,
-    uint32_t num_monomials
-) {
+    uint32_t num_monomials, cudaStream_t stream) {
     if (num_monomials == 0)
         return 0;
 
     constexpr uint32_t threads = 256;
     uint32_t blocks = div_ceil(num_monomials, threads);
-    precompute_lambda_combinations_kernel<<<blocks, threads>>>(
+    precompute_lambda_combinations_kernel<<<blocks, threads, 0, stream>>>(
         out, headers, lambda_terms, lambda_pows, num_monomials
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 // ============================================================================
@@ -160,8 +159,7 @@ extern "C" int _zerocheck_monomial_batched(
     uint32_t num_blocks,
     uint32_t num_x,
     uint32_t num_airs,
-    uint32_t threads_per_block
-) {
+    uint32_t threads_per_block, cudaStream_t stream) {
     if (num_blocks == 0) {
         return 0;
     }
@@ -174,10 +172,10 @@ extern "C" int _zerocheck_monomial_batched(
     size_t shmem = div_ceil(block.x, WARP_SIZE) * sizeof(FpExt);
 
     // Phase 1: Main monomial evaluation kernel
-    zerocheck_monomial_kernel<<<grid, block, shmem>>>(
+    zerocheck_monomial_kernel<<<grid, block, shmem, stream>>>(
         tmp_sums, block_ctxs, air_ctxs, threads_per_block
     );
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0)
         return err;
 
@@ -188,11 +186,11 @@ extern "C" int _zerocheck_monomial_batched(
     size_t reduce_shmem = std::max(1u, reduce_warps) * sizeof(FpExt);
 
     dim3 reduce_grid(num_airs, num_x);
-    sumcheck::batched_final_reduce_block_sums<<<reduce_grid, reduce_block, reduce_shmem>>>(
+    sumcheck::batched_final_reduce_block_sums<<<reduce_grid, reduce_block, reduce_shmem, stream>>>(
         tmp_sums, output, air_block_offsets, num_x
     );
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 // ============================================================================
@@ -269,8 +267,7 @@ extern "C" int _zerocheck_monomial_par_y_batched(
     uint32_t num_x,
     uint32_t num_airs,
     uint32_t chunk_size,
-    uint32_t threads_per_block
-) {
+    uint32_t threads_per_block, cudaStream_t stream) {
     if (num_blocks == 0) {
         return 0;
     }
@@ -283,10 +280,10 @@ extern "C" int _zerocheck_monomial_par_y_batched(
     size_t shmem = div_ceil(block.x, WARP_SIZE) * sizeof(FpExt);
 
     // Phase 1: Main par-y kernel
-    zerocheck_monomial_par_y_kernel<<<grid, block, shmem>>>(
+    zerocheck_monomial_par_y_kernel<<<grid, block, shmem, stream>>>(
         tmp_sums, block_ctxs, air_ctxs, threads_per_block, chunk_size
     );
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0)
         return err;
 
@@ -296,11 +293,11 @@ extern "C" int _zerocheck_monomial_par_y_batched(
     size_t reduce_shmem = std::max(1u, reduce_warps) * sizeof(FpExt);
 
     dim3 reduce_grid(num_airs, num_x);
-    sumcheck::batched_final_reduce_block_sums<<<reduce_grid, reduce_block, reduce_shmem>>>(
+    sumcheck::batched_final_reduce_block_sums<<<reduce_grid, reduce_block, reduce_shmem, stream>>>(
         tmp_sums, output, air_block_offsets, num_x
     );
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 // ============================================================================
@@ -338,17 +335,16 @@ extern "C" int _precompute_logup_numer_combinations(
     const MonomialHeader *headers,
     const InteractionMonomialTerm *terms,
     const FpExt *eq_3bs,
-    uint32_t num_monomials
-) {
+    uint32_t num_monomials, cudaStream_t stream) {
     if (num_monomials == 0)
         return 0;
 
     constexpr uint32_t threads = 256;
     uint32_t blocks = div_ceil(num_monomials, threads);
-    precompute_logup_combinations_kernel<false><<<blocks, threads>>>(
+    precompute_logup_combinations_kernel<false><<<blocks, threads, 0, stream>>>(
         out, headers, terms, nullptr, eq_3bs, num_monomials
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _precompute_logup_denom_combinations(
@@ -357,17 +353,16 @@ extern "C" int _precompute_logup_denom_combinations(
     const InteractionMonomialTerm *terms,
     const FpExt *beta_pows,
     const FpExt *eq_3bs,
-    uint32_t num_monomials
-) {
+    uint32_t num_monomials, cudaStream_t stream) {
     if (num_monomials == 0)
         return 0;
 
     constexpr uint32_t threads = 256;
     uint32_t blocks = div_ceil(num_monomials, threads);
-    precompute_logup_combinations_kernel<true><<<blocks, threads>>>(
+    precompute_logup_combinations_kernel<true><<<blocks, threads, 0, stream>>>(
         out, headers, terms, beta_pows, eq_3bs, num_monomials
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 // AIR context for logup monomial MLE evaluation
@@ -459,8 +454,7 @@ extern "C" int _logup_monomial_batched(
     uint32_t num_blocks,
     uint32_t num_x,
     uint32_t num_airs,
-    uint32_t threads_per_block
-) {
+    uint32_t threads_per_block, cudaStream_t stream) {
     if (num_blocks == 0)
         return 0;
     if (!valid_frac_grid_y_dim(num_x)) {
@@ -472,18 +466,18 @@ extern "C" int _logup_monomial_batched(
     size_t shmem = div_ceil(threads_per_block, WARP_SIZE) * sizeof(FpExt);
 
     // Phase 1: Evaluate numerator monomials
-    logup_monomial_kernel<false><<<grid, block, shmem>>>(
+    logup_monomial_kernel<false><<<grid, block, shmem, stream>>>(
         tmp_sums, block_ctxs, common_ctxs, numer_ctxs
     );
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0)
         return err;
 
     // Phase 1b: Evaluate denominator monomials
-    logup_monomial_kernel<true><<<grid, block, shmem>>>(
+    logup_monomial_kernel<true><<<grid, block, shmem, stream>>>(
         tmp_sums, block_ctxs, common_ctxs, denom_ctxs
     );
-    err = CHECK_KERNEL();
+    err = CHECK_KERNEL_ON(stream);
     if (err != 0)
         return err;
 
@@ -494,14 +488,14 @@ extern "C" int _logup_monomial_batched(
     size_t reduce_shmem = std::max(1u, reduce_warps) * sizeof(FpExt);
 
     dim3 reduce_grid(num_airs, 2 * num_x);
-    sumcheck::batched_final_reduce_block_sums<<<reduce_grid, reduce_block, reduce_shmem>>>(
+    sumcheck::batched_final_reduce_block_sums<<<reduce_grid, reduce_block, reduce_shmem, stream>>>(
         reinterpret_cast<FpExt *>(tmp_sums),
         reinterpret_cast<FpExt *>(output),
         air_block_offsets,
         2 * num_x
     );
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 } // namespace logup_zerocheck_mle

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/eval_config.cuh
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/eval_config.cuh
@@ -68,7 +68,7 @@ inline std::pair<dim3, dim3> eval_constraints_launch_params(
 }
 
 template <bool COSET_PARALLEL>
-inline uint32_t temp_sums_buffer_size(
+inline size_t temp_sums_buffer_size(
     uint32_t buffer_size,
     uint32_t skip_domain,
     uint32_t num_x,
@@ -87,11 +87,11 @@ inline uint32_t temp_sums_buffer_size(
         threads_per_block
     );
     // Output layout: [num_blocks][num_cosets * skip_domain]
-    return grid.x * num_cosets * skip_domain;
+    return static_cast<size_t>(grid.x) * num_cosets * skip_domain;
 }
 
 template <bool COSET_PARALLEL>
-inline uint32_t intermediates_buffer_size(
+inline size_t intermediates_buffer_size(
     uint32_t buffer_size,
     uint32_t skip_domain,
     uint32_t num_x,
@@ -113,7 +113,7 @@ inline uint32_t intermediates_buffer_size(
         threads_per_block
     );
     // Layout: [buffer_size][num_threads][num_cosets]
-    return grid.x * block.x * buffer_size * num_cosets;
+    return static_cast<size_t>(grid.x) * block.x * buffer_size * num_cosets;
 }
 
 } // namespace round0_config_impl

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
@@ -625,14 +625,15 @@ inline void launch_precompute_m_build_partial_kernel(
     const FpExt *eq_tail_high,
     uint32_t log_eq_tail_low_cap,
     uint32_t tail_tile,
-    FpExt *partial_out
+    FpExt *partial_out,
+    cudaStream_t stream
 ) {
     constexpr uint32_t m = 1u << W;
     dim3 block(m, m);
     constexpr uint32_t sh_stride = m + 1;  // +1 padding to match kernel
     size_t shmem_bytes =
         (4 * sh_stride * PRECOMPUTE_M_TAIL_BATCH + PRECOMPUTE_M_TAIL_BATCH) * sizeof(FpExt);
-    precompute_m_build_partial_kernel<inline_fold, W><<<grid, block, shmem_bytes>>>(
+    precompute_m_build_partial_kernel<inline_fold, W><<<grid, block, shmem_bytes, stream>>>(
         pq,
         rem_n,
         lambda,
@@ -657,11 +658,12 @@ inline int launch_precompute_m_build_partial_dispatch(
     const FpExt *eq_tail_high,
     uint32_t log_eq_tail_low_cap,
     uint32_t tail_tile,
-    FpExt *partial_out
+    FpExt *partial_out,
+    cudaStream_t stream
 ) {
     using LauncherFn = void (*)(
         dim3, const FracExt *, uint32_t, FpExt, FpExt, const FpExt *, const FpExt *, uint32_t,
-        uint32_t, FpExt *
+        uint32_t, FpExt *, cudaStream_t
     );
     static constexpr LauncherFn launchers[] = {
         &launch_precompute_m_build_partial_kernel<inline_fold, 1>,
@@ -688,7 +690,8 @@ inline int launch_precompute_m_build_partial_dispatch(
         eq_tail_high,
         log_eq_tail_low_cap,
         tail_tile,
-        partial_out
+        partial_out,
+        stream
     );
     return 0;
 }
@@ -883,10 +886,10 @@ __global__ void frac_build_tree_two_layers_kernel(
 // LAUNCHERS
 // ============================================================================
 template <bool revert, bool apply_alpha>
-int launch_frac_build_tree_layer(FracExt *layer, size_t layer_size, FpExt alpha) {
+int launch_frac_build_tree_layer(FracExt *layer, size_t layer_size, FpExt alpha, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(layer_size);
-    frac_build_tree_layer_kernel<revert, apply_alpha><<<grid, block>>>(layer, layer_size, alpha);
-    return CHECK_KERNEL();
+    frac_build_tree_layer_kernel<revert, apply_alpha><<<grid, block, 0, stream>>>(layer, layer_size, alpha);
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _frac_build_tree_layer(
@@ -894,7 +897,8 @@ extern "C" int _frac_build_tree_layer(
     size_t layer_size,
     bool revert,
     FpExt alpha,
-    bool apply_alpha
+    bool apply_alpha,
+    cudaStream_t stream
 ) {
     if (layer_size == 0) {
         return 0;
@@ -903,21 +907,21 @@ extern "C" int _frac_build_tree_layer(
     layer_size /= 2;
 
     return DISPATCH_BOOL_PAIR(
-        launch_frac_build_tree_layer, revert, apply_alpha, layer, layer_size, alpha
+        launch_frac_build_tree_layer, revert, apply_alpha, layer, layer_size, alpha, stream
     );
 }
 
 // Launcher for fused two-layer tree build.
 // half_i1 = N >> (i+2), where i is the index of the first layer to fuse.
 // Requires half_i1 >= 1 and half_i1 * 4 <= total array size.
-extern "C" int _frac_build_tree_two_layers(FracExt *layer, size_t half_i1) {
+extern "C" int _frac_build_tree_two_layers(FracExt *layer, size_t half_i1, cudaStream_t stream) {
     if (half_i1 == 0) return 0;
     // Use 256 threads/block (not 1024) to give the compiler more register headroom.
     // frac_build_tree_two_layers_kernel does 4 FracExt loads + 3 frac_add ops,
     // which has higher register pressure than the single-layer build kernel.
     auto [grid, block] = kernel_launch_params(half_i1, 256);
-    frac_build_tree_two_layers_kernel<<<grid, block>>>(layer, (uint32_t)half_i1);
-    return CHECK_KERNEL();
+    frac_build_tree_two_layers_kernel<<<grid, block, 0, stream>>>(layer, (uint32_t)half_i1);
+    return CHECK_KERNEL_ON(stream);
 }
 
 inline uint32_t min_blocks_target_for_device(uint32_t blocks_per_sm, uint32_t fallback_blocks) {
@@ -973,14 +977,14 @@ extern "C" uint32_t _frac_compute_round_temp_buffer_size(uint32_t num_x) {
     return grid.x * GKR_SP_DEG;
 }
 
-inline int final_reduce_block_sums(FpExt *tmp_block_sums, FpExt *out, uint32_t num_blocks) {
+inline int final_reduce_block_sums(FpExt *tmp_block_sums, FpExt *out, uint32_t num_blocks, cudaStream_t stream) {
     auto [unused_grid, reduce_block] = kernel_launch_params(num_blocks);
     (void)unused_grid;
     unsigned int reduce_warps = div_ceil(reduce_block.x, WARP_SIZE);
     size_t reduce_shmem = std::max(1u, reduce_warps) * sizeof(FpExt);
     sumcheck::static_final_reduce_block_sums<GKR_SP_DEG>
-        <<<GKR_SP_DEG, reduce_block, reduce_shmem>>>(tmp_block_sums, out, num_blocks);
-    return CHECK_KERNEL();
+        <<<GKR_SP_DEG, reduce_block, reduce_shmem, stream>>>(tmp_block_sums, out, num_blocks);
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _frac_compute_round(
@@ -991,7 +995,8 @@ extern "C" int _frac_compute_round(
     size_t eq_low_cap,
     FpExt lambda,
     FpExt *out,           // Output: [d=2] final results
-    FpExt *tmp_block_sums // Temporary buffer: [gridDim.x * d]
+    FpExt *tmp_block_sums, // Temporary buffer: [gridDim.x * d]
+    cudaStream_t stream
 ) {
     assert(num_x > 1);
 
@@ -999,7 +1004,7 @@ extern "C" int _frac_compute_round(
     size_t shmem_bytes = div_ceil(block.x, WARP_SIZE) * sizeof(FpExt);
 
     // Launch main kernel - writes to tmp_block_sums
-    compute_round_block_sum_kernel<<<grid, block, shmem_bytes>>>(
+    compute_round_block_sum_kernel<<<grid, block, shmem_bytes, stream>>>(
         eq_xi_low,
         eq_xi_high,
         pq_buffer,
@@ -1008,12 +1013,12 @@ extern "C" int _frac_compute_round(
         lambda,
         tmp_block_sums
     );
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0)
         return err;
 
     // Launch final reduction kernel - reads from tmp_block_sums, writes to output.
-    return final_reduce_block_sums(tmp_block_sums, out, grid.x);
+    return final_reduce_block_sums(tmp_block_sums, out, grid.x, stream);
 }
 
 // Fused compute round + tree layer revert launcher.
@@ -1026,7 +1031,8 @@ extern "C" int _frac_compute_round_and_revert(
     size_t eq_low_cap,
     FpExt lambda,
     FpExt *out,               // Output: [d=2] final results
-    FpExt *tmp_block_sums     // Temporary buffer: [gridDim.x * d]
+    FpExt *tmp_block_sums,     // Temporary buffer: [gridDim.x * d]
+    cudaStream_t stream
 ) {
     assert(num_x > 1);
 
@@ -1034,7 +1040,7 @@ extern "C" int _frac_compute_round_and_revert(
     size_t shmem_bytes = div_ceil(block.x, WARP_SIZE) * sizeof(FpExt);
 
     // Launch fused revert + compute kernel
-    compute_round_and_revert_kernel<<<grid, block, shmem_bytes>>>(
+    compute_round_and_revert_kernel<<<grid, block, shmem_bytes, stream>>>(
         eq_xi_low,
         eq_xi_high,
         layer,
@@ -1043,12 +1049,12 @@ extern "C" int _frac_compute_round_and_revert(
         lambda,
         tmp_block_sums
     );
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0)
         return err;
 
     // Launch final reduction kernel.
-    return final_reduce_block_sums(tmp_block_sums, out, grid.x);
+    return final_reduce_block_sums(tmp_block_sums, out, grid.x, stream);
 }
 
 // Fused compute round + fold launcher.
@@ -1064,7 +1070,8 @@ extern "C" int _frac_compute_round_and_fold(
     FpExt lambda,
     FpExt r_prev,
     FpExt *out,                   // Output: [d=2] final results
-    FpExt *tmp_block_sums         // Temporary buffer: [gridDim.x * d]
+    FpExt *tmp_block_sums,         // Temporary buffer: [gridDim.x * d]
+    cudaStream_t stream
 ) {
     assert(src_pq_size > 2);
     // Post-fold sizes
@@ -1076,7 +1083,7 @@ extern "C" int _frac_compute_round_and_fold(
     size_t shmem_bytes = div_ceil(block.x, WARP_SIZE) * sizeof(FpExt);
 
     // Launch fused kernel - writes to tmp_block_sums and dst_pq_buffer
-    compute_round_and_fold_kernel<<<grid, block, shmem_bytes>>>(
+    compute_round_and_fold_kernel<<<grid, block, shmem_bytes, stream>>>(
         eq_xi_low,
         eq_xi_high,
         src_pq_buffer,
@@ -1087,12 +1094,12 @@ extern "C" int _frac_compute_round_and_fold(
         tmp_block_sums,
         dst_pq_buffer
     );
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0)
         return err;
 
     // Launch final reduction kernel - reads from tmp_block_sums, writes to output.
-    return final_reduce_block_sums(tmp_block_sums, out, grid.x);
+    return final_reduce_block_sums(tmp_block_sums, out, grid.x, stream);
 }
 
 // Fused compute round + fold launcher (IN-PLACE version).
@@ -1107,7 +1114,8 @@ extern "C" int _frac_compute_round_and_fold_inplace(
     FpExt lambda,
     FpExt r_prev,
     FpExt *out,                   // Output: [d=2] final results
-    FpExt *tmp_block_sums         // Temporary buffer: [gridDim.x * d]
+    FpExt *tmp_block_sums,         // Temporary buffer: [gridDim.x * d]
+    cudaStream_t stream
 ) {
     assert(src_pq_size > 2);
     // Post-fold sizes
@@ -1119,7 +1127,7 @@ extern "C" int _frac_compute_round_and_fold_inplace(
     size_t shmem_bytes = div_ceil(block.x, WARP_SIZE) * sizeof(FpExt);
 
     // Launch fused in-place kernel - writes to tmp_block_sums and pq_buffer (first half)
-    compute_round_and_fold_inplace_kernel<<<grid, block, shmem_bytes>>>(
+    compute_round_and_fold_inplace_kernel<<<grid, block, shmem_bytes, stream>>>(
         eq_xi_low,
         eq_xi_high,
         pq_buffer,
@@ -1129,12 +1137,12 @@ extern "C" int _frac_compute_round_and_fold_inplace(
         r_prev,
         tmp_block_sums
     );
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0)
         return err;
 
     // Launch final reduction kernel - reads from tmp_block_sums, writes to output.
-    return final_reduce_block_sums(tmp_block_sums, out, grid.x);
+    return final_reduce_block_sums(tmp_block_sums, out, grid.x, stream);
 }
 
 extern "C" int _frac_precompute_m_build(
@@ -1150,7 +1158,8 @@ extern "C" int _frac_precompute_m_build(
     size_t tail_tile,
     FpExt *partial_out,
     size_t partial_len,
-    FpExt *m_total
+    FpExt *m_total,
+    cudaStream_t stream
 ) {
     assert(rem_n > 0);
     assert(w > 0 && w <= rem_n);
@@ -1181,7 +1190,8 @@ extern "C" int _frac_precompute_m_build(
             eq_tail_high,
             log_eq_tail_low_cap,
             tail_tile_u32,
-            partial_out
+            partial_out,
+            stream
         );
     } else {
         launch_err = launch_precompute_m_build_partial_dispatch<false>(
@@ -1195,26 +1205,27 @@ extern "C" int _frac_precompute_m_build(
             eq_tail_high,
             log_eq_tail_low_cap,
             tail_tile_u32,
-            partial_out
+            partial_out,
+            stream
         );
     }
     if (launch_err != 0) {
         return launch_err;
     }
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0) {
         return err;
     }
 
     dim3 reduce_block(128);
     dim3 reduce_grid(div_ceil((uint32_t)total_entries, reduce_block.x));
-    precompute_m_reduce_partials_kernel<<<reduce_grid, reduce_block>>>(
+    precompute_m_reduce_partials_kernel<<<reduce_grid, reduce_block, 0, stream>>>(
         partial_out,
         num_blocks,
         (uint32_t)total_entries,
         m_total
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _frac_precompute_m_eval_round(
@@ -1223,14 +1234,15 @@ extern "C" int _frac_precompute_m_eval_round(
     size_t t,
     const FpExt *eq_r_prefix,
     const FpExt *eq_suffix,
-    FpExt *out
+    FpExt *out,
+    cudaStream_t stream
 ) {
     assert(w > 0);
     assert(t < w);
 
     dim3 block(256);
     size_t shmem_bytes = div_ceil(block.x, WARP_SIZE) * sizeof(FpExt);
-    precompute_m_eval_round_kernel<<<1, block, shmem_bytes>>>(
+    precompute_m_eval_round_kernel<<<1, block, shmem_bytes, stream>>>(
         m_total,
         (uint32_t)w,
         (uint32_t)t,
@@ -1238,7 +1250,7 @@ extern "C" int _frac_precompute_m_eval_round(
         eq_suffix,
         out
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _frac_multifold(
@@ -1246,7 +1258,8 @@ extern "C" int _frac_multifold(
     FracExt *dst,
     size_t rem_n,
     size_t w,
-    const FpExt *eq_r_window
+    const FpExt *eq_r_window,
+    cudaStream_t stream
 ) {
     assert(rem_n > 0);
     assert(w > 0 && w <= rem_n);
@@ -1255,8 +1268,8 @@ extern "C" int _frac_multifold(
     auto [grid, block] = kernel_launch_params(out_len, 256);
 
 #define DISPATCH_MULTIFOLD(W) \
-    multifold_kernel<W><<<grid, block>>>(src, dst, (uint32_t)out_len, eq_r_window); \
-    return CHECK_KERNEL();
+    multifold_kernel<W><<<grid, block, 0, stream>>>(src, dst, (uint32_t)out_len, eq_r_window); \
+    return CHECK_KERNEL_ON(stream);
 
     switch (w) {
         case 2: { DISPATCH_MULTIFOLD(2) }
@@ -1268,7 +1281,7 @@ extern "C" int _frac_multifold(
 #undef DISPATCH_MULTIFOLD
 }
 
-extern "C" int _frac_fold_fpext_columns(const FracExt *src, FracExt *dst, size_t size, FpExt r) {
+extern "C" int _frac_fold_fpext_columns(const FracExt *src, FracExt *dst, size_t size, FpExt r, cudaStream_t stream) {
     if (size <= 2) {
         return 0;
     }
@@ -1277,23 +1290,23 @@ extern "C" int _frac_fold_fpext_columns(const FracExt *src, FracExt *dst, size_t
     // quarter_fpext = (size / 4) * 2 = size / 2
     uint32_t quarter_fpext = size >> 1;
     auto [grid, block] = kernel_launch_params(quarter_fpext);
-    fold_ef_columns_kernel<<<grid, block>>>(
+    fold_ef_columns_kernel<<<grid, block, 0, stream>>>(
         reinterpret_cast<const FpExt *>(src), reinterpret_cast<FpExt *>(dst), quarter_fpext, r
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
-extern "C" int _frac_add_alpha(FracExt *data, size_t len, FpExt alpha) {
+extern "C" int _frac_add_alpha(FracExt *data, size_t len, FpExt alpha, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(len);
-    add_alpha_kernel<<<grid, block>>>(data, len, alpha);
-    return CHECK_KERNEL();
+    add_alpha_kernel<<<grid, block, 0, stream>>>(data, len, alpha);
+    return CHECK_KERNEL_ON(stream);
 }
 
-extern "C" int _frac_vector_scalar_multiply_ext_fp(FracExt *frac_vec, Fp scalar, uint32_t length) {
+extern "C" int _frac_vector_scalar_multiply_ext_fp(FracExt *frac_vec, Fp scalar, uint32_t length, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(length);
     frac_vector_scalar_multiply_kernel<Fp, FpExt>
-        <<<grid, block>>>(reinterpret_cast<std::pair<FpExt, FpExt> *>(frac_vec), scalar, length);
-    return CHECK_KERNEL();
+        <<<grid, block, 0, stream>>>(reinterpret_cast<std::pair<FpExt, FpExt> *>(frac_vec), scalar, length);
+    return CHECK_KERNEL_ON(stream);
 }
 
 
@@ -1429,7 +1442,7 @@ void bit_rev_frac_build_k2_kernel(
 // Requires domain_size >= 256 (uses Z-tile shmem kernel).
 // Applies alpha to denominators and fuses tree layers 0 and 1 in shmem.
 extern "C" int _bit_rev_frac_ext_build_k2(
-    FracExt* inout, uint32_t lg_domain_size, FpExt alpha)
+    FracExt* inout, uint32_t lg_domain_size, FpExt alpha, cudaStream_t stream)
 {
     constexpr uint32_t Z_COUNT = 8;
     constexpr uint32_t bsize = 256;
@@ -1444,9 +1457,9 @@ extern "C" int _bit_rev_frac_ext_build_k2(
     if (domain_size < (size_t)(bsize * Z_COUNT))
         return cudaErrorInvalidValue;
     uint32_t grid_x = (uint32_t)(domain_size / Z_COUNT / bsize);
-    bit_rev_frac_build_k2_kernel<<<dim3(grid_x), bsize, shmem_bytes>>>(
+    bit_rev_frac_build_k2_kernel<<<dim3(grid_x), bsize, shmem_bytes, stream>>>(
         inout, lg_domain_size, alpha);
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 } // namespace fractional_sumcheck_gkr

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
@@ -889,7 +889,7 @@ template <bool revert, bool apply_alpha>
 int launch_frac_build_tree_layer(FracExt *layer, size_t layer_size, FpExt alpha, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(layer_size);
     frac_build_tree_layer_kernel<revert, apply_alpha><<<grid, block, 0, stream>>>(layer, layer_size, alpha);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _frac_build_tree_layer(
@@ -921,7 +921,7 @@ extern "C" int _frac_build_tree_two_layers(FracExt *layer, size_t half_i1, cudaS
     // which has higher register pressure than the single-layer build kernel.
     auto [grid, block] = kernel_launch_params(half_i1, 256);
     frac_build_tree_two_layers_kernel<<<grid, block, 0, stream>>>(layer, (uint32_t)half_i1);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 inline uint32_t min_blocks_target_for_device(uint32_t blocks_per_sm, uint32_t fallback_blocks) {
@@ -984,7 +984,7 @@ inline int final_reduce_block_sums(FpExt *tmp_block_sums, FpExt *out, uint32_t n
     size_t reduce_shmem = std::max(1u, reduce_warps) * sizeof(FpExt);
     sumcheck::static_final_reduce_block_sums<GKR_SP_DEG>
         <<<GKR_SP_DEG, reduce_block, reduce_shmem, stream>>>(tmp_block_sums, out, num_blocks);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _frac_compute_round(
@@ -1013,7 +1013,7 @@ extern "C" int _frac_compute_round(
         lambda,
         tmp_block_sums
     );
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0)
         return err;
 
@@ -1049,7 +1049,7 @@ extern "C" int _frac_compute_round_and_revert(
         lambda,
         tmp_block_sums
     );
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0)
         return err;
 
@@ -1094,7 +1094,7 @@ extern "C" int _frac_compute_round_and_fold(
         tmp_block_sums,
         dst_pq_buffer
     );
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0)
         return err;
 
@@ -1137,7 +1137,7 @@ extern "C" int _frac_compute_round_and_fold_inplace(
         r_prev,
         tmp_block_sums
     );
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0)
         return err;
 
@@ -1212,7 +1212,7 @@ extern "C" int _frac_precompute_m_build(
     if (launch_err != 0) {
         return launch_err;
     }
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0) {
         return err;
     }
@@ -1225,7 +1225,7 @@ extern "C" int _frac_precompute_m_build(
         (uint32_t)total_entries,
         m_total
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _frac_precompute_m_eval_round(
@@ -1250,7 +1250,7 @@ extern "C" int _frac_precompute_m_eval_round(
         eq_suffix,
         out
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _frac_multifold(
@@ -1269,7 +1269,7 @@ extern "C" int _frac_multifold(
 
 #define DISPATCH_MULTIFOLD(W) \
     multifold_kernel<W><<<grid, block, 0, stream>>>(src, dst, (uint32_t)out_len, eq_r_window); \
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 
     switch (w) {
         case 2: { DISPATCH_MULTIFOLD(2) }
@@ -1293,20 +1293,20 @@ extern "C" int _frac_fold_fpext_columns(const FracExt *src, FracExt *dst, size_t
     fold_ef_columns_kernel<<<grid, block, 0, stream>>>(
         reinterpret_cast<const FpExt *>(src), reinterpret_cast<FpExt *>(dst), quarter_fpext, r
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _frac_add_alpha(FracExt *data, size_t len, FpExt alpha, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(len);
     add_alpha_kernel<<<grid, block, 0, stream>>>(data, len, alpha);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _frac_vector_scalar_multiply_ext_fp(FracExt *frac_vec, Fp scalar, uint32_t length, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(length);
     frac_vector_scalar_multiply_kernel<Fp, FpExt>
         <<<grid, block, 0, stream>>>(reinterpret_cast<std::pair<FpExt, FpExt> *>(frac_vec), scalar, length);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 
@@ -1459,7 +1459,7 @@ extern "C" int _bit_rev_frac_ext_build_k2(
     uint32_t grid_x = (uint32_t)(domain_size / Z_COUNT / bsize);
     bit_rev_frac_build_k2_kernel<<<dim3(grid_x), bsize, shmem_bytes, stream>>>(
         inout, lg_domain_size, alpha);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 } // namespace fractional_sumcheck_gkr

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
@@ -972,7 +972,7 @@ inline std::pair<dim3, dim3> frac_compute_round_launch_params(uint32_t num_x) {
     return {dim3(blocks_needed), dim3(block_size)};
 }
 
-extern "C" uint32_t _frac_compute_round_temp_buffer_size(uint32_t num_x) {
+extern "C" uint32_t _frac_compute_round_temp_buffer_size(uint32_t num_x, cudaStream_t stream) {
     auto [grid, block] = frac_compute_round_launch_params(num_x);
     return grid.x * GKR_SP_DEG;
 }

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/gkr_input.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/gkr_input.cu
@@ -226,12 +226,11 @@ extern "C" int _logup_gkr_input_eval(
     const uint32_t *d_pair_idxs,
     size_t used_nodes_len,
     uint32_t permutation_height,
-    uint32_t num_rows_per_tile
-) {
+    uint32_t num_rows_per_tile, cudaStream_t stream) {
     auto count = is_global ? TASK_SIZE : permutation_height;
     auto [grid, block] = kernel_launch_params(count, 256);
     if (is_global) {
-        evaluate_interactions_gkr_kernel<true><<<grid, block>>>(
+        evaluate_interactions_gkr_kernel<true><<<grid, block, 0, stream>>>(
             d_fracs,
             d_preprocessed,
             d_main,
@@ -246,7 +245,7 @@ extern "C" int _logup_gkr_input_eval(
             num_rows_per_tile
         );
     } else {
-        evaluate_interactions_gkr_kernel<false><<<grid, block>>>(
+        evaluate_interactions_gkr_kernel<false><<<grid, block, 0, stream>>>(
             d_fracs,
             d_preprocessed,
             d_main,
@@ -261,7 +260,7 @@ extern "C" int _logup_gkr_input_eval(
             num_rows_per_tile
         );
     }
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 } // namespace logup_gkr_input_evaluation

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/gkr_input.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/gkr_input.cu
@@ -260,7 +260,7 @@ extern "C" int _logup_gkr_input_eval(
             num_rows_per_tile
         );
     }
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 } // namespace logup_gkr_input_evaluation

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/logup_round0.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/logup_round0.cu
@@ -536,7 +536,8 @@ int launch_logup_ntt_eval_interactions(
     uint32_t num_x,
     uint32_t height,
     Fp g_shift,
-    size_t max_temp_bytes
+    size_t max_temp_bytes,
+    cudaStream_t stream
 ) {
     auto [grid, block] = coset_round0_config::eval_constraints_launch_params(
         buffer_size, skip_domain, num_x, NUM_COSETS, max_temp_bytes, BUFFER_THRESHOLD, MAX_THREADS
@@ -548,7 +549,7 @@ int launch_logup_ntt_eval_interactions(
     size_t shmem_bytes = shared_sum_size + ntt_buffers_size;
 
     logup_r0_ntt_eval_interactions_kernel<NUM_COSETS, GLOBAL, NEEDS_SHMEM>
-        <<<grid, block, shmem_bytes>>>(
+        <<<grid, block, shmem_bytes, stream>>>(
             tmp_sums_buffer,
             selectors_cube,
             preprocessed,
@@ -568,7 +569,7 @@ int launch_logup_ntt_eval_interactions(
             g_shift
         );
 
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0) {
         return err;
     }
@@ -578,10 +579,10 @@ int launch_logup_ntt_eval_interactions(
     unsigned int reduce_warps = div_ceil(reduce_block.x, WARP_SIZE);
     size_t reduce_shmem = std::max(1u, reduce_warps) * sizeof(FpExt);
     auto large_domain = NUM_COSETS * skip_domain;
-    sumcheck::final_reduce_block_sums<<<2 * large_domain, reduce_block, reduce_shmem>>>(
+    sumcheck::final_reduce_block_sums<<<2 * large_domain, reduce_block, reduce_shmem, stream>>>(
         reinterpret_cast<FpExt *>(tmp_sums_buffer), reinterpret_cast<FpExt *>(output), num_blocks
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 // Generate dispatcher for num_cosets (1-4) x is_global x needs_shmem
@@ -609,7 +610,8 @@ int launch_logup_coset_parallel(
     uint32_t height,
     uint32_t num_cosets,
     Fp g_shift,
-    size_t max_temp_bytes
+    size_t max_temp_bytes,
+    cudaStream_t stream
 ) {
     auto [grid, block] = coset_parallel_round0_config::eval_constraints_launch_params(
         buffer_size, skip_domain, num_x, num_cosets, max_temp_bytes, BUFFER_THRESHOLD, MAX_THREADS
@@ -620,7 +622,7 @@ int launch_logup_coset_parallel(
     size_t shmem_bytes = shared_sum_size + ntt_buffers_size;
 
     logup_r0_ntt_eval_interactions_coset_parallel_kernel<GLOBAL, NEEDS_SHMEM>
-        <<<grid, block, shmem_bytes>>>(
+        <<<grid, block, shmem_bytes, stream>>>(
             tmp_sums_buffer,
             selectors_cube,
             preprocessed,
@@ -639,7 +641,7 @@ int launch_logup_coset_parallel(
             height,
             g_shift
         );
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0) {
         return err;
     }
@@ -650,11 +652,11 @@ int launch_logup_coset_parallel(
     unsigned int reduce_warps = div_ceil(reduce_block.x, WARP_SIZE);
     size_t reduce_shmem = std::max(1u, reduce_warps) * sizeof(FpExt);
     auto large_domain = num_cosets * skip_domain;
-    sumcheck::final_reduce_block_sums<<<2 * large_domain, reduce_block, reduce_shmem>>>(
+    sumcheck::final_reduce_block_sums<<<2 * large_domain, reduce_block, reduce_shmem, stream>>>(
         reinterpret_cast<FpExt *>(tmp_sums_buffer), reinterpret_cast<FpExt *>(output), num_blocks
     );
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _logup_bary_eval_interactions_round0(
@@ -677,7 +679,8 @@ extern "C" int _logup_bary_eval_interactions_round0(
     uint32_t height,
     uint32_t num_cosets,
     Fp g_shift,
-    size_t max_temp_bytes
+    size_t max_temp_bytes,
+    cudaStream_t stream
 ) {
     bool is_global = buffer_size > BUFFER_THRESHOLD;
     bool use_coset_parallel = use_coset_parallel_mode(num_x, skip_domain);
@@ -706,7 +709,8 @@ extern "C" int _logup_bary_eval_interactions_round0(
                                    height,
                                    num_cosets,
                                    g_shift,
-                                   max_temp_bytes
+                                   max_temp_bytes,
+                                   stream
                                )
                              : launch_logup_coset_parallel<false, false>(
                                    tmp_sums_buffer,
@@ -728,7 +732,8 @@ extern "C" int _logup_bary_eval_interactions_round0(
                                    height,
                                    num_cosets,
                                    g_shift,
-                                   max_temp_bytes
+                                   max_temp_bytes,
+                                   stream
                                );
         }
         return dispatch_logup(
@@ -753,7 +758,8 @@ extern "C" int _logup_bary_eval_interactions_round0(
             num_x,
             height,
             g_shift,
-            max_temp_bytes
+            max_temp_bytes,
+            stream
         );
     }
 
@@ -784,7 +790,8 @@ extern "C" int _logup_bary_eval_interactions_round0(
                     height,
                     num_cosets,
                     g_shift,
-                    max_temp_bytes
+                    max_temp_bytes,
+                    stream
                 );
             } else {
                 return launch_logup_coset_parallel<true, false>(
@@ -807,7 +814,8 @@ extern "C" int _logup_bary_eval_interactions_round0(
                     height,
                     num_cosets,
                     g_shift,
-                    max_temp_bytes
+                    max_temp_bytes,
+                    stream
                 );
             }
         } else {
@@ -832,7 +840,8 @@ extern "C" int _logup_bary_eval_interactions_round0(
                     height,
                     num_cosets,
                     g_shift,
-                    max_temp_bytes
+                    max_temp_bytes,
+                    stream
                 );
             } else {
                 return launch_logup_coset_parallel<false, false>(
@@ -855,7 +864,8 @@ extern "C" int _logup_bary_eval_interactions_round0(
                     height,
                     num_cosets,
                     g_shift,
-                    max_temp_bytes
+                    max_temp_bytes,
+                    stream
                 );
             }
         }
@@ -883,7 +893,8 @@ extern "C" int _logup_bary_eval_interactions_round0(
             num_x,
             height,
             g_shift,
-            max_temp_bytes
+            max_temp_bytes,
+            stream
         );
     }
 }

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/logup_round0.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/logup_round0.cu
@@ -479,7 +479,8 @@ extern "C" size_t _logup_r0_temp_sums_buffer_size(
     uint32_t skip_domain,
     uint32_t num_x,
     uint32_t num_cosets,
-    size_t max_temp_bytes
+    size_t max_temp_bytes,
+    cudaStream_t stream
 ) {
     // Both modes use the same buffer size formula
     return DISPATCH_BOOL(
@@ -500,7 +501,8 @@ extern "C" size_t _logup_r0_intermediates_buffer_size(
     uint32_t skip_domain,
     uint32_t num_x,
     uint32_t num_cosets,
-    size_t max_temp_bytes
+    size_t max_temp_bytes,
+    cudaStream_t stream
 ) {
     // Both modes use the same buffer size formula
     return DISPATCH_BOOL(

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/logup_round0.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/logup_round0.cu
@@ -569,7 +569,7 @@ int launch_logup_ntt_eval_interactions(
             g_shift
         );
 
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0) {
         return err;
     }
@@ -582,7 +582,7 @@ int launch_logup_ntt_eval_interactions(
     sumcheck::final_reduce_block_sums<<<2 * large_domain, reduce_block, reduce_shmem, stream>>>(
         reinterpret_cast<FpExt *>(tmp_sums_buffer), reinterpret_cast<FpExt *>(output), num_blocks
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 // Generate dispatcher for num_cosets (1-4) x is_global x needs_shmem
@@ -641,7 +641,7 @@ int launch_logup_coset_parallel(
             height,
             g_shift
         );
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0) {
         return err;
     }
@@ -656,7 +656,7 @@ int launch_logup_coset_parallel(
         reinterpret_cast<FpExt *>(tmp_sums_buffer), reinterpret_cast<FpExt *>(output), num_blocks
     );
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _logup_bary_eval_interactions_round0(

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/mle.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/mle.cu
@@ -340,7 +340,7 @@ constexpr uint32_t MAX_THREADS = 128;
 
 // (Not a launcher) Utility function to calculate required size of temp sum buffer.
 // Required length of *temp_sum_buffer in FpExt elements
-extern "C" size_t _zerocheck_mle_temp_sums_buffer_size(uint32_t num_x, uint32_t num_y) {
+extern "C" size_t _zerocheck_mle_temp_sums_buffer_size(uint32_t num_x, uint32_t num_y, cudaStream_t stream) {
     return mle_rounds_config::temp_sums_buffer_size(num_x, num_y, MAX_THREADS);
 }
 
@@ -348,7 +348,8 @@ extern "C" size_t _zerocheck_mle_temp_sums_buffer_size(uint32_t num_x, uint32_t 
 extern "C" size_t _zerocheck_mle_intermediates_buffer_size(
     uint32_t buffer_size,
     uint32_t num_x,
-    uint32_t num_y
+    uint32_t num_y,
+    cudaStream_t stream
 ) {
     return mle_rounds_config::intermediates_buffer_size(
         buffer_size, num_x, num_y, ZEROCHECK_BUFFER_THRESHOLD, MAX_THREADS
@@ -406,7 +407,7 @@ extern "C" int _zerocheck_eval_mle(
 
 // (Not a launcher) Utility function to calculate required size of temp sum buffer.
 // Required length of *temp_sum_buffer in FracExt elements
-extern "C" size_t _logup_mle_temp_sums_buffer_size(uint32_t num_x, uint32_t num_y) {
+extern "C" size_t _logup_mle_temp_sums_buffer_size(uint32_t num_x, uint32_t num_y, cudaStream_t stream) {
     return mle_rounds_config::temp_sums_buffer_size(num_x, num_y, MAX_THREADS);
 }
 
@@ -414,7 +415,8 @@ extern "C" size_t _logup_mle_temp_sums_buffer_size(uint32_t num_x, uint32_t num_
 extern "C" size_t _logup_mle_intermediates_buffer_size(
     uint32_t buffer_size,
     uint32_t num_x,
-    uint32_t num_y
+    uint32_t num_y,
+    cudaStream_t stream
 ) {
     return mle_rounds_config::intermediates_buffer_size(
         buffer_size, num_x, num_y, LOGUP_BUFFER_THRESHOLD, MAX_THREADS

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/mle.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/mle.cu
@@ -372,8 +372,7 @@ extern "C" int _zerocheck_eval_mle(
     uint32_t buffer_size,
     FpExt *intermediates,
     uint32_t num_y,
-    uint32_t num_x
-) {
+    uint32_t num_x, cudaStream_t stream) {
     if (!valid_grid_y_dim(num_x)) {
         return cudaErrorInvalidValue;
     }
@@ -386,11 +385,11 @@ extern "C" int _zerocheck_eval_mle(
         rules_len, used_nodes, used_nodes_len, lambda_len, buffer_size, intermediates, num_y
 
     if (buffer_size > ZEROCHECK_BUFFER_THRESHOLD) {
-        zerocheck_mle_kernel<true><<<grid, block, shmem_bytes>>>(ZEROCHECK_KERNEL_ARGS);
+        zerocheck_mle_kernel<true><<<grid, block, shmem_bytes, stream>>>(ZEROCHECK_KERNEL_ARGS);
     } else {
-        zerocheck_mle_kernel<false><<<grid, block, shmem_bytes>>>(ZEROCHECK_KERNEL_ARGS);
+        zerocheck_mle_kernel<false><<<grid, block, shmem_bytes, stream>>>(ZEROCHECK_KERNEL_ARGS);
     }
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0)
         return err;
 
@@ -399,10 +398,10 @@ extern "C" int _zerocheck_eval_mle(
     auto [reduce_grid, reduce_block] = kernel_launch_params(num_blocks);
     unsigned int reduce_warps = (reduce_block.x + WARP_SIZE - 1) / WARP_SIZE;
     size_t reduce_shmem = std::max(1u, reduce_warps) * sizeof(FpExt);
-    sumcheck::final_reduce_block_sums<<<num_x, reduce_block, reduce_shmem>>>(
+    sumcheck::final_reduce_block_sums<<<num_x, reduce_block, reduce_shmem, stream>>>(
         tmp_sums_buffer, output, num_blocks
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 // (Not a launcher) Utility function to calculate required size of temp sum buffer.
@@ -439,8 +438,7 @@ extern "C" int _logup_eval_mle(
     uint32_t buffer_size,
     FpExt *intermediates,
     uint32_t num_y,
-    uint32_t num_x
-) {
+    uint32_t num_x, cudaStream_t stream) {
     if (!valid_grid_y_dim(num_x)) {
         return cudaErrorInvalidValue;
     }
@@ -453,11 +451,11 @@ extern "C" int _logup_eval_mle(
         rules, used_nodes, pair_idxs, used_nodes_len, buffer_size, intermediates, num_y
 
     if (buffer_size > LOGUP_BUFFER_THRESHOLD) {
-        logup_mle_kernel<true><<<grid, block, shmem_bytes>>>(LOGUP_KERNEL_ARGS);
+        logup_mle_kernel<true><<<grid, block, shmem_bytes, stream>>>(LOGUP_KERNEL_ARGS);
     } else {
-        logup_mle_kernel<false><<<grid, block, shmem_bytes>>>(LOGUP_KERNEL_ARGS);
+        logup_mle_kernel<false><<<grid, block, shmem_bytes, stream>>>(LOGUP_KERNEL_ARGS);
     }
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0)
         return err;
 
@@ -467,10 +465,10 @@ extern "C" int _logup_eval_mle(
     unsigned int reduce_warps = (reduce_block.x + WARP_SIZE - 1) / WARP_SIZE;
     size_t reduce_shmem = std::max(1u, reduce_warps) * sizeof(FpExt);
     // FracExt = (FpExt, FpExt) so we set block = 2 * large_domain
-    sumcheck::final_reduce_block_sums<<<2 * num_x, reduce_block, reduce_shmem>>>(
+    sumcheck::final_reduce_block_sums<<<2 * num_x, reduce_block, reduce_shmem, stream>>>(
         reinterpret_cast<FpExt *>(tmp_sums_buffer), reinterpret_cast<FpExt *>(output), num_blocks
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 } // namespace logup_zerocheck_mle

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/mle.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/mle.cu
@@ -389,7 +389,7 @@ extern "C" int _zerocheck_eval_mle(
     } else {
         zerocheck_mle_kernel<false><<<grid, block, shmem_bytes, stream>>>(ZEROCHECK_KERNEL_ARGS);
     }
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0)
         return err;
 
@@ -401,7 +401,7 @@ extern "C" int _zerocheck_eval_mle(
     sumcheck::final_reduce_block_sums<<<num_x, reduce_block, reduce_shmem, stream>>>(
         tmp_sums_buffer, output, num_blocks
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 // (Not a launcher) Utility function to calculate required size of temp sum buffer.
@@ -455,7 +455,7 @@ extern "C" int _logup_eval_mle(
     } else {
         logup_mle_kernel<false><<<grid, block, shmem_bytes, stream>>>(LOGUP_KERNEL_ARGS);
     }
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0)
         return err;
 
@@ -468,7 +468,7 @@ extern "C" int _logup_eval_mle(
     sumcheck::final_reduce_block_sums<<<2 * num_x, reduce_block, reduce_shmem, stream>>>(
         reinterpret_cast<FpExt *>(tmp_sums_buffer), reinterpret_cast<FpExt *>(output), num_blocks
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 } // namespace logup_zerocheck_mle

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/utils.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/utils.cu
@@ -183,7 +183,7 @@ extern "C" int _fold_ple_from_evals(
             new_height
         );
     }
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _interpolate_columns(
@@ -195,7 +195,7 @@ extern "C" int _interpolate_columns(
     auto [grid, block] = kernel_launch_params(num_y * num_columns, 512);
 
     interpolate_columns_kernel<<<grid, block, 0, stream>>>(interpolated, columns, s_deg, num_y, num_columns);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _frac_matrix_vertically_repeat(
@@ -209,7 +209,7 @@ extern "C" int _frac_matrix_vertically_repeat(
     grid.z = (width + grid.y - 1) / grid.y;
     assert(grid.z <= MAX_GRID_DIM);
     frac_matrix_vertically_repeat_kernel<<<grid, block, 0, stream>>>(out, in, width, lifted_height, height);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _frac_matrix_vertically_repeat_ext(
@@ -233,7 +233,7 @@ extern "C" int _frac_matrix_vertically_repeat_ext(
         lifted_height,
         height
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 } // namespace

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/utils.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/utils.cu
@@ -144,8 +144,7 @@ extern "C" int _fold_ple_from_evals(
     uint32_t width,
     uint32_t l_skip,
     uint32_t new_height,
-    bool rotate
-) {
+    bool rotate, cudaStream_t stream) {
     uint32_t skip_domain = 1u << l_skip;
 
     // Block size: at least skip_domain, prefer 256 for occupancy
@@ -162,7 +161,7 @@ extern "C" int _fold_ple_from_evals(
     size_t smem_bytes = (skip_domain > WARP_SIZE) ? total_warps_in_block * sizeof(FpExt) : 0;
 
     if (rotate) {
-        fold_ple_from_evals_kernel<true><<<grid, block, smem_bytes>>>(
+        fold_ple_from_evals_kernel<true><<<grid, block, smem_bytes, stream>>>(
             input_matrix,
             output_matrix,
             omega_skip_pows,
@@ -173,7 +172,7 @@ extern "C" int _fold_ple_from_evals(
             new_height
         );
     } else {
-        fold_ple_from_evals_kernel<false><<<grid, block, smem_bytes>>>(
+        fold_ple_from_evals_kernel<false><<<grid, block, smem_bytes, stream>>>(
             input_matrix,
             output_matrix,
             omega_skip_pows,
@@ -184,7 +183,7 @@ extern "C" int _fold_ple_from_evals(
             new_height
         );
     }
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _interpolate_columns(
@@ -192,12 +191,11 @@ extern "C" int _interpolate_columns(
     const FpExt *const *columns,
     size_t s_deg,
     size_t num_y,
-    size_t num_columns
-) {
+    size_t num_columns, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(num_y * num_columns, 512);
 
-    interpolate_columns_kernel<<<grid, block>>>(interpolated, columns, s_deg, num_y, num_columns);
-    return CHECK_KERNEL();
+    interpolate_columns_kernel<<<grid, block, 0, stream>>>(interpolated, columns, s_deg, num_y, num_columns);
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _frac_matrix_vertically_repeat(
@@ -205,14 +203,13 @@ extern "C" int _frac_matrix_vertically_repeat(
     const std::pair<FpExt, FpExt> *in,
     const uint32_t width,
     const uint32_t lifted_height,
-    const uint32_t height
-) {
+    const uint32_t height, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(lifted_height);
     grid.y = std::min(width, MAX_GRID_DIM);
     grid.z = (width + grid.y - 1) / grid.y;
     assert(grid.z <= MAX_GRID_DIM);
-    frac_matrix_vertically_repeat_kernel<<<grid, block>>>(out, in, width, lifted_height, height);
-    return CHECK_KERNEL();
+    frac_matrix_vertically_repeat_kernel<<<grid, block, 0, stream>>>(out, in, width, lifted_height, height);
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _frac_matrix_vertically_repeat_ext(
@@ -222,13 +219,12 @@ extern "C" int _frac_matrix_vertically_repeat_ext(
     const FpExt *in_denominators,
     const uint32_t width,
     const uint32_t lifted_height,
-    const uint32_t height
-) {
+    const uint32_t height, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(lifted_height);
     grid.y = std::min(width, MAX_GRID_DIM);
     grid.z = (width + grid.y - 1) / grid.y;
     assert(grid.z <= MAX_GRID_DIM);
-    frac_matrix_vertically_repeat_mixed_kernel<<<grid, block>>>(
+    frac_matrix_vertically_repeat_mixed_kernel<<<grid, block, 0, stream>>>(
         out_numerators,
         out_denominators,
         in_numerators,
@@ -237,7 +233,7 @@ extern "C" int _frac_matrix_vertically_repeat_ext(
         lifted_height,
         height
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 } // namespace

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/zerocheck_round0.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/zerocheck_round0.cu
@@ -485,7 +485,8 @@ extern "C" size_t _zerocheck_r0_temp_sums_buffer_size(
     uint32_t skip_domain,
     uint32_t num_x,
     uint32_t num_cosets,
-    size_t max_temp_bytes
+    size_t max_temp_bytes,
+    cudaStream_t stream
 ) {
     // Both modes use the same buffer size formula
     return DISPATCH_BOOL(
@@ -506,7 +507,8 @@ extern "C" size_t _zerocheck_r0_intermediates_buffer_size(
     uint32_t skip_domain,
     uint32_t num_x,
     uint32_t num_cosets,
-    size_t max_temp_bytes
+    size_t max_temp_bytes,
+    cudaStream_t stream
 ) {
     // Both modes use the same buffer size formula
     return DISPATCH_BOOL(

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/zerocheck_round0.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/zerocheck_round0.cu
@@ -543,7 +543,8 @@ int launch_zerocheck_ntt_evaluate_constraints(
     uint32_t num_x,
     uint32_t height,
     Fp g_shift,
-    size_t max_temp_bytes
+    size_t max_temp_bytes,
+    cudaStream_t stream
 ) {
     auto [grid, block] = coset_round0_config::eval_constraints_launch_params(
         buffer_size, skip_domain, num_x, NUM_COSETS, max_temp_bytes, BUFFER_THRESHOLD, MAX_THREADS
@@ -555,7 +556,7 @@ int launch_zerocheck_ntt_evaluate_constraints(
     size_t shmem_bytes = shared_sum_size + ntt_buffers_size;
 
     zerocheck_ntt_evaluate_constraints_kernel<NUM_COSETS, GLOBAL, NEEDS_SHMEM>
-        <<<grid, block, shmem_bytes>>>(
+        <<<grid, block, shmem_bytes, stream>>>(
             tmp_sums_buffer,
             selectors_cube,
             preprocessed,
@@ -575,7 +576,7 @@ int launch_zerocheck_ntt_evaluate_constraints(
             height,
             g_shift
         );
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0) {
         return err;
     }
@@ -585,11 +586,11 @@ int launch_zerocheck_ntt_evaluate_constraints(
     auto [reduce_grid, reduce_block] = kernel_launch_params(num_blocks);
     unsigned int reduce_warps = div_ceil(reduce_block.x, WARP_SIZE);
     size_t reduce_shmem = std::max(1u, reduce_warps) * sizeof(FpExt);
-    sumcheck::final_reduce_block_sums<<<NUM_COSETS * skip_domain, reduce_block, reduce_shmem>>>(
+    sumcheck::final_reduce_block_sums<<<NUM_COSETS * skip_domain, reduce_block, reduce_shmem, stream>>>(
         tmp_sums_buffer, output, num_blocks
     );
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 // Generate dispatcher for num_cosets (1-4) x is_global x needs_shmem
@@ -618,7 +619,8 @@ int launch_zerocheck_coset_parallel(
     uint32_t height,
     uint32_t num_cosets,
     Fp g_shift,
-    size_t max_temp_bytes
+    size_t max_temp_bytes,
+    cudaStream_t stream
 ) {
     auto [grid, block] = coset_parallel_round0_config::eval_constraints_launch_params(
         buffer_size, skip_domain, num_x, num_cosets, max_temp_bytes, BUFFER_THRESHOLD, MAX_THREADS
@@ -629,7 +631,7 @@ int launch_zerocheck_coset_parallel(
     size_t shmem_bytes = shared_sum_size + ntt_buffers_size;
 
     zerocheck_ntt_evaluate_constraints_coset_parallel_kernel<GLOBAL, NEEDS_SHMEM>
-        <<<grid, block, shmem_bytes>>>(
+        <<<grid, block, shmem_bytes, stream>>>(
             tmp_sums_buffer,
             selectors_cube,
             preprocessed,
@@ -649,7 +651,7 @@ int launch_zerocheck_coset_parallel(
             height,
             g_shift
         );
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0) {
         return err;
     }
@@ -659,11 +661,11 @@ int launch_zerocheck_coset_parallel(
     auto [reduce_grid, reduce_block] = kernel_launch_params(num_blocks);
     unsigned int reduce_warps = div_ceil(reduce_block.x, WARP_SIZE);
     size_t reduce_shmem = std::max(1u, reduce_warps) * sizeof(FpExt);
-    sumcheck::final_reduce_block_sums<<<num_cosets * skip_domain, reduce_block, reduce_shmem>>>(
+    sumcheck::final_reduce_block_sums<<<num_cosets * skip_domain, reduce_block, reduce_shmem, stream>>>(
         tmp_sums_buffer, output, num_blocks
     );
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _zerocheck_ntt_eval_constraints(
@@ -687,7 +689,8 @@ extern "C" int _zerocheck_ntt_eval_constraints(
     uint32_t height,
     uint32_t num_cosets,
     Fp g_shift,
-    size_t max_temp_bytes
+    size_t max_temp_bytes,
+    cudaStream_t stream
 ) {
     bool is_global = buffer_size > BUFFER_THRESHOLD;
     bool use_coset_parallel = use_coset_parallel_mode(num_x, skip_domain);
@@ -703,14 +706,14 @@ extern "C" int _zerocheck_ntt_eval_constraints(
     if (skip_domain == 1) {
         if (use_coset_parallel) {
             return is_global ? launch_zerocheck_coset_parallel<true, false>(
-                                   KERNEL_ARGS, num_cosets, g_shift, max_temp_bytes
+                                   KERNEL_ARGS, num_cosets, g_shift, max_temp_bytes, stream
                                )
                              : launch_zerocheck_coset_parallel<false, false>(
-                                   KERNEL_ARGS, num_cosets, g_shift, max_temp_bytes
+                                   KERNEL_ARGS, num_cosets, g_shift, max_temp_bytes, stream
                                );
         }
         return dispatch_zerocheck(
-            num_cosets, is_global, false, KERNEL_ARGS, g_shift, max_temp_bytes
+            num_cosets, is_global, false, KERNEL_ARGS, g_shift, max_temp_bytes, stream
         );
     }
 
@@ -726,12 +729,13 @@ extern "C" int _zerocheck_ntt_eval_constraints(
             KERNEL_ARGS,
             num_cosets,
             g_shift,
-            max_temp_bytes
+            max_temp_bytes,
+            stream
         );
     } else {
         // Lockstep mode: single thread handles all cosets
         return dispatch_zerocheck(
-            num_cosets, is_global, needs_shmem, KERNEL_ARGS, g_shift, max_temp_bytes
+            num_cosets, is_global, needs_shmem, KERNEL_ARGS, g_shift, max_temp_bytes, stream
         );
     }
 #undef KERNEL_ARGS
@@ -742,11 +746,12 @@ extern "C" int _fold_selectors_round0(
     const Fp *in,
     FpExt is_first,
     FpExt is_last,
-    uint32_t num_x
+    uint32_t num_x,
+    cudaStream_t stream
 ) {
     auto [grid, block] = kernel_launch_params(num_x);
-    fold_selectors_round0_kernel<<<grid, block>>>(out, in, is_first, is_last, num_x);
-    return CHECK_KERNEL();
+    fold_selectors_round0_kernel<<<grid, block, 0, stream>>>(out, in, is_first, is_last, num_x);
+    return CHECK_KERNEL_ON(stream);
 }
 
 } // namespace zerocheck_round0

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/zerocheck_round0.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/zerocheck_round0.cu
@@ -576,7 +576,7 @@ int launch_zerocheck_ntt_evaluate_constraints(
             height,
             g_shift
         );
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0) {
         return err;
     }
@@ -590,7 +590,7 @@ int launch_zerocheck_ntt_evaluate_constraints(
         tmp_sums_buffer, output, num_blocks
     );
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 // Generate dispatcher for num_cosets (1-4) x is_global x needs_shmem
@@ -651,7 +651,7 @@ int launch_zerocheck_coset_parallel(
             height,
             g_shift
         );
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0) {
         return err;
     }
@@ -665,7 +665,7 @@ int launch_zerocheck_coset_parallel(
         tmp_sums_buffer, output, num_blocks
     );
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _zerocheck_ntt_eval_constraints(
@@ -751,7 +751,7 @@ extern "C" int _fold_selectors_round0(
 ) {
     auto [grid, block] = kernel_launch_params(num_x);
     fold_selectors_round0_kernel<<<grid, block, 0, stream>>>(out, in, is_first, is_last, num_x);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 } // namespace zerocheck_round0

--- a/crates/cuda-backend/cuda/src/matrix.cu
+++ b/crates/cuda-backend/cuda/src/matrix.cu
@@ -227,29 +227,30 @@ __global__ void batch_expand_pad_wide_kernel(
 constexpr uint32_t MAX_GRID_DIM = 65535u;
 
 template <typename T>
-int matrix_transpose_impl(T *output, const T *input, size_t col_size, size_t row_size) {
+int matrix_transpose_impl(T *output, const T *input, size_t col_size, size_t row_size, cudaStream_t stream) {
     uint32_t grid_x = (col_size + TILE_SIZE - 1) / TILE_SIZE;
     uint32_t grid_y = (row_size + TILE_SIZE - 1) / TILE_SIZE;
 
     dim3 grid(grid_x * grid_y);
     dim3 block(TILE_SIZE);
 
-    matrix_transpose_kernel<T><<<grid, block>>>(output, input, col_size, row_size);
+    matrix_transpose_kernel<T><<<grid, block, 0, stream>>>(output, input, col_size, row_size);
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
-extern "C" int _matrix_transpose_fp(Fp *output, const Fp *input, size_t col_size, size_t row_size) {
-    return matrix_transpose_impl(output, input, col_size, row_size);
+extern "C" int _matrix_transpose_fp(Fp *output, const Fp *input, size_t col_size, size_t row_size, cudaStream_t stream) {
+    return matrix_transpose_impl(output, input, col_size, row_size, stream);
 }
 
 extern "C" int _matrix_transpose_fpext(
     FpExt *output,
     const FpExt *input,
     size_t col_size,
-    size_t row_size
+    size_t row_size,
+    cudaStream_t stream
 ) {
-    return matrix_transpose_impl(output, input, col_size, row_size);
+    return matrix_transpose_impl(output, input, col_size, row_size, stream);
 }
 
 extern "C" int _matrix_get_rows_fp(
@@ -258,7 +259,8 @@ extern "C" int _matrix_get_rows_fp(
     uint32_t *row_indices,
     uint64_t matrix_width,
     uint64_t matrix_height,
-    uint32_t row_indices_len
+    uint32_t row_indices_len,
+    cudaStream_t stream
 ) {
     if (matrix_width == 0 || row_indices_len == 0) {
         return cudaSuccess;
@@ -268,23 +270,24 @@ extern "C" int _matrix_get_rows_fp(
     }
     auto block = WARP_SIZE;
     dim3 grid = dim3(div_ceil(matrix_width, WARP_SIZE), row_indices_len);
-    matrix_get_rows_fp_kernel<<<grid, block>>>(
+    matrix_get_rows_fp_kernel<<<grid, block, 0, stream>>>(
         output, input, row_indices, matrix_width, matrix_height
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _split_ext_to_base_col_major_matrix(
     Fp *d_matrix,
     FpExt *d_poly,
     uint64_t poly_len,
-    uint32_t matrix_height
+    uint32_t matrix_height,
+    cudaStream_t stream
 ) {
     auto [grid, block] = kernel_launch_params(matrix_height);
-    split_ext_to_base_col_major_matrix_kernel<<<grid, block>>>(
+    split_ext_to_base_col_major_matrix_kernel<<<grid, block, 0, stream>>>(
         d_matrix, d_poly, poly_len, matrix_height
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _batch_rotate_pad(
@@ -293,14 +296,15 @@ extern "C" int _batch_rotate_pad(
     uint32_t width,
     uint32_t num_x, // = (in.height() / domain_size)
     uint32_t domain_size,
-    uint32_t padded_size
+    uint32_t padded_size,
+    cudaStream_t stream
 ) {
     auto [grid, block] = kernel_launch_params(padded_size);
     auto num_poly = width * num_x;
     grid.y = std::min(num_poly, MAX_GRID_DIM);
     grid.z = (num_poly + grid.y - 1) / grid.y;
-    batch_rotate_pad_kernel<<<grid, block>>>(out, in, width, num_x, domain_size, padded_size);
-    return CHECK_KERNEL();
+    batch_rotate_pad_kernel<<<grid, block, 0, stream>>>(out, in, width, num_x, domain_size, padded_size);
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _lift_padded_matrix_evals(
@@ -308,13 +312,14 @@ extern "C" int _lift_padded_matrix_evals(
     uint32_t width,
     uint32_t height,
     uint32_t lifted_height,
-    uint32_t padded_height
+    uint32_t padded_height,
+    cudaStream_t stream
 ) {
     auto [grid, block] = kernel_launch_2d_params(lifted_height, width);
-    lift_padded_matrix_evals_kernel<<<grid, block>>>(
+    lift_padded_matrix_evals_kernel<<<grid, block, 0, stream>>>(
         matrix, width, height, lifted_height, padded_height
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _collapse_strided_matrix(
@@ -322,12 +327,13 @@ extern "C" int _collapse_strided_matrix(
     const Fp *in,
     uint32_t width,
     uint32_t height,
-    uint32_t stride
+    uint32_t stride,
+    cudaStream_t stream
 ) {
     auto lifted_height = height * stride;
     auto [grid, block] = kernel_launch_2d_params(height, width);
-    collapse_strided_matrix_kernel<<<grid, block>>>(out, in, width, lifted_height, height, stride);
-    return CHECK_KERNEL();
+    collapse_strided_matrix_kernel<<<grid, block, 0, stream>>>(out, in, width, lifted_height, height, stride);
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _batch_expand_pad(
@@ -335,11 +341,12 @@ extern "C" int _batch_expand_pad(
     const Fp *in,
     const uint32_t polyCount,
     const uint32_t outSize,
-    const uint32_t inSize
+    const uint32_t inSize,
+    cudaStream_t stream
 ) {
     auto [grid, block] = kernel_launch_params(outSize);
-    batch_expand_pad_kernel<<<grid, block>>>(out, in, polyCount, outSize, inSize);
-    return CHECK_KERNEL();
+    batch_expand_pad_kernel<<<grid, block, 0, stream>>>(out, in, polyCount, outSize, inSize);
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _batch_expand_pad_wide(
@@ -347,12 +354,13 @@ extern "C" int _batch_expand_pad_wide(
     const Fp *in,
     const uint32_t width,
     const uint32_t padded_height,
-    const uint32_t height
+    const uint32_t height,
+    cudaStream_t stream
 ) {
     auto [grid, block] = kernel_launch_params(padded_height);
     grid.y = std::min(width, MAX_GRID_DIM);
     grid.z = (width + grid.y - 1) / grid.y;
     assert(grid.z <= MAX_GRID_DIM);
-    batch_expand_pad_wide_kernel<<<grid, block>>>(out, in, width, padded_height, height);
-    return CHECK_KERNEL();
+    batch_expand_pad_wide_kernel<<<grid, block, 0, stream>>>(out, in, width, padded_height, height);
+    return CHECK_KERNEL_ON(stream);
 }

--- a/crates/cuda-backend/cuda/src/matrix.cu
+++ b/crates/cuda-backend/cuda/src/matrix.cu
@@ -90,8 +90,8 @@ __global__ void split_ext_to_base_col_major_matrix_kernel(
         return;
     }
 
-    uint32_t col_num = (poly_len / matrix_height); // SPLIT_FACTOR = 2
-    for (uint32_t col_idx = 0; col_idx < col_num; col_idx++) {
+    uint64_t col_num = (poly_len / matrix_height); // SPLIT_FACTOR = 2
+    for (uint64_t col_idx = 0; col_idx < col_num; col_idx++) {
         FpExt ext_val = d_poly[col_idx * matrix_height + row_idx];
         d_matrix[(col_idx * 4 + 0) * matrix_height + row_idx] = ext_val.elems[0];
         d_matrix[(col_idx * 4 + 1) * matrix_height + row_idx] = ext_val.elems[1];
@@ -114,6 +114,8 @@ __global__ void batch_rotate_pad_kernel(
 ) {
     auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
     auto pidx = blockIdx.y + blockIdx.z * gridDim.y;
+    const size_t padded_stride = padded_size;
+    const size_t domain_stride = domain_size;
 
     if (pidx >= width * num_x) {
         return;
@@ -129,9 +131,9 @@ __global__ void batch_rotate_pad_kernel(
                 pidx_rot -= num_x;
             }
         }
-        out[padded_size * pidx + tidx] = in[domain_size * pidx_rot + tidx_rot];
+        out[padded_stride * pidx + tidx] = in[domain_stride * pidx_rot + tidx_rot];
     } else if (tidx < padded_size) {
-        out[padded_size * pidx + tidx] = Fp(0);
+        out[padded_stride * pidx + tidx] = Fp(0);
     }
 }
 
@@ -147,11 +149,12 @@ __global__ void lift_padded_matrix_evals_kernel(
 ) {
     auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
     auto col = threadIdx.y + blockIdx.y * blockDim.y;
+    const size_t col_stride = padded_height;
     if (tidx >= lifted_height || col >= width) {
         return;
     }
     // lhs = rhs when tidx < height
-    matrix[col * padded_height + tidx] = matrix[col * padded_height + (tidx % height)];
+    matrix[col * col_stride + tidx] = matrix[col * col_stride + (tidx % height)];
 }
 
 // Required: lifted_height = height * stride
@@ -165,11 +168,14 @@ __global__ void collapse_strided_matrix_kernel(
 ) {
     auto row = threadIdx.x + blockIdx.x * blockDim.x;
     auto col = threadIdx.y + blockIdx.y * blockDim.y;
+    const size_t out_col_stride = height;
+    const size_t in_col_stride = lifted_height;
+    const size_t row_stride = stride;
     if (row >= height || col >= width) {
         return;
     }
 
-    out[col * height + row] = in[col * lifted_height + row * stride];
+    out[col * out_col_stride + row] = in[col * in_col_stride + row * row_stride];
 }
 
 // memory layout of in: column-major
@@ -186,13 +192,15 @@ __global__ void batch_expand_pad_kernel(
     const uint32_t inSize
 ) {
     uint idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const size_t in_stride = inSize;
+    const size_t out_stride = outSize;
     if (idx < outSize) {
         for (uint32_t i = 0; i < polyCount; i++) {
             Fp res = Fp(0);
             if (idx < inSize) {
-                res = in[i * inSize + idx];
+                res = in[i * in_stride + idx];
             }
-            out[i * outSize + idx] = res;
+            out[i * out_stride + idx] = res;
         }
     }
 }
@@ -210,13 +218,15 @@ __global__ void batch_expand_pad_wide_kernel(
 ) {
     uint32_t row = blockIdx.x * blockDim.x + threadIdx.x;
     uint32_t col = blockIdx.y + blockIdx.z * gridDim.y;
+    const size_t padded_stride = padded_height;
+    const size_t in_stride = height;
     if (col >= width) {
         return;
     }
     if (row < height) {
-        out[col * padded_height + row] = in[col * height + row];
+        out[col * padded_stride + row] = in[col * in_stride + row];
     } else if (row < padded_height) {
-        out[col * padded_height + row] = Fp(0);
+        out[col * padded_stride + row] = Fp(0);
     }
 }
 

--- a/crates/cuda-backend/cuda/src/matrix.cu
+++ b/crates/cuda-backend/cuda/src/matrix.cu
@@ -236,7 +236,7 @@ int matrix_transpose_impl(T *output, const T *input, size_t col_size, size_t row
 
     matrix_transpose_kernel<T><<<grid, block, 0, stream>>>(output, input, col_size, row_size);
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _matrix_transpose_fp(Fp *output, const Fp *input, size_t col_size, size_t row_size, cudaStream_t stream) {
@@ -273,7 +273,7 @@ extern "C" int _matrix_get_rows_fp(
     matrix_get_rows_fp_kernel<<<grid, block, 0, stream>>>(
         output, input, row_indices, matrix_width, matrix_height
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _split_ext_to_base_col_major_matrix(
@@ -287,7 +287,7 @@ extern "C" int _split_ext_to_base_col_major_matrix(
     split_ext_to_base_col_major_matrix_kernel<<<grid, block, 0, stream>>>(
         d_matrix, d_poly, poly_len, matrix_height
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _batch_rotate_pad(
@@ -304,7 +304,7 @@ extern "C" int _batch_rotate_pad(
     grid.y = std::min(num_poly, MAX_GRID_DIM);
     grid.z = (num_poly + grid.y - 1) / grid.y;
     batch_rotate_pad_kernel<<<grid, block, 0, stream>>>(out, in, width, num_x, domain_size, padded_size);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _lift_padded_matrix_evals(
@@ -319,7 +319,7 @@ extern "C" int _lift_padded_matrix_evals(
     lift_padded_matrix_evals_kernel<<<grid, block, 0, stream>>>(
         matrix, width, height, lifted_height, padded_height
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _collapse_strided_matrix(
@@ -333,7 +333,7 @@ extern "C" int _collapse_strided_matrix(
     auto lifted_height = height * stride;
     auto [grid, block] = kernel_launch_2d_params(height, width);
     collapse_strided_matrix_kernel<<<grid, block, 0, stream>>>(out, in, width, lifted_height, height, stride);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _batch_expand_pad(
@@ -346,7 +346,7 @@ extern "C" int _batch_expand_pad(
 ) {
     auto [grid, block] = kernel_launch_params(outSize);
     batch_expand_pad_kernel<<<grid, block, 0, stream>>>(out, in, polyCount, outSize, inSize);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _batch_expand_pad_wide(
@@ -362,5 +362,5 @@ extern "C" int _batch_expand_pad_wide(
     grid.z = (width + grid.y - 1) / grid.y;
     assert(grid.z <= MAX_GRID_DIM);
     batch_expand_pad_wide_kernel<<<grid, block, 0, stream>>>(out, in, width, padded_height, height);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }

--- a/crates/cuda-backend/cuda/src/merkle_tree.cu
+++ b/crates/cuda-backend/cuda/src/merkle_tree.cu
@@ -231,7 +231,7 @@ extern "C" int _poseidon2_compressing_row_hashes(
     poseidon2_compressing_row_hashes_kernel<<<grid, block, shmem_bytes, stream>>>(
         out, matrix, width, height, query_stride, log_rows_per_query
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _poseidon2_compressing_row_hashes_ext(
@@ -254,7 +254,7 @@ extern "C" int _poseidon2_compressing_row_hashes_ext(
     poseidon2_compressing_row_hashes_ext_kernel<<<grid, block, shmem_bytes, stream>>>(
         out, matrix, width, height, query_stride, log_rows_per_query
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _poseidon2_strided_compress_layer(
@@ -266,7 +266,7 @@ extern "C" int _poseidon2_strided_compress_layer(
     poseidon2_strided_compress_layer_kernel<<<grid, block, 0, stream>>>(
         output, prev_layer, output_size, stride
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 // NOTE[jpw]: adding this function in CUDA to ensure the compiler can optimize stride = 1 (not sure this would happen across FFI boundary).
@@ -277,7 +277,7 @@ extern "C" int _poseidon2_adjacent_compress_layer(
     size_t output_size, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(output_size);
     poseidon2_strided_compress_layer_kernel<<<grid, block, 0, stream>>>(output, prev_layer, output_size, 1);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _query_digest_layers(
@@ -300,5 +300,5 @@ extern "C" int _query_digest_layers(
     query_digest_layers<<<grid, block, 0, stream>>>(
         d_digest_matrix, d_layers_ptr, d_indices, num_query, num_layer
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }

--- a/crates/cuda-backend/cuda/src/merkle_tree.cu
+++ b/crates/cuda-backend/cuda/src/merkle_tree.cu
@@ -216,8 +216,7 @@ extern "C" int _poseidon2_compressing_row_hashes(
     const Fp *matrix,
     size_t width,
     size_t query_stride,
-    size_t log_rows_per_query
-) {
+    size_t log_rows_per_query, cudaStream_t stream) {
     if (log_rows_per_query > 10) {
         return cudaErrorInvalidValue;
     }
@@ -229,10 +228,10 @@ extern "C" int _poseidon2_compressing_row_hashes(
     size_t shmem_bytes = CELLS_OUT * shared_stride * sizeof(Fp);
     auto height = query_stride << log_rows_per_query;
 
-    poseidon2_compressing_row_hashes_kernel<<<grid, block, shmem_bytes>>>(
+    poseidon2_compressing_row_hashes_kernel<<<grid, block, shmem_bytes, stream>>>(
         out, matrix, width, height, query_stride, log_rows_per_query
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _poseidon2_compressing_row_hashes_ext(
@@ -240,8 +239,7 @@ extern "C" int _poseidon2_compressing_row_hashes_ext(
     const FpExt *matrix,
     size_t width,
     size_t query_stride,
-    size_t log_rows_per_query
-) {
+    size_t log_rows_per_query, cudaStream_t stream) {
     if (log_rows_per_query > 10) {
         return cudaErrorInvalidValue;
     }
@@ -253,23 +251,22 @@ extern "C" int _poseidon2_compressing_row_hashes_ext(
     size_t shmem_bytes = CELLS_OUT * shared_stride * sizeof(Fp);
     auto height = query_stride << log_rows_per_query;
 
-    poseidon2_compressing_row_hashes_ext_kernel<<<grid, block, shmem_bytes>>>(
+    poseidon2_compressing_row_hashes_ext_kernel<<<grid, block, shmem_bytes, stream>>>(
         out, matrix, width, height, query_stride, log_rows_per_query
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _poseidon2_strided_compress_layer(
     digest_t *output,
     const digest_t *prev_layer,
     size_t output_size,
-    size_t stride
-) {
+    size_t stride, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(output_size);
-    poseidon2_strided_compress_layer_kernel<<<grid, block>>>(
+    poseidon2_strided_compress_layer_kernel<<<grid, block, 0, stream>>>(
         output, prev_layer, output_size, stride
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 // NOTE[jpw]: adding this function in CUDA to ensure the compiler can optimize stride = 1 (not sure this would happen across FFI boundary).
@@ -277,11 +274,10 @@ extern "C" int _poseidon2_strided_compress_layer(
 extern "C" int _poseidon2_adjacent_compress_layer(
     digest_t *output,
     const digest_t *prev_layer,
-    size_t output_size
-) {
+    size_t output_size, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(output_size);
-    poseidon2_strided_compress_layer_kernel<<<grid, block>>>(output, prev_layer, output_size, 1);
-    return CHECK_KERNEL();
+    poseidon2_strided_compress_layer_kernel<<<grid, block, 0, stream>>>(output, prev_layer, output_size, 1);
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _query_digest_layers(
@@ -289,8 +285,7 @@ extern "C" int _query_digest_layers(
     const uint64_t *d_layers_ptr,
     uint64_t *d_indices,
     uint64_t num_query,
-    uint64_t num_layer
-) {
+    uint64_t num_layer, cudaStream_t stream) {
     if (num_query == 0 || num_layer == 0) {
         return cudaSuccess;
     }
@@ -302,8 +297,8 @@ extern "C" int _query_digest_layers(
 
     auto block = QUERY_DIGEST_THREADS;
     dim3 grid = dim3(div_ceil(num_layer * DIGEST_WIDTH, block), num_query);
-    query_digest_layers<<<grid, block>>>(
+    query_digest_layers<<<grid, block, 0, stream>>>(
         d_digest_matrix, d_layers_ptr, d_indices, num_query, num_layer
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }

--- a/crates/cuda-backend/cuda/src/mle_interpolate.cu
+++ b/crates/cuda-backend/cuda/src/mle_interpolate.cu
@@ -226,7 +226,7 @@ int launch_mle_interpolate_stage(Field *buffer, size_t buffer_len, uint32_t step
     size_t total_pairs = buffer_len >> 1;
     auto [grid, block] = kernel_launch_params(total_pairs);
     mle_interpolate_stage_kernel<Field, EvalToCoeff><<<grid, block, 0, stream>>>(buffer, total_pairs, step);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _mle_interpolate_stage(
@@ -279,7 +279,7 @@ int launch_mle_interpolate_stage_2d(
     grid.y = width;
     mle_interpolate_stage_2d_kernel<Field, EvalToCoeff>
         <<<grid, block, 0, stream>>>(buffer, padded_height, span, step);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _mle_interpolate_stage_2d(
@@ -324,7 +324,7 @@ int launch_mle_interpolate_fused_2d(
     grid.y = width;
     mle_interpolate_fused_2d_kernel<EvalToCoeff, NumStages, RightPad>
         <<<grid, block, 0, stream>>>(buffer, padded_height, log_stride, start_step);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 // Recursive template dispatch for num_stages (1-5)
@@ -409,7 +409,7 @@ int launch_mle_interpolate_shared_2d(
         <<<grid, block_size, smem_size, stream>>>(
             buffer, padded_height, log_stride, start_log_step, end_log_step
         );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _mle_interpolate_shared_2d(

--- a/crates/cuda-backend/cuda/src/mle_interpolate.cu
+++ b/crates/cuda-backend/cuda/src/mle_interpolate.cu
@@ -222,27 +222,28 @@ __global__ void mle_interpolate_shared_2d_kernel(
 // ============================================================================
 
 template <typename Field, bool EvalToCoeff>
-int launch_mle_interpolate_stage(Field *buffer, size_t buffer_len, uint32_t step) {
+int launch_mle_interpolate_stage(Field *buffer, size_t buffer_len, uint32_t step, cudaStream_t stream) {
     size_t total_pairs = buffer_len >> 1;
     auto [grid, block] = kernel_launch_params(total_pairs);
-    mle_interpolate_stage_kernel<Field, EvalToCoeff><<<grid, block>>>(buffer, total_pairs, step);
-    return CHECK_KERNEL();
+    mle_interpolate_stage_kernel<Field, EvalToCoeff><<<grid, block, 0, stream>>>(buffer, total_pairs, step);
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _mle_interpolate_stage(
     Fp *buffer,
     size_t buffer_len,
     uint32_t step,
-    bool is_eval_to_coeff
+    bool is_eval_to_coeff,
+    cudaStream_t stream
 ) {
     if (buffer_len < 2 || step == 0) {
         return 0;
     }
 
     if (is_eval_to_coeff) {
-        return launch_mle_interpolate_stage<Fp, true>(buffer, buffer_len, step);
+        return launch_mle_interpolate_stage<Fp, true>(buffer, buffer_len, step, stream);
     } else {
-        return launch_mle_interpolate_stage<Fp, false>(buffer, buffer_len, step);
+        return launch_mle_interpolate_stage<Fp, false>(buffer, buffer_len, step, stream);
     }
 }
 
@@ -250,16 +251,17 @@ extern "C" int _mle_interpolate_stage_ext(
     FpExt *buffer,
     size_t buffer_len,
     uint32_t step,
-    bool is_eval_to_coeff
+    bool is_eval_to_coeff,
+    cudaStream_t stream
 ) {
     if (buffer_len < 2 || step == 0) {
         return 0;
     }
 
     if (is_eval_to_coeff) {
-        return launch_mle_interpolate_stage<FpExt, true>(buffer, buffer_len, step);
+        return launch_mle_interpolate_stage<FpExt, true>(buffer, buffer_len, step, stream);
     } else {
-        return launch_mle_interpolate_stage<FpExt, false>(buffer, buffer_len, step);
+        return launch_mle_interpolate_stage<FpExt, false>(buffer, buffer_len, step, stream);
     }
 }
 
@@ -269,14 +271,15 @@ int launch_mle_interpolate_stage_2d(
     uint16_t width,
     uint32_t height,
     uint32_t padded_height,
-    uint32_t step
+    uint32_t step,
+    cudaStream_t stream
 ) {
     auto span = step * 2;
     auto [grid, block] = kernel_launch_params(height >> 1);
     grid.y = width;
     mle_interpolate_stage_2d_kernel<Field, EvalToCoeff>
-        <<<grid, block>>>(buffer, padded_height, span, step);
-    return CHECK_KERNEL();
+        <<<grid, block, 0, stream>>>(buffer, padded_height, span, step);
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _mle_interpolate_stage_2d(
@@ -285,18 +288,19 @@ extern "C" int _mle_interpolate_stage_2d(
     uint32_t height,
     uint32_t padded_height,
     uint32_t step,
-    bool is_eval_to_coeff
+    bool is_eval_to_coeff,
+    cudaStream_t stream
 ) {
     if (width == 0) {
         return cudaErrorInvalidValue;
     }
     if (is_eval_to_coeff) {
         return launch_mle_interpolate_stage_2d<Fp, true>(
-            buffer, width, height, padded_height, step
+            buffer, width, height, padded_height, step, stream
         );
     } else {
         return launch_mle_interpolate_stage_2d<Fp, false>(
-            buffer, width, height, padded_height, step
+            buffer, width, height, padded_height, step, stream
         );
     }
 }
@@ -312,14 +316,15 @@ int launch_mle_interpolate_fused_2d(
     uint16_t width,
     uint32_t padded_height,
     uint32_t log_stride,
-    uint32_t start_step
+    uint32_t start_step,
+    cudaStream_t stream
 ) {
     uint32_t meaningful_count = padded_height >> log_stride;
     auto [grid, block] = kernel_launch_params(meaningful_count);
     grid.y = width;
     mle_interpolate_fused_2d_kernel<EvalToCoeff, NumStages, RightPad>
-        <<<grid, block>>>(buffer, padded_height, log_stride, start_step);
-    return CHECK_KERNEL();
+        <<<grid, block, 0, stream>>>(buffer, padded_height, log_stride, start_step);
+    return CHECK_KERNEL_ON(stream);
 }
 
 // Recursive template dispatch for num_stages (1-5)
@@ -330,18 +335,19 @@ int dispatch_mle_interpolate_fused_2d(
     uint32_t padded_height,
     uint32_t log_stride,
     uint32_t start_step,
-    uint32_t num_stages
+    uint32_t num_stages,
+    cudaStream_t stream
 ) {
     if constexpr (N == 0) {
         return cudaErrorInvalidValue;
     } else {
         if (num_stages == N) {
             return launch_mle_interpolate_fused_2d<EvalToCoeff, N, RightPad>(
-                buffer, width, padded_height, log_stride, start_step
+                buffer, width, padded_height, log_stride, start_step, stream
             );
         }
         return dispatch_mle_interpolate_fused_2d<EvalToCoeff, RightPad, N - 1>(
-            buffer, width, padded_height, log_stride, start_step, num_stages
+            buffer, width, padded_height, log_stride, start_step, num_stages, stream
         );
     }
 }
@@ -354,7 +360,8 @@ extern "C" int _mle_interpolate_fused_2d(
     uint32_t start_step,
     uint32_t num_stages,
     bool is_eval_to_coeff,
-    bool right_pad
+    bool right_pad,
+    cudaStream_t stream
 ) {
     if (width == 0) {
         return cudaErrorInvalidValue;
@@ -368,7 +375,8 @@ extern "C" int _mle_interpolate_fused_2d(
         padded_height,
         log_stride,
         start_step,
-        num_stages
+        num_stages,
+        stream
     );
 }
 
@@ -385,7 +393,8 @@ int launch_mle_interpolate_shared_2d(
     uint32_t padded_height,
     uint32_t log_stride,
     uint32_t start_log_step,
-    uint32_t end_log_step
+    uint32_t end_log_step,
+    cudaStream_t stream
 ) {
     constexpr uint32_t tile_size = 1 << MLE_SHARED_TILE_LOG_SIZE;
     constexpr uint32_t block_size = 256;
@@ -397,10 +406,10 @@ int launch_mle_interpolate_shared_2d(
     dim3 grid(num_tiles, width);
 
     mle_interpolate_shared_2d_kernel<EvalToCoeff, MLE_SHARED_TILE_LOG_SIZE, RightPad>
-        <<<grid, block_size, smem_size>>>(
+        <<<grid, block_size, smem_size, stream>>>(
             buffer, padded_height, log_stride, start_log_step, end_log_step
         );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _mle_interpolate_shared_2d(
@@ -411,7 +420,8 @@ extern "C" int _mle_interpolate_shared_2d(
     uint32_t start_log_step,
     uint32_t end_log_step,
     bool is_eval_to_coeff,
-    bool right_pad
+    bool right_pad,
+    cudaStream_t stream
 ) {
     if (width == 0) {
         return cudaErrorInvalidValue;
@@ -429,6 +439,7 @@ extern "C" int _mle_interpolate_shared_2d(
         padded_height,
         log_stride,
         start_log_step,
-        end_log_step
+        end_log_step,
+        stream
     );
 }

--- a/crates/cuda-backend/cuda/src/poly.cu
+++ b/crates/cuda-backend/cuda/src/poly.cu
@@ -223,47 +223,50 @@ extern "C" int _algebraic_batch_matrices(
     const uint32_t *mu_idxs, // Starting index in `mu_powers` for each matrix. Length = num_mats
     const uint32_t *widths,  // Width of each matrix
     size_t height,
-    size_t num_mats
+    size_t num_mats,
+    cudaStream_t stream
 ) {
     auto [grid, block] = kernel_launch_params(height);
-    algebraic_batch_matrices_kernel<<<grid, block>>>(
+    algebraic_batch_matrices_kernel<<<grid, block, 0, stream>>>(
         output, mats, mu_powers, mu_idxs, widths, height, num_mats
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
-extern "C" int _eq_hypercube_stage_ext(FpExt *out, FpExt x_i, uint32_t step) {
+extern "C" int _eq_hypercube_stage_ext(FpExt *out, FpExt x_i, uint32_t step, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(step);
-    eq_hypercube_stage_ext_kernel<<<grid, block>>>(out, x_i, step);
-    return CHECK_KERNEL();
+    eq_hypercube_stage_ext_kernel<<<grid, block, 0, stream>>>(out, x_i, step);
+    return CHECK_KERNEL_ON(stream);
 }
 
-extern "C" int _mobius_eq_hypercube_stage_ext(FpExt *out, FpExt omega_i, uint32_t step) {
+extern "C" int _mobius_eq_hypercube_stage_ext(FpExt *out, FpExt omega_i, uint32_t step, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(step);
-    mobius_eq_hypercube_stage_ext_kernel<<<grid, block>>>(out, omega_i, step);
-    return CHECK_KERNEL();
+    mobius_eq_hypercube_stage_ext_kernel<<<grid, block, 0, stream>>>(out, omega_i, step);
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _eq_hypercube_nonoverlapping_stage_ext(
     FpExt *out,
     const FpExt *in,
     FpExt x_i,
-    uint32_t step
+    uint32_t step,
+    cudaStream_t stream
 ) {
     auto [grid, block] = kernel_launch_params(step);
-    eq_hypercube_nonoverlapping_stage_ext_kernel<<<grid, block>>>(out, in, x_i, step);
-    return CHECK_KERNEL();
+    eq_hypercube_nonoverlapping_stage_ext_kernel<<<grid, block, 0, stream>>>(out, in, x_i, step);
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _eq_hypercube_interleaved_stage_ext(
     FpExt *out,
     const FpExt *in,
     FpExt x_i,
-    uint32_t step
+    uint32_t step,
+    cudaStream_t stream
 ) {
     auto [grid, block] = kernel_launch_params(step);
-    eq_hypercube_interleaved_stage_ext_kernel<<<grid, block>>>(out, in, x_i, step);
-    return CHECK_KERNEL();
+    eq_hypercube_interleaved_stage_ext_kernel<<<grid, block, 0, stream>>>(out, in, x_i, step);
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _batch_eq_hypercube_stage(
@@ -271,49 +274,49 @@ extern "C" int _batch_eq_hypercube_stage(
     Fp *x,
     uint32_t step,
     uint32_t width,
-    uint32_t height
+    uint32_t height,
+    cudaStream_t stream
 ) {
-
     auto [grid, block] = kernel_launch_params(step);
     grid.y = width;
-    batch_eq_hypercube_stage_kernel<<<grid, block>>>(out, x, step, width, height);
-    return CHECK_KERNEL();
+    batch_eq_hypercube_stage_kernel<<<grid, block, 0, stream>>>(out, x, step, width, height);
+    return CHECK_KERNEL_ON(stream);
 }
 
 // Helper to dispatch templated kernel based on runtime block size
 template <int BlockSize>
-int launch_eval_poly_ext_at_point(const Fp *coeffs, size_t len, FpExt x, FpExt *out) {
+int launch_eval_poly_ext_at_point(const Fp *coeffs, size_t len, FpExt x, FpExt *out, cudaStream_t stream) {
     // Shared memory size: num_warps elements for warp reduction results
     // (also reused for x^chunk_size storage in smem[0])
     // This eliminates bank conflicts by using warp shuffle for intra-warp reduction
     constexpr unsigned int num_warps = (BlockSize + WARP_SIZE - 1) / WARP_SIZE;
     size_t smem_size = num_warps * sizeof(FpExt);
-    eval_poly_ext_at_point_kernel<BlockSize><<<1, BlockSize, smem_size>>>(coeffs, len, x, out);
-    return CHECK_KERNEL();
+    eval_poly_ext_at_point_kernel<BlockSize><<<1, BlockSize, smem_size, stream>>>(coeffs, len, x, out);
+    return CHECK_KERNEL_ON(stream);
 }
 
-extern "C" int _eval_poly_ext_at_point(const Fp *coeffs, size_t len, FpExt x, FpExt *out) {
+extern "C" int _eval_poly_ext_at_point(const Fp *coeffs, size_t len, FpExt x, FpExt *out, cudaStream_t stream) {
     // Choose block size based on polynomial length for optimal performance
     // Larger polynomials benefit from more parallelism
     if (len <= 256) {
-        return launch_eval_poly_ext_at_point<64>(coeffs, len, x, out);
+        return launch_eval_poly_ext_at_point<64>(coeffs, len, x, out, stream);
     } else if (len <= 4096) {
-        return launch_eval_poly_ext_at_point<128>(coeffs, len, x, out);
+        return launch_eval_poly_ext_at_point<128>(coeffs, len, x, out, stream);
     } else if (len <= 65536) {
-        return launch_eval_poly_ext_at_point<256>(coeffs, len, x, out);
+        return launch_eval_poly_ext_at_point<256>(coeffs, len, x, out, stream);
     } else {
-        return launch_eval_poly_ext_at_point<512>(coeffs, len, x, out);
+        return launch_eval_poly_ext_at_point<512>(coeffs, len, x, out, stream);
     }
 }
 
-extern "C" int _vector_scalar_multiply_ext(FpExt *vec, FpExt scalar, uint32_t length) {
+extern "C" int _vector_scalar_multiply_ext(FpExt *vec, FpExt scalar, uint32_t length, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(length);
-    vector_scalar_multiply_kernel<FpExt><<<grid, block>>>(vec, scalar, length);
-    return CHECK_KERNEL();
+    vector_scalar_multiply_kernel<FpExt><<<grid, block, 0, stream>>>(vec, scalar, length);
+    return CHECK_KERNEL_ON(stream);
 }
 
-extern "C" int _transpose_fp_to_fpext_vec(FpExt *output, const Fp *input, uint32_t height) {
+extern "C" int _transpose_fp_to_fpext_vec(FpExt *output, const Fp *input, uint32_t height, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(height);
-    transpose_fp_to_fpext_vec_kernel<<<grid, block>>>(output, input, height);
-    return CHECK_KERNEL();
+    transpose_fp_to_fpext_vec_kernel<<<grid, block, 0, stream>>>(output, input, height);
+    return CHECK_KERNEL_ON(stream);
 }

--- a/crates/cuda-backend/cuda/src/poly.cu
+++ b/crates/cuda-backend/cuda/src/poly.cu
@@ -230,19 +230,19 @@ extern "C" int _algebraic_batch_matrices(
     algebraic_batch_matrices_kernel<<<grid, block, 0, stream>>>(
         output, mats, mu_powers, mu_idxs, widths, height, num_mats
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _eq_hypercube_stage_ext(FpExt *out, FpExt x_i, uint32_t step, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(step);
     eq_hypercube_stage_ext_kernel<<<grid, block, 0, stream>>>(out, x_i, step);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _mobius_eq_hypercube_stage_ext(FpExt *out, FpExt omega_i, uint32_t step, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(step);
     mobius_eq_hypercube_stage_ext_kernel<<<grid, block, 0, stream>>>(out, omega_i, step);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _eq_hypercube_nonoverlapping_stage_ext(
@@ -254,7 +254,7 @@ extern "C" int _eq_hypercube_nonoverlapping_stage_ext(
 ) {
     auto [grid, block] = kernel_launch_params(step);
     eq_hypercube_nonoverlapping_stage_ext_kernel<<<grid, block, 0, stream>>>(out, in, x_i, step);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _eq_hypercube_interleaved_stage_ext(
@@ -266,7 +266,7 @@ extern "C" int _eq_hypercube_interleaved_stage_ext(
 ) {
     auto [grid, block] = kernel_launch_params(step);
     eq_hypercube_interleaved_stage_ext_kernel<<<grid, block, 0, stream>>>(out, in, x_i, step);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _batch_eq_hypercube_stage(
@@ -280,7 +280,7 @@ extern "C" int _batch_eq_hypercube_stage(
     auto [grid, block] = kernel_launch_params(step);
     grid.y = width;
     batch_eq_hypercube_stage_kernel<<<grid, block, 0, stream>>>(out, x, step, width, height);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 // Helper to dispatch templated kernel based on runtime block size
@@ -292,7 +292,7 @@ int launch_eval_poly_ext_at_point(const Fp *coeffs, size_t len, FpExt x, FpExt *
     constexpr unsigned int num_warps = (BlockSize + WARP_SIZE - 1) / WARP_SIZE;
     size_t smem_size = num_warps * sizeof(FpExt);
     eval_poly_ext_at_point_kernel<BlockSize><<<1, BlockSize, smem_size, stream>>>(coeffs, len, x, out);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _eval_poly_ext_at_point(const Fp *coeffs, size_t len, FpExt x, FpExt *out, cudaStream_t stream) {
@@ -312,11 +312,11 @@ extern "C" int _eval_poly_ext_at_point(const Fp *coeffs, size_t len, FpExt x, Fp
 extern "C" int _vector_scalar_multiply_ext(FpExt *vec, FpExt scalar, uint32_t length, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(length);
     vector_scalar_multiply_kernel<FpExt><<<grid, block, 0, stream>>>(vec, scalar, length);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _transpose_fp_to_fpext_vec(FpExt *output, const Fp *input, uint32_t height, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(height);
     transpose_fp_to_fpext_vec_kernel<<<grid, block, 0, stream>>>(output, input, height);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }

--- a/crates/cuda-backend/cuda/src/prefix.cu
+++ b/crates/cuda-backend/cuda/src/prefix.cu
@@ -126,7 +126,7 @@ extern "C" int _prefix_scan_block_ext(
     uint64_t round_stride,
     uint64_t block_num, cudaStream_t stream) {
     prefix_scan_block_ext<<<block_num, SHARED_DATA, 0, stream>>>(d_inout, length, round_stride);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _prefix_scan_block_downsweep_ext(
@@ -140,7 +140,7 @@ extern "C" int _prefix_scan_block_downsweep_ext(
     prefix_scan_block_downsweep_ext<<<block_num, SHARED_DATA, 0, stream>>>(
         d_inout, length, round_stride, element_per_block
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _prefix_scan_epilogue_ext(FpExt *d_inout, uint64_t length, cudaStream_t stream) {
@@ -149,5 +149,5 @@ extern "C" int _prefix_scan_epilogue_ext(FpExt *d_inout, uint64_t length, cudaSt
     prefix_scan_epilogue_ext<<<epilogue_block_num, SHARED_DATA, 0, stream>>>(
         d_inout, length, element_per_block
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }

--- a/crates/cuda-backend/cuda/src/prefix.cu
+++ b/crates/cuda-backend/cuda/src/prefix.cu
@@ -124,32 +124,30 @@ extern "C" int _prefix_scan_block_ext(
     FpExt *d_inout,
     uint64_t length,
     uint64_t round_stride,
-    uint64_t block_num
-) {
-    prefix_scan_block_ext<<<block_num, SHARED_DATA>>>(d_inout, length, round_stride);
-    return CHECK_KERNEL();
+    uint64_t block_num, cudaStream_t stream) {
+    prefix_scan_block_ext<<<block_num, SHARED_DATA, 0, stream>>>(d_inout, length, round_stride);
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _prefix_scan_block_downsweep_ext(
     FpExt *d_inout,
     uint64_t length,
-    uint64_t round_stride
-) {
+    uint64_t round_stride, cudaStream_t stream) {
     auto element_per_block = ACC_PER_THREAD * SHARED_DATA;
     auto low_level_round_stride = round_stride / element_per_block;
     auto node_num = div_ceil(length, low_level_round_stride);
     auto block_num = div_ceil(node_num, SHARED_DATA);
-    prefix_scan_block_downsweep_ext<<<block_num, SHARED_DATA>>>(
+    prefix_scan_block_downsweep_ext<<<block_num, SHARED_DATA, 0, stream>>>(
         d_inout, length, round_stride, element_per_block
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
-extern "C" int _prefix_scan_epilogue_ext(FpExt *d_inout, uint64_t length) {
+extern "C" int _prefix_scan_epilogue_ext(FpExt *d_inout, uint64_t length, cudaStream_t stream) {
     auto element_per_block = ACC_PER_THREAD * SHARED_DATA;
     auto epilogue_block_num = div_ceil(length, SHARED_DATA);
-    prefix_scan_epilogue_ext<<<epilogue_block_num, SHARED_DATA>>>(
+    prefix_scan_epilogue_ext<<<epilogue_block_num, SHARED_DATA, 0, stream>>>(
         d_inout, length, element_per_block
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }

--- a/crates/cuda-backend/cuda/src/sponge.cu
+++ b/crates/cuda-backend/cuda/src/sponge.cu
@@ -113,5 +113,5 @@ extern "C" int _sponge_grind(
         return err;
     }
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }

--- a/crates/cuda-backend/cuda/src/sponge.cu
+++ b/crates/cuda-backend/cuda/src/sponge.cu
@@ -93,14 +93,14 @@ extern "C" int _sponge_grind(
     uint32_t bits,
     uint32_t min_witness,
     uint32_t max_witness,
-    uint32_t* result  // Output: device pointer where the found witness value will be written.
-    // Must be set to `UINT32_MAX` before this function call
-) {
+    uint32_t* result,  // Output: device pointer where the found witness value will be written.
+    // Must be set to `UINT32_MAX` before this function call.
+    cudaStream_t stream) {
     if (bits >= 32 || (uint64_t{1} << bits) >= Fp::P) {
         return cudaErrorInvalidValue;
     }
     auto const [grid, block] = kernel_launch_params(1 << bits);
-    grind_kernel<<<grid, block>>>(init_state, bits, min_witness, max_witness, result);
+    grind_kernel<<<grid, block, 0, stream>>>(init_state, bits, min_witness, max_witness, result);
 
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess) {
@@ -108,10 +108,10 @@ extern "C" int _sponge_grind(
     }
 
     // Synchronize and copy result back
-    err = cudaDeviceSynchronize();
+    err = cudaStreamSynchronize(stream);
     if (err != cudaSuccess) {
         return err;
     }
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }

--- a/crates/cuda-backend/cuda/src/stacked_reduction.cu
+++ b/crates/cuda-backend/cuda/src/stacked_reduction.cu
@@ -424,7 +424,7 @@ extern "C" int _stacked_reduction_sumcheck_round0(
         skip_domain - 1, num_x, 31 - __builtin_clz(stride)
     );
 
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0)
         return err;
 
@@ -436,7 +436,7 @@ extern "C" int _stacked_reduction_sumcheck_round0(
     sumcheck::final_reduce_block_sums<true>
         <<<output_size, reduce_block, reduce_shmem, stream>>>(block_sums, output, num_blocks);
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 // Parallelizes barycentric interpolation across 2^l_skip threads per output cell
@@ -468,7 +468,7 @@ extern "C" int _stacked_reduction_fold_ple(
         src, dst, omega_skip_pows, inv_lagrange_denoms, trace_height, new_height, skip_domain
     );
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _initialize_k_rot_from_eq_segments(
@@ -484,7 +484,7 @@ extern "C" int _initialize_k_rot_from_eq_segments(
         eq_r_ns, k_rot_ns, k_rot_uni_0, k_rot_uni_1
     );
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _stacked_reduction_sumcheck_mle_round(
@@ -527,7 +527,7 @@ extern "C" int _stacked_reduction_sumcheck_mle_round(
         q_evals, eq_r_ns, k_rot_ns, unstacked_cols, lambda_pows, output, q_height, window_len, num_y
     );
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _stacked_reduction_sumcheck_mle_round_degenerate(
@@ -561,5 +561,5 @@ extern "C" int _stacked_reduction_sumcheck_mle_round_degenerate(
         shift_factor
     );
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }

--- a/crates/cuda-backend/cuda/src/stacked_reduction.cu
+++ b/crates/cuda-backend/cuda/src/stacked_reduction.cu
@@ -409,8 +409,7 @@ extern "C" int _stacked_reduction_sumcheck_round0(
     uint32_t trace_height,
     uint32_t trace_width,
     uint32_t l_skip,
-    uint32_t num_x
-) {
+    uint32_t num_x, cudaStream_t stream) {
     uint32_t skip_domain = 1u << l_skip;
     uint32_t stride = std::max(skip_domain / trace_height, 1u);
     auto [grid, block] = stacked_reduction_round0_launch_params(trace_height, trace_width, l_skip);
@@ -419,13 +418,13 @@ extern "C" int _stacked_reduction_sumcheck_round0(
     // NUM_G=3 outputs per z (G0, G1, G2)
     size_t shmem_sum_size = sizeof(FpExt) * (block.x + 1) * NUM_G;
 
-    stacked_reduction_round0_block_sum_kernel<<<grid, block, shmem_sum_size>>>(
+    stacked_reduction_round0_block_sum_kernel<<<grid, block, shmem_sum_size, stream>>>(
         eq_r_ns, trace_ptr, lambda_pows, block_sums,
         trace_height, trace_width, l_skip,
         skip_domain - 1, num_x, 31 - __builtin_clz(stride)
     );
 
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0)
         return err;
 
@@ -435,9 +434,9 @@ extern "C" int _stacked_reduction_sumcheck_round0(
     auto [reduce_grid, reduce_block] = kernel_launch_params(num_blocks);
     size_t reduce_shmem = div_ceil(reduce_block.x, WARP_SIZE) * sizeof(FpExt);
     sumcheck::final_reduce_block_sums<true>
-        <<<output_size, reduce_block, reduce_shmem>>>(block_sums, output, num_blocks);
+        <<<output_size, reduce_block, reduce_shmem, stream>>>(block_sums, output, num_blocks);
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 // Parallelizes barycentric interpolation across 2^l_skip threads per output cell
@@ -448,8 +447,7 @@ extern "C" int _stacked_reduction_fold_ple(
     const FpExt *inv_lagrange_denoms,
     uint32_t trace_height,
     uint32_t trace_width,
-    uint32_t l_skip
-) {
+    uint32_t l_skip, cudaStream_t stream) {
     uint32_t skip_domain = 1u << l_skip;
     uint32_t new_height = std::max(trace_height, skip_domain) / skip_domain;
 
@@ -466,11 +464,11 @@ extern "C" int _stacked_reduction_fold_ple(
     uint32_t total_warps_in_block = block_size / WARP_SIZE;
     size_t smem_bytes = (skip_domain > WARP_SIZE) ? total_warps_in_block * sizeof(FpExt) : 0;
 
-    stacked_reduction_fold_ple_kernel<<<grid, block, smem_bytes>>>(
+    stacked_reduction_fold_ple_kernel<<<grid, block, smem_bytes, stream>>>(
         src, dst, omega_skip_pows, inv_lagrange_denoms, trace_height, new_height, skip_domain
     );
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _initialize_k_rot_from_eq_segments(
@@ -478,16 +476,15 @@ extern "C" int _initialize_k_rot_from_eq_segments(
     FpExt *k_rot_ns,
     FpExt k_rot_uni_0,
     FpExt k_rot_uni_1,
-    uint32_t max_n
-) {
+    uint32_t max_n, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(1 << max_n);
     grid.y = max_n + 1;
 
-    initialize_k_rot_from_eq_segments_kernel<<<grid, block>>>(
+    initialize_k_rot_from_eq_segments_kernel<<<grid, block, 0, stream>>>(
         eq_r_ns, k_rot_ns, k_rot_uni_0, k_rot_uni_1
     );
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _stacked_reduction_sumcheck_mle_round(
@@ -500,8 +497,7 @@ extern "C" int _stacked_reduction_sumcheck_mle_round(
     uint32_t q_height,
     uint32_t window_len,
     uint32_t num_y,
-    uint32_t sm_count
-) {
+    uint32_t sm_count, cudaStream_t stream) {
     // Smaller block size for more eligible warps to hide latency
     auto [grid, block] = kernel_launch_params(num_y, 256);
     assert(sm_count);
@@ -527,11 +523,11 @@ extern "C" int _stacked_reduction_sumcheck_mle_round(
     assert((size_t)num_y * grid.y < (size_t)1u << 32);
     size_t shmem_bytes = div_ceil(block.x, WARP_SIZE) * sizeof(FpExt);
 
-    stacked_reduction_sumcheck_mle_round_kernel<<<grid, block, shmem_bytes>>>(
+    stacked_reduction_sumcheck_mle_round_kernel<<<grid, block, shmem_bytes, stream>>>(
         q_evals, eq_r_ns, k_rot_ns, unstacked_cols, lambda_pows, output, q_height, window_len, num_y
     );
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _stacked_reduction_sumcheck_mle_round_degenerate(
@@ -545,15 +541,14 @@ extern "C" int _stacked_reduction_sumcheck_mle_round_degenerate(
     uint32_t q_height,
     uint32_t window_len,
     uint32_t l_skip,
-    uint32_t round
-) {
+    uint32_t round, cudaStream_t stream) {
     auto shift_factor = l_skip + round;
     dim3 block(std::min(window_len, 256u));
     dim3 grid(1);
     // block.x <= 512 < 2^32 so atomic u64 will not overflow
     size_t shmem_bytes = div_ceil(block.x, WARP_SIZE) * sizeof(FpExt);
 
-    stacked_reduction_sumcheck_mle_round_degenerate_kernel<<<grid, block, shmem_bytes>>>(
+    stacked_reduction_sumcheck_mle_round_degenerate_kernel<<<grid, block, shmem_bytes, stream>>>(
         q_evals,
         eq_ub_ptr,
         eq_r,
@@ -566,5 +561,5 @@ extern "C" int _stacked_reduction_sumcheck_mle_round_degenerate(
         shift_factor
     );
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }

--- a/crates/cuda-backend/cuda/src/stacked_reduction.cu
+++ b/crates/cuda-backend/cuda/src/stacked_reduction.cu
@@ -392,7 +392,8 @@ inline std::pair<dim3, dim3> stacked_reduction_round0_launch_params(
 extern "C" uint32_t _stacked_reduction_r0_required_temp_buffer_size(
     uint32_t trace_height,
     uint32_t trace_width,
-    uint32_t l_skip
+    uint32_t l_skip,
+    cudaStream_t stream
 ) {
     auto [grid, block] = stacked_reduction_round0_launch_params(trace_height, trace_width, l_skip);
     return ((grid.x * grid.y) << l_skip) * NUM_G;

--- a/crates/cuda-backend/cuda/src/sumcheck.cu
+++ b/crates/cuda-backend/cuda/src/sumcheck.cu
@@ -300,24 +300,23 @@ extern "C" int _fold_mle(
     const uint16_t num_matrices,
     const uint32_t output_height,
     const uint32_t max_output_cells,
-    const FpExt r_val
-) {
+    const FpExt r_val, cudaStream_t stream) {
     auto [grid, block] = fold_mle_launch_params(max_output_cells, num_matrices);
     uint8_t log_output_height = static_cast<uint8_t>(31 - __builtin_clz(output_height));
-    fold_mle_kernel<<<grid, block>>>(
+    fold_mle_kernel<<<grid, block, 0, stream>>>(
         input_matrices, output_matrices, widths, num_matrices, log_output_height, r_val
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
-extern "C" int _fold_mle_column(FpExt *buffer, size_t size, FpExt r) {
+extern "C" int _fold_mle_column(FpExt *buffer, size_t size, FpExt r, cudaStream_t stream) {
     if (size <= 1) {
         return 0;
     }
     size_t half = size >> 1;
     auto [grid, block] = kernel_launch_params(half);
-    fold_mle_column_kernel<<<grid, block>>>(buffer, half, r);
-    return CHECK_KERNEL();
+    fold_mle_column_kernel<<<grid, block, 0, stream>>>(buffer, half, r);
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _batch_fold_mle(
@@ -327,13 +326,12 @@ extern "C" int _batch_fold_mle(
     const uint16_t num_matrices,
     const uint8_t *log_output_heights,
     const uint32_t max_output_cells, // max(height * width)
-    const FpExt r_val
-) {
+    const FpExt r_val, cudaStream_t stream) {
     auto [grid, block] = fold_mle_launch_params(max_output_cells, num_matrices);
-    batch_fold_mle_kernel<<<grid, block>>>(
+    batch_fold_mle_kernel<<<grid, block, 0, stream>>>(
         input_matrices, output_matrices, widths, num_matrices, log_output_heights, r_val
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _fold_ple_from_coeffs(
@@ -342,16 +340,15 @@ extern "C" int _fold_ple_from_coeffs(
     const uint32_t num_x,
     const uint32_t width,
     const uint32_t domain_size,
-    const FpExt r_val
-) {
+    const FpExt r_val, cudaStream_t stream) {
     int total_polys = num_x * width;
     auto [grid, block] = kernel_launch_params(total_polys);
 
-    fold_ple_from_coeffs_kernel<<<grid, block>>>(
+    fold_ple_from_coeffs_kernel<<<grid, block, 0, stream>>>(
         input_coeffs, output, num_x, width, domain_size, r_val
     );
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _reduce_over_x_and_cols(
@@ -359,13 +356,12 @@ extern "C" int _reduce_over_x_and_cols(
     Fp *output,
     uint32_t num_x,
     uint32_t num_cols,
-    uint32_t large_domain_size
-) {
+    uint32_t large_domain_size, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(large_domain_size);
-    reduce_over_x_and_cols_kernel<<<grid, block>>>(
+    reduce_over_x_and_cols_kernel<<<grid, block, 0, stream>>>(
         input, output, num_x, num_cols, large_domain_size
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 // WD = 1
@@ -376,8 +372,7 @@ extern "C" int _sumcheck_mle_round(
     const uint32_t *widths,
     const uint32_t num_matrices,
     const uint32_t height,
-    const uint32_t d
-) {
+    const uint32_t d, cudaStream_t stream) {
     if (d == 0 || d > 5) {
         return cudaErrorInvalidValue;
     }
@@ -387,11 +382,11 @@ extern "C" int _sumcheck_mle_round(
     size_t shmem_bytes = std::max(1u, num_warps) * sizeof(FpExt);
 
     // Launch main kernel - writes to tmp_block_sums
-    sumcheck_mle_round_kernel<1><<<grid, block, shmem_bytes>>>(
+    sumcheck_mle_round_kernel<1><<<grid, block, shmem_bytes, stream>>>(
         input_matrices, tmp_block_sums, widths, num_matrices, height, d
     );
 
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0)
         return err;
 
@@ -401,23 +396,22 @@ extern "C" int _sumcheck_mle_round(
     unsigned int reduce_warps = (reduce_block.x + WARP_SIZE - 1) / WARP_SIZE;
     size_t reduce_shmem = std::max(1u, reduce_warps) * sizeof(FpExt);
     reduce_blocks_sumcheck<1>
-        <<<d, reduce_block, reduce_shmem>>>(tmp_block_sums, output, num_blocks, d);
+        <<<d, reduce_block, reduce_shmem, stream>>>(tmp_block_sums, output, num_blocks, d);
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _triangular_fold_mle(
     FpExt *output,
     const FpExt *input,
     FpExt r,
-    uint32_t output_max_n
-) {
+    uint32_t output_max_n, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(1 << output_max_n);
     grid.y = output_max_n + 1;
 
-    triangular_fold_mle_kernel<<<grid, block>>>(output, input, r);
+    triangular_fold_mle_kernel<<<grid, block, 0, stream>>>(output, input, r);
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 } // namespace plain_sumcheck

--- a/crates/cuda-backend/cuda/src/sumcheck.cu
+++ b/crates/cuda-backend/cuda/src/sumcheck.cu
@@ -306,7 +306,7 @@ extern "C" int _fold_mle(
     fold_mle_kernel<<<grid, block, 0, stream>>>(
         input_matrices, output_matrices, widths, num_matrices, log_output_height, r_val
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _fold_mle_column(FpExt *buffer, size_t size, FpExt r, cudaStream_t stream) {
@@ -316,7 +316,7 @@ extern "C" int _fold_mle_column(FpExt *buffer, size_t size, FpExt r, cudaStream_
     size_t half = size >> 1;
     auto [grid, block] = kernel_launch_params(half);
     fold_mle_column_kernel<<<grid, block, 0, stream>>>(buffer, half, r);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _batch_fold_mle(
@@ -331,7 +331,7 @@ extern "C" int _batch_fold_mle(
     batch_fold_mle_kernel<<<grid, block, 0, stream>>>(
         input_matrices, output_matrices, widths, num_matrices, log_output_heights, r_val
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _fold_ple_from_coeffs(
@@ -348,7 +348,7 @@ extern "C" int _fold_ple_from_coeffs(
         input_coeffs, output, num_x, width, domain_size, r_val
     );
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _reduce_over_x_and_cols(
@@ -361,7 +361,7 @@ extern "C" int _reduce_over_x_and_cols(
     reduce_over_x_and_cols_kernel<<<grid, block, 0, stream>>>(
         input, output, num_x, num_cols, large_domain_size
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 // WD = 1
@@ -386,7 +386,7 @@ extern "C" int _sumcheck_mle_round(
         input_matrices, tmp_block_sums, widths, num_matrices, height, d
     );
 
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0)
         return err;
 
@@ -398,7 +398,7 @@ extern "C" int _sumcheck_mle_round(
     reduce_blocks_sumcheck<1>
         <<<d, reduce_block, reduce_shmem, stream>>>(tmp_block_sums, output, num_blocks, d);
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _triangular_fold_mle(
@@ -411,7 +411,7 @@ extern "C" int _triangular_fold_mle(
 
     triangular_fold_mle_kernel<<<grid, block, 0, stream>>>(output, input, r);
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 } // namespace plain_sumcheck

--- a/crates/cuda-backend/cuda/src/whir.cu
+++ b/crates/cuda-backend/cuda/src/whir.cu
@@ -230,13 +230,12 @@ extern "C" int _whir_algebraic_batch_traces(
     const FpExt *mu_powers, // Len is sum of widths of all matrices
     size_t stacked_height,
     size_t num_packets,
-    uint32_t skip_domain
-) {
+    uint32_t skip_domain, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(stacked_height);
-    whir_algebraic_batch_traces_kernel<<<grid, block>>>(
+    whir_algebraic_batch_traces_kernel<<<grid, block, 0, stream>>>(
         output, packets, mu_powers, stacked_height, num_packets, skip_domain
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 inline std::pair<dim3, dim3> whir_sumcheck_coeff_moments_launch_params(uint32_t height) {
@@ -253,17 +252,16 @@ extern "C" int _whir_sumcheck_coeff_moments_round(
     const FpExt *w_moments,
     FpExt *output,         // Output: [d=2] final results
     FpExt *tmp_block_sums, // Temporary buffer: [num_blocks * d]
-    const uint32_t height
-) {
+    const uint32_t height, cudaStream_t stream) {
     auto [grid, block] = whir_sumcheck_coeff_moments_launch_params(height);
     unsigned int num_warps = (block.x + WARP_SIZE - 1) / WARP_SIZE;
     size_t shmem_bytes = std::max(1u, num_warps) * sizeof(FpExt);
 
-    whir_sumcheck_coeff_moments_round_kernel<<<grid, block, shmem_bytes>>>(
+    whir_sumcheck_coeff_moments_round_kernel<<<grid, block, shmem_bytes, stream>>>(
         f_coeffs, w_moments, tmp_block_sums, height
     );
 
-    int err = CHECK_KERNEL();
+    int err = CHECK_KERNEL_ON(stream);
     if (err != 0)
         return err;
 
@@ -272,9 +270,9 @@ extern "C" int _whir_sumcheck_coeff_moments_round(
     unsigned int reduce_warps = (reduce_block.x + WARP_SIZE - 1) / WARP_SIZE;
     size_t reduce_shmem = std::max(1u, reduce_warps) * sizeof(FpExt);
     sumcheck::static_final_reduce_block_sums<S_DEG>
-        <<<S_DEG, reduce_block, reduce_shmem>>>(tmp_block_sums, output, num_blocks);
+        <<<S_DEG, reduce_block, reduce_shmem, stream>>>(tmp_block_sums, output, num_blocks);
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _whir_fold_coeffs_and_moments(
@@ -283,13 +281,12 @@ extern "C" int _whir_fold_coeffs_and_moments(
     FpExt *f_folded_coeffs,
     FpExt *w_folded_moments,
     FpExt alpha,
-    uint32_t height
-) {
+    uint32_t height, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(height >> 1);
-    whir_fold_coeffs_and_moments_kernel<<<grid, block>>>(
+    whir_fold_coeffs_and_moments_kernel<<<grid, block, 0, stream>>>(
         f_coeffs, w_moments, f_folded_coeffs, w_folded_moments, alpha, height >> 1
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _w_moments_accumulate(
@@ -299,11 +296,10 @@ extern "C" int _w_moments_accumulate(
     FpExt gamma,
     uint32_t num_queries,
     uint32_t log_height,
-    uint32_t height
-) {
+    uint32_t height, cudaStream_t stream) {
     auto [grid, block] = kernel_launch_params(height, 256);
-    w_moments_accumulate_kernel<<<grid, block>>>(
+    w_moments_accumulate_kernel<<<grid, block, 0, stream>>>(
         w_moments, z0_pows2, z_pows2, gamma, num_queries, log_height, height
     );
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }

--- a/crates/cuda-backend/cuda/src/whir.cu
+++ b/crates/cuda-backend/cuda/src/whir.cu
@@ -242,7 +242,7 @@ inline std::pair<dim3, dim3> whir_sumcheck_coeff_moments_launch_params(uint32_t 
     return kernel_launch_params(height >> 1, 256);
 }
 
-extern "C" uint32_t _whir_sumcheck_coeff_moments_required_temp_buffer_size(uint32_t height) {
+extern "C" uint32_t _whir_sumcheck_coeff_moments_required_temp_buffer_size(uint32_t height, cudaStream_t stream) {
     auto [grid, block] = whir_sumcheck_coeff_moments_launch_params(height);
     return grid.x * S_DEG;
 }

--- a/crates/cuda-backend/cuda/src/whir.cu
+++ b/crates/cuda-backend/cuda/src/whir.cu
@@ -235,7 +235,7 @@ extern "C" int _whir_algebraic_batch_traces(
     whir_algebraic_batch_traces_kernel<<<grid, block, 0, stream>>>(
         output, packets, mu_powers, stacked_height, num_packets, skip_domain
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 inline std::pair<dim3, dim3> whir_sumcheck_coeff_moments_launch_params(uint32_t height) {
@@ -261,7 +261,7 @@ extern "C" int _whir_sumcheck_coeff_moments_round(
         f_coeffs, w_moments, tmp_block_sums, height
     );
 
-    int err = CHECK_KERNEL_ON(stream);
+    int err = CHECK_KERNEL();
     if (err != 0)
         return err;
 
@@ -272,7 +272,7 @@ extern "C" int _whir_sumcheck_coeff_moments_round(
     sumcheck::static_final_reduce_block_sums<S_DEG>
         <<<S_DEG, reduce_block, reduce_shmem, stream>>>(tmp_block_sums, output, num_blocks);
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _whir_fold_coeffs_and_moments(
@@ -286,7 +286,7 @@ extern "C" int _whir_fold_coeffs_and_moments(
     whir_fold_coeffs_and_moments_kernel<<<grid, block, 0, stream>>>(
         f_coeffs, w_moments, f_folded_coeffs, w_folded_moments, alpha, height >> 1
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _w_moments_accumulate(
@@ -301,5 +301,5 @@ extern "C" int _w_moments_accumulate(
     w_moments_accumulate_kernel<<<grid, block, 0, stream>>>(
         w_moments, z0_pows2, z_pows2, gamma, num_queries, log_height, height
     );
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }

--- a/crates/cuda-backend/cuda/supra/ntt.cu
+++ b/crates/cuda-backend/cuda/supra/ntt.cu
@@ -211,8 +211,7 @@ extern "C" int _ct_mixed_radix_narrow(
     uint32_t iterations,
     uint32_t padded_poly_size,
     uint32_t poly_count,
-    bool is_intt
-) {
+    bool is_intt, cudaStream_t stream) {
     if (lg_domain_size > MAX_LG_DOMAIN_SIZE)
         return cudaErrorInvalidValue;
 
@@ -241,15 +240,15 @@ extern "C" int _ct_mixed_radix_narrow(
 
     // [DIFF]: N -> dim3(N, poly_count) in grid_size; stream -> cudaStreamPerThread
     if (num_blocks < Z_COUNT)
-        _CT_NTT<1><<<dim3(num_blocks, grid_y, grid_z), block_size, shared_sz>>>(NTT_ARGUMENTS);
+        _CT_NTT<1><<<dim3(num_blocks, grid_y, grid_z), block_size, shared_sz, stream>>>(NTT_ARGUMENTS);
     else if (stage == 0 || lg_domain_size < 12)
-        _CT_NTT<Z_COUNT><<<dim3(num_blocks / Z_COUNT, grid_y, grid_z), block_size, Z_COUNT*shared_sz>>>(NTT_ARGUMENTS);
+        _CT_NTT<Z_COUNT><<<dim3(num_blocks / Z_COUNT, grid_y, grid_z), block_size, Z_COUNT*shared_sz, stream>>>(NTT_ARGUMENTS);
     else if (lg_domain_size <= MAX_LG_DOMAIN_SIZE)
-        _CT_NTT<Z_COUNT, true><<<dim3(num_blocks / Z_COUNT, grid_y, grid_z), block_size, Z_COUNT*shared_sz>>>(NTT_ARGUMENTS);
+        _CT_NTT<Z_COUNT, true><<<dim3(num_blocks / Z_COUNT, grid_y, grid_z), block_size, Z_COUNT*shared_sz, stream>>>(NTT_ARGUMENTS);
     else
         assert(lg_domain_size <= MAX_LG_DOMAIN_SIZE);
             
     #undef NTT_ARGUMENTS
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }

--- a/crates/cuda-backend/cuda/supra/ntt.cu
+++ b/crates/cuda-backend/cuda/supra/ntt.cu
@@ -250,5 +250,5 @@ extern "C" int _ct_mixed_radix_narrow(
             
     #undef NTT_ARGUMENTS
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }

--- a/crates/cuda-backend/cuda/supra/ntt.cu
+++ b/crates/cuda-backend/cuda/supra/ntt.cu
@@ -238,7 +238,7 @@ extern "C" int _ct_mixed_radix_narrow(
     #define NTT_ARGUMENTS radix, lg_domain_size, stage, iterations, \
             d_inout, padded_poly_size, poly_count, is_intt, domain_size_inverse[lg_domain_size]
 
-    // [DIFF]: N -> dim3(N, poly_count) in grid_size; stream -> cudaStreamPerThread
+    // [DIFF]: N -> dim3(N, poly_count) in grid_size; stream -> caller-provided stream
     if (num_blocks < Z_COUNT)
         _CT_NTT<1><<<dim3(num_blocks, grid_y, grid_z), block_size, shared_sz, stream>>>(NTT_ARGUMENTS);
     else if (stage == 0 || lg_domain_size < 12)

--- a/crates/cuda-backend/cuda/supra/ntt_bitrev.cu
+++ b/crates/cuda-backend/cuda/supra/ntt_bitrev.cu
@@ -161,7 +161,7 @@ void bit_rev_permutation_z(T* out, const T* in, uint32_t lg_domain_size,
 
 template<typename T>
 static int bit_rev_impl(T* d_out, const T* d_inp,
-    uint32_t lg_domain_size, uint32_t padded_poly_size, uint32_t poly_count)
+    uint32_t lg_domain_size, uint32_t padded_poly_size, uint32_t poly_count, cudaStream_t stream)
 {
     size_t domain_size = (size_t)1 << lg_domain_size;
     // aim to read 4 cache lines of consecutive data per read
@@ -178,14 +178,14 @@ static int bit_rev_impl(T* d_out, const T* d_inp,
 
     // [DIFF]: N -> dim3(N, poly_count) in grid_size; stream -> cudaStreamPerThread
     if (domain_size <= 1024)
-        bit_rev_permutation<T><<<dim3(1u, grid_y, grid_z), domain_size>>>
+        bit_rev_permutation<T><<<dim3(1u, grid_y, grid_z), domain_size, 0, stream>>>
                             (d_out, d_inp, lg_domain_size, padded_poly_size, poly_count);
     else if (domain_size < bsize * Z_COUNT)
-        bit_rev_permutation<T><<<dim3(domain_size / WARP_SIZE, grid_y, grid_z), WARP_SIZE>>>
+        bit_rev_permutation<T><<<dim3(domain_size / WARP_SIZE, grid_y, grid_z), WARP_SIZE, 0, stream>>>
                             (d_out, d_inp, lg_domain_size, padded_poly_size, poly_count);
     else if (Z_COUNT > WARP_SIZE || lg_domain_size <= 32)
         bit_rev_permutation_z<T, Z_COUNT><<<dim3(domain_size / Z_COUNT / bsize, grid_y, grid_z), bsize,
-                                            bsize * Z_COUNT * sizeof(T)>>>
+                                            bsize * Z_COUNT * sizeof(T), stream>>>
                             (d_out, d_inp, lg_domain_size, padded_poly_size, poly_count);
     else {
         // Those GPUs that can reserve 96KB of shared memory can
@@ -196,27 +196,27 @@ static int bit_rev_impl(T* d_out, const T* d_inp,
         cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device);
 
         bit_rev_permutation_z<T, Z_COUNT><<<dim3(sm_count * 2, grid_y, grid_z), 192,
-                                            192 * Z_COUNT * sizeof(T)>>>
+                                            192 * Z_COUNT * sizeof(T), stream>>>
                                 (d_out, d_inp, lg_domain_size, padded_poly_size, poly_count);
     }
 
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
 extern "C" int _bit_rev(fr_t* d_out, const fr_t* d_inp,
-    uint32_t lg_domain_size, uint32_t padded_poly_size, uint32_t poly_count)
+    uint32_t lg_domain_size, uint32_t padded_poly_size, uint32_t poly_count, cudaStream_t stream)
 {
-    return bit_rev_impl(d_out, d_inp, lg_domain_size, padded_poly_size, poly_count);
+    return bit_rev_impl(d_out, d_inp, lg_domain_size, padded_poly_size, poly_count, stream);
 }
 
 extern "C" int _bit_rev_ext(bb31_4_t* d_out, const bb31_4_t* d_inp,
-    uint32_t lg_domain_size, uint32_t padded_poly_size, uint32_t poly_count)
+    uint32_t lg_domain_size, uint32_t padded_poly_size, uint32_t poly_count, cudaStream_t stream)
 {
-    return bit_rev_impl(d_out, d_inp, lg_domain_size, padded_poly_size, poly_count);
+    return bit_rev_impl(d_out, d_inp, lg_domain_size, padded_poly_size, poly_count, stream);
 }
 
 extern "C" int _bit_rev_frac_ext(frac_fpext_t* d_out, const frac_fpext_t* d_inp,
-    uint32_t lg_domain_size, uint32_t padded_poly_size, uint32_t poly_count)
+    uint32_t lg_domain_size, uint32_t padded_poly_size, uint32_t poly_count, cudaStream_t stream)
 {
-    return bit_rev_impl(d_out, d_inp, lg_domain_size, padded_poly_size, poly_count);
+    return bit_rev_impl(d_out, d_inp, lg_domain_size, padded_poly_size, poly_count, stream);
 }

--- a/crates/cuda-backend/cuda/supra/ntt_bitrev.cu
+++ b/crates/cuda-backend/cuda/supra/ntt_bitrev.cu
@@ -176,7 +176,7 @@ static int bit_rev_impl(T* d_out, const T* d_inp,
     uint32_t grid_y = poly_count < MAX_Y ? poly_count : MAX_Y;
     uint32_t grid_z = (poly_count + grid_y - 1) / grid_y;
 
-    // [DIFF]: N -> dim3(N, poly_count) in grid_size; stream -> cudaStreamPerThread
+    // [DIFF]: N -> dim3(N, poly_count) in grid_size; stream -> caller-provided stream
     if (domain_size <= 1024)
         bit_rev_permutation<T><<<dim3(1u, grid_y, grid_z), domain_size, 0, stream>>>
                             (d_out, d_inp, lg_domain_size, padded_poly_size, poly_count);

--- a/crates/cuda-backend/cuda/supra/ntt_bitrev.cu
+++ b/crates/cuda-backend/cuda/supra/ntt_bitrev.cu
@@ -200,7 +200,7 @@ static int bit_rev_impl(T* d_out, const T* d_inp,
                                 (d_out, d_inp, lg_domain_size, padded_poly_size, poly_count);
     }
 
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _bit_rev(fr_t* d_out, const fr_t* d_inp,

--- a/crates/cuda-backend/cuda/supra/ntt_params.cu
+++ b/crates/cuda-backend/cuda/supra/ntt_params.cu
@@ -66,10 +66,8 @@ __global__ void generate_partial_twiddles(fr_t (*roots)[WINDOW_SIZE],
     }
 }
 
-extern "C" int _generate_all_twiddles(fr_t* twiddles, bool inverse) {
+extern "C" int _generate_all_twiddles(fr_t* twiddles, bool inverse, cudaStream_t stream) {
     const fr_t* roots = inverse ? inverse_roots_of_unity : forward_roots_of_unity;
-    cudaStream_t stream = cudaStreamPerThread;
-
     generate_all_twiddles<<<TWIDDLES_SIZE/32, 32, 0, stream>>>(
             twiddles, roots[6], roots[7], roots[8], roots[9], roots[10]);
 
@@ -81,12 +79,11 @@ extern "C" int _generate_all_twiddles(fr_t* twiddles, bool inverse) {
                                 0, cudaMemcpyDeviceToDevice, stream);
     }
     cudaStreamSynchronize(stream);
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }
 
-extern "C" int _generate_partial_twiddles(fr_t (*partial_twiddles)[WINDOW_SIZE], bool inverse) {
+extern "C" int _generate_partial_twiddles(fr_t (*partial_twiddles)[WINDOW_SIZE], bool inverse, cudaStream_t stream) {
     const fr_t* roots = inverse ? inverse_roots_of_unity : forward_roots_of_unity;
-    cudaStream_t stream = cudaStreamPerThread;
     generate_partial_twiddles<<<WINDOW_SIZE/32, 32, 0, stream>>>(
             partial_twiddles, roots[MAX_LG_DOMAIN_SIZE]);
 
@@ -98,5 +95,5 @@ extern "C" int _generate_partial_twiddles(fr_t (*partial_twiddles)[WINDOW_SIZE],
                                 0, cudaMemcpyDeviceToDevice, stream);
     }
     cudaStreamSynchronize(stream);
-    return CHECK_KERNEL();
+    return CHECK_KERNEL_ON(stream);
 }

--- a/crates/cuda-backend/cuda/supra/ntt_params.cu
+++ b/crates/cuda-backend/cuda/supra/ntt_params.cu
@@ -5,7 +5,7 @@
  * 
  * LOCAL CHANGES (high level):
  * - 2025-08-13: NTTParameters constructor async on custom stream
- * - 2025-08-26: NTTParameters constructor on cudaStreamPerThread
+ * - 2025-08-26: NTTParameters constructor on caller-provided stream
  * - 2025-09-05: Stop using __constant__ for twiddles[0]
  * - 2025-09-10: Delete NTTParameters & add extern "C" launcher
  * - 2025-10-02: move all twiddles to __constant__

--- a/crates/cuda-backend/cuda/supra/ntt_params.cu
+++ b/crates/cuda-backend/cuda/supra/ntt_params.cu
@@ -79,7 +79,7 @@ extern "C" int _generate_all_twiddles(fr_t* twiddles, bool inverse, cudaStream_t
                                 0, cudaMemcpyDeviceToDevice, stream);
     }
     cudaStreamSynchronize(stream);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }
 
 extern "C" int _generate_partial_twiddles(fr_t (*partial_twiddles)[WINDOW_SIZE], bool inverse, cudaStream_t stream) {
@@ -95,5 +95,5 @@ extern "C" int _generate_partial_twiddles(fr_t (*partial_twiddles)[WINDOW_SIZE],
                                 0, cudaMemcpyDeviceToDevice, stream);
     }
     cudaStreamSynchronize(stream);
-    return CHECK_KERNEL_ON(stream);
+    return CHECK_KERNEL();
 }

--- a/crates/cuda-backend/examples/keccakf.rs
+++ b/crates/cuda-backend/examples/keccakf.rs
@@ -4,7 +4,6 @@
 use std::sync::Arc;
 
 use openvm_cuda_backend::{prelude::SC, BabyBearPoseidon2GpuEngine, GpuBackend};
-use openvm_cuda_common::stream::current_stream_id;
 use openvm_stark_backend::{
     p3_air::{Air, AirBuilder, BaseAir},
     p3_field::Field,
@@ -120,8 +119,8 @@ fn main() {
                 let proof = engine.prove(&d_pk, ctx).expect("proving failed");
                 engine.verify(&vk, &proof).expect("verification failed");
                 println!(
-                    "[task {t} - stream {}] Proof verified",
-                    current_stream_id().unwrap()
+                    "[task {t} - stream {:?}] Proof verified",
+                    engine.device().ctx.stream.as_raw()
                 );
             }
         }));

--- a/crates/cuda-backend/examples/keccakf.rs
+++ b/crates/cuda-backend/examples/keccakf.rs
@@ -120,7 +120,7 @@ fn main() {
                 engine.verify(&vk, &proof).expect("verification failed");
                 println!(
                     "[task {t} - stream {:?}] Proof verified",
-                    engine.device().ctx.stream.as_raw()
+                    engine.device().device_ctx.stream.as_raw()
                 );
             }
         }));

--- a/crates/cuda-backend/src/base.rs
+++ b/crates/cuda-backend/src/base.rs
@@ -55,14 +55,6 @@ impl<T> DeviceMatrix<T> {
         }
     }
 
-    pub fn with_capacity(height: usize, width: usize) -> Self {
-        Self {
-            buffer: Arc::new(DeviceBuffer::with_capacity(height * width)),
-            height,
-            width,
-        }
-    }
-
     pub fn with_capacity_on(height: usize, width: usize, ctx: &DeviceContext) -> Self {
         let buffer = DeviceBuffer::with_capacity_on(height * width, ctx);
         Self::new(Arc::new(buffer), height, width)
@@ -103,8 +95,8 @@ impl<T> MatrixDimensions for DeviceMatrix<T> {
 }
 
 impl<T> MemCopyD2H<T> for DeviceMatrix<T> {
-    fn to_host(&self) -> Result<Vec<T>, MemCopyError> {
-        self.buffer.to_host()
+    fn to_host_on(&self, ctx: &DeviceContext) -> Result<Vec<T>, MemCopyError> {
+        self.buffer.to_host_on(ctx)
     }
 }
 
@@ -214,7 +206,8 @@ mod tests {
 
     #[test]
     fn test_device_matrix() {
-        let buffer = Arc::new(DeviceBuffer::<i32>::with_capacity(12));
+        let ctx = DeviceContext::for_current_device().unwrap();
+        let buffer = Arc::new(DeviceBuffer::<i32>::with_capacity_on(12, &ctx));
         let matrix = DeviceMatrix::<i32>::new(buffer, 3, 4);
         assert_eq!(matrix.height(), 3);
         assert_eq!(matrix.width(), 4);

--- a/crates/cuda-backend/src/base.rs
+++ b/crates/cuda-backend/src/base.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 
 use openvm_cuda_common::{
-    copy::MemCopyD2H, d_buffer::DeviceBuffer, error::MemCopyError, stream::DeviceContext,
+    copy::MemCopyD2H, d_buffer::DeviceBuffer, error::MemCopyError, stream::GpuDeviceCtx,
 };
 use openvm_stark_backend::prover::MatrixDimensions;
 
@@ -55,7 +55,7 @@ impl<T> DeviceMatrix<T> {
         }
     }
 
-    pub fn with_capacity_on(height: usize, width: usize, device_ctx: &DeviceContext) -> Self {
+    pub fn with_capacity_on(height: usize, width: usize, device_ctx: &GpuDeviceCtx) -> Self {
         let buffer = DeviceBuffer::with_capacity_on(height * width, device_ctx);
         Self::new(Arc::new(buffer), height, width)
     }
@@ -95,7 +95,7 @@ impl<T> MatrixDimensions for DeviceMatrix<T> {
 }
 
 impl<T> MemCopyD2H<T> for DeviceMatrix<T> {
-    fn to_host_on(&self, device_ctx: &DeviceContext) -> Result<Vec<T>, MemCopyError> {
+    fn to_host_on(&self, device_ctx: &GpuDeviceCtx) -> Result<Vec<T>, MemCopyError> {
         self.buffer.to_host_on(device_ctx)
     }
 }
@@ -206,7 +206,7 @@ mod tests {
 
     #[test]
     fn test_device_matrix() {
-        let device_ctx = DeviceContext::for_current_device().unwrap();
+        let device_ctx = GpuDeviceCtx::for_current_device().unwrap();
         let buffer = Arc::new(DeviceBuffer::<i32>::with_capacity_on(12, &device_ctx));
         let matrix = DeviceMatrix::<i32>::new(buffer, 3, 4);
         assert_eq!(matrix.height(), 3);

--- a/crates/cuda-backend/src/base.rs
+++ b/crates/cuda-backend/src/base.rs
@@ -1,6 +1,8 @@
 use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 
-use openvm_cuda_common::{copy::MemCopyD2H, d_buffer::DeviceBuffer, error::MemCopyError};
+use openvm_cuda_common::{
+    copy::MemCopyD2H, d_buffer::DeviceBuffer, error::MemCopyError, stream::DeviceContext,
+};
 use openvm_stark_backend::prover::MatrixDimensions;
 
 pub struct DeviceMatrix<T> {
@@ -59,6 +61,11 @@ impl<T> DeviceMatrix<T> {
             height,
             width,
         }
+    }
+
+    pub fn with_capacity_on(height: usize, width: usize, ctx: &DeviceContext) -> Self {
+        let buffer = DeviceBuffer::with_capacity_on(height * width, ctx);
+        Self::new(Arc::new(buffer), height, width)
     }
 
     pub fn dummy() -> Self {

--- a/crates/cuda-backend/src/base.rs
+++ b/crates/cuda-backend/src/base.rs
@@ -55,8 +55,8 @@ impl<T> DeviceMatrix<T> {
         }
     }
 
-    pub fn with_capacity_on(height: usize, width: usize, ctx: &DeviceContext) -> Self {
-        let buffer = DeviceBuffer::with_capacity_on(height * width, ctx);
+    pub fn with_capacity_on(height: usize, width: usize, device_ctx: &DeviceContext) -> Self {
+        let buffer = DeviceBuffer::with_capacity_on(height * width, device_ctx);
         Self::new(Arc::new(buffer), height, width)
     }
 
@@ -95,8 +95,8 @@ impl<T> MatrixDimensions for DeviceMatrix<T> {
 }
 
 impl<T> MemCopyD2H<T> for DeviceMatrix<T> {
-    fn to_host_on(&self, ctx: &DeviceContext) -> Result<Vec<T>, MemCopyError> {
-        self.buffer.to_host_on(ctx)
+    fn to_host_on(&self, device_ctx: &DeviceContext) -> Result<Vec<T>, MemCopyError> {
+        self.buffer.to_host_on(device_ctx)
     }
 }
 
@@ -206,8 +206,8 @@ mod tests {
 
     #[test]
     fn test_device_matrix() {
-        let ctx = DeviceContext::for_current_device().unwrap();
-        let buffer = Arc::new(DeviceBuffer::<i32>::with_capacity_on(12, &ctx));
+        let device_ctx = DeviceContext::for_current_device().unwrap();
+        let buffer = Arc::new(DeviceBuffer::<i32>::with_capacity_on(12, &device_ctx));
         let matrix = DeviceMatrix::<i32>::new(buffer, 3, 4);
         assert_eq!(matrix.height(), 3);
         assert_eq!(matrix.width(), 4);

--- a/crates/cuda-backend/src/bin/bench.rs
+++ b/crates/cuda-backend/src/bin/bench.rs
@@ -5,7 +5,11 @@ use openvm_cuda_backend::{
     prelude::EF,
     sponge::DuplexSpongeGpu,
 };
-use openvm_cuda_common::{copy::MemCopyD2D, stream::CudaStream};
+use openvm_cuda_common::{
+    common::get_device,
+    copy::MemCopyD2D,
+    stream::{CudaStream, DeviceContext, StreamGuard},
+};
 use p3_field::PrimeCharacteristicRing;
 
 fn parse_usize(var: &str, default: usize) -> usize {
@@ -21,29 +25,25 @@ fn bench_fractional_sumcheck() -> Result<(), Box<dyn std::error::Error>> {
     let repeats = parse_usize("SWIRL_BENCH_REPEATS", 3);
     let warmups = parse_usize("SWIRL_BENCH_WARMUPS", 1);
 
-    let stream = CudaStream::new_non_blocking()?;
-    let template = make_synthetic_leaves(n)?;
+    let ctx = DeviceContext {
+        device_id: get_device()? as u32,
+        stream: StreamGuard::new(CudaStream::new_non_blocking()?),
+    };
+    let template = make_synthetic_leaves(n, &ctx)?;
 
     println!("run_idx,is_warmup,elapsed_ms");
 
     for run_idx in 0..(warmups + repeats) {
         let is_warmup = run_idx < warmups;
-        let leaves = template.device_copy().expect("device copy leaves");
+        let leaves = template.device_copy_on(&ctx).expect("device copy leaves");
 
         let mut transcript = DuplexSpongeGpu::default();
         let mut mem = openvm_cuda_common::memory_manager::MemTracker::start("bench.fractional");
 
-        stream.synchronize().expect("sync before timing");
+        ctx.stream.synchronize().expect("sync before timing");
         let t0 = std::time::Instant::now();
-        let _ = fractional_sumcheck_gpu(
-            &mut transcript,
-            leaves,
-            EF::ZERO,
-            false,
-            &mut mem,
-            stream.as_raw(),
-        )?;
-        stream.synchronize().expect("sync after timing");
+        let _ = fractional_sumcheck_gpu(&mut transcript, leaves, EF::ZERO, false, &mut mem, &ctx)?;
+        ctx.stream.synchronize().expect("sync after timing");
         let ms = t0.elapsed().as_secs_f64() * 1000.0;
 
         println!("{run_idx},{},{:.4}", is_warmup as u8, ms);

--- a/crates/cuda-backend/src/bin/bench.rs
+++ b/crates/cuda-backend/src/bin/bench.rs
@@ -25,25 +25,34 @@ fn bench_fractional_sumcheck() -> Result<(), Box<dyn std::error::Error>> {
     let repeats = parse_usize("SWIRL_BENCH_REPEATS", 3);
     let warmups = parse_usize("SWIRL_BENCH_WARMUPS", 1);
 
-    let ctx = DeviceContext {
+    let device_ctx = DeviceContext {
         device_id: get_device()? as u32,
         stream: StreamGuard::new(CudaStream::new_non_blocking()?),
     };
-    let template = make_synthetic_leaves(n, &ctx)?;
+    let template = make_synthetic_leaves(n, &device_ctx)?;
 
     println!("run_idx,is_warmup,elapsed_ms");
 
     for run_idx in 0..(warmups + repeats) {
         let is_warmup = run_idx < warmups;
-        let leaves = template.device_copy_on(&ctx).expect("device copy leaves");
+        let leaves = template
+            .device_copy_on(&device_ctx)
+            .expect("device copy leaves");
 
         let mut transcript = DuplexSpongeGpu::default();
         let mut mem = openvm_cuda_common::memory_manager::MemTracker::start("bench.fractional");
 
-        ctx.stream.synchronize().expect("sync before timing");
+        device_ctx.stream.synchronize().expect("sync before timing");
         let t0 = std::time::Instant::now();
-        let _ = fractional_sumcheck_gpu(&mut transcript, leaves, EF::ZERO, false, &mut mem, &ctx)?;
-        ctx.stream.synchronize().expect("sync after timing");
+        let _ = fractional_sumcheck_gpu(
+            &mut transcript,
+            leaves,
+            EF::ZERO,
+            false,
+            &mut mem,
+            &device_ctx,
+        )?;
+        device_ctx.stream.synchronize().expect("sync after timing");
         let ms = t0.elapsed().as_secs_f64() * 1000.0;
 
         println!("{run_idx},{},{:.4}", is_warmup as u8, ms);

--- a/crates/cuda-backend/src/bin/bench.rs
+++ b/crates/cuda-backend/src/bin/bench.rs
@@ -8,7 +8,7 @@ use openvm_cuda_backend::{
 use openvm_cuda_common::{
     common::get_device,
     copy::MemCopyD2D,
-    stream::{CudaStream, DeviceContext, StreamGuard},
+    stream::{CudaStream, GpuDeviceCtx, StreamGuard},
 };
 use p3_field::PrimeCharacteristicRing;
 
@@ -25,7 +25,7 @@ fn bench_fractional_sumcheck() -> Result<(), Box<dyn std::error::Error>> {
     let repeats = parse_usize("SWIRL_BENCH_REPEATS", 3);
     let warmups = parse_usize("SWIRL_BENCH_WARMUPS", 1);
 
-    let device_ctx = DeviceContext {
+    let device_ctx = GpuDeviceCtx {
         device_id: get_device()? as u32,
         stream: StreamGuard::new(CudaStream::new_non_blocking()?),
     };

--- a/crates/cuda-backend/src/bin/bench.rs
+++ b/crates/cuda-backend/src/bin/bench.rs
@@ -5,7 +5,7 @@ use openvm_cuda_backend::{
     prelude::EF,
     sponge::DuplexSpongeGpu,
 };
-use openvm_cuda_common::copy::MemCopyD2D;
+use openvm_cuda_common::{copy::MemCopyD2D, stream::CudaStream};
 use p3_field::PrimeCharacteristicRing;
 
 fn parse_usize(var: &str, default: usize) -> usize {
@@ -21,6 +21,7 @@ fn bench_fractional_sumcheck() -> Result<(), Box<dyn std::error::Error>> {
     let repeats = parse_usize("SWIRL_BENCH_REPEATS", 3);
     let warmups = parse_usize("SWIRL_BENCH_WARMUPS", 1);
 
+    let stream = CudaStream::new_non_blocking()?;
     let template = make_synthetic_leaves(n)?;
 
     println!("run_idx,is_warmup,elapsed_ms");
@@ -32,10 +33,17 @@ fn bench_fractional_sumcheck() -> Result<(), Box<dyn std::error::Error>> {
         let mut transcript = DuplexSpongeGpu::default();
         let mut mem = openvm_cuda_common::memory_manager::MemTracker::start("bench.fractional");
 
-        openvm_cuda_common::stream::current_stream_sync().expect("sync before timing");
+        stream.synchronize().expect("sync before timing");
         let t0 = std::time::Instant::now();
-        let _ = fractional_sumcheck_gpu(&mut transcript, leaves, EF::ZERO, false, &mut mem)?;
-        openvm_cuda_common::stream::current_stream_sync().expect("sync after timing");
+        let _ = fractional_sumcheck_gpu(
+            &mut transcript,
+            leaves,
+            EF::ZERO,
+            false,
+            &mut mem,
+            stream.as_raw(),
+        )?;
+        stream.synchronize().expect("sync after timing");
         let ms = t0.elapsed().as_secs_f64() * 1000.0;
 
         println!("{run_idx},{},{:.4}", is_warmup as u8, ms);

--- a/crates/cuda-backend/src/bn254_sponge.rs
+++ b/crates/cuda-backend/src/bn254_sponge.rs
@@ -5,7 +5,9 @@
 
 use std::ffi::c_void;
 
-use openvm_cuda_common::{copy::cuda_memcpy, d_buffer::DeviceBuffer, error::MemCopyError};
+use openvm_cuda_common::{
+    copy::cuda_memcpy_on, d_buffer::DeviceBuffer, error::MemCopyError, stream::DeviceContext,
+};
 use openvm_stark_backend::FiatShamirTranscript;
 use openvm_stark_sdk::config::{
     baby_bear_bn254_poseidon2::{BabyBearBn254Poseidon2Config, Bn254Scalar, Transcript},
@@ -125,9 +127,9 @@ impl MultiFieldTranscriptGpu {
         Self::default()
     }
 
-    fn ensure_device_allocated(&mut self) {
+    fn ensure_device_allocated(&mut self, ctx: &DeviceContext) {
         if self.device.is_empty() {
-            self.device = DeviceBuffer::with_capacity(1);
+            self.device = DeviceBuffer::with_capacity_on(1, ctx);
         }
     }
 
@@ -141,8 +143,8 @@ impl MultiFieldTranscriptGpu {
     /// [`Transcript`] still has buffered samples from a prior host-side
     /// `sample()`, device-side sampling after this snapshot can diverge from the
     /// host transcript.
-    pub fn sync_h2d(&mut self) -> Result<(), MemCopyError> {
-        self.ensure_device_allocated();
+    pub fn sync_h2d(&mut self, ctx: &DeviceContext) -> Result<(), MemCopyError> {
+        self.ensure_device_allocated(ctx);
 
         let mut ds = DeviceBn254SpongeState::default();
 
@@ -160,10 +162,11 @@ impl MultiFieldTranscriptGpu {
         ds.observe_buf_len = self.inner.observe_buf().len() as u32;
 
         unsafe {
-            cuda_memcpy::<false, true>(
+            cuda_memcpy_on::<false, true>(
                 self.device.as_mut_ptr() as *mut c_void,
                 &ds as *const DeviceBn254SpongeState as *const c_void,
                 std::mem::size_of::<DeviceBn254SpongeState>(),
+                ctx,
             )
         }
     }
@@ -191,7 +194,7 @@ impl FiatShamirTranscript<BabyBearBn254Poseidon2Config> for MultiFieldTranscript
 }
 
 impl GpuFiatShamirTranscript<BabyBearBn254Poseidon2Config> for MultiFieldTranscriptGpu {
-    fn grind_gpu(&mut self, bits: usize) -> Result<BabyBear, GrindError> {
+    fn grind_gpu(&mut self, bits: usize, ctx: &DeviceContext) -> Result<BabyBear, GrindError> {
         validate_gpu_grind_bits(bits)?;
         // Trivial case: 0 bits mean no PoW is required and any witness is valid.
         if bits == 0 {
@@ -199,7 +202,7 @@ impl GpuFiatShamirTranscript<BabyBearBn254Poseidon2Config> for MultiFieldTranscr
         }
 
         // 1. Sync host state to device.
-        self.sync_h2d()?;
+        self.sync_h2d(ctx)?;
 
         // 2. Run the BN254 grinding kernel.
         let witness_u32 = unsafe {
@@ -207,6 +210,7 @@ impl GpuFiatShamirTranscript<BabyBearBn254Poseidon2Config> for MultiFieldTranscr
                 self.device.as_ptr(),
                 bits as u32,
                 BabyBear::ORDER_U32 - 1,
+                ctx,
             )?
         };
 

--- a/crates/cuda-backend/src/bn254_sponge.rs
+++ b/crates/cuda-backend/src/bn254_sponge.rs
@@ -127,9 +127,9 @@ impl MultiFieldTranscriptGpu {
         Self::default()
     }
 
-    fn ensure_device_allocated(&mut self, ctx: &DeviceContext) {
+    fn ensure_device_allocated(&mut self, device_ctx: &DeviceContext) {
         if self.device.is_empty() {
-            self.device = DeviceBuffer::with_capacity_on(1, ctx);
+            self.device = DeviceBuffer::with_capacity_on(1, device_ctx);
         }
     }
 
@@ -143,8 +143,8 @@ impl MultiFieldTranscriptGpu {
     /// [`Transcript`] still has buffered samples from a prior host-side
     /// `sample()`, device-side sampling after this snapshot can diverge from the
     /// host transcript.
-    pub fn sync_h2d(&mut self, ctx: &DeviceContext) -> Result<(), MemCopyError> {
-        self.ensure_device_allocated(ctx);
+    pub fn sync_h2d(&mut self, device_ctx: &DeviceContext) -> Result<(), MemCopyError> {
+        self.ensure_device_allocated(device_ctx);
 
         let mut ds = DeviceBn254SpongeState::default();
 
@@ -166,7 +166,7 @@ impl MultiFieldTranscriptGpu {
                 self.device.as_mut_ptr() as *mut c_void,
                 &ds as *const DeviceBn254SpongeState as *const c_void,
                 std::mem::size_of::<DeviceBn254SpongeState>(),
-                ctx,
+                device_ctx,
             )
         }
     }
@@ -194,7 +194,11 @@ impl FiatShamirTranscript<BabyBearBn254Poseidon2Config> for MultiFieldTranscript
 }
 
 impl GpuFiatShamirTranscript<BabyBearBn254Poseidon2Config> for MultiFieldTranscriptGpu {
-    fn grind_gpu(&mut self, bits: usize, ctx: &DeviceContext) -> Result<BabyBear, GrindError> {
+    fn grind_gpu(
+        &mut self,
+        bits: usize,
+        device_ctx: &DeviceContext,
+    ) -> Result<BabyBear, GrindError> {
         validate_gpu_grind_bits(bits)?;
         // Trivial case: 0 bits mean no PoW is required and any witness is valid.
         if bits == 0 {
@@ -202,7 +206,7 @@ impl GpuFiatShamirTranscript<BabyBearBn254Poseidon2Config> for MultiFieldTranscr
         }
 
         // 1. Sync host state to device.
-        self.sync_h2d(ctx)?;
+        self.sync_h2d(device_ctx)?;
 
         // 2. Run the BN254 grinding kernel.
         let witness_u32 = unsafe {
@@ -210,7 +214,7 @@ impl GpuFiatShamirTranscript<BabyBearBn254Poseidon2Config> for MultiFieldTranscr
                 self.device.as_ptr(),
                 bits as u32,
                 BabyBear::ORDER_U32 - 1,
-                ctx,
+                device_ctx,
             )?
         };
 

--- a/crates/cuda-backend/src/bn254_sponge.rs
+++ b/crates/cuda-backend/src/bn254_sponge.rs
@@ -6,7 +6,7 @@
 use std::ffi::c_void;
 
 use openvm_cuda_common::{
-    copy::cuda_memcpy_on, d_buffer::DeviceBuffer, error::MemCopyError, stream::DeviceContext,
+    copy::cuda_memcpy_on, d_buffer::DeviceBuffer, error::MemCopyError, stream::GpuDeviceCtx,
 };
 use openvm_stark_backend::FiatShamirTranscript;
 use openvm_stark_sdk::config::{
@@ -127,7 +127,7 @@ impl MultiFieldTranscriptGpu {
         Self::default()
     }
 
-    fn ensure_device_allocated(&mut self, device_ctx: &DeviceContext) {
+    fn ensure_device_allocated(&mut self, device_ctx: &GpuDeviceCtx) {
         if self.device.is_empty() {
             self.device = DeviceBuffer::with_capacity_on(1, device_ctx);
         }
@@ -143,7 +143,7 @@ impl MultiFieldTranscriptGpu {
     /// [`Transcript`] still has buffered samples from a prior host-side
     /// `sample()`, device-side sampling after this snapshot can diverge from the
     /// host transcript.
-    pub fn sync_h2d(&mut self, device_ctx: &DeviceContext) -> Result<(), MemCopyError> {
+    pub fn sync_h2d(&mut self, device_ctx: &GpuDeviceCtx) -> Result<(), MemCopyError> {
         self.ensure_device_allocated(device_ctx);
 
         let mut ds = DeviceBn254SpongeState::default();
@@ -197,7 +197,7 @@ impl GpuFiatShamirTranscript<BabyBearBn254Poseidon2Config> for MultiFieldTranscr
     fn grind_gpu(
         &mut self,
         bits: usize,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<BabyBear, GrindError> {
         validate_gpu_grind_bits(bits)?;
         // Trivial case: 0 bits mean no PoW is required and any witness is valid.

--- a/crates/cuda-backend/src/cuda/batch_ntt_small.rs
+++ b/crates/cuda-backend/src/cuda/batch_ntt_small.rs
@@ -8,7 +8,7 @@ use openvm_cuda_common::{
     common::{device_reset_epoch, get_device},
     d_buffer::DeviceBuffer,
     error::{check, CudaError},
-    stream::{cudaStream_t, CudaStream, DeviceContext, StreamGuard},
+    stream::{cudaStream_t, DeviceContext},
 };
 
 use crate::prelude::F;
@@ -59,10 +59,7 @@ pub fn ensure_device_ntt_twiddles_initialized() -> Result<(), CudaError> {
         // Temporary staging buffer for the generated twiddles. The CUDA side copies from this
         // buffer into constant memory and synchronizes before returning, so it is safe to free
         // the buffer once `generate_device_ntt_twiddles` completes.
-        let ctx = DeviceContext {
-            device_id: get_device()? as u32,
-            stream: StreamGuard::new(CudaStream::new_non_blocking()?),
-        };
+        let ctx = DeviceContext::for_device(device_key.0 as u32)?;
         let twiddles = DeviceBuffer::<F>::with_capacity_on(DEVICE_NTT_TWIDDLES_SIZE, &ctx);
         unsafe {
             generate_device_ntt_twiddles(&twiddles, ctx.stream.as_raw())?;

--- a/crates/cuda-backend/src/cuda/batch_ntt_small.rs
+++ b/crates/cuda-backend/src/cuda/batch_ntt_small.rs
@@ -8,7 +8,7 @@ use openvm_cuda_common::{
     common::{device_reset_epoch, get_device},
     d_buffer::DeviceBuffer,
     error::{check, CudaError},
-    stream::{cudaStream_t, DeviceContext},
+    stream::{cudaStream_t, GpuDeviceCtx},
 };
 
 use crate::prelude::F;
@@ -59,7 +59,7 @@ pub fn ensure_device_ntt_twiddles_initialized() -> Result<(), CudaError> {
         // Temporary staging buffer for the generated twiddles. The CUDA side copies from this
         // buffer into constant memory and synchronizes before returning, so it is safe to free
         // the buffer once `generate_device_ntt_twiddles` completes.
-        let device_ctx = DeviceContext::for_device(device_key.0 as u32)?;
+        let device_ctx = GpuDeviceCtx::for_device(device_key.0 as u32)?;
         let twiddles = DeviceBuffer::<F>::with_capacity_on(DEVICE_NTT_TWIDDLES_SIZE, &device_ctx);
         unsafe {
             generate_device_ntt_twiddles(&twiddles, device_ctx.stream.as_raw())?;

--- a/crates/cuda-backend/src/cuda/batch_ntt_small.rs
+++ b/crates/cuda-backend/src/cuda/batch_ntt_small.rs
@@ -8,7 +8,7 @@ use openvm_cuda_common::{
     common::{device_reset_epoch, get_device},
     d_buffer::DeviceBuffer,
     error::{check, CudaError},
-    stream::{cudaStreamPerThread, cudaStream_t},
+    stream::{cudaStream_t, CudaStream, DeviceContext, StreamGuard},
 };
 
 use crate::prelude::F;
@@ -59,9 +59,13 @@ pub fn ensure_device_ntt_twiddles_initialized() -> Result<(), CudaError> {
         // Temporary staging buffer for the generated twiddles. The CUDA side copies from this
         // buffer into constant memory and synchronizes before returning, so it is safe to free
         // the buffer once `generate_device_ntt_twiddles` completes.
-        let twiddles = DeviceBuffer::<F>::with_capacity(DEVICE_NTT_TWIDDLES_SIZE);
+        let ctx = DeviceContext {
+            device_id: get_device()? as u32,
+            stream: StreamGuard::new(CudaStream::new_non_blocking()?),
+        };
+        let twiddles = DeviceBuffer::<F>::with_capacity_on(DEVICE_NTT_TWIDDLES_SIZE, &ctx);
         unsafe {
-            generate_device_ntt_twiddles(&twiddles, cudaStreamPerThread)?;
+            generate_device_ntt_twiddles(&twiddles, ctx.stream.as_raw())?;
         }
     }
     initialized.insert(device_key);

--- a/crates/cuda-backend/src/cuda/batch_ntt_small.rs
+++ b/crates/cuda-backend/src/cuda/batch_ntt_small.rs
@@ -59,10 +59,10 @@ pub fn ensure_device_ntt_twiddles_initialized() -> Result<(), CudaError> {
         // Temporary staging buffer for the generated twiddles. The CUDA side copies from this
         // buffer into constant memory and synchronizes before returning, so it is safe to free
         // the buffer once `generate_device_ntt_twiddles` completes.
-        let ctx = DeviceContext::for_device(device_key.0 as u32)?;
-        let twiddles = DeviceBuffer::<F>::with_capacity_on(DEVICE_NTT_TWIDDLES_SIZE, &ctx);
+        let device_ctx = DeviceContext::for_device(device_key.0 as u32)?;
+        let twiddles = DeviceBuffer::<F>::with_capacity_on(DEVICE_NTT_TWIDDLES_SIZE, &device_ctx);
         unsafe {
-            generate_device_ntt_twiddles(&twiddles, ctx.stream.as_raw())?;
+            generate_device_ntt_twiddles(&twiddles, device_ctx.stream.as_raw())?;
         }
     }
     initialized.insert(device_key);

--- a/crates/cuda-backend/src/cuda/batch_ntt_small.rs
+++ b/crates/cuda-backend/src/cuda/batch_ntt_small.rs
@@ -8,7 +8,7 @@ use openvm_cuda_common::{
     common::{device_reset_epoch, get_device},
     d_buffer::DeviceBuffer,
     error::{check, CudaError},
-    stream::cudaStream_t,
+    stream::{cudaStreamPerThread, cudaStream_t},
 };
 
 use crate::prelude::F;
@@ -61,7 +61,7 @@ pub fn ensure_device_ntt_twiddles_initialized() -> Result<(), CudaError> {
         // the buffer once `generate_device_ntt_twiddles` completes.
         let twiddles = DeviceBuffer::<F>::with_capacity(DEVICE_NTT_TWIDDLES_SIZE);
         unsafe {
-            generate_device_ntt_twiddles(&twiddles)?;
+            generate_device_ntt_twiddles(&twiddles, cudaStreamPerThread)?;
         }
     }
     initialized.insert(device_key);

--- a/crates/cuda-backend/src/cuda/batch_ntt_small.rs
+++ b/crates/cuda-backend/src/cuda/batch_ntt_small.rs
@@ -8,6 +8,7 @@ use openvm_cuda_common::{
     common::{device_reset_epoch, get_device},
     d_buffer::DeviceBuffer,
     error::{check, CudaError},
+    stream::cudaStream_t,
 };
 
 use crate::prelude::F;
@@ -35,9 +36,10 @@ extern "C" {
         l_skip: usize,
         cnt_blocks: usize,
         is_intt: bool,
+        stream: cudaStream_t,
     ) -> i32;
 
-    fn _generate_device_ntt_twiddles(d_twiddles: *mut c_void) -> i32;
+    fn _generate_device_ntt_twiddles(d_twiddles: *mut c_void, stream: cudaStream_t) -> i32;
 }
 
 static INIT_DEVICE_NTT_TWIDDLES: OnceLock<Mutex<BTreeSet<(i32, u64)>>> = OnceLock::new();
@@ -68,8 +70,14 @@ pub fn ensure_device_ntt_twiddles_initialized() -> Result<(), CudaError> {
 
 /// Generate device NTT twiddles and copy to constant memory.
 /// `d_twiddles` must have capacity for `DEVICE_NTT_TWIDDLES_SIZE` elements.
-unsafe fn generate_device_ntt_twiddles(d_twiddles: &DeviceBuffer<F>) -> Result<(), CudaError> {
-    CudaError::from_result(_generate_device_ntt_twiddles(d_twiddles.as_mut_raw_ptr()))
+unsafe fn generate_device_ntt_twiddles(
+    d_twiddles: &DeviceBuffer<F>,
+    stream: cudaStream_t,
+) -> Result<(), CudaError> {
+    CudaError::from_result(_generate_device_ntt_twiddles(
+        d_twiddles.as_mut_raw_ptr(),
+        stream,
+    ))
 }
 
 pub unsafe fn batch_ntt_small(
@@ -77,6 +85,7 @@ pub unsafe fn batch_ntt_small(
     l_skip: usize,
     cnt_blocks: usize,
     is_intt: bool,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     if l_skip == 0 || cnt_blocks == 0 {
         return Ok(());
@@ -89,5 +98,6 @@ pub unsafe fn batch_ntt_small(
         l_skip,
         cnt_blocks,
         is_intt,
+        stream,
     ))
 }

--- a/crates/cuda-backend/src/cuda/bn254_merkle_tree.rs
+++ b/crates/cuda-backend/src/cuda/bn254_merkle_tree.rs
@@ -9,7 +9,7 @@ use openvm_cuda_common::{
     common::{device_reset_epoch, get_device},
     d_buffer::DeviceBuffer,
     error::CudaError,
-    stream::{cudaStream_t, CudaStream, DeviceContext, StreamGuard},
+    stream::{cudaStream_t, DeviceContext},
 };
 use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::Bn254Scalar;
 
@@ -272,10 +272,7 @@ pub fn init_bn254_poseidon2_rc() -> Result<(), CudaError> {
         return Ok(());
     }
 
-    let ctx = DeviceContext {
-        device_id: device_key.0 as u32,
-        stream: StreamGuard::new(CudaStream::new_non_blocking()?),
-    };
+    let ctx = DeviceContext::for_device(device_key.0 as u32)?;
 
     // Width-3 constants (leaf hashing)
     let (initial, partial, terminal) = RC_W3_CONSTANTS.get_or_init(compute_bn254_rc_w3_constants);

--- a/crates/cuda-backend/src/cuda/bn254_merkle_tree.rs
+++ b/crates/cuda-backend/src/cuda/bn254_merkle_tree.rs
@@ -9,7 +9,7 @@ use openvm_cuda_common::{
     common::{device_reset_epoch, get_device},
     d_buffer::DeviceBuffer,
     error::CudaError,
-    stream::{cudaStream_t, DeviceContext},
+    stream::{cudaStream_t, GpuDeviceCtx},
 };
 use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::Bn254Scalar;
 
@@ -272,7 +272,7 @@ pub fn init_bn254_poseidon2_rc() -> Result<(), CudaError> {
         return Ok(());
     }
 
-    let device_ctx = DeviceContext::for_device(device_key.0 as u32)?;
+    let device_ctx = GpuDeviceCtx::for_device(device_key.0 as u32)?;
 
     // Width-3 constants (leaf hashing)
     let (initial, partial, terminal) = RC_W3_CONSTANTS.get_or_init(compute_bn254_rc_w3_constants);
@@ -385,7 +385,7 @@ pub unsafe fn bn254_sponge_grind(
     init_state: *const DeviceBn254SpongeState,
     bits: u32,
     max_witness: u32,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<u32, crate::sponge::GrindError> {
     use openvm_cuda_common::copy::{MemCopyD2H, MemCopyH2D};
 

--- a/crates/cuda-backend/src/cuda/bn254_merkle_tree.rs
+++ b/crates/cuda-backend/src/cuda/bn254_merkle_tree.rs
@@ -9,6 +9,7 @@ use openvm_cuda_common::{
     common::{device_reset_epoch, get_device},
     d_buffer::DeviceBuffer,
     error::CudaError,
+    stream::{cudaStreamPerThread, cudaStream_t},
 };
 use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::Bn254Scalar;
 
@@ -63,12 +64,14 @@ extern "C" {
         initial_rc: *const u64,  // [4*3*4] = 48 u64s
         partial_rc: *const u64,  // [56*4]  = 224 u64s
         terminal_rc: *const u64, // [4*3*4] = 48 u64s
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _init_bn254_poseidon2_rc_w2(
         initial_rc: *const u64,  // [3*2*4] = 24 u64s
         partial_rc: *const u64,  // [50*4]  = 200 u64s
         terminal_rc: *const u64, // [3*2*4] = 24 u64s
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _bn254_poseidon2_compressing_row_hashes(
@@ -77,6 +80,7 @@ extern "C" {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _bn254_poseidon2_compressing_row_hashes_ext(
@@ -85,12 +89,14 @@ extern "C" {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _bn254_poseidon2_adjacent_compress_layer(
         output: *mut Bn254FrRaw,
         prev_layer: *const Bn254FrRaw,
         output_size: usize,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _bn254_sponge_grind(
@@ -99,6 +105,7 @@ extern "C" {
         min_witness: u32,
         max_witness: u32,
         result: *mut u32,
+        stream: cudaStream_t,
     ) -> i32;
 }
 
@@ -267,8 +274,14 @@ pub fn init_bn254_poseidon2_rc() -> Result<(), CudaError> {
 
     // Width-3 constants (leaf hashing)
     let (initial, partial, terminal) = RC_W3_CONSTANTS.get_or_init(compute_bn254_rc_w3_constants);
-    let code =
-        unsafe { _init_bn254_poseidon2_rc(initial.as_ptr(), partial.as_ptr(), terminal.as_ptr()) };
+    let code = unsafe {
+        _init_bn254_poseidon2_rc(
+            initial.as_ptr(),
+            partial.as_ptr(),
+            terminal.as_ptr(),
+            cudaStreamPerThread,
+        )
+    };
     CudaError::from_result(code)?;
 
     // Width-2 constants (compression)
@@ -279,6 +292,7 @@ pub fn init_bn254_poseidon2_rc() -> Result<(), CudaError> {
             initial_w2.as_ptr(),
             partial_w2.as_ptr(),
             terminal_w2.as_ptr(),
+            cudaStreamPerThread,
         )
     };
     CudaError::from_result(code)?;
@@ -302,6 +316,7 @@ pub unsafe fn bn254_poseidon2_compressing_row_hashes(
     width: usize,
     query_stride: usize,
     log_rows_per_query: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     init_bn254_poseidon2_rc()?;
     super::merkle_tree::validate_merkle_log_rows_per_query(log_rows_per_query)?;
@@ -311,6 +326,7 @@ pub unsafe fn bn254_poseidon2_compressing_row_hashes(
         width,
         query_stride,
         log_rows_per_query,
+        stream,
     ))
 }
 
@@ -325,6 +341,7 @@ pub unsafe fn bn254_poseidon2_compressing_row_hashes_ext(
     width: usize,
     query_stride: usize,
     log_rows_per_query: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     init_bn254_poseidon2_rc()?;
     super::merkle_tree::validate_merkle_log_rows_per_query(log_rows_per_query)?;
@@ -334,6 +351,7 @@ pub unsafe fn bn254_poseidon2_compressing_row_hashes_ext(
         width,
         query_stride,
         log_rows_per_query,
+        stream,
     ))
 }
 
@@ -346,12 +364,14 @@ pub unsafe fn bn254_poseidon2_adjacent_compress_layer(
     output: &mut DeviceBuffer<Bn254Digest>,
     prev_layer: &DeviceBuffer<Bn254Digest>,
     output_size: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     init_bn254_poseidon2_rc()?;
     CudaError::from_result(_bn254_poseidon2_adjacent_compress_layer(
         output.as_mut_ptr().cast::<Bn254FrRaw>(),
         prev_layer.as_ptr().cast::<Bn254FrRaw>(),
         output_size,
+        stream,
     ))
 }
 
@@ -363,6 +383,7 @@ pub unsafe fn bn254_sponge_grind(
     init_state: *const DeviceBn254SpongeState,
     bits: u32,
     max_witness: u32,
+    stream: cudaStream_t,
 ) -> Result<u32, crate::sponge::GrindError> {
     use openvm_cuda_common::copy::{MemCopyD2H, MemCopyH2D};
 
@@ -378,6 +399,7 @@ pub unsafe fn bn254_sponge_grind(
             start,
             max_witness,
             d_result.as_mut_ptr(),
+            stream,
         ))?;
 
         let result = d_result.to_host()?[0];

--- a/crates/cuda-backend/src/cuda/bn254_merkle_tree.rs
+++ b/crates/cuda-backend/src/cuda/bn254_merkle_tree.rs
@@ -9,7 +9,7 @@ use openvm_cuda_common::{
     common::{device_reset_epoch, get_device},
     d_buffer::DeviceBuffer,
     error::CudaError,
-    stream::{cudaStreamPerThread, cudaStream_t},
+    stream::{cudaStream_t, CudaStream, DeviceContext, StreamGuard},
 };
 use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::Bn254Scalar;
 
@@ -272,6 +272,11 @@ pub fn init_bn254_poseidon2_rc() -> Result<(), CudaError> {
         return Ok(());
     }
 
+    let ctx = DeviceContext {
+        device_id: device_key.0 as u32,
+        stream: StreamGuard::new(CudaStream::new_non_blocking()?),
+    };
+
     // Width-3 constants (leaf hashing)
     let (initial, partial, terminal) = RC_W3_CONSTANTS.get_or_init(compute_bn254_rc_w3_constants);
     let code = unsafe {
@@ -279,7 +284,7 @@ pub fn init_bn254_poseidon2_rc() -> Result<(), CudaError> {
             initial.as_ptr(),
             partial.as_ptr(),
             terminal.as_ptr(),
-            cudaStreamPerThread,
+            ctx.stream.as_raw(),
         )
     };
     CudaError::from_result(code)?;
@@ -292,7 +297,7 @@ pub fn init_bn254_poseidon2_rc() -> Result<(), CudaError> {
             initial_w2.as_ptr(),
             partial_w2.as_ptr(),
             terminal_w2.as_ptr(),
-            cudaStreamPerThread,
+            ctx.stream.as_raw(),
         )
     };
     CudaError::from_result(code)?;
@@ -383,14 +388,14 @@ pub unsafe fn bn254_sponge_grind(
     init_state: *const DeviceBn254SpongeState,
     bits: u32,
     max_witness: u32,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<u32, crate::sponge::GrindError> {
     use openvm_cuda_common::copy::{MemCopyD2H, MemCopyH2D};
 
     init_bn254_poseidon2_rc()?;
     validate_gpu_grind_bits(bits as usize)?;
-    let mut d_result: DeviceBuffer<u32> = DeviceBuffer::with_capacity(1);
-    [u32::MAX].copy_to(&mut d_result)?;
+    let mut d_result: DeviceBuffer<u32> = DeviceBuffer::with_capacity_on(1, ctx);
+    [u32::MAX].copy_to_on(&mut d_result, ctx)?;
 
     for start in (0..=max_witness).step_by(1 << bits) {
         CudaError::from_result(_bn254_sponge_grind(
@@ -399,10 +404,10 @@ pub unsafe fn bn254_sponge_grind(
             start,
             max_witness,
             d_result.as_mut_ptr(),
-            stream,
+            ctx.stream.as_raw(),
         ))?;
 
-        let result = d_result.to_host()?[0];
+        let result = d_result.to_host_on(ctx)?[0];
         if result < u32::MAX {
             return Ok(result);
         }

--- a/crates/cuda-backend/src/cuda/bn254_merkle_tree.rs
+++ b/crates/cuda-backend/src/cuda/bn254_merkle_tree.rs
@@ -272,7 +272,7 @@ pub fn init_bn254_poseidon2_rc() -> Result<(), CudaError> {
         return Ok(());
     }
 
-    let ctx = DeviceContext::for_device(device_key.0 as u32)?;
+    let device_ctx = DeviceContext::for_device(device_key.0 as u32)?;
 
     // Width-3 constants (leaf hashing)
     let (initial, partial, terminal) = RC_W3_CONSTANTS.get_or_init(compute_bn254_rc_w3_constants);
@@ -281,7 +281,7 @@ pub fn init_bn254_poseidon2_rc() -> Result<(), CudaError> {
             initial.as_ptr(),
             partial.as_ptr(),
             terminal.as_ptr(),
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )
     };
     CudaError::from_result(code)?;
@@ -294,7 +294,7 @@ pub fn init_bn254_poseidon2_rc() -> Result<(), CudaError> {
             initial_w2.as_ptr(),
             partial_w2.as_ptr(),
             terminal_w2.as_ptr(),
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )
     };
     CudaError::from_result(code)?;
@@ -385,14 +385,14 @@ pub unsafe fn bn254_sponge_grind(
     init_state: *const DeviceBn254SpongeState,
     bits: u32,
     max_witness: u32,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<u32, crate::sponge::GrindError> {
     use openvm_cuda_common::copy::{MemCopyD2H, MemCopyH2D};
 
     init_bn254_poseidon2_rc()?;
     validate_gpu_grind_bits(bits as usize)?;
-    let mut d_result: DeviceBuffer<u32> = DeviceBuffer::with_capacity_on(1, ctx);
-    [u32::MAX].copy_to_on(&mut d_result, ctx)?;
+    let mut d_result: DeviceBuffer<u32> = DeviceBuffer::with_capacity_on(1, device_ctx);
+    [u32::MAX].copy_to_on(&mut d_result, device_ctx)?;
 
     for start in (0..=max_witness).step_by(1 << bits) {
         CudaError::from_result(_bn254_sponge_grind(
@@ -401,10 +401,10 @@ pub unsafe fn bn254_sponge_grind(
             start,
             max_witness,
             d_result.as_mut_ptr(),
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         ))?;
 
-        let result = d_result.to_host_on(ctx)?[0];
+        let result = d_result.to_host_on(device_ctx)?[0];
         if result < u32::MAX {
             return Ok(result);
         }

--- a/crates/cuda-backend/src/cuda/device_info.rs
+++ b/crates/cuda-backend/src/cuda/device_info.rs
@@ -1,11 +1,11 @@
-use openvm_cuda_common::error::CudaError;
+use openvm_cuda_common::{error::CudaError, stream::cudaStream_t};
 
 extern "C" {
-    fn _cuda_get_sm_count(device_id: u32, out_sm_count: *mut u32) -> i32;
+    fn _cuda_get_sm_count(device_id: u32, out_sm_count: *mut u32, stream: cudaStream_t) -> i32;
 }
 
-pub fn get_sm_count(device_id: u32) -> Result<u32, CudaError> {
+pub fn get_sm_count(device_id: u32, stream: cudaStream_t) -> Result<u32, CudaError> {
     let mut sm_count = 0u32;
-    unsafe { CudaError::from_result(_cuda_get_sm_count(device_id, &mut sm_count))? };
+    unsafe { CudaError::from_result(_cuda_get_sm_count(device_id, &mut sm_count, stream))? };
     Ok(sm_count)
 }

--- a/crates/cuda-backend/src/cuda/logup_zerocheck.rs
+++ b/crates/cuda-backend/src/cuda/logup_zerocheck.rs
@@ -112,7 +112,11 @@ extern "C" {
     /// Fused two-layer tree build. Applies layers i and i+1 in one kernel pass,
     /// keeping intermediate right-half nodes for revert operations.
     /// `half_i1` = N >> (i+2), where i is the first of the two layers.
-    fn _frac_build_tree_two_layers(layer: *mut Frac<EF>, half_i1: usize, stream: cudaStream_t) -> i32;
+    fn _frac_build_tree_two_layers(
+        layer: *mut Frac<EF>,
+        half_i1: usize,
+        stream: cudaStream_t,
+    ) -> i32;
 
     pub fn _frac_compute_round_temp_buffer_size(stride: u32, stream: cudaStream_t) -> u32;
 
@@ -219,9 +223,19 @@ extern "C" {
         stream: cudaStream_t,
     ) -> i32;
 
-    fn _frac_add_alpha(data: *mut std::ffi::c_void, len: usize, alpha: EF, stream: cudaStream_t) -> i32;
+    fn _frac_add_alpha(
+        data: *mut std::ffi::c_void,
+        len: usize,
+        alpha: EF,
+        stream: cudaStream_t,
+    ) -> i32;
 
-    fn _frac_vector_scalar_multiply_ext_fp(frac_vec: *mut Frac<EF>, scalar: F, length: u32, stream: cudaStream_t) -> i32;
+    fn _frac_vector_scalar_multiply_ext_fp(
+        frac_vec: *mut Frac<EF>,
+        scalar: F,
+        length: u32,
+        stream: cudaStream_t,
+    ) -> i32;
 
     // utils.cu
     fn _fold_ple_from_evals(
@@ -381,7 +395,11 @@ extern "C" {
     ) -> i32;
 
     // mle.cu
-    pub fn _zerocheck_mle_temp_sums_buffer_size(num_x: u32, num_y: u32, stream: cudaStream_t) -> usize;
+    pub fn _zerocheck_mle_temp_sums_buffer_size(
+        num_x: u32,
+        num_y: u32,
+        stream: cudaStream_t,
+    ) -> usize;
 
     pub fn _zerocheck_mle_intermediates_buffer_size(
         buffer_size: u32,
@@ -413,7 +431,12 @@ extern "C" {
 
     pub fn _logup_mle_temp_sums_buffer_size(num_x: u32, num_y: u32, stream: cudaStream_t) -> usize;
 
-    pub fn _logup_mle_intermediates_buffer_size(buffer_size: u32, num_x: u32, num_y: u32, stream: cudaStream_t) -> usize;
+    pub fn _logup_mle_intermediates_buffer_size(
+        buffer_size: u32,
+        num_x: u32,
+        num_y: u32,
+        stream: cudaStream_t,
+    ) -> usize;
 
     fn _logup_eval_mle(
         tmp_sums_buffer: *mut Frac<EF>,
@@ -594,7 +617,11 @@ pub unsafe fn frac_build_tree_two_layers(
     half_i1: usize,
     stream: cudaStream_t,
 ) -> Result<(), CudaError> {
-    CudaError::from_result(_frac_build_tree_two_layers(layer.as_mut_ptr(), half_i1, stream))
+    CudaError::from_result(_frac_build_tree_two_layers(
+        layer.as_mut_ptr(),
+        half_i1,
+        stream,
+    ))
 }
 
 // `eq_xi` will not store evaluations for the first hypercube coordinate because the prover factors
@@ -976,7 +1003,12 @@ pub unsafe fn frac_add_alpha(
     alpha: EF,
     stream: cudaStream_t,
 ) -> Result<(), CudaError> {
-    CudaError::from_result(_frac_add_alpha(data.as_mut_raw_ptr(), data.len(), alpha, stream))
+    CudaError::from_result(_frac_add_alpha(
+        data.as_mut_raw_ptr(),
+        data.len(),
+        alpha,
+        stream,
+    ))
 }
 
 /// # Safety
@@ -1413,6 +1445,7 @@ pub unsafe fn frac_matrix_vertically_repeat(
     ))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub unsafe fn frac_matrix_vertically_repeat_ext(
     out_numerators: *mut EF,
     out_denominators: *mut EF,

--- a/crates/cuda-backend/src/cuda/logup_zerocheck.rs
+++ b/crates/cuda-backend/src/cuda/logup_zerocheck.rs
@@ -1,3 +1,5 @@
+use openvm_cuda_common::stream::cudaStream_t;
+
 use super::*;
 use crate::{
     monomial::{InteractionMonomialTerm, LambdaTerm, MonomialHeader, PackedVar},
@@ -104,14 +106,15 @@ extern "C" {
         revert: bool,
         alpha: EF,
         apply_alpha: bool,
+        stream: cudaStream_t,
     ) -> i32;
 
     /// Fused two-layer tree build. Applies layers i and i+1 in one kernel pass,
     /// keeping intermediate right-half nodes for revert operations.
     /// `half_i1` = N >> (i+2), where i is the first of the two layers.
-    fn _frac_build_tree_two_layers(layer: *mut Frac<EF>, half_i1: usize) -> i32;
+    fn _frac_build_tree_two_layers(layer: *mut Frac<EF>, half_i1: usize, stream: cudaStream_t) -> i32;
 
-    pub fn _frac_compute_round_temp_buffer_size(stride: u32) -> u32;
+    pub fn _frac_compute_round_temp_buffer_size(stride: u32, stream: cudaStream_t) -> u32;
 
     fn _frac_compute_round(
         eq_xi_low: *const EF,
@@ -122,6 +125,7 @@ extern "C" {
         lambda: EF,
         out_device: *mut EF,
         tmp_block_sums: *mut EF,
+        stream: cudaStream_t,
     ) -> i32;
 
     /// Fused compute round + tree layer revert. Combines frac_build_tree_layer(revert=true)
@@ -135,6 +139,7 @@ extern "C" {
         lambda: EF,
         out_device: *mut EF,
         tmp_block_sums: *mut EF,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _frac_fold_fpext_columns(
@@ -142,6 +147,7 @@ extern "C" {
         dst: *mut Frac<EF>,
         size: usize,
         r: EF,
+        stream: cudaStream_t,
     ) -> i32;
 
     /// Fused compute round + fold (out-of-place). Reads from pre-fold src_pq_buffer (size
@@ -158,6 +164,7 @@ extern "C" {
         r_prev: EF,
         out_device: *mut EF,
         tmp_block_sums: *mut EF,
+        stream: cudaStream_t,
     ) -> i32;
 
     /// Fused compute round + fold (in-place). Reads from pre-fold pq_buffer (size src_pq_size),
@@ -173,6 +180,7 @@ extern "C" {
         r_prev: EF,
         out_device: *mut EF,
         tmp_block_sums: *mut EF,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _frac_precompute_m_build(
@@ -189,6 +197,7 @@ extern "C" {
         partial_out: *mut EF,
         partial_len: usize,
         m_total: *mut EF,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _frac_precompute_m_eval_round(
@@ -198,6 +207,7 @@ extern "C" {
         eq_r_prefix: *const EF,
         eq_suffix: *const EF,
         out: *mut EF,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _frac_multifold(
@@ -206,11 +216,12 @@ extern "C" {
         rem_n: usize,
         w: usize,
         eq_r_window: *const EF,
+        stream: cudaStream_t,
     ) -> i32;
 
-    fn _frac_add_alpha(data: *mut std::ffi::c_void, len: usize, alpha: EF) -> i32;
+    fn _frac_add_alpha(data: *mut std::ffi::c_void, len: usize, alpha: EF, stream: cudaStream_t) -> i32;
 
-    fn _frac_vector_scalar_multiply_ext_fp(frac_vec: *mut Frac<EF>, scalar: F, length: u32) -> i32;
+    fn _frac_vector_scalar_multiply_ext_fp(frac_vec: *mut Frac<EF>, scalar: F, length: u32, stream: cudaStream_t) -> i32;
 
     // utils.cu
     fn _fold_ple_from_evals(
@@ -223,6 +234,7 @@ extern "C" {
         l_skip: u32,
         new_height: u32,
         rotate: bool,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _interpolate_columns(
@@ -231,6 +243,7 @@ extern "C" {
         s_deg: usize,
         num_y: usize,
         num_columns: usize,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _frac_matrix_vertically_repeat(
@@ -239,6 +252,7 @@ extern "C" {
         width: u32,
         lifted_height: u32,
         height: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _frac_matrix_vertically_repeat_ext(
@@ -249,6 +263,7 @@ extern "C" {
         width: u32,
         lifted_height: u32,
         height: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     // gkr_input.cu
@@ -266,6 +281,7 @@ extern "C" {
         used_nodes_len: usize,
         height: u32,
         num_rows_per_tile: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     // logup_round0.cu
@@ -275,6 +291,7 @@ extern "C" {
         num_x: u32,
         num_cosets: u32,
         max_temp_bytes: usize,
+        stream: cudaStream_t,
     ) -> usize;
 
     pub fn _logup_r0_intermediates_buffer_size(
@@ -283,6 +300,7 @@ extern "C" {
         num_x: u32,
         num_cosets: u32,
         max_temp_bytes: usize,
+        stream: cudaStream_t,
     ) -> usize;
 
     fn _logup_bary_eval_interactions_round0(
@@ -306,6 +324,7 @@ extern "C" {
         num_cosets: u32,
         g_shift: F,
         max_temp_bytes: usize,
+        stream: cudaStream_t,
     ) -> i32;
 
     // zerocheck_round0.cu
@@ -315,6 +334,7 @@ extern "C" {
         num_x: u32,
         num_cosets: u32,
         max_temp_bytes: usize,
+        stream: cudaStream_t,
     ) -> usize;
 
     pub fn _zerocheck_r0_intermediates_buffer_size(
@@ -323,6 +343,7 @@ extern "C" {
         num_x: u32,
         num_cosets: u32,
         max_temp_bytes: usize,
+        stream: cudaStream_t,
     ) -> usize;
 
     fn _zerocheck_ntt_eval_constraints(
@@ -347,6 +368,7 @@ extern "C" {
         num_cosets: u32,
         g_shift: F,
         max_temp_bytes: usize,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _fold_selectors_round0(
@@ -355,15 +377,17 @@ extern "C" {
         is_first: EF,
         is_last: EF,
         num_x: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     // mle.cu
-    pub fn _zerocheck_mle_temp_sums_buffer_size(num_x: u32, num_y: u32) -> usize;
+    pub fn _zerocheck_mle_temp_sums_buffer_size(num_x: u32, num_y: u32, stream: cudaStream_t) -> usize;
 
     pub fn _zerocheck_mle_intermediates_buffer_size(
         buffer_size: u32,
         num_x: u32,
         num_y: u32,
+        stream: cudaStream_t,
     ) -> usize;
 
     fn _zerocheck_eval_mle(
@@ -384,11 +408,12 @@ extern "C" {
         intermediates: *mut EF,
         num_y: u32,
         num_x: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
-    pub fn _logup_mle_temp_sums_buffer_size(num_x: u32, num_y: u32) -> usize;
+    pub fn _logup_mle_temp_sums_buffer_size(num_x: u32, num_y: u32, stream: cudaStream_t) -> usize;
 
-    pub fn _logup_mle_intermediates_buffer_size(buffer_size: u32, num_x: u32, num_y: u32) -> usize;
+    pub fn _logup_mle_intermediates_buffer_size(buffer_size: u32, num_x: u32, num_y: u32, stream: cudaStream_t) -> usize;
 
     fn _logup_eval_mle(
         tmp_sums_buffer: *mut Frac<EF>,
@@ -408,6 +433,7 @@ extern "C" {
         intermediates: *mut EF,
         num_y: u32,
         num_x: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     // batch_mle.cu (batch kernels always use global intermediates when buffer_size > 0)
@@ -415,12 +441,14 @@ extern "C" {
         buffer_size: u32,
         num_x: u32,
         num_y: u32,
+        stream: cudaStream_t,
     ) -> usize;
 
     pub fn _logup_batch_mle_intermediates_buffer_size(
         buffer_size: u32,
         num_x: u32,
         num_y: u32,
+        stream: cudaStream_t,
     ) -> usize;
 
     fn _zerocheck_batch_eval_mle(
@@ -435,6 +463,7 @@ extern "C" {
         num_x: u32,
         num_airs: u32,
         threads_per_block: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _logup_batch_eval_mle(
@@ -447,6 +476,7 @@ extern "C" {
         num_x: u32,
         num_airs: u32,
         threads_per_block: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _zerocheck_monomial_batched(
@@ -459,6 +489,7 @@ extern "C" {
         num_x: u32,
         num_airs: u32,
         threads_per_block: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _zerocheck_monomial_par_y_batched(
@@ -472,6 +503,7 @@ extern "C" {
         num_airs: u32,
         chunk_size: u32,
         threads_per_block: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _precompute_lambda_combinations(
@@ -480,6 +512,7 @@ extern "C" {
         lambda_terms: *const LambdaTerm<F>,
         lambda_pows: *const EF,
         num_monomials: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     // Logup monomial kernels
@@ -489,6 +522,7 @@ extern "C" {
         terms: *const InteractionMonomialTerm<F>,
         eq_3bs: *const EF,
         num_monomials: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _precompute_logup_denom_combinations(
@@ -498,6 +532,7 @@ extern "C" {
         beta_pows: *const EF,
         eq_3bs: *const EF,
         num_monomials: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _logup_monomial_batched(
@@ -512,6 +547,7 @@ extern "C" {
         num_x: u32,
         num_airs: u32,
         threads_per_block: u32,
+        stream: cudaStream_t,
     ) -> i32;
 }
 
@@ -520,6 +556,7 @@ pub unsafe fn interpolate_columns_gpu(
     columns: &DeviceBuffer<*const EF>,
     s_deg: usize,
     num_y: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_interpolate_columns(
         interpolated.as_mut_ptr(),
@@ -527,6 +564,7 @@ pub unsafe fn interpolate_columns_gpu(
         s_deg,
         num_y,
         columns.len(),
+        stream,
     ))
 }
 
@@ -536,6 +574,7 @@ pub unsafe fn frac_build_tree_layer(
     revert: bool,
     alpha: EF,
     apply_alpha: bool,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(layer.len() >= layer_size);
     CudaError::from_result(_frac_build_tree_layer(
@@ -544,6 +583,7 @@ pub unsafe fn frac_build_tree_layer(
         revert,
         alpha,
         apply_alpha,
+        stream,
     ))
 }
 
@@ -552,8 +592,9 @@ pub unsafe fn frac_build_tree_layer(
 pub unsafe fn frac_build_tree_two_layers(
     layer: &mut DeviceBuffer<Frac<EF>>,
     half_i1: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
-    CudaError::from_result(_frac_build_tree_two_layers(layer.as_mut_ptr(), half_i1))
+    CudaError::from_result(_frac_build_tree_two_layers(layer.as_mut_ptr(), half_i1, stream))
 }
 
 // `eq_xi` will not store evaluations for the first hypercube coordinate because the prover factors
@@ -566,6 +607,7 @@ pub unsafe fn frac_compute_round(
     lambda: EF,
     out_device: &mut DeviceBuffer<EF>,
     tmp_block_sums: &mut DeviceBuffer<EF>,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     let low_n = eq_xi.low_n();
     let high_n = eq_xi.high_n();
@@ -574,7 +616,7 @@ pub unsafe fn frac_compute_round(
     #[cfg(debug_assertions)]
     {
         let len = tmp_block_sums.len();
-        let required = _frac_compute_round_temp_buffer_size(num_x.try_into().unwrap());
+        let required = _frac_compute_round_temp_buffer_size(num_x.try_into().unwrap(), stream);
         assert!(
             len >= required as usize,
             "tmp_block_sums len={len} < required={required}"
@@ -589,6 +631,7 @@ pub unsafe fn frac_compute_round(
         lambda,
         out_device.as_mut_ptr(),
         tmp_block_sums.as_mut_ptr(),
+        stream,
     ))
 }
 
@@ -607,6 +650,7 @@ pub unsafe fn frac_compute_round_and_revert(
     lambda: EF,
     out_device: &mut DeviceBuffer<EF>,
     tmp_block_sums: &mut DeviceBuffer<EF>,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     let low_n = eq_xi.low_n();
     let high_n = eq_xi.high_n();
@@ -614,7 +658,7 @@ pub unsafe fn frac_compute_round_and_revert(
     #[cfg(debug_assertions)]
     {
         let len = tmp_block_sums.len();
-        let required = _frac_compute_round_temp_buffer_size(num_x.try_into().unwrap());
+        let required = _frac_compute_round_temp_buffer_size(num_x.try_into().unwrap(), stream);
         assert!(
             len >= required as usize,
             "tmp_block_sums len={len} < required={required}"
@@ -630,6 +674,7 @@ pub unsafe fn frac_compute_round_and_revert(
         lambda,
         out_device.as_mut_ptr(),
         tmp_block_sums.as_mut_ptr(),
+        stream,
     ))
 }
 
@@ -641,6 +686,7 @@ pub unsafe fn fold_ef_frac_columns(
     dst: &mut DeviceBuffer<Frac<EF>>,
     size: usize,
     r: EF,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(src.len() >= size);
     debug_assert!(dst.len() >= size / 2);
@@ -649,6 +695,7 @@ pub unsafe fn fold_ef_frac_columns(
         dst.as_mut_ptr(),
         size,
         r,
+        stream,
     ))
 }
 
@@ -657,10 +704,11 @@ pub unsafe fn fold_ef_frac_columns_inplace(
     buffer: &mut DeviceBuffer<Frac<EF>>,
     size: usize,
     r: EF,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(buffer.len() >= size);
     let ptr = buffer.as_mut_ptr();
-    CudaError::from_result(_frac_fold_fpext_columns(ptr, ptr, size, r))
+    CudaError::from_result(_frac_fold_fpext_columns(ptr, ptr, size, r, stream))
 }
 
 /// Fused compute round + fold kernel.
@@ -683,6 +731,7 @@ pub unsafe fn frac_compute_round_and_fold(
     r_prev: EF,
     out_device: &mut DeviceBuffer<EF>,
     tmp_block_sums: &mut DeviceBuffer<EF>,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     let low_n = eq_xi.low_n();
     let high_n = eq_xi.high_n();
@@ -707,7 +756,7 @@ pub unsafe fn frac_compute_round_and_fold(
             pq_size
         );
         let len = tmp_block_sums.len();
-        let required = _frac_compute_round_temp_buffer_size(num_x as u32);
+        let required = _frac_compute_round_temp_buffer_size(num_x as u32, stream);
         assert!(
             len >= required as usize,
             "tmp_block_sums len={len} < required={required}"
@@ -724,6 +773,7 @@ pub unsafe fn frac_compute_round_and_fold(
         r_prev,
         out_device.as_mut_ptr(),
         tmp_block_sums.as_mut_ptr(),
+        stream,
     ))
 }
 
@@ -743,6 +793,7 @@ pub unsafe fn frac_compute_round_and_fold_inplace(
     r_prev: EF,
     out_device: &mut DeviceBuffer<EF>,
     tmp_block_sums: &mut DeviceBuffer<EF>,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     let low_n = eq_xi.low_n();
     let high_n = eq_xi.high_n();
@@ -760,7 +811,7 @@ pub unsafe fn frac_compute_round_and_fold_inplace(
             src_pq_size
         );
         let len = tmp_block_sums.len();
-        let required = _frac_compute_round_temp_buffer_size(num_x as u32);
+        let required = _frac_compute_round_temp_buffer_size(num_x as u32, stream);
         assert!(
             len >= required as usize,
             "tmp_block_sums len={len} < required={required}"
@@ -776,6 +827,7 @@ pub unsafe fn frac_compute_round_and_fold_inplace(
         r_prev,
         out_device.as_mut_ptr(),
         tmp_block_sums.as_mut_ptr(),
+        stream,
     ))
 }
 
@@ -794,6 +846,7 @@ pub unsafe fn frac_precompute_m_build_raw(
     partial_out: *mut EF,
     partial_len: usize,
     m_total: *mut EF,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(rem_n > 0);
     debug_assert!(w > 0 && w <= rem_n);
@@ -813,6 +866,7 @@ pub unsafe fn frac_precompute_m_build_raw(
         partial_out,
         partial_len,
         m_total,
+        stream,
     ))
 }
 
@@ -824,6 +878,7 @@ pub unsafe fn frac_precompute_m_eval_round_raw(
     eq_r_prefix: *const EF,
     eq_suffix: *const EF,
     out: *mut EF,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(w > 0);
     debug_assert!(t < w);
@@ -834,6 +889,7 @@ pub unsafe fn frac_precompute_m_eval_round_raw(
         eq_r_prefix,
         eq_suffix,
         out,
+        stream,
     ))
 }
 
@@ -843,10 +899,11 @@ pub unsafe fn frac_multifold_raw(
     rem_n: usize,
     w: usize,
     eq_r_window: *const EF,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(rem_n > 0);
     debug_assert!(w > 0 && w <= rem_n);
-    CudaError::from_result(_frac_multifold(src, dst, rem_n, w, eq_r_window))
+    CudaError::from_result(_frac_multifold(src, dst, rem_n, w, eq_r_window, stream))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -860,6 +917,7 @@ pub unsafe fn fold_ple_from_evals(
     l_skip: u32,
     new_height: u32,
     rotate: bool,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_fold_ple_from_evals(
         input_matrix.as_ptr(),
@@ -871,6 +929,7 @@ pub unsafe fn fold_ple_from_evals(
         l_skip,
         new_height,
         rotate,
+        stream,
     ))
 }
 
@@ -891,6 +950,7 @@ pub unsafe fn logup_gkr_input_eval(
     pair_idxs: &DeviceBuffer<u32>,
     height: u32,
     num_rows_per_tile: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert_eq!(used_nodes.len(), pair_idxs.len());
     CudaError::from_result(_logup_gkr_input_eval(
@@ -907,11 +967,16 @@ pub unsafe fn logup_gkr_input_eval(
         used_nodes.len(),
         height,
         num_rows_per_tile,
+        stream,
     ))
 }
 
-pub unsafe fn frac_add_alpha(data: &DeviceBuffer<Frac<EF>>, alpha: EF) -> Result<(), CudaError> {
-    CudaError::from_result(_frac_add_alpha(data.as_mut_raw_ptr(), data.len(), alpha))
+pub unsafe fn frac_add_alpha(
+    data: &DeviceBuffer<Frac<EF>>,
+    alpha: EF,
+    stream: cudaStream_t,
+) -> Result<(), CudaError> {
+    CudaError::from_result(_frac_add_alpha(data.as_mut_raw_ptr(), data.len(), alpha, stream))
 }
 
 /// # Safety
@@ -940,6 +1005,7 @@ pub unsafe fn zerocheck_ntt_eval_constraints(
     num_cosets: u32,
     g_shift: F,
     max_temp_bytes: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_zerocheck_ntt_eval_constraints(
         tmp_sums_buffer.as_mut_ptr(),
@@ -963,6 +1029,7 @@ pub unsafe fn zerocheck_ntt_eval_constraints(
         num_cosets,
         g_shift,
         max_temp_bytes,
+        stream,
     ))
 }
 
@@ -994,6 +1061,7 @@ pub unsafe fn logup_bary_eval_interactions_round0(
     num_cosets: u32,
     g_shift: F,
     max_temp_bytes: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_logup_bary_eval_interactions_round0(
         tmp_sums_buffer.as_mut_ptr(),
@@ -1016,6 +1084,7 @@ pub unsafe fn logup_bary_eval_interactions_round0(
         num_cosets,
         g_shift,
         max_temp_bytes,
+        stream,
     ))
 }
 
@@ -1039,6 +1108,7 @@ pub unsafe fn zerocheck_eval_mle(
     intermediates: &mut DeviceBuffer<EF>,
     num_y: u32,
     num_x: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_zerocheck_eval_mle(
         tmp_sums_buffer.as_mut_ptr(),
@@ -1058,6 +1128,7 @@ pub unsafe fn zerocheck_eval_mle(
         intermediates.as_mut_ptr(),
         num_y,
         num_x,
+        stream,
     ))
 }
 
@@ -1074,6 +1145,7 @@ pub unsafe fn zerocheck_batch_eval_mle(
     num_x: u32,
     num_airs: u32,
     threads_per_block: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_zerocheck_batch_eval_mle(
         tmp_sums_buffer.as_mut_ptr(),
@@ -1087,6 +1159,7 @@ pub unsafe fn zerocheck_batch_eval_mle(
         num_x,
         num_airs,
         threads_per_block,
+        stream,
     ))
 }
 
@@ -1110,6 +1183,7 @@ pub unsafe fn logup_eval_mle(
     intermediates: &mut DeviceBuffer<EF>,
     num_y: u32,
     num_x: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_logup_eval_mle(
         tmp_sums_buffer.as_mut_ptr(),
@@ -1129,6 +1203,7 @@ pub unsafe fn logup_eval_mle(
         intermediates.as_mut_ptr(),
         num_y,
         num_x,
+        stream,
     ))
 }
 
@@ -1143,6 +1218,7 @@ pub unsafe fn logup_batch_eval_mle(
     num_x: u32,
     num_airs: u32,
     threads_per_block: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_logup_batch_eval_mle(
         tmp_sums_buffer.as_mut_ptr(),
@@ -1154,6 +1230,7 @@ pub unsafe fn logup_batch_eval_mle(
         num_x,
         num_airs,
         threads_per_block,
+        stream,
     ))
 }
 
@@ -1168,6 +1245,7 @@ pub unsafe fn zerocheck_monomial_batched(
     num_x: u32,
     num_airs: u32,
     threads_per_block: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_zerocheck_monomial_batched(
         tmp_sums.as_mut_ptr(),
@@ -1179,6 +1257,7 @@ pub unsafe fn zerocheck_monomial_batched(
         num_x,
         num_airs,
         threads_per_block,
+        stream,
     ))
 }
 
@@ -1194,6 +1273,7 @@ pub unsafe fn zerocheck_monomial_par_y_batched(
     num_airs: u32,
     chunk_size: u32,
     threads_per_block: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_zerocheck_monomial_par_y_batched(
         tmp_sums.as_mut_ptr(),
@@ -1206,6 +1286,7 @@ pub unsafe fn zerocheck_monomial_par_y_batched(
         num_airs,
         chunk_size,
         threads_per_block,
+        stream,
     ))
 }
 
@@ -1215,6 +1296,7 @@ pub unsafe fn precompute_lambda_combinations(
     lambda_terms: *const LambdaTerm<F>,
     lambda_pows: &DeviceBuffer<EF>,
     num_monomials: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_precompute_lambda_combinations(
         out.as_mut_ptr(),
@@ -1222,6 +1304,7 @@ pub unsafe fn precompute_lambda_combinations(
         lambda_terms,
         lambda_pows.as_ptr(),
         num_monomials,
+        stream,
     ))
 }
 
@@ -1231,6 +1314,7 @@ pub unsafe fn precompute_logup_numer_combinations(
     terms: *const InteractionMonomialTerm<F>,
     eq_3bs: &DeviceBuffer<EF>,
     num_monomials: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_precompute_logup_numer_combinations(
         out.as_mut_ptr(),
@@ -1238,6 +1322,7 @@ pub unsafe fn precompute_logup_numer_combinations(
         terms,
         eq_3bs.as_ptr(),
         num_monomials,
+        stream,
     ))
 }
 
@@ -1248,6 +1333,7 @@ pub unsafe fn precompute_logup_denom_combinations(
     beta_pows: &DeviceBuffer<EF>,
     eq_3bs: &DeviceBuffer<EF>,
     num_monomials: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_precompute_logup_denom_combinations(
         out.as_mut_ptr(),
@@ -1256,6 +1342,7 @@ pub unsafe fn precompute_logup_denom_combinations(
         beta_pows.as_ptr(),
         eq_3bs.as_ptr(),
         num_monomials,
+        stream,
     ))
 }
 
@@ -1272,6 +1359,7 @@ pub unsafe fn logup_monomial_batched(
     num_x: u32,
     num_airs: u32,
     threads_per_block: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_logup_monomial_batched(
         tmp_sums.as_mut_ptr(),
@@ -1285,6 +1373,7 @@ pub unsafe fn logup_monomial_batched(
         num_x,
         num_airs,
         threads_per_block,
+        stream,
     ))
 }
 
@@ -1292,9 +1381,10 @@ pub unsafe fn frac_vector_scalar_multiply_ext_fp(
     frac_vec: *mut Frac<EF>,
     scalar: F,
     length: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_frac_vector_scalar_multiply_ext_fp(
-        frac_vec, scalar, length,
+        frac_vec, scalar, length, stream,
     ))
 }
 
@@ -1310,6 +1400,7 @@ pub unsafe fn frac_matrix_vertically_repeat(
     width: u32,
     lifted_height: u32,
     height: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(lifted_height > height);
     CudaError::from_result(_frac_matrix_vertically_repeat(
@@ -1318,6 +1409,7 @@ pub unsafe fn frac_matrix_vertically_repeat(
         width,
         lifted_height,
         height,
+        stream,
     ))
 }
 
@@ -1329,6 +1421,7 @@ pub unsafe fn frac_matrix_vertically_repeat_ext(
     width: u32,
     lifted_height: u32,
     height: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(lifted_height > height);
     CudaError::from_result(_frac_matrix_vertically_repeat_ext(
@@ -1339,6 +1432,7 @@ pub unsafe fn frac_matrix_vertically_repeat_ext(
         width,
         lifted_height,
         height,
+        stream,
     ))
 }
 
@@ -1351,6 +1445,7 @@ pub unsafe fn fold_selectors_round0(
     is_first: EF,
     is_last: EF,
     num_x: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_fold_selectors_round0(
         out,
@@ -1358,5 +1453,6 @@ pub unsafe fn fold_selectors_round0(
         is_first,
         is_last,
         num_x as u32,
+        stream,
     ))
 }

--- a/crates/cuda-backend/src/cuda/matrix.rs
+++ b/crates/cuda-backend/src/cuda/matrix.rs
@@ -1,4 +1,4 @@
-use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError};
+use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::cudaStream_t};
 
 use crate::prelude::{EF, F};
 
@@ -10,6 +10,7 @@ extern "C" {
         input: *const F,
         col_size: usize,
         row_size: usize,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _matrix_transpose_fpext(
@@ -17,6 +18,7 @@ extern "C" {
         input: *const EF,
         col_size: usize,
         row_size: usize,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _matrix_get_rows_fp(
@@ -26,6 +28,7 @@ extern "C" {
         matrix_width: u64,
         matrix_height: u64,
         row_indices_len: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _split_ext_to_base_col_major_matrix(
@@ -33,6 +36,7 @@ extern "C" {
         d_poly: *const EF,
         poly_len: u64,
         matrix_height: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _batch_rotate_pad(
@@ -42,6 +46,7 @@ extern "C" {
         num_x: u32,
         domain_size: u32,
         padded_size: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _lift_padded_matrix_evals(
@@ -50,6 +55,7 @@ extern "C" {
         height: u32,
         lifted_height: u32,
         padded_height: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _collapse_strided_matrix(
@@ -58,6 +64,7 @@ extern "C" {
         width: u32,
         height: u32,
         stride: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _batch_expand_pad(
@@ -66,6 +73,7 @@ extern "C" {
         poly_count: u32,
         out_size: u32,
         in_size: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _batch_expand_pad_wide(
@@ -74,6 +82,7 @@ extern "C" {
         width: u32,
         padded_height: u32,
         height: u32,
+        stream: cudaStream_t,
     ) -> i32;
 }
 
@@ -85,12 +94,14 @@ pub unsafe fn matrix_transpose_fp(
     input: &DeviceBuffer<F>,
     width: usize,
     height: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_matrix_transpose_fp(
         output.as_mut_ptr(),
         input.as_ptr(),
         width,
         height,
+        stream,
     ))
 }
 
@@ -102,12 +113,14 @@ pub unsafe fn matrix_transpose_fpext(
     input: &DeviceBuffer<EF>,
     width: usize,
     height: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_matrix_transpose_fpext(
         output.as_mut_ptr(),
         input.as_ptr(),
         width,
         height,
+        stream,
     ))
 }
 
@@ -118,6 +131,7 @@ pub unsafe fn matrix_get_rows_fp_kernel(
     matrix_width: u64,
     matrix_height: u64,
     row_indices_len: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     if matrix_width == 0 || row_indices_len == 0 {
         return Ok(());
@@ -132,6 +146,7 @@ pub unsafe fn matrix_get_rows_fp_kernel(
         matrix_width,
         matrix_height,
         row_indices_len as u32,
+        stream,
     ))
 }
 
@@ -140,12 +155,14 @@ pub unsafe fn split_ext_to_base_col_major_matrix(
     d_poly: &DeviceBuffer<EF>,
     poly_len: u64,
     matrix_height: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_split_ext_to_base_col_major_matrix(
         d_matrix.as_mut_ptr(),
         d_poly.as_ptr(),
         poly_len,
         matrix_height,
+        stream,
     ))
 }
 
@@ -167,6 +184,7 @@ pub unsafe fn batch_rotate_pad(
     num_x: u32,
     domain_size: u32,
     padded_size: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(domain_size <= padded_size);
     debug_assert!(width.checked_mul(num_x).unwrap() < u16::MAX as u32 * u16::MAX as u32);
@@ -177,6 +195,7 @@ pub unsafe fn batch_rotate_pad(
         num_x,
         domain_size,
         padded_size,
+        stream,
     ))
 }
 
@@ -195,6 +214,7 @@ pub unsafe fn lift_padded_matrix_evals(
     height: u32,
     lifted_height: u32,
     padded_height: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(height <= lifted_height && lifted_height <= padded_height);
     CudaError::from_result(_lift_padded_matrix_evals(
@@ -203,6 +223,7 @@ pub unsafe fn lift_padded_matrix_evals(
         height,
         lifted_height,
         padded_height,
+        stream,
     ))
 }
 
@@ -218,9 +239,10 @@ pub unsafe fn collapse_strided_matrix(
     width: u32,
     height: u32,
     stride: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_collapse_strided_matrix(
-        output, input, width, height, stride,
+        output, input, width, height, stride, stream,
     ))
 }
 
@@ -230,9 +252,10 @@ pub unsafe fn batch_expand_pad(
     poly_count: u32,
     out_size: u32,
     in_size: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_batch_expand_pad(
-        output, input, poly_count, out_size, in_size,
+        output, input, poly_count, out_size, in_size, stream,
     ))
 }
 
@@ -249,6 +272,7 @@ pub unsafe fn batch_expand_pad_wide(
     width: u32,
     padded_height: u32,
     height: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(padded_height > height);
     CudaError::from_result(_batch_expand_pad_wide(
@@ -257,5 +281,6 @@ pub unsafe fn batch_expand_pad_wide(
         width,
         padded_height,
         height,
+        stream,
     ))
 }

--- a/crates/cuda-backend/src/cuda/merkle_tree.rs
+++ b/crates/cuda-backend/src/cuda/merkle_tree.rs
@@ -1,4 +1,4 @@
-use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError};
+use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::cudaStream_t};
 
 use crate::prelude::{Digest, EF, F};
 
@@ -21,6 +21,7 @@ extern "C" {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _poseidon2_compressing_row_hashes_ext(
@@ -29,6 +30,7 @@ extern "C" {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _poseidon2_strided_compress_layer(
@@ -36,12 +38,14 @@ extern "C" {
         prev_layer: *const Digest,
         output_size: usize,
         stride: usize,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _poseidon2_adjacent_compress_layer(
         output: *mut Digest,
         prev_layer: *const Digest,
         output_size: usize,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _query_digest_layers(
@@ -50,6 +54,7 @@ extern "C" {
         d_indices: *const u64,
         num_query: u64,
         num_layer: u64,
+        stream: cudaStream_t,
     ) -> i32;
 }
 
@@ -67,6 +72,7 @@ pub unsafe fn poseidon2_compressing_row_hashes(
     width: usize,
     query_stride: usize,
     log_rows_per_query: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     validate_merkle_log_rows_per_query(log_rows_per_query)?;
     debug_assert!(matrix.len() >= width * (query_stride << log_rows_per_query));
@@ -77,6 +83,7 @@ pub unsafe fn poseidon2_compressing_row_hashes(
         width,
         query_stride,
         log_rows_per_query,
+        stream,
     ))
 }
 
@@ -97,6 +104,7 @@ pub unsafe fn poseidon2_compressing_row_hashes_ext(
     width: usize,
     query_stride: usize,
     log_rows_per_query: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     validate_merkle_log_rows_per_query(log_rows_per_query)?;
     debug_assert!(matrix.len() >= width * (query_stride << log_rows_per_query));
@@ -107,6 +115,7 @@ pub unsafe fn poseidon2_compressing_row_hashes_ext(
         width,
         query_stride,
         log_rows_per_query,
+        stream,
     ))
 }
 
@@ -124,6 +133,7 @@ pub unsafe fn poseidon2_strided_compress_layer(
     prev_layer: &DeviceBuffer<Digest>,
     output_size: usize,
     stride: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(stride > 0 && stride <= output_size);
     debug_assert!(output.len() >= output_size);
@@ -133,6 +143,7 @@ pub unsafe fn poseidon2_strided_compress_layer(
         prev_layer.as_ptr(),
         output_size,
         stride,
+        stream,
     ))
 }
 
@@ -147,6 +158,7 @@ pub unsafe fn poseidon2_adjacent_compress_layer(
     output: &mut DeviceBuffer<Digest>,
     prev_layer: &DeviceBuffer<Digest>,
     output_size: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(output.len() >= output_size);
     debug_assert!(prev_layer.len() >= output_size * 2);
@@ -154,6 +166,7 @@ pub unsafe fn poseidon2_adjacent_compress_layer(
         output.as_mut_ptr(),
         prev_layer.as_ptr(),
         output_size,
+        stream,
     ))
 }
 
@@ -163,6 +176,7 @@ pub unsafe fn query_digest_layers(
     d_indices: &DeviceBuffer<u64>,
     num_query: usize,
     num_layer: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     if num_query == 0 || num_layer == 0 {
         return Ok(());
@@ -176,5 +190,6 @@ pub unsafe fn query_digest_layers(
         d_indices.as_ptr(),
         num_query as u64,
         num_layer as u64,
+        stream,
     ))
 }

--- a/crates/cuda-backend/src/cuda/mle_interpolate.rs
+++ b/crates/cuda-backend/src/cuda/mle_interpolate.rs
@@ -1,6 +1,7 @@
 use openvm_cuda_common::{
     d_buffer::DeviceBuffer,
     error::{check, CudaError},
+    stream::cudaStream_t,
 };
 
 use crate::{
@@ -14,6 +15,7 @@ extern "C" {
         total_len: usize,
         step: u32,
         is_eval_to_coeff: bool,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _mle_interpolate_stage_ext(
@@ -21,6 +23,7 @@ extern "C" {
         total_len: usize,
         step: u32,
         is_eval_to_coeff: bool,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _mle_interpolate_stage_2d(
@@ -30,6 +33,7 @@ extern "C" {
         padded_height: u32,
         step: u32,
         is_eval_to_coeff: bool,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _mle_interpolate_fused_2d(
@@ -41,6 +45,7 @@ extern "C" {
         num_stages: u32,
         is_eval_to_coeff: bool,
         right_pad: bool,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _mle_interpolate_shared_2d(
@@ -52,6 +57,7 @@ extern "C" {
         end_log_step: u32,
         is_eval_to_coeff: bool,
         right_pad: bool,
+        stream: cudaStream_t,
     ) -> i32;
 }
 
@@ -78,12 +84,14 @@ pub unsafe fn mle_interpolate_stage(
     buffer: &mut DeviceBuffer<F>,
     step: u32,
     is_eval_to_coeff: bool,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     check(_mle_interpolate_stage(
         buffer.as_mut_ptr(),
         buffer.len(),
         step,
         is_eval_to_coeff,
+        stream,
     ))
 }
 
@@ -92,12 +100,14 @@ pub unsafe fn mle_interpolate_stage_ext(
     buffer: &mut DeviceBuffer<EF>,
     step: u32,
     is_eval_to_coeff: bool,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     check(_mle_interpolate_stage_ext(
         buffer.as_mut_ptr(),
         buffer.len(),
         step,
         is_eval_to_coeff,
+        stream,
     ))
 }
 
@@ -115,6 +125,7 @@ pub unsafe fn mle_interpolate_stage_2d(
     padded_height: u32,
     step: u32,
     is_eval_to_coeff: bool,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     let width = narrow_mle_width(width)?;
     debug_assert!(height <= padded_height);
@@ -126,6 +137,7 @@ pub unsafe fn mle_interpolate_stage_2d(
         padded_height,
         step,
         is_eval_to_coeff,
+        stream,
     ))
 }
 
@@ -156,6 +168,7 @@ pub unsafe fn mle_interpolate_fused_2d(
     num_stages: u32,
     is_eval_to_coeff: bool,
     right_pad: bool,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     let width = narrow_mle_width(width)?;
     debug_assert!((1..=LOG_WARP_SIZE as u32).contains(&num_stages));
@@ -169,6 +182,7 @@ pub unsafe fn mle_interpolate_fused_2d(
         num_stages,
         is_eval_to_coeff,
         right_pad,
+        stream,
     ))
 }
 
@@ -197,6 +211,7 @@ pub unsafe fn mle_interpolate_shared_2d(
     end_log_step: u32,
     is_eval_to_coeff: bool,
     right_pad: bool,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     let width = narrow_mle_width(width)?;
     debug_assert!(end_log_step < MLE_SHARED_TILE_LOG_SIZE);
@@ -209,5 +224,6 @@ pub unsafe fn mle_interpolate_shared_2d(
         end_log_step,
         is_eval_to_coeff,
         right_pad,
+        stream,
     ))
 }

--- a/crates/cuda-backend/src/cuda/mod.rs
+++ b/crates/cuda-backend/src/cuda/mod.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 #![allow(clippy::missing_safety_doc)]
 
-use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError};
+use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::cudaStream_t};
 use openvm_stark_backend::prover::fractional_sumcheck_gkr::Frac;
 
 use crate::prelude::{EF, F};
@@ -40,6 +40,7 @@ pub mod sumcheck {
             num_matrices: u32,
             height: u32,
             d: u32,
+            stream: cudaStream_t,
         ) -> i32;
 
         fn _fold_mle(
@@ -50,9 +51,10 @@ pub mod sumcheck {
             output_height: u32,
             max_output_cells: u32,
             r_val: EF,
+            stream: cudaStream_t,
         ) -> i32;
 
-        fn _fold_mle_column(buffer: *mut std::ffi::c_void, size: usize, r: EF) -> i32;
+        fn _fold_mle_column(buffer: *mut std::ffi::c_void, size: usize, r: EF, stream: cudaStream_t) -> i32;
 
         fn _batch_fold_mle(
             input_matrices: *const *const EF,
@@ -62,6 +64,7 @@ pub mod sumcheck {
             log_output_heights: *const u8,
             max_output_cells: u32,
             r_val: EF,
+            stream: cudaStream_t,
         ) -> i32;
 
         fn _reduce_over_x_and_cols(
@@ -70,6 +73,7 @@ pub mod sumcheck {
             num_x: u32,
             num_cols: u32,
             large_domain_size: u32,
+            stream: cudaStream_t,
         ) -> i32;
 
         fn _fold_ple_from_coeffs(
@@ -79,9 +83,10 @@ pub mod sumcheck {
             width: u32,
             domain_size: u32,
             r: EF,
+            stream: cudaStream_t,
         ) -> i32;
 
-        fn _triangular_fold_mle(output: *mut EF, input: *const EF, r: EF, output_max_n: u32)
+        fn _triangular_fold_mle(output: *mut EF, input: *const EF, r: EF, output_max_n: u32, stream: cudaStream_t)
             -> i32;
     }
 
@@ -93,6 +98,7 @@ pub mod sumcheck {
         num_matrices: u32,
         height: u32,
         d: u32,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError> {
         if d == 0 || d > MAX_SUMCHECK_MLE_ROUND_D {
             return Err(CudaError::new(1));
@@ -105,6 +111,7 @@ pub mod sumcheck {
             num_matrices,
             height,
             d,
+            stream,
         ))
     }
 
@@ -119,6 +126,7 @@ pub mod sumcheck {
         output_height: u32,
         max_output_cells: u32,
         r_val: EF,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError> {
         CudaError::from_result(_fold_mle(
             input_matrices.as_ptr(),
@@ -128,6 +136,7 @@ pub mod sumcheck {
             output_height,
             max_output_cells,
             r_val,
+            stream,
         ))
     }
 
@@ -135,8 +144,9 @@ pub mod sumcheck {
         buffer: &mut DeviceBuffer<EF>,
         size: usize,
         r: EF,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError> {
-        CudaError::from_result(_fold_mle_column(buffer.as_mut_raw_ptr(), size, r))
+        CudaError::from_result(_fold_mle_column(buffer.as_mut_raw_ptr(), size, r, stream))
     }
 
     /// # Safety
@@ -150,6 +160,7 @@ pub mod sumcheck {
         log_output_heights: &DeviceBuffer<u8>,
         max_output_cells: u32,
         r_val: EF,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError> {
         CudaError::from_result(_batch_fold_mle(
             input_matrices.as_ptr(),
@@ -159,6 +170,7 @@ pub mod sumcheck {
             log_output_heights.as_ptr(),
             max_output_cells,
             r_val,
+            stream,
         ))
     }
 
@@ -169,6 +181,7 @@ pub mod sumcheck {
         width: u32,
         domain_size: u32,
         r: EF,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError> {
         CudaError::from_result(_fold_ple_from_coeffs(
             input_coeffs as *const c_void,
@@ -177,6 +190,7 @@ pub mod sumcheck {
             width,
             domain_size,
             r,
+            stream,
         ))
     }
 
@@ -186,6 +200,7 @@ pub mod sumcheck {
         num_x: u32,
         num_cols: u32,
         large_domain_size: u32,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError> {
         CudaError::from_result(_reduce_over_x_and_cols(
             input.as_raw_ptr(),
@@ -193,6 +208,7 @@ pub mod sumcheck {
             num_x,
             num_cols,
             large_domain_size,
+            stream,
         ))
     }
 
@@ -206,6 +222,7 @@ pub mod sumcheck {
         input: &EqEvalSegments<EF>,
         r: EF,
         output_max_n: usize,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError> {
         debug_assert_eq!(output.buffer.len(), 2 << output_max_n);
         debug_assert_eq!(input.buffer.len(), 4 << output_max_n);
@@ -214,6 +231,7 @@ pub mod sumcheck {
             input.buffer.as_ptr(),
             r,
             output_max_n as u32,
+            stream,
         ))
     }
 }
@@ -228,15 +246,17 @@ pub mod prefix {
             length: u64,
             round_stride: u64,
             block_num: u64,
+            stream: cudaStream_t,
         ) -> i32;
 
         fn _prefix_scan_block_downsweep_ext(
             d_inout: *mut std::ffi::c_void,
             length: u64,
             round_stride: u64,
+            stream: cudaStream_t,
         ) -> i32;
 
-        fn _prefix_scan_epilogue_ext(d_inout: *mut std::ffi::c_void, length: u64) -> i32;
+        fn _prefix_scan_epilogue_ext(d_inout: *mut std::ffi::c_void, length: u64, stream: cudaStream_t) -> i32;
     }
 
     pub unsafe fn prefix_scan_block_ext<T>(
@@ -244,12 +264,14 @@ pub mod prefix {
         length: u64,
         round_stride: u64,
         block_num: u64,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError> {
         CudaError::from_result(_prefix_scan_block_ext(
             d_inout.as_mut_raw_ptr(),
             length,
             round_stride,
             block_num,
+            stream,
         ))
     }
 
@@ -257,18 +279,21 @@ pub mod prefix {
         d_inout: &DeviceBuffer<T>,
         length: u64,
         round_stride: u64,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError> {
         CudaError::from_result(_prefix_scan_block_downsweep_ext(
             d_inout.as_mut_raw_ptr(),
             length,
             round_stride,
+            stream,
         ))
     }
 
     pub unsafe fn prefix_scan_epilogue_ext<T>(
         d_inout: &DeviceBuffer<T>,
         length: u64,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError> {
-        CudaError::from_result(_prefix_scan_epilogue_ext(d_inout.as_mut_raw_ptr(), length))
+        CudaError::from_result(_prefix_scan_epilogue_ext(d_inout.as_mut_raw_ptr(), length, stream))
     }
 }

--- a/crates/cuda-backend/src/cuda/mod.rs
+++ b/crates/cuda-backend/src/cuda/mod.rs
@@ -54,7 +54,12 @@ pub mod sumcheck {
             stream: cudaStream_t,
         ) -> i32;
 
-        fn _fold_mle_column(buffer: *mut std::ffi::c_void, size: usize, r: EF, stream: cudaStream_t) -> i32;
+        fn _fold_mle_column(
+            buffer: *mut std::ffi::c_void,
+            size: usize,
+            r: EF,
+            stream: cudaStream_t,
+        ) -> i32;
 
         fn _batch_fold_mle(
             input_matrices: *const *const EF,
@@ -86,10 +91,16 @@ pub mod sumcheck {
             stream: cudaStream_t,
         ) -> i32;
 
-        fn _triangular_fold_mle(output: *mut EF, input: *const EF, r: EF, output_max_n: u32, stream: cudaStream_t)
-            -> i32;
+        fn _triangular_fold_mle(
+            output: *mut EF,
+            input: *const EF,
+            r: EF,
+            output_max_n: u32,
+            stream: cudaStream_t,
+        ) -> i32;
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub unsafe fn sumcheck_mle_round(
         input_matrices: &DeviceBuffer<*const EF>,
         output: &DeviceBuffer<EF>,
@@ -118,6 +129,7 @@ pub mod sumcheck {
     /// # Safety
     /// - `input_matrices` must consist of pointers to device memory locations.
     /// - `output_matrices` must consist of pointers to device memory locations.
+    #[allow(clippy::too_many_arguments)]
     pub unsafe fn fold_mle(
         input_matrices: &DeviceBuffer<*const EF>,
         output_matrices: &DeviceBuffer<*mut EF>,
@@ -152,6 +164,7 @@ pub mod sumcheck {
     /// # Safety
     /// - `input_matrices` must consist of pointers to device memory locations.
     /// - `output_matrices` must consist of pointers to device memory locations.
+    #[allow(clippy::too_many_arguments)]
     pub unsafe fn batch_fold_mle(
         input_matrices: &DeviceBuffer<*const EF>,
         output_matrices: &DeviceBuffer<*mut EF>,
@@ -256,7 +269,11 @@ pub mod prefix {
             stream: cudaStream_t,
         ) -> i32;
 
-        fn _prefix_scan_epilogue_ext(d_inout: *mut std::ffi::c_void, length: u64, stream: cudaStream_t) -> i32;
+        fn _prefix_scan_epilogue_ext(
+            d_inout: *mut std::ffi::c_void,
+            length: u64,
+            stream: cudaStream_t,
+        ) -> i32;
     }
 
     pub unsafe fn prefix_scan_block_ext<T>(
@@ -294,6 +311,10 @@ pub mod prefix {
         length: u64,
         stream: cudaStream_t,
     ) -> Result<(), CudaError> {
-        CudaError::from_result(_prefix_scan_epilogue_ext(d_inout.as_mut_raw_ptr(), length, stream))
+        CudaError::from_result(_prefix_scan_epilogue_ext(
+            d_inout.as_mut_raw_ptr(),
+            length,
+            stream,
+        ))
     }
 }

--- a/crates/cuda-backend/src/cuda/ntt.rs
+++ b/crates/cuda-backend/src/cuda/ntt.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::too_many_arguments)]
 
-use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError};
+use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::cudaStream_t};
 
 use crate::prelude::{EF, F};
 
@@ -9,24 +9,27 @@ pub const MAX_CUDA_NTT_LOG_DOMAIN_SIZE: u32 = 27;
 
 // relate to supra/ntt_params.cu
 extern "C" {
-    fn _generate_all_twiddles(twiddles: *mut std::ffi::c_void, inverse: bool) -> i32;
-    fn _generate_partial_twiddles(partial_twiddles: *mut std::ffi::c_void, inverse: bool) -> i32;
+    fn _generate_all_twiddles(twiddles: *mut std::ffi::c_void, inverse: bool, stream: cudaStream_t) -> i32;
+    fn _generate_partial_twiddles(partial_twiddles: *mut std::ffi::c_void, inverse: bool, stream: cudaStream_t) -> i32;
 }
 
 pub unsafe fn generate_all_twiddles<F>(
     twiddles: &DeviceBuffer<F>,
     inverse: bool,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
-    CudaError::from_result(_generate_all_twiddles(twiddles.as_mut_raw_ptr(), inverse))
+    CudaError::from_result(_generate_all_twiddles(twiddles.as_mut_raw_ptr(), inverse, stream))
 }
 
 pub unsafe fn generate_partial_twiddles<F>(
     partial_twiddles: &DeviceBuffer<F>,
     inverse: bool,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_generate_partial_twiddles(
         partial_twiddles.as_mut_raw_ptr(),
         inverse,
+        stream,
     ))
 }
 
@@ -38,6 +41,7 @@ extern "C" {
         lg_domain_size: u32,
         padded_poly_size: u32,
         poly_count: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _bit_rev_ext(
@@ -46,6 +50,7 @@ extern "C" {
         lg_domain_size: u32,
         padded_poly_size: u32,
         poly_count: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _bit_rev_frac_ext(
@@ -54,6 +59,7 @@ extern "C" {
         lg_domain_size: u32,
         padded_poly_size: u32,
         poly_count: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     /// Fused bitrev + K=2 tree build for a single frac_fpext_t buffer.
@@ -63,6 +69,7 @@ extern "C" {
         inout: *mut std::ffi::c_void,
         lg_domain_size: u32,
         alpha: EF,
+        stream: cudaStream_t,
     ) -> i32;
 }
 
@@ -72,6 +79,7 @@ pub unsafe fn bit_rev(
     lg_domain_size: u32,
     padded_poly_size: u32,
     poly_count: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_bit_rev(
         d_out.as_mut_raw_ptr(),
@@ -79,6 +87,7 @@ pub unsafe fn bit_rev(
         lg_domain_size,
         padded_poly_size,
         poly_count,
+        stream,
     ))
 }
 
@@ -88,6 +97,7 @@ pub unsafe fn bit_rev_ext(
     lg_domain_size: u32,
     padded_poly_size: u32,
     poly_count: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_bit_rev_ext(
         d_out.as_mut_raw_ptr(),
@@ -95,6 +105,7 @@ pub unsafe fn bit_rev_ext(
         lg_domain_size,
         padded_poly_size,
         poly_count,
+        stream,
     ))
 }
 
@@ -104,6 +115,7 @@ pub unsafe fn bit_rev_frac_ext(
     lg_domain_size: u32,
     padded_poly_size: u32,
     poly_count: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_bit_rev_frac_ext(
         d_out.as_mut_raw_ptr(),
@@ -111,6 +123,7 @@ pub unsafe fn bit_rev_frac_ext(
         lg_domain_size,
         padded_poly_size,
         poly_count,
+        stream,
     ))
 }
 
@@ -118,11 +131,13 @@ pub unsafe fn bit_rev_frac_ext_build_k2(
     inout: &DeviceBuffer<(EF, EF)>,
     lg_domain_size: u32,
     alpha: EF,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_bit_rev_frac_ext_build_k2(
         inout.as_mut_raw_ptr(),
         lg_domain_size,
         alpha,
+        stream,
     ))
 }
 
@@ -137,6 +152,7 @@ extern "C" {
         padded_poly_size: u32,
         poly_count: u32,
         is_intt: bool,
+        stream: cudaStream_t,
     ) -> i32;
 }
 
@@ -149,6 +165,7 @@ pub unsafe fn ct_mixed_radix_narrow(
     padded_poly_size: u32,
     poly_count: u32,
     is_intt: bool,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     if lg_domain_size > MAX_CUDA_NTT_LOG_DOMAIN_SIZE {
         return Err(CudaError::new(1));
@@ -162,5 +179,6 @@ pub unsafe fn ct_mixed_radix_narrow(
         padded_poly_size,
         poly_count,
         is_intt,
+        stream,
     ))
 }

--- a/crates/cuda-backend/src/cuda/ntt.rs
+++ b/crates/cuda-backend/src/cuda/ntt.rs
@@ -9,8 +9,16 @@ pub const MAX_CUDA_NTT_LOG_DOMAIN_SIZE: u32 = 27;
 
 // relate to supra/ntt_params.cu
 extern "C" {
-    fn _generate_all_twiddles(twiddles: *mut std::ffi::c_void, inverse: bool, stream: cudaStream_t) -> i32;
-    fn _generate_partial_twiddles(partial_twiddles: *mut std::ffi::c_void, inverse: bool, stream: cudaStream_t) -> i32;
+    fn _generate_all_twiddles(
+        twiddles: *mut std::ffi::c_void,
+        inverse: bool,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn _generate_partial_twiddles(
+        partial_twiddles: *mut std::ffi::c_void,
+        inverse: bool,
+        stream: cudaStream_t,
+    ) -> i32;
 }
 
 pub unsafe fn generate_all_twiddles<F>(
@@ -18,7 +26,11 @@ pub unsafe fn generate_all_twiddles<F>(
     inverse: bool,
     stream: cudaStream_t,
 ) -> Result<(), CudaError> {
-    CudaError::from_result(_generate_all_twiddles(twiddles.as_mut_raw_ptr(), inverse, stream))
+    CudaError::from_result(_generate_all_twiddles(
+        twiddles.as_mut_raw_ptr(),
+        inverse,
+        stream,
+    ))
 }
 
 pub unsafe fn generate_partial_twiddles<F>(

--- a/crates/cuda-backend/src/cuda/poly.rs
+++ b/crates/cuda-backend/src/cuda/poly.rs
@@ -2,7 +2,7 @@ use openvm_cuda_common::{
     copy::MemCopyD2H,
     d_buffer::DeviceBuffer,
     error::{check, CudaError},
-    stream::{cudaStream_t, DeviceContext},
+    stream::{cudaStream_t, GpuDeviceCtx},
 };
 
 use crate::{
@@ -221,7 +221,7 @@ pub unsafe fn eval_poly_ext_at_point_from_base(
     base_coeffs: &DeviceBuffer<F>,
     coeff_len: usize,
     x: EF,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<EF, KernelError> {
     debug_assert!(base_coeffs.len() >= coeff_len * D_EF);
     let d_out = DeviceBuffer::<EF>::with_capacity_on(1, device_ctx);

--- a/crates/cuda-backend/src/cuda/poly.rs
+++ b/crates/cuda-backend/src/cuda/poly.rs
@@ -221,19 +221,19 @@ pub unsafe fn eval_poly_ext_at_point_from_base(
     base_coeffs: &DeviceBuffer<F>,
     coeff_len: usize,
     x: EF,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<EF, KernelError> {
     debug_assert!(base_coeffs.len() >= coeff_len * D_EF);
-    let d_out = DeviceBuffer::<EF>::with_capacity_on(1, ctx);
+    let d_out = DeviceBuffer::<EF>::with_capacity_on(1, device_ctx);
     check(_eval_poly_ext_at_point(
         base_coeffs.as_ptr(),
         coeff_len,
         x,
         d_out.as_mut_ptr(),
-        ctx.stream.as_raw(),
+        device_ctx.stream.as_raw(),
     ))
     .map_err(KernelError::Kernel)?;
-    let out = d_out.to_host_on(ctx).map_err(KernelError::MemCopy)?;
+    let out = d_out.to_host_on(device_ctx).map_err(KernelError::MemCopy)?;
     Ok(out[0])
 }
 

--- a/crates/cuda-backend/src/cuda/poly.rs
+++ b/crates/cuda-backend/src/cuda/poly.rs
@@ -24,7 +24,12 @@ extern "C" {
 
     fn _eq_hypercube_stage_ext(out: *mut EF, x_i: EF, step: u32, stream: cudaStream_t) -> i32;
 
-    fn _mobius_eq_hypercube_stage_ext(out: *mut EF, omega_i: EF, step: u32, stream: cudaStream_t) -> i32;
+    fn _mobius_eq_hypercube_stage_ext(
+        out: *mut EF,
+        omega_i: EF,
+        step: u32,
+        stream: cudaStream_t,
+    ) -> i32;
 
     fn _eq_hypercube_nonoverlapping_stage_ext(
         out: *mut EF,
@@ -53,12 +58,27 @@ extern "C" {
     ) -> i32;
 
     // `out` must be device ptr
-    fn _eval_poly_ext_at_point(base_coeffs: *const F, coeff_len: usize, x: EF, out: *mut EF, stream: cudaStream_t)
-        -> i32;
+    fn _eval_poly_ext_at_point(
+        base_coeffs: *const F,
+        coeff_len: usize,
+        x: EF,
+        out: *mut EF,
+        stream: cudaStream_t,
+    ) -> i32;
 
-    fn _vector_scalar_multiply_ext(vec: *mut EF, scalar: EF, length: u32, stream: cudaStream_t) -> i32;
+    fn _vector_scalar_multiply_ext(
+        vec: *mut EF,
+        scalar: EF,
+        length: u32,
+        stream: cudaStream_t,
+    ) -> i32;
 
-    fn _transpose_fp_to_fpext_vec(output: *mut EF, input: *const F, height: u32, stream: cudaStream_t) -> i32;
+    fn _transpose_fp_to_fpext_vec(
+        output: *mut EF,
+        input: *const F,
+        height: u32,
+        stream: cudaStream_t,
+    ) -> i32;
 }
 
 /// Computes the algebraic batch of the column vectors from input matrices `mats`, in order.
@@ -69,6 +89,7 @@ extern "C" {
 /// - `mats[i]` must have length `>= widths[i] * height` for all `i`.
 /// - `mats`, `mu_idxs`, `widths` must have length `>= num_mats`.
 /// - `mu_idxs[i] < mu_powers.len()` for all `i`.
+#[allow(clippy::too_many_arguments)]
 pub unsafe fn algebraic_batch_matrices(
     output: &mut DeviceBuffer<EF>,
     mat_ptrs: &DeviceBuffer<*const F>,
@@ -100,7 +121,12 @@ pub unsafe fn algebraic_batch_matrices(
 ///
 /// # Safety
 /// - `out` is **device** pointer with length `>= 2 * step`.
-pub unsafe fn eq_hypercube_stage_ext(out: *mut EF, x_i: EF, step: u32, stream: cudaStream_t) -> Result<(), CudaError> {
+pub unsafe fn eq_hypercube_stage_ext(
+    out: *mut EF,
+    x_i: EF,
+    step: u32,
+    stream: cudaStream_t,
+) -> Result<(), CudaError> {
     check(_eq_hypercube_stage_ext(out, x_i, step, stream))
 }
 
@@ -155,7 +181,9 @@ pub unsafe fn eq_hypercube_interleaved_stage_ext(
     step: u32,
     stream: cudaStream_t,
 ) -> Result<(), CudaError> {
-    check(_eq_hypercube_interleaved_stage_ext(out, input, x_i, step, stream))
+    check(_eq_hypercube_interleaved_stage_ext(
+        out, input, x_i, step, stream,
+    ))
 }
 
 /// Same as `eq_hypercube_stage`, over base field, but computes `eq` evals in batch for multiple
@@ -210,7 +238,11 @@ pub unsafe fn eval_poly_ext_at_point_from_base(
 }
 
 /// Scalar multiplication of a vector in-place by `scalar.
-pub fn vector_scalar_multiply_ext(vec: &mut DeviceBuffer<EF>, scalar: EF, stream: cudaStream_t) -> Result<(), CudaError> {
+pub fn vector_scalar_multiply_ext(
+    vec: &mut DeviceBuffer<EF>,
+    scalar: EF,
+    stream: cudaStream_t,
+) -> Result<(), CudaError> {
     // SAFETY: `vec` is allocated for `vec.len()` so scalar multiplication is safe.
     unsafe {
         check(_vector_scalar_multiply_ext(

--- a/crates/cuda-backend/src/cuda/poly.rs
+++ b/crates/cuda-backend/src/cuda/poly.rs
@@ -2,7 +2,7 @@ use openvm_cuda_common::{
     copy::MemCopyD2H,
     d_buffer::DeviceBuffer,
     error::{check, CudaError},
-    stream::cudaStream_t,
+    stream::{cudaStream_t, DeviceContext},
 };
 
 use crate::{
@@ -221,19 +221,19 @@ pub unsafe fn eval_poly_ext_at_point_from_base(
     base_coeffs: &DeviceBuffer<F>,
     coeff_len: usize,
     x: EF,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<EF, KernelError> {
     debug_assert!(base_coeffs.len() >= coeff_len * D_EF);
-    let d_out = DeviceBuffer::<EF>::with_capacity(1);
+    let d_out = DeviceBuffer::<EF>::with_capacity_on(1, ctx);
     check(_eval_poly_ext_at_point(
         base_coeffs.as_ptr(),
         coeff_len,
         x,
         d_out.as_mut_ptr(),
-        stream,
+        ctx.stream.as_raw(),
     ))
     .map_err(KernelError::Kernel)?;
-    let out = d_out.to_host().map_err(KernelError::MemCopy)?;
+    let out = d_out.to_host_on(ctx).map_err(KernelError::MemCopy)?;
     Ok(out[0])
 }
 

--- a/crates/cuda-backend/src/cuda/poly.rs
+++ b/crates/cuda-backend/src/cuda/poly.rs
@@ -201,7 +201,7 @@ pub unsafe fn batch_eq_hypercube_stage(
 ) -> Result<(), CudaError> {
     let width = x.len() as u32;
     debug_assert!(step < height);
-    debug_assert!(out.len() <= (width * height) as usize);
+    debug_assert!(out.len() >= (width * height) as usize);
     check(_batch_eq_hypercube_stage(
         out.as_mut_ptr(),
         x.as_ptr(),

--- a/crates/cuda-backend/src/cuda/poly.rs
+++ b/crates/cuda-backend/src/cuda/poly.rs
@@ -2,6 +2,7 @@ use openvm_cuda_common::{
     copy::MemCopyD2H,
     d_buffer::DeviceBuffer,
     error::{check, CudaError},
+    stream::cudaStream_t,
 };
 
 use crate::{
@@ -18,17 +19,19 @@ extern "C" {
         widths: *const u32,
         height: usize,
         num_mats: usize,
+        stream: cudaStream_t,
     ) -> i32;
 
-    fn _eq_hypercube_stage_ext(out: *mut EF, x_i: EF, step: u32) -> i32;
+    fn _eq_hypercube_stage_ext(out: *mut EF, x_i: EF, step: u32, stream: cudaStream_t) -> i32;
 
-    fn _mobius_eq_hypercube_stage_ext(out: *mut EF, omega_i: EF, step: u32) -> i32;
+    fn _mobius_eq_hypercube_stage_ext(out: *mut EF, omega_i: EF, step: u32, stream: cudaStream_t) -> i32;
 
     fn _eq_hypercube_nonoverlapping_stage_ext(
         out: *mut EF,
         input: *const EF,
         x_i: EF,
         step: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _eq_hypercube_interleaved_stage_ext(
@@ -36,6 +39,7 @@ extern "C" {
         input: *const EF,
         x_i: EF,
         step: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     // `x` must be **device** buffer
@@ -45,15 +49,16 @@ extern "C" {
         step: u32,
         width: u32,
         height: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     // `out` must be device ptr
-    fn _eval_poly_ext_at_point(base_coeffs: *const F, coeff_len: usize, x: EF, out: *mut EF)
+    fn _eval_poly_ext_at_point(base_coeffs: *const F, coeff_len: usize, x: EF, out: *mut EF, stream: cudaStream_t)
         -> i32;
 
-    fn _vector_scalar_multiply_ext(vec: *mut EF, scalar: EF, length: u32) -> i32;
+    fn _vector_scalar_multiply_ext(vec: *mut EF, scalar: EF, length: u32, stream: cudaStream_t) -> i32;
 
-    fn _transpose_fp_to_fpext_vec(output: *mut EF, input: *const F, height: u32) -> i32;
+    fn _transpose_fp_to_fpext_vec(output: *mut EF, input: *const F, height: u32, stream: cudaStream_t) -> i32;
 }
 
 /// Computes the algebraic batch of the column vectors from input matrices `mats`, in order.
@@ -72,6 +77,7 @@ pub unsafe fn algebraic_batch_matrices(
     widths: &DeviceBuffer<u32>,
     height: usize,
     num_mats: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     check(_algebraic_batch_matrices(
         output.as_mut_ptr(),
@@ -81,6 +87,7 @@ pub unsafe fn algebraic_batch_matrices(
         widths.as_ptr(),
         height,
         num_mats,
+        stream,
     ))
 }
 
@@ -93,8 +100,8 @@ pub unsafe fn algebraic_batch_matrices(
 ///
 /// # Safety
 /// - `out` is **device** pointer with length `>= 2 * step`.
-pub unsafe fn eq_hypercube_stage_ext(out: *mut EF, x_i: EF, step: u32) -> Result<(), CudaError> {
-    check(_eq_hypercube_stage_ext(out, x_i, step))
+pub unsafe fn eq_hypercube_stage_ext(out: *mut EF, x_i: EF, step: u32, stream: cudaStream_t) -> Result<(), CudaError> {
+    check(_eq_hypercube_stage_ext(out, x_i, step, stream))
 }
 
 /// Performs an in-place update for the Möbius-adjusted equality kernel:
@@ -110,8 +117,9 @@ pub unsafe fn mobius_eq_hypercube_stage_ext(
     out: *mut EF,
     omega_i: EF,
     step: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
-    check(_mobius_eq_hypercube_stage_ext(out, omega_i, step))
+    check(_mobius_eq_hypercube_stage_ext(out, omega_i, step, stream))
 }
 
 /// Performs an update of:
@@ -132,9 +140,10 @@ pub unsafe fn eq_hypercube_nonoverlapping_stage_ext(
     input: *const EF,
     x_i: EF,
     step: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     check(_eq_hypercube_nonoverlapping_stage_ext(
-        out, input, x_i, step,
+        out, input, x_i, step, stream,
     ))
 }
 
@@ -144,8 +153,9 @@ pub unsafe fn eq_hypercube_interleaved_stage_ext(
     input: *const EF,
     x_i: EF,
     step: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
-    check(_eq_hypercube_interleaved_stage_ext(out, input, x_i, step))
+    check(_eq_hypercube_interleaved_stage_ext(out, input, x_i, step, stream))
 }
 
 /// Same as `eq_hypercube_stage`, over base field, but computes `eq` evals in batch for multiple
@@ -159,6 +169,7 @@ pub unsafe fn batch_eq_hypercube_stage(
     x: &DeviceBuffer<F>,
     step: u32,
     height: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     let width = x.len() as u32;
     debug_assert!(step < height);
@@ -169,6 +180,7 @@ pub unsafe fn batch_eq_hypercube_stage(
         step,
         width,
         height,
+        stream,
     ))
 }
 
@@ -181,6 +193,7 @@ pub unsafe fn eval_poly_ext_at_point_from_base(
     base_coeffs: &DeviceBuffer<F>,
     coeff_len: usize,
     x: EF,
+    stream: cudaStream_t,
 ) -> Result<EF, KernelError> {
     debug_assert!(base_coeffs.len() >= coeff_len * D_EF);
     let d_out = DeviceBuffer::<EF>::with_capacity(1);
@@ -189,6 +202,7 @@ pub unsafe fn eval_poly_ext_at_point_from_base(
         coeff_len,
         x,
         d_out.as_mut_ptr(),
+        stream,
     ))
     .map_err(KernelError::Kernel)?;
     let out = d_out.to_host().map_err(KernelError::MemCopy)?;
@@ -196,13 +210,14 @@ pub unsafe fn eval_poly_ext_at_point_from_base(
 }
 
 /// Scalar multiplication of a vector in-place by `scalar.
-pub fn vector_scalar_multiply_ext(vec: &mut DeviceBuffer<EF>, scalar: EF) -> Result<(), CudaError> {
+pub fn vector_scalar_multiply_ext(vec: &mut DeviceBuffer<EF>, scalar: EF, stream: cudaStream_t) -> Result<(), CudaError> {
     // SAFETY: `vec` is allocated for `vec.len()` so scalar multiplication is safe.
     unsafe {
         check(_vector_scalar_multiply_ext(
             vec.as_mut_ptr(),
             scalar,
             vec.len() as u32,
+            stream,
         ))
     }
 }
@@ -215,6 +230,7 @@ pub fn vector_scalar_multiply_ext(vec: &mut DeviceBuffer<EF>, scalar: EF) -> Res
 pub unsafe fn transpose_fp_to_fpext_vec(
     output: &mut DeviceBuffer<EF>,
     input: &DeviceBuffer<F>,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     let height = output.len();
     debug_assert_eq!(height * D_EF, input.len());
@@ -222,5 +238,6 @@ pub unsafe fn transpose_fp_to_fpext_vec(
         output.as_mut_ptr(),
         input.as_ptr(),
         height as u32,
+        stream,
     ))
 }

--- a/crates/cuda-backend/src/cuda/sponge.rs
+++ b/crates/cuda-backend/src/cuda/sponge.rs
@@ -4,7 +4,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     error::CudaError,
-    stream::{cudaStream_t, DeviceContext},
+    stream::{cudaStream_t, GpuDeviceCtx},
 };
 
 use crate::sponge::{validate_gpu_grind_bits, DeviceSpongeState, GrindError};
@@ -36,7 +36,7 @@ pub unsafe fn sponge_grind(
     init_state: *const DeviceSpongeState,
     bits: u32,
     max_witness: u32,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<u32, GrindError> {
     validate_gpu_grind_bits(bits as usize)?;
     let mut d_result = DeviceBuffer::with_capacity_on(1, device_ctx);

--- a/crates/cuda-backend/src/cuda/sponge.rs
+++ b/crates/cuda-backend/src/cuda/sponge.rs
@@ -4,6 +4,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     error::CudaError,
+    stream::cudaStream_t,
 };
 
 use crate::sponge::{validate_gpu_grind_bits, DeviceSpongeState, GrindError};
@@ -15,6 +16,7 @@ extern "C" {
         min_witness: u32,
         max_witness: u32,
         result: *mut u32,
+        stream: cudaStream_t,
     ) -> i32;
 }
 
@@ -34,6 +36,7 @@ pub unsafe fn sponge_grind(
     init_state: *const DeviceSpongeState,
     bits: u32,
     max_witness: u32,
+    stream: cudaStream_t,
 ) -> Result<u32, GrindError> {
     validate_gpu_grind_bits(bits as usize)?;
     let mut d_result = DeviceBuffer::with_capacity(1);
@@ -45,6 +48,7 @@ pub unsafe fn sponge_grind(
             start,
             max_witness,
             d_result.as_mut_ptr(),
+            stream,
         ))?;
 
         let result = d_result.to_host()?[0];

--- a/crates/cuda-backend/src/cuda/sponge.rs
+++ b/crates/cuda-backend/src/cuda/sponge.rs
@@ -36,11 +36,11 @@ pub unsafe fn sponge_grind(
     init_state: *const DeviceSpongeState,
     bits: u32,
     max_witness: u32,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<u32, GrindError> {
     validate_gpu_grind_bits(bits as usize)?;
-    let mut d_result = DeviceBuffer::with_capacity_on(1, ctx);
-    [u32::MAX].copy_to_on(&mut d_result, ctx)?;
+    let mut d_result = DeviceBuffer::with_capacity_on(1, device_ctx);
+    [u32::MAX].copy_to_on(&mut d_result, device_ctx)?;
     for start in (0..=max_witness).step_by(1 << bits) {
         CudaError::from_result(_sponge_grind(
             init_state,
@@ -48,10 +48,10 @@ pub unsafe fn sponge_grind(
             start,
             max_witness,
             d_result.as_mut_ptr(),
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         ))?;
 
-        let result = d_result.to_host_on(ctx)?[0];
+        let result = d_result.to_host_on(device_ctx)?[0];
         if result < u32::MAX {
             return Ok(result);
         }

--- a/crates/cuda-backend/src/cuda/sponge.rs
+++ b/crates/cuda-backend/src/cuda/sponge.rs
@@ -4,7 +4,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     error::CudaError,
-    stream::cudaStream_t,
+    stream::{cudaStream_t, DeviceContext},
 };
 
 use crate::sponge::{validate_gpu_grind_bits, DeviceSpongeState, GrindError};
@@ -36,11 +36,11 @@ pub unsafe fn sponge_grind(
     init_state: *const DeviceSpongeState,
     bits: u32,
     max_witness: u32,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<u32, GrindError> {
     validate_gpu_grind_bits(bits as usize)?;
-    let mut d_result = DeviceBuffer::with_capacity(1);
-    [u32::MAX].copy_to(&mut d_result)?;
+    let mut d_result = DeviceBuffer::with_capacity_on(1, ctx);
+    [u32::MAX].copy_to_on(&mut d_result, ctx)?;
     for start in (0..=max_witness).step_by(1 << bits) {
         CudaError::from_result(_sponge_grind(
             init_state,
@@ -48,10 +48,10 @@ pub unsafe fn sponge_grind(
             start,
             max_witness,
             d_result.as_mut_ptr(),
-            stream,
+            ctx.stream.as_raw(),
         ))?;
 
-        let result = d_result.to_host()?[0];
+        let result = d_result.to_host_on(ctx)?[0];
         if result < u32::MAX {
             return Ok(result);
         }

--- a/crates/cuda-backend/src/cuda/stacked_reduction.rs
+++ b/crates/cuda-backend/src/cuda/stacked_reduction.rs
@@ -1,6 +1,7 @@
 use openvm_cuda_common::{
     d_buffer::DeviceBuffer,
     error::{check, CudaError},
+    stream::cudaStream_t,
 };
 
 use crate::{
@@ -17,6 +18,7 @@ extern "C" {
         trace_height: u32,
         trace_width: u32,
         l_skip: u32,
+        stream: cudaStream_t,
     ) -> u32;
 
     // SP_DEG=1: no z_packets needed, outputs [NUM_G * skip_domain] to be ADDed
@@ -30,6 +32,7 @@ extern "C" {
         trace_width: u32,
         l_skip: u32,
         num_x: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _stacked_reduction_fold_ple(
@@ -40,6 +43,7 @@ extern "C" {
         trace_height: u32,
         trace_width: u32,
         l_skip: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _initialize_k_rot_from_eq_segments(
@@ -48,6 +52,7 @@ extern "C" {
         k_rot_uni_0: EF,
         k_rot_uni_1: EF,
         max_n: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _stacked_reduction_sumcheck_mle_round(
@@ -61,6 +66,7 @@ extern "C" {
         window_len: u32,
         num_y: u32,
         sm_count: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _stacked_reduction_sumcheck_mle_round_degenerate(
@@ -75,6 +81,7 @@ extern "C" {
         window_len: u32,
         l_skip: u32,
         round: u32,
+        stream: cudaStream_t,
     ) -> i32;
 }
 
@@ -108,6 +115,7 @@ pub unsafe fn stacked_reduction_sumcheck_round0(
     height: usize,
     width: usize,
     l_skip: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     let output_size = NUM_G << l_skip;
     let num_x = (height >> l_skip).max(1) as u32;
@@ -123,6 +131,7 @@ pub unsafe fn stacked_reduction_sumcheck_round0(
         width as u32,
         l_skip as u32,
         num_x,
+        stream,
     ))
 }
 
@@ -147,6 +156,7 @@ pub unsafe fn stacked_reduction_fold_ple(
     trace_height: usize,
     trace_width: usize,
     l_skip: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     let skip_domain = 1 << l_skip;
     debug_assert!(omega_skip_pows.len() >= skip_domain);
@@ -159,6 +169,7 @@ pub unsafe fn stacked_reduction_fold_ple(
         trace_height as u32,
         trace_width as u32,
         l_skip as u32,
+        stream,
     ))
 }
 
@@ -174,6 +185,7 @@ pub unsafe fn initialize_k_rot_from_eq_segments(
     k_rot_uni_0: EF,
     k_rot_uni_1: EF,
     max_n: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert_eq!(eq_r_ns.buffer.len(), 2 << max_n);
     debug_assert_eq!(k_rot_ns.len(), eq_r_ns.buffer.len());
@@ -184,6 +196,7 @@ pub unsafe fn initialize_k_rot_from_eq_segments(
         k_rot_uni_0,
         k_rot_uni_1,
         max_n,
+        stream,
     ))
 }
 
@@ -217,6 +230,7 @@ pub unsafe fn stacked_reduction_sumcheck_mle_round(
     window_len: usize,
     num_y: usize,
     sm_count: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(output.len() >= STACKED_REDUCTION_S_DEG * D_EF);
 
@@ -231,6 +245,7 @@ pub unsafe fn stacked_reduction_sumcheck_mle_round(
         window_len as u32,
         num_y as u32,
         sm_count,
+        stream,
     ))
 }
 
@@ -254,6 +269,7 @@ pub unsafe fn stacked_reduction_sumcheck_mle_round_degenerate(
     window_len: usize,
     l_skip: usize,
     round: usize,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(output.len() >= STACKED_REDUCTION_S_DEG * D_EF);
 
@@ -269,5 +285,6 @@ pub unsafe fn stacked_reduction_sumcheck_mle_round_degenerate(
         window_len as u32,
         l_skip as u32,
         round as u32,
+        stream,
     ))
 }

--- a/crates/cuda-backend/src/cuda/whir.rs
+++ b/crates/cuda-backend/src/cuda/whir.rs
@@ -20,7 +20,10 @@ extern "C" {
         stream: cudaStream_t,
     ) -> i32;
 
-    pub fn _whir_sumcheck_coeff_moments_required_temp_buffer_size(height: u32, stream: cudaStream_t) -> u32;
+    pub fn _whir_sumcheck_coeff_moments_required_temp_buffer_size(
+        height: u32,
+        stream: cudaStream_t,
+    ) -> u32;
 
     fn _whir_sumcheck_coeff_moments_round(
         f_coeffs: *const EF,

--- a/crates/cuda-backend/src/cuda/whir.rs
+++ b/crates/cuda-backend/src/cuda/whir.rs
@@ -1,6 +1,7 @@
 use openvm_cuda_common::{
     d_buffer::DeviceBuffer,
     error::{check, CudaError},
+    stream::cudaStream_t,
 };
 
 use crate::{
@@ -16,9 +17,10 @@ extern "C" {
         stacked_height: usize,
         num_packets: usize,
         skip_domain: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
-    pub fn _whir_sumcheck_coeff_moments_required_temp_buffer_size(height: u32) -> u32;
+    pub fn _whir_sumcheck_coeff_moments_required_temp_buffer_size(height: u32, stream: cudaStream_t) -> u32;
 
     fn _whir_sumcheck_coeff_moments_round(
         f_coeffs: *const EF,
@@ -26,6 +28,7 @@ extern "C" {
         output: *mut EF,
         tmp_block_sums: *mut EF,
         height: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _whir_fold_coeffs_and_moments(
@@ -35,6 +38,7 @@ extern "C" {
         w_folded_moments: *mut EF,
         alpha: EF,
         height: u32,
+        stream: cudaStream_t,
     ) -> i32;
 
     fn _w_moments_accumulate(
@@ -45,6 +49,7 @@ extern "C" {
         num_queries: u32,
         log_height: u32,
         height: u32,
+        stream: cudaStream_t,
     ) -> i32;
 }
 
@@ -58,6 +63,7 @@ pub unsafe fn whir_algebraic_batch_traces(
     packets: &DeviceBuffer<BatchingTracePacket>,
     mu_powers: &DeviceBuffer<EF>,
     skip_domain: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert_eq!(output.len() % D_EF, 0);
     check(_whir_algebraic_batch_traces(
@@ -67,6 +73,7 @@ pub unsafe fn whir_algebraic_batch_traces(
         output.len() / D_EF,
         packets.len(),
         skip_domain,
+        stream,
     ))
 }
 
@@ -83,13 +90,14 @@ pub unsafe fn whir_sumcheck_coeff_moments_round(
     output: &mut DeviceBuffer<EF>,
     tmp_block_sums: &mut DeviceBuffer<EF>,
     height: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(f_coeffs.len() >= height as usize);
     debug_assert!(w_moments.len() >= height as usize);
     #[cfg(debug_assertions)]
     {
         let len = tmp_block_sums.len();
-        let required = _whir_sumcheck_coeff_moments_required_temp_buffer_size(height);
+        let required = _whir_sumcheck_coeff_moments_required_temp_buffer_size(height, stream);
         assert!(
             len >= required as usize,
             "tmp_block_sums len={len} < required={required}"
@@ -101,6 +109,7 @@ pub unsafe fn whir_sumcheck_coeff_moments_round(
         output.as_mut_ptr(),
         tmp_block_sums.as_mut_ptr(),
         height,
+        stream,
     ))
 }
 
@@ -116,6 +125,7 @@ pub unsafe fn whir_fold_coeffs_and_moments(
     w_folded_moments: &mut DeviceBuffer<EF>,
     alpha: EF,
     height: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(f_coeffs.len() >= height as usize);
     debug_assert!(w_moments.len() >= height as usize);
@@ -128,6 +138,7 @@ pub unsafe fn whir_fold_coeffs_and_moments(
         w_folded_moments.as_mut_ptr(),
         alpha,
         height,
+        stream,
     ))
 }
 
@@ -144,6 +155,7 @@ pub unsafe fn w_moments_accumulate(
     gamma: EF,
     num_queries: u32,
     log_height: u32,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     let height = w_moments.len();
     debug_assert_eq!(z0_pows2.len(), log_height as usize);
@@ -156,5 +168,6 @@ pub unsafe fn w_moments_accumulate(
         num_queries,
         log_height,
         height as u32,
+        stream,
     ))
 }

--- a/crates/cuda-backend/src/data_transporter.rs
+++ b/crates/cuda-backend/src/data_transporter.rs
@@ -36,7 +36,7 @@ impl<HS: GpuHashScheme> DeviceDataTransporter<HS::SC, GenericGpuBackend<HS>> for
         &self,
         mpk: &MultiStarkProvingKey<HS::SC>,
     ) -> DeviceMultiStarkProvingKey<GenericGpuBackend<HS>> {
-        let ctx = &self.ctx;
+        let device_ctx = &self.device_ctx;
         let _span = info_span!("transport_pk_to_device").entered();
         let per_air = mpk
             .per_air
@@ -46,11 +46,11 @@ impl<HS: GpuHashScheme> DeviceDataTransporter<HS::SC, GenericGpuBackend<HS>> for
                     transport_and_unstack_single_data_h2d::<HS>(
                         d.as_ref(),
                         self.prover_config(),
-                        ctx,
+                        device_ctx,
                     )
                     .unwrap()
                 });
-                let other_data = AirDataGpu::new(pk, ctx).unwrap();
+                let other_data = AirDataGpu::new(pk, device_ctx).unwrap();
                 let num_monomials = other_data
                     .zerocheck_monomials
                     .as_ref()
@@ -67,7 +67,7 @@ impl<HS: GpuHashScheme> DeviceDataTransporter<HS::SC, GenericGpuBackend<HS>> for
             })
             .collect();
         // Synchronize in case the proving key is shared between threads/streams
-        self.ctx.stream.synchronize().unwrap();
+        self.device_ctx.stream.synchronize().unwrap();
 
         DeviceMultiStarkProvingKey::new(
             per_air,
@@ -79,28 +79,29 @@ impl<HS: GpuHashScheme> DeviceDataTransporter<HS::SC, GenericGpuBackend<HS>> for
     }
 
     fn transport_matrix_to_device(&self, matrix: &ColMajorMatrix<F>) -> DeviceMatrix<F> {
-        transport_matrix_h2d_col_major(matrix, &self.ctx).unwrap()
+        transport_matrix_h2d_col_major(matrix, &self.device_ctx).unwrap()
     }
 
     fn transport_pcs_data_to_device(
         &self,
         pcs_data: &StackedPcsData<F, HS::Digest>,
     ) -> StackedPcsDataGpu<F, HS::Digest> {
-        transport_pcs_data_h2d::<HS::Digest>(pcs_data, self.prover_config(), &self.ctx).unwrap()
+        transport_pcs_data_h2d::<HS::Digest>(pcs_data, self.prover_config(), &self.device_ctx)
+            .unwrap()
     }
 
     fn transport_matrix_from_device_to_host(&self, matrix: &DeviceMatrix<F>) -> ColMajorMatrix<F> {
-        transport_matrix_d2h_col_major(matrix, &self.ctx).unwrap()
+        transport_matrix_d2h_col_major(matrix, &self.device_ctx).unwrap()
     }
 }
 
 pub fn transport_matrix_h2d_col_major<T>(
     matrix: &ColMajorMatrix<T>,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<DeviceMatrix<T>, MemCopyError> {
     // matrix is already col-major, so this is just H2D buffer transfer
-    let buffer = matrix.values.to_device_on(ctx)?;
-    unsafe { sync_stream(ctx.stream.as_raw())? };
+    let buffer = matrix.values.to_device_on(device_ctx)?;
+    unsafe { sync_stream(device_ctx.stream.as_raw())? };
     Ok(DeviceMatrix::new(
         Arc::new(buffer),
         matrix.height(),
@@ -110,22 +111,25 @@ pub fn transport_matrix_h2d_col_major<T>(
 
 pub fn transport_matrix_h2d_row(
     matrix: &RowMajorMatrix<F>,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<DeviceMatrix<F>, MemCopyError> {
     let data = matrix.values.as_slice();
-    let input_buffer = data.to_device_on(ctx).unwrap();
-    let output =
-        DeviceMatrix::<F>::with_capacity_on(Matrix::height(matrix), Matrix::width(matrix), ctx);
+    let input_buffer = data.to_device_on(device_ctx).unwrap();
+    let output = DeviceMatrix::<F>::with_capacity_on(
+        Matrix::height(matrix),
+        Matrix::width(matrix),
+        device_ctx,
+    );
     unsafe {
         matrix_transpose_fp(
             output.buffer(),
             &input_buffer,
             Matrix::width(matrix),
             Matrix::height(matrix),
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )?;
     }
-    unsafe { sync_stream(ctx.stream.as_raw())? };
+    unsafe { sync_stream(device_ctx.stream.as_raw())? };
     assert_eq!(output.strong_count(), 1);
     Ok(output)
 }
@@ -136,7 +140,7 @@ pub fn transport_matrix_h2d_row(
 pub fn transport_and_unstack_single_data_h2d<HS: GpuHashScheme>(
     d: &StackedPcsData<F, HS::Digest>,
     prover_config: &GpuProverConfig,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<CommittedTraceData<GenericGpuBackend<HS>>, ProverError> {
     let _span = info_span!("transport_unstack_h2d").entered();
     debug_assert!(d
@@ -155,8 +159,8 @@ pub fn transport_and_unstack_single_data_h2d<HS: GpuHashScheme>(
     debug_assert!(d.matrix.values.len() >= lifted_height * width);
     let stacked_width = d.matrix.width();
     let stacked_height = d.matrix.height();
-    let d_matrix_evals = d.matrix.values.to_device_on(ctx)?;
-    let strided_trace = DeviceBuffer::<F>::with_capacity_on(lifted_height * width, ctx);
+    let d_matrix_evals = d.matrix.values.to_device_on(device_ctx)?;
+    let strided_trace = DeviceBuffer::<F>::with_capacity_on(lifted_height * width, device_ctx);
     // SAFETY: D2D copy
     // - `d_matrix_evals` is the stacked matrix, guaranteed to have length `>= lifted_height *
     //   width` by definition of stacking
@@ -166,13 +170,13 @@ pub fn transport_and_unstack_single_data_h2d<HS: GpuHashScheme>(
             strided_trace.as_mut_raw_ptr(),
             d_matrix_evals.as_raw_ptr(),
             lifted_height * width * size_of::<F>(),
-            ctx,
+            device_ctx,
         )?;
     }
     let trace_buffer = if stride == 1 {
         strided_trace
     } else {
-        let buf = DeviceBuffer::<F>::with_capacity_on(height * width, ctx);
+        let buf = DeviceBuffer::<F>::with_capacity_on(height * width, device_ctx);
         unsafe {
             collapse_strided_matrix(
                 buf.as_mut_ptr(),
@@ -180,19 +184,27 @@ pub fn transport_and_unstack_single_data_h2d<HS: GpuHashScheme>(
                 width as u32,
                 height as u32,
                 stride as u32,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
             .map_err(ProverError::CollapseStrided)?;
         }
         // Wait for kernel to finish so we can safely drop strided_trace
-        unsafe { sync_stream(ctx.stream.as_raw()) }.map_err(ProverError::StreamSynchronize)?;
+        unsafe { sync_stream(device_ctx.stream.as_raw()) }
+            .map_err(ProverError::StreamSynchronize)?;
         drop(strided_trace);
         buf
     };
-    let d_matrix = prover_config
-        .cache_stacked_matrix
-        .then(|| PleMatrix::from_evals(l_skip, d_matrix_evals, stacked_height, stacked_width, ctx));
-    let d_tree = transport_merkle_tree_h2d(&d.tree, prover_config.cache_rs_code_matrix, ctx)?;
+    let d_matrix = prover_config.cache_stacked_matrix.then(|| {
+        PleMatrix::from_evals(
+            l_skip,
+            d_matrix_evals,
+            stacked_height,
+            stacked_width,
+            device_ctx,
+        )
+    });
+    let d_tree =
+        transport_merkle_tree_h2d(&d.tree, prover_config.cache_rs_code_matrix, device_ctx)?;
     let d_data = StackedPcsDataGpu {
         layout: d.layout.clone(),
         matrix: d_matrix,
@@ -215,19 +227,22 @@ pub fn transport_and_unstack_single_data_h2d<HS: GpuHashScheme>(
 pub fn transport_merkle_tree_h2d<F, Digest: Clone>(
     tree: &MerkleTree<F, Digest>,
     cache_backing_matrix: bool,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<MerkleTreeGpu<F, Digest>, MemCopyError> {
     let backing_matrix = if cache_backing_matrix {
-        Some(transport_matrix_h2d_col_major(tree.backing_matrix(), ctx)?)
+        Some(transport_matrix_h2d_col_major(
+            tree.backing_matrix(),
+            device_ctx,
+        )?)
     } else {
         None
     };
     let digest_layers = tree
         .digest_layers()
         .iter()
-        .map(|layer| layer.to_device_on(ctx))
+        .map(|layer| layer.to_device_on(device_ctx))
         .collect::<Result<Vec<_>, _>>()?;
-    unsafe { sync_stream(ctx.stream.as_raw())? };
+    unsafe { sync_stream(device_ctx.stream.as_raw())? };
     Ok(MerkleTreeGpu {
         backing_matrix,
         digest_layers,
@@ -239,7 +254,7 @@ pub fn transport_merkle_tree_h2d<F, Digest: Clone>(
 pub fn transport_pcs_data_h2d<D: Copy + Clone + PartialEq + Send + Sync + 'static>(
     pcs_data: &StackedPcsData<F, D>,
     prover_config: &GpuProverConfig,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<StackedPcsDataGpu<F, D>, ProverError> {
     let _span = info_span!("transport_pcs_data_h2d").entered();
     let StackedPcsData {
@@ -249,12 +264,12 @@ pub fn transport_pcs_data_h2d<D: Copy + Clone + PartialEq + Send + Sync + 'stati
     } = pcs_data;
     let width = matrix.width();
     let height = matrix.height();
-    let d_matrix_evals = matrix.values.to_device_on(ctx)?;
+    let d_matrix_evals = matrix.values.to_device_on(device_ctx)?;
     let d_matrix = prover_config
         .cache_stacked_matrix
-        .then(|| PleMatrix::from_evals(layout.l_skip(), d_matrix_evals, height, width, ctx));
-    let d_tree = transport_merkle_tree_h2d(tree, prover_config.cache_rs_code_matrix, ctx)?;
-    unsafe { sync_stream(ctx.stream.as_raw()) }.map_err(ProverError::StreamSynchronize)?;
+        .then(|| PleMatrix::from_evals(layout.l_skip(), d_matrix_evals, height, width, device_ctx));
+    let d_tree = transport_merkle_tree_h2d(tree, prover_config.cache_rs_code_matrix, device_ctx)?;
+    unsafe { sync_stream(device_ctx.stream.as_raw()) }.map_err(ProverError::StreamSynchronize)?;
 
     Ok(StackedPcsDataGpu {
         layout: layout.clone(),
@@ -265,14 +280,14 @@ pub fn transport_pcs_data_h2d<D: Copy + Clone + PartialEq + Send + Sync + 'stati
 
 pub fn transport_air_proving_ctx_to_device<HS: GpuHashScheme>(
     cpu_ctx: AirProvingContext<CpuColMajorBackend<SC>>,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> AirProvingContext<GenericGpuBackend<HS>> {
     let _span = info_span!("transport_air_ctx_h2d").entered();
     assert!(
         cpu_ctx.cached_mains.is_empty(),
         "CPU to GPU transfer of cached traces not supported"
     );
-    let trace = transport_matrix_h2d_col_major(&cpu_ctx.common_main, ctx).unwrap();
+    let trace = transport_matrix_h2d_col_major(&cpu_ctx.common_main, device_ctx).unwrap();
     AirProvingContext {
         cached_mains: vec![],
         common_main: trace,
@@ -283,12 +298,17 @@ pub fn transport_air_proving_ctx_to_device<HS: GpuHashScheme>(
 pub fn transport_proving_ctx_to_host(
     gpu_ctx: ProvingContext<GpuBackend>,
     l_skip: usize,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> ProvingContext<CpuColMajorBackend<SC>> {
     let per_trace = gpu_ctx
         .per_trace
         .into_iter()
-        .map(|(i, air_ctx)| (i, transport_air_proving_ctx_to_host(air_ctx, l_skip, ctx)))
+        .map(|(i, air_ctx)| {
+            (
+                i,
+                transport_air_proving_ctx_to_host(air_ctx, l_skip, device_ctx),
+            )
+        })
         .collect_vec();
     ProvingContext { per_trace }
 }
@@ -296,9 +316,9 @@ pub fn transport_proving_ctx_to_host(
 pub fn transport_air_proving_ctx_to_host(
     gpu_ctx: AirProvingContext<GpuBackend>,
     l_skip: usize,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> AirProvingContext<CpuColMajorBackend<SC>> {
-    let trace = transport_matrix_d2h_col_major(&gpu_ctx.common_main, ctx).unwrap();
+    let trace = transport_matrix_d2h_col_major(&gpu_ctx.common_main, device_ctx).unwrap();
     let cached_mains = gpu_ctx
         .cached_mains
         .into_iter()
@@ -311,15 +331,15 @@ pub fn transport_air_proving_ctx_to_host(
                 .matrix
                 .as_ref()
                 .unwrap()
-                .to_evals(l_skip, ctx)
+                .to_evals(l_skip, device_ctx)
                 .unwrap();
             CommittedTraceData {
                 commitment: mat.commitment,
-                trace: transport_matrix_d2h_col_major(&mat.trace, ctx).unwrap(),
+                trace: transport_matrix_d2h_col_major(&mat.trace, device_ctx).unwrap(),
                 data: Arc::new(StackedPcsData {
                     layout: mat.data.layout.clone(),
-                    matrix: transport_matrix_d2h_col_major(&evals_matrix, ctx).unwrap(),
-                    tree: transport_merkle_tree_to_host(&mat.data.tree, ctx),
+                    matrix: transport_matrix_d2h_col_major(&evals_matrix, device_ctx).unwrap(),
+                    tree: transport_merkle_tree_to_host(&mat.data.tree, device_ctx),
                 }),
             }
         })
@@ -333,28 +353,29 @@ pub fn transport_air_proving_ctx_to_host(
 
 pub fn transport_matrix_d2h_col_major<T>(
     matrix: &DeviceMatrix<T>,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<ColMajorMatrix<T>, MemCopyError> {
-    let values_host = matrix.buffer().to_host_on(ctx)?;
+    let values_host = matrix.buffer().to_host_on(device_ctx)?;
     Ok(ColMajorMatrix::new(values_host, matrix.width()))
 }
 
 pub fn transport_matrix_d2h_row_major(
     matrix: &DeviceMatrix<F>,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<RowMajorMatrix<F>, MemCopyError> {
-    let matrix_buffer = DeviceBuffer::<F>::with_capacity_on(matrix.height() * matrix.width(), ctx);
+    let matrix_buffer =
+        DeviceBuffer::<F>::with_capacity_on(matrix.height() * matrix.width(), device_ctx);
     unsafe {
         matrix_transpose_fp(
             &matrix_buffer,
             matrix.buffer(),
             matrix.height(),
             matrix.width(),
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )?;
     }
     Ok(RowMajorMatrix::<F>::new(
-        matrix_buffer.to_host_on(ctx)?,
+        matrix_buffer.to_host_on(device_ctx)?,
         matrix.width(),
     ))
 }
@@ -365,14 +386,14 @@ pub fn transport_matrix_d2h_row_major(
 /// If `tree.backing_matrix` is `None`.
 pub fn transport_merkle_tree_to_host(
     tree: &MerkleTreeGpu<F, Digest>,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> MerkleTree<F, Digest> {
     let backing_matrix =
-        transport_matrix_d2h_col_major(tree.backing_matrix.as_ref().unwrap(), ctx).unwrap();
+        transport_matrix_d2h_col_major(tree.backing_matrix.as_ref().unwrap(), device_ctx).unwrap();
     let digest_layers = tree
         .digest_layers
         .iter()
-        .map(|layer| layer.to_host_on(ctx).unwrap())
+        .map(|layer| layer.to_host_on(device_ctx).unwrap())
         .collect_vec();
     // Safety: assuming the tree is properly constructed on device, the layers are correct after D2H
     // transfer.
@@ -384,11 +405,11 @@ pub fn transport_merkle_tree_to_host(
 pub fn assert_eq_host_and_device_matrix_col_maj<T: Clone + Send + Sync + PartialEq + Debug>(
     cpu: &ColMajorMatrix<T>,
     gpu: &DeviceMatrix<T>,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) {
     assert_eq!(gpu.width(), cpu.width());
     assert_eq!(gpu.height(), cpu.height());
-    let gpu = gpu.buffer().to_host_on(ctx).unwrap();
+    let gpu = gpu.buffer().to_host_on(device_ctx).unwrap();
     for r in 0..cpu.height() {
         for c in 0..cpu.width() {
             assert_eq!(
@@ -405,13 +426,13 @@ pub fn assert_eq_host_and_device_matrix_col_maj<T: Clone + Send + Sync + Partial
 pub fn assert_eq_device_matrix<T: Clone + Send + Sync + PartialEq + Debug>(
     a: &DeviceMatrix<T>,
     b: &DeviceMatrix<T>,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) {
     assert_eq!(a.height(), b.height());
     assert_eq!(a.width(), b.width());
     assert_eq!(a.buffer().len(), b.buffer().len());
-    let a_host = a.buffer().to_host_on(ctx).unwrap();
-    let b_host = b.buffer().to_host_on(ctx).unwrap();
+    let a_host = a.buffer().to_host_on(device_ctx).unwrap();
+    let b_host = b.buffer().to_host_on(device_ctx).unwrap();
     for r in 0..a.height() {
         for c in 0..a.width() {
             assert_eq!(
@@ -428,11 +449,11 @@ pub fn assert_eq_device_matrix<T: Clone + Send + Sync + PartialEq + Debug>(
 pub fn assert_eq_host_and_device_matrix<T: Clone + Send + Sync + PartialEq + Debug>(
     cpu: Arc<RowMajorMatrix<T>>,
     gpu: &DeviceMatrix<T>,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) {
     assert_eq!(gpu.width(), Matrix::width(cpu.as_ref()));
     assert_eq!(gpu.height(), Matrix::height(cpu.as_ref()));
-    let gpu = gpu.buffer().to_host_on(ctx).unwrap();
+    let gpu = gpu.buffer().to_host_on(device_ctx).unwrap();
     for r in 0..Matrix::height(cpu.as_ref()) {
         for c in 0..Matrix::width(cpu.as_ref()) {
             assert_eq!(

--- a/crates/cuda-backend/src/data_transporter.rs
+++ b/crates/cuda-backend/src/data_transporter.rs
@@ -185,7 +185,7 @@ pub fn transport_and_unstack_single_data_h2d<HS: GpuHashScheme>(
             .map_err(ProverError::CollapseStrided)?;
         }
         // Wait for kernel to finish so we can safely drop strided_trace
-        unsafe { sync_stream(ctx.stream.as_raw()) }.map_err(ProverError::CurrentStreamSync)?;
+        unsafe { sync_stream(ctx.stream.as_raw()) }.map_err(ProverError::StreamSynchronize)?;
         drop(strided_trace);
         buf
     };
@@ -254,7 +254,7 @@ pub fn transport_pcs_data_h2d<D: Copy + Clone + PartialEq + Send + Sync + 'stati
         .cache_stacked_matrix
         .then(|| PleMatrix::from_evals(layout.l_skip(), d_matrix_evals, height, width, ctx));
     let d_tree = transport_merkle_tree_h2d(tree, prover_config.cache_rs_code_matrix, ctx)?;
-    unsafe { sync_stream(ctx.stream.as_raw()) }.map_err(ProverError::CurrentStreamSync)?;
+    unsafe { sync_stream(ctx.stream.as_raw()) }.map_err(ProverError::StreamSynchronize)?;
 
     Ok(StackedPcsDataGpu {
         layout: layout.clone(),

--- a/crates/cuda-backend/src/data_transporter.rs
+++ b/crates/cuda-backend/src/data_transporter.rs
@@ -5,7 +5,7 @@ use openvm_cuda_common::{
     copy::{cuda_memcpy, MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     error::MemCopyError,
-    stream::current_stream_sync,
+    stream::{cudaStreamPerThread, current_stream_sync},
 };
 use openvm_stark_backend::{
     keygen::types::MultiStarkProvingKey,
@@ -114,6 +114,7 @@ pub fn transport_matrix_h2d_row(
             &input_buffer,
             Matrix::width(matrix),
             Matrix::height(matrix),
+            cudaStreamPerThread,
         )?;
     }
     current_stream_sync()?;
@@ -169,6 +170,7 @@ pub fn transport_and_unstack_single_data_h2d<HS: GpuHashScheme>(
                 width as u32,
                 height as u32,
                 stride as u32,
+                cudaStreamPerThread,
             )
             .map_err(ProverError::CollapseStrided)?;
         }
@@ -325,6 +327,7 @@ pub fn transport_matrix_d2h_row_major(
             matrix.buffer(),
             matrix.height(),
             matrix.width(),
+            cudaStreamPerThread,
         )?;
     }
     Ok(RowMajorMatrix::<F>::new(

--- a/crates/cuda-backend/src/data_transporter.rs
+++ b/crates/cuda-backend/src/data_transporter.rs
@@ -2,10 +2,10 @@ use std::{cmp::max, fmt::Debug, sync::Arc};
 
 use itertools::Itertools;
 use openvm_cuda_common::{
-    copy::{cuda_memcpy, MemCopyD2H, MemCopyH2D},
+    copy::{cuda_memcpy_on, MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     error::MemCopyError,
-    stream::{cudaStream_t, sync_stream},
+    stream::{sync_stream, DeviceContext},
 };
 use openvm_stark_backend::{
     keygen::types::MultiStarkProvingKey,
@@ -36,7 +36,7 @@ impl<HS: GpuHashScheme> DeviceDataTransporter<HS::SC, GenericGpuBackend<HS>> for
         &self,
         mpk: &MultiStarkProvingKey<HS::SC>,
     ) -> DeviceMultiStarkProvingKey<GenericGpuBackend<HS>> {
-        let stream = self.ctx.stream.as_raw();
+        let ctx = &self.ctx;
         let _span = info_span!("transport_pk_to_device").entered();
         let per_air = mpk
             .per_air
@@ -46,11 +46,11 @@ impl<HS: GpuHashScheme> DeviceDataTransporter<HS::SC, GenericGpuBackend<HS>> for
                     transport_and_unstack_single_data_h2d::<HS>(
                         d.as_ref(),
                         self.prover_config(),
-                        stream,
+                        ctx,
                     )
                     .unwrap()
                 });
-                let other_data = AirDataGpu::new(pk).unwrap();
+                let other_data = AirDataGpu::new(pk, ctx).unwrap();
                 let num_monomials = other_data
                     .zerocheck_monomials
                     .as_ref()
@@ -79,30 +79,28 @@ impl<HS: GpuHashScheme> DeviceDataTransporter<HS::SC, GenericGpuBackend<HS>> for
     }
 
     fn transport_matrix_to_device(&self, matrix: &ColMajorMatrix<F>) -> DeviceMatrix<F> {
-        let stream = self.ctx.stream.as_raw();
-        transport_matrix_h2d_col_major(matrix, stream).unwrap()
+        transport_matrix_h2d_col_major(matrix, &self.ctx).unwrap()
     }
 
     fn transport_pcs_data_to_device(
         &self,
         pcs_data: &StackedPcsData<F, HS::Digest>,
     ) -> StackedPcsDataGpu<F, HS::Digest> {
-        let stream = self.ctx.stream.as_raw();
-        transport_pcs_data_h2d::<HS::Digest>(pcs_data, self.prover_config(), stream).unwrap()
+        transport_pcs_data_h2d::<HS::Digest>(pcs_data, self.prover_config(), &self.ctx).unwrap()
     }
 
     fn transport_matrix_from_device_to_host(&self, matrix: &DeviceMatrix<F>) -> ColMajorMatrix<F> {
-        transport_matrix_d2h_col_major(matrix).unwrap()
+        transport_matrix_d2h_col_major(matrix, &self.ctx).unwrap()
     }
 }
 
 pub fn transport_matrix_h2d_col_major<T>(
     matrix: &ColMajorMatrix<T>,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<DeviceMatrix<T>, MemCopyError> {
     // matrix is already col-major, so this is just H2D buffer transfer
-    let buffer = matrix.values.to_device()?;
-    unsafe { sync_stream(stream)? };
+    let buffer = matrix.values.to_device_on(ctx)?;
+    unsafe { sync_stream(ctx.stream.as_raw())? };
     Ok(DeviceMatrix::new(
         Arc::new(buffer),
         matrix.height(),
@@ -112,21 +110,22 @@ pub fn transport_matrix_h2d_col_major<T>(
 
 pub fn transport_matrix_h2d_row(
     matrix: &RowMajorMatrix<F>,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<DeviceMatrix<F>, MemCopyError> {
     let data = matrix.values.as_slice();
-    let input_buffer = data.to_device().unwrap();
-    let output = DeviceMatrix::<F>::with_capacity(Matrix::height(matrix), Matrix::width(matrix));
+    let input_buffer = data.to_device_on(ctx).unwrap();
+    let output =
+        DeviceMatrix::<F>::with_capacity_on(Matrix::height(matrix), Matrix::width(matrix), ctx);
     unsafe {
         matrix_transpose_fp(
             output.buffer(),
             &input_buffer,
             Matrix::width(matrix),
             Matrix::height(matrix),
-            stream,
+            ctx.stream.as_raw(),
         )?;
     }
-    unsafe { sync_stream(stream)? };
+    unsafe { sync_stream(ctx.stream.as_raw())? };
     assert_eq!(output.strong_count(), 1);
     Ok(output)
 }
@@ -137,7 +136,7 @@ pub fn transport_matrix_h2d_row(
 pub fn transport_and_unstack_single_data_h2d<HS: GpuHashScheme>(
     d: &StackedPcsData<F, HS::Digest>,
     prover_config: &GpuProverConfig,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<CommittedTraceData<GenericGpuBackend<HS>>, ProverError> {
     let _span = info_span!("transport_unstack_h2d").entered();
     debug_assert!(d
@@ -156,23 +155,24 @@ pub fn transport_and_unstack_single_data_h2d<HS: GpuHashScheme>(
     debug_assert!(d.matrix.values.len() >= lifted_height * width);
     let stacked_width = d.matrix.width();
     let stacked_height = d.matrix.height();
-    let d_matrix_evals = d.matrix.values.to_device()?;
-    let strided_trace = DeviceBuffer::<F>::with_capacity(lifted_height * width);
+    let d_matrix_evals = d.matrix.values.to_device_on(ctx)?;
+    let strided_trace = DeviceBuffer::<F>::with_capacity_on(lifted_height * width, ctx);
     // SAFETY: D2D copy
     // - `d_matrix_evals` is the stacked matrix, guaranteed to have length `>= lifted_height *
     //   width` by definition of stacking
     // - `d_matrix_evals` stacks a single trace matrix
     unsafe {
-        cuda_memcpy::<true, true>(
+        cuda_memcpy_on::<true, true>(
             strided_trace.as_mut_raw_ptr(),
             d_matrix_evals.as_raw_ptr(),
             lifted_height * width * size_of::<F>(),
+            ctx,
         )?;
     }
     let trace_buffer = if stride == 1 {
         strided_trace
     } else {
-        let buf = DeviceBuffer::<F>::with_capacity(height * width);
+        let buf = DeviceBuffer::<F>::with_capacity_on(height * width, ctx);
         unsafe {
             collapse_strided_matrix(
                 buf.as_mut_ptr(),
@@ -180,25 +180,19 @@ pub fn transport_and_unstack_single_data_h2d<HS: GpuHashScheme>(
                 width as u32,
                 height as u32,
                 stride as u32,
-                stream,
+                ctx.stream.as_raw(),
             )
             .map_err(ProverError::CollapseStrided)?;
         }
         // Wait for kernel to finish so we can safely drop strided_trace
-        unsafe { sync_stream(stream) }.map_err(ProverError::CurrentStreamSync)?;
+        unsafe { sync_stream(ctx.stream.as_raw()) }.map_err(ProverError::CurrentStreamSync)?;
         drop(strided_trace);
         buf
     };
-    let d_matrix = prover_config.cache_stacked_matrix.then(|| {
-        PleMatrix::from_evals(
-            l_skip,
-            d_matrix_evals,
-            stacked_height,
-            stacked_width,
-            stream,
-        )
-    });
-    let d_tree = transport_merkle_tree_h2d(&d.tree, prover_config.cache_rs_code_matrix, stream)?;
+    let d_matrix = prover_config
+        .cache_stacked_matrix
+        .then(|| PleMatrix::from_evals(l_skip, d_matrix_evals, stacked_height, stacked_width, ctx));
+    let d_tree = transport_merkle_tree_h2d(&d.tree, prover_config.cache_rs_code_matrix, ctx)?;
     let d_data = StackedPcsDataGpu {
         layout: d.layout.clone(),
         matrix: d_matrix,
@@ -221,22 +215,19 @@ pub fn transport_and_unstack_single_data_h2d<HS: GpuHashScheme>(
 pub fn transport_merkle_tree_h2d<F, Digest: Clone>(
     tree: &MerkleTree<F, Digest>,
     cache_backing_matrix: bool,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<MerkleTreeGpu<F, Digest>, MemCopyError> {
     let backing_matrix = if cache_backing_matrix {
-        Some(transport_matrix_h2d_col_major(
-            tree.backing_matrix(),
-            stream,
-        )?)
+        Some(transport_matrix_h2d_col_major(tree.backing_matrix(), ctx)?)
     } else {
         None
     };
     let digest_layers = tree
         .digest_layers()
         .iter()
-        .map(|layer| layer.to_device())
+        .map(|layer| layer.to_device_on(ctx))
         .collect::<Result<Vec<_>, _>>()?;
-    unsafe { sync_stream(stream)? };
+    unsafe { sync_stream(ctx.stream.as_raw())? };
     Ok(MerkleTreeGpu {
         backing_matrix,
         digest_layers,
@@ -248,7 +239,7 @@ pub fn transport_merkle_tree_h2d<F, Digest: Clone>(
 pub fn transport_pcs_data_h2d<D: Copy + Clone + PartialEq + Send + Sync + 'static>(
     pcs_data: &StackedPcsData<F, D>,
     prover_config: &GpuProverConfig,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<StackedPcsDataGpu<F, D>, ProverError> {
     let _span = info_span!("transport_pcs_data_h2d").entered();
     let StackedPcsData {
@@ -258,12 +249,12 @@ pub fn transport_pcs_data_h2d<D: Copy + Clone + PartialEq + Send + Sync + 'stati
     } = pcs_data;
     let width = matrix.width();
     let height = matrix.height();
-    let d_matrix_evals = matrix.values.to_device()?;
+    let d_matrix_evals = matrix.values.to_device_on(ctx)?;
     let d_matrix = prover_config
         .cache_stacked_matrix
-        .then(|| PleMatrix::from_evals(layout.l_skip(), d_matrix_evals, height, width, stream));
-    let d_tree = transport_merkle_tree_h2d(tree, prover_config.cache_rs_code_matrix, stream)?;
-    unsafe { sync_stream(stream) }.map_err(ProverError::CurrentStreamSync)?;
+        .then(|| PleMatrix::from_evals(layout.l_skip(), d_matrix_evals, height, width, ctx));
+    let d_tree = transport_merkle_tree_h2d(tree, prover_config.cache_rs_code_matrix, ctx)?;
+    unsafe { sync_stream(ctx.stream.as_raw()) }.map_err(ProverError::CurrentStreamSync)?;
 
     Ok(StackedPcsDataGpu {
         layout: layout.clone(),
@@ -274,14 +265,14 @@ pub fn transport_pcs_data_h2d<D: Copy + Clone + PartialEq + Send + Sync + 'stati
 
 pub fn transport_air_proving_ctx_to_device<HS: GpuHashScheme>(
     cpu_ctx: AirProvingContext<CpuColMajorBackend<SC>>,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> AirProvingContext<GenericGpuBackend<HS>> {
     let _span = info_span!("transport_air_ctx_h2d").entered();
     assert!(
         cpu_ctx.cached_mains.is_empty(),
         "CPU to GPU transfer of cached traces not supported"
     );
-    let trace = transport_matrix_h2d_col_major(&cpu_ctx.common_main, stream).unwrap();
+    let trace = transport_matrix_h2d_col_major(&cpu_ctx.common_main, ctx).unwrap();
     AirProvingContext {
         cached_mains: vec![],
         common_main: trace,
@@ -292,12 +283,12 @@ pub fn transport_air_proving_ctx_to_device<HS: GpuHashScheme>(
 pub fn transport_proving_ctx_to_host(
     gpu_ctx: ProvingContext<GpuBackend>,
     l_skip: usize,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> ProvingContext<CpuColMajorBackend<SC>> {
     let per_trace = gpu_ctx
         .per_trace
         .into_iter()
-        .map(|(i, ctx)| (i, transport_air_proving_ctx_to_host(ctx, l_skip, stream)))
+        .map(|(i, air_ctx)| (i, transport_air_proving_ctx_to_host(air_ctx, l_skip, ctx)))
         .collect_vec();
     ProvingContext { per_trace }
 }
@@ -305,9 +296,9 @@ pub fn transport_proving_ctx_to_host(
 pub fn transport_air_proving_ctx_to_host(
     gpu_ctx: AirProvingContext<GpuBackend>,
     l_skip: usize,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> AirProvingContext<CpuColMajorBackend<SC>> {
-    let trace = transport_matrix_d2h_col_major(&gpu_ctx.common_main).unwrap();
+    let trace = transport_matrix_d2h_col_major(&gpu_ctx.common_main, ctx).unwrap();
     let cached_mains = gpu_ctx
         .cached_mains
         .into_iter()
@@ -320,15 +311,15 @@ pub fn transport_air_proving_ctx_to_host(
                 .matrix
                 .as_ref()
                 .unwrap()
-                .to_evals(l_skip, stream)
+                .to_evals(l_skip, ctx)
                 .unwrap();
             CommittedTraceData {
                 commitment: mat.commitment,
-                trace: transport_matrix_d2h_col_major(&mat.trace).unwrap(),
+                trace: transport_matrix_d2h_col_major(&mat.trace, ctx).unwrap(),
                 data: Arc::new(StackedPcsData {
                     layout: mat.data.layout.clone(),
-                    matrix: transport_matrix_d2h_col_major(&evals_matrix).unwrap(),
-                    tree: transport_merkle_tree_to_host(&mat.data.tree),
+                    matrix: transport_matrix_d2h_col_major(&evals_matrix, ctx).unwrap(),
+                    tree: transport_merkle_tree_to_host(&mat.data.tree, ctx),
                 }),
             }
         })
@@ -342,27 +333,28 @@ pub fn transport_air_proving_ctx_to_host(
 
 pub fn transport_matrix_d2h_col_major<T>(
     matrix: &DeviceMatrix<T>,
+    ctx: &DeviceContext,
 ) -> Result<ColMajorMatrix<T>, MemCopyError> {
-    let values_host = matrix.buffer().to_host()?;
+    let values_host = matrix.buffer().to_host_on(ctx)?;
     Ok(ColMajorMatrix::new(values_host, matrix.width()))
 }
 
 pub fn transport_matrix_d2h_row_major(
     matrix: &DeviceMatrix<F>,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<RowMajorMatrix<F>, MemCopyError> {
-    let matrix_buffer = DeviceBuffer::<F>::with_capacity(matrix.height() * matrix.width());
+    let matrix_buffer = DeviceBuffer::<F>::with_capacity_on(matrix.height() * matrix.width(), ctx);
     unsafe {
         matrix_transpose_fp(
             &matrix_buffer,
             matrix.buffer(),
             matrix.height(),
             matrix.width(),
-            stream,
+            ctx.stream.as_raw(),
         )?;
     }
     Ok(RowMajorMatrix::<F>::new(
-        matrix_buffer.to_host()?,
+        matrix_buffer.to_host_on(ctx)?,
         matrix.width(),
     ))
 }
@@ -371,13 +363,16 @@ pub fn transport_matrix_d2h_row_major(
 ///
 /// # Panics
 /// If `tree.backing_matrix` is `None`.
-pub fn transport_merkle_tree_to_host(tree: &MerkleTreeGpu<F, Digest>) -> MerkleTree<F, Digest> {
+pub fn transport_merkle_tree_to_host(
+    tree: &MerkleTreeGpu<F, Digest>,
+    ctx: &DeviceContext,
+) -> MerkleTree<F, Digest> {
     let backing_matrix =
-        transport_matrix_d2h_col_major(tree.backing_matrix.as_ref().unwrap()).unwrap();
+        transport_matrix_d2h_col_major(tree.backing_matrix.as_ref().unwrap(), ctx).unwrap();
     let digest_layers = tree
         .digest_layers
         .iter()
-        .map(|layer| layer.to_host().unwrap())
+        .map(|layer| layer.to_host_on(ctx).unwrap())
         .collect_vec();
     // Safety: assuming the tree is properly constructed on device, the layers are correct after D2H
     // transfer.
@@ -389,10 +384,11 @@ pub fn transport_merkle_tree_to_host(tree: &MerkleTreeGpu<F, Digest>) -> MerkleT
 pub fn assert_eq_host_and_device_matrix_col_maj<T: Clone + Send + Sync + PartialEq + Debug>(
     cpu: &ColMajorMatrix<T>,
     gpu: &DeviceMatrix<T>,
+    ctx: &DeviceContext,
 ) {
     assert_eq!(gpu.width(), cpu.width());
     assert_eq!(gpu.height(), cpu.height());
-    let gpu = gpu.to_host().unwrap();
+    let gpu = gpu.buffer().to_host_on(ctx).unwrap();
     for r in 0..cpu.height() {
         for c in 0..cpu.width() {
             assert_eq!(
@@ -409,12 +405,13 @@ pub fn assert_eq_host_and_device_matrix_col_maj<T: Clone + Send + Sync + Partial
 pub fn assert_eq_device_matrix<T: Clone + Send + Sync + PartialEq + Debug>(
     a: &DeviceMatrix<T>,
     b: &DeviceMatrix<T>,
+    ctx: &DeviceContext,
 ) {
     assert_eq!(a.height(), b.height());
     assert_eq!(a.width(), b.width());
     assert_eq!(a.buffer().len(), b.buffer().len());
-    let a_host = a.to_host().unwrap();
-    let b_host = b.to_host().unwrap();
+    let a_host = a.buffer().to_host_on(ctx).unwrap();
+    let b_host = b.buffer().to_host_on(ctx).unwrap();
     for r in 0..a.height() {
         for c in 0..a.width() {
             assert_eq!(
@@ -431,10 +428,11 @@ pub fn assert_eq_device_matrix<T: Clone + Send + Sync + PartialEq + Debug>(
 pub fn assert_eq_host_and_device_matrix<T: Clone + Send + Sync + PartialEq + Debug>(
     cpu: Arc<RowMajorMatrix<T>>,
     gpu: &DeviceMatrix<T>,
+    ctx: &DeviceContext,
 ) {
     assert_eq!(gpu.width(), Matrix::width(cpu.as_ref()));
     assert_eq!(gpu.height(), Matrix::height(cpu.as_ref()));
-    let gpu = gpu.to_host().unwrap();
+    let gpu = gpu.buffer().to_host_on(ctx).unwrap();
     for r in 0..Matrix::height(cpu.as_ref()) {
         for c in 0..Matrix::width(cpu.as_ref()) {
             assert_eq!(

--- a/crates/cuda-backend/src/data_transporter.rs
+++ b/crates/cuda-backend/src/data_transporter.rs
@@ -42,7 +42,7 @@ impl<HS: GpuHashScheme> DeviceDataTransporter<HS::SC, GenericGpuBackend<HS>> for
             .iter()
             .map(|pk| {
                 let preprocessed_data = pk.preprocessed_data.as_ref().map(|d| {
-                    transport_and_unstack_single_data_h2d::<HS>(d.as_ref(), &self.prover_config)
+                    transport_and_unstack_single_data_h2d::<HS>(d.as_ref(), self.prover_config())
                         .unwrap()
                 });
                 let other_data = AirDataGpu::new(pk).unwrap();
@@ -81,7 +81,7 @@ impl<HS: GpuHashScheme> DeviceDataTransporter<HS::SC, GenericGpuBackend<HS>> for
         &self,
         pcs_data: &StackedPcsData<F, HS::Digest>,
     ) -> StackedPcsDataGpu<F, HS::Digest> {
-        transport_pcs_data_h2d::<HS::Digest>(pcs_data, &self.prover_config).unwrap()
+        transport_pcs_data_h2d::<HS::Digest>(pcs_data, self.prover_config()).unwrap()
     }
 
     fn transport_matrix_from_device_to_host(&self, matrix: &DeviceMatrix<F>) -> ColMajorMatrix<F> {

--- a/crates/cuda-backend/src/data_transporter.rs
+++ b/crates/cuda-backend/src/data_transporter.rs
@@ -5,7 +5,7 @@ use openvm_cuda_common::{
     copy::{cuda_memcpy, MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     error::MemCopyError,
-    stream::{cudaStreamPerThread, current_stream_sync},
+    stream::{cudaStream_t, sync_stream},
 };
 use openvm_stark_backend::{
     keygen::types::MultiStarkProvingKey,
@@ -36,14 +36,19 @@ impl<HS: GpuHashScheme> DeviceDataTransporter<HS::SC, GenericGpuBackend<HS>> for
         &self,
         mpk: &MultiStarkProvingKey<HS::SC>,
     ) -> DeviceMultiStarkProvingKey<GenericGpuBackend<HS>> {
+        let stream = self.ctx.stream.as_raw();
         let _span = info_span!("transport_pk_to_device").entered();
         let per_air = mpk
             .per_air
             .iter()
             .map(|pk| {
                 let preprocessed_data = pk.preprocessed_data.as_ref().map(|d| {
-                    transport_and_unstack_single_data_h2d::<HS>(d.as_ref(), self.prover_config())
-                        .unwrap()
+                    transport_and_unstack_single_data_h2d::<HS>(
+                        d.as_ref(),
+                        self.prover_config(),
+                        stream,
+                    )
+                    .unwrap()
                 });
                 let other_data = AirDataGpu::new(pk).unwrap();
                 let num_monomials = other_data
@@ -62,7 +67,7 @@ impl<HS: GpuHashScheme> DeviceDataTransporter<HS::SC, GenericGpuBackend<HS>> for
             })
             .collect();
         // Synchronize in case the proving key is shared between threads/streams
-        current_stream_sync().unwrap();
+        self.ctx.stream.synchronize().unwrap();
 
         DeviceMultiStarkProvingKey::new(
             per_air,
@@ -74,14 +79,16 @@ impl<HS: GpuHashScheme> DeviceDataTransporter<HS::SC, GenericGpuBackend<HS>> for
     }
 
     fn transport_matrix_to_device(&self, matrix: &ColMajorMatrix<F>) -> DeviceMatrix<F> {
-        transport_matrix_h2d_col_major(matrix).unwrap()
+        let stream = self.ctx.stream.as_raw();
+        transport_matrix_h2d_col_major(matrix, stream).unwrap()
     }
 
     fn transport_pcs_data_to_device(
         &self,
         pcs_data: &StackedPcsData<F, HS::Digest>,
     ) -> StackedPcsDataGpu<F, HS::Digest> {
-        transport_pcs_data_h2d::<HS::Digest>(pcs_data, self.prover_config()).unwrap()
+        let stream = self.ctx.stream.as_raw();
+        transport_pcs_data_h2d::<HS::Digest>(pcs_data, self.prover_config(), stream).unwrap()
     }
 
     fn transport_matrix_from_device_to_host(&self, matrix: &DeviceMatrix<F>) -> ColMajorMatrix<F> {
@@ -91,10 +98,11 @@ impl<HS: GpuHashScheme> DeviceDataTransporter<HS::SC, GenericGpuBackend<HS>> for
 
 pub fn transport_matrix_h2d_col_major<T>(
     matrix: &ColMajorMatrix<T>,
+    stream: cudaStream_t,
 ) -> Result<DeviceMatrix<T>, MemCopyError> {
     // matrix is already col-major, so this is just H2D buffer transfer
     let buffer = matrix.values.to_device()?;
-    current_stream_sync()?;
+    unsafe { sync_stream(stream)? };
     Ok(DeviceMatrix::new(
         Arc::new(buffer),
         matrix.height(),
@@ -104,6 +112,7 @@ pub fn transport_matrix_h2d_col_major<T>(
 
 pub fn transport_matrix_h2d_row(
     matrix: &RowMajorMatrix<F>,
+    stream: cudaStream_t,
 ) -> Result<DeviceMatrix<F>, MemCopyError> {
     let data = matrix.values.as_slice();
     let input_buffer = data.to_device().unwrap();
@@ -114,10 +123,10 @@ pub fn transport_matrix_h2d_row(
             &input_buffer,
             Matrix::width(matrix),
             Matrix::height(matrix),
-            cudaStreamPerThread,
+            stream,
         )?;
     }
-    current_stream_sync()?;
+    unsafe { sync_stream(stream)? };
     assert_eq!(output.strong_count(), 1);
     Ok(output)
 }
@@ -128,6 +137,7 @@ pub fn transport_matrix_h2d_row(
 pub fn transport_and_unstack_single_data_h2d<HS: GpuHashScheme>(
     d: &StackedPcsData<F, HS::Digest>,
     prover_config: &GpuProverConfig,
+    stream: cudaStream_t,
 ) -> Result<CommittedTraceData<GenericGpuBackend<HS>>, ProverError> {
     let _span = info_span!("transport_unstack_h2d").entered();
     debug_assert!(d
@@ -170,19 +180,25 @@ pub fn transport_and_unstack_single_data_h2d<HS: GpuHashScheme>(
                 width as u32,
                 height as u32,
                 stride as u32,
-                cudaStreamPerThread,
+                stream,
             )
             .map_err(ProverError::CollapseStrided)?;
         }
         // Wait for kernel to finish so we can safely drop strided_trace
-        current_stream_sync().map_err(ProverError::CurrentStreamSync)?;
+        unsafe { sync_stream(stream) }.map_err(ProverError::CurrentStreamSync)?;
         drop(strided_trace);
         buf
     };
-    let d_matrix = prover_config
-        .cache_stacked_matrix
-        .then(|| PleMatrix::from_evals(l_skip, d_matrix_evals, stacked_height, stacked_width));
-    let d_tree = transport_merkle_tree_h2d(&d.tree, prover_config.cache_rs_code_matrix)?;
+    let d_matrix = prover_config.cache_stacked_matrix.then(|| {
+        PleMatrix::from_evals(
+            l_skip,
+            d_matrix_evals,
+            stacked_height,
+            stacked_width,
+            stream,
+        )
+    });
+    let d_tree = transport_merkle_tree_h2d(&d.tree, prover_config.cache_rs_code_matrix, stream)?;
     let d_data = StackedPcsDataGpu {
         layout: d.layout.clone(),
         matrix: d_matrix,
@@ -205,9 +221,13 @@ pub fn transport_and_unstack_single_data_h2d<HS: GpuHashScheme>(
 pub fn transport_merkle_tree_h2d<F, Digest: Clone>(
     tree: &MerkleTree<F, Digest>,
     cache_backing_matrix: bool,
+    stream: cudaStream_t,
 ) -> Result<MerkleTreeGpu<F, Digest>, MemCopyError> {
     let backing_matrix = if cache_backing_matrix {
-        Some(transport_matrix_h2d_col_major(tree.backing_matrix())?)
+        Some(transport_matrix_h2d_col_major(
+            tree.backing_matrix(),
+            stream,
+        )?)
     } else {
         None
     };
@@ -216,7 +236,7 @@ pub fn transport_merkle_tree_h2d<F, Digest: Clone>(
         .iter()
         .map(|layer| layer.to_device())
         .collect::<Result<Vec<_>, _>>()?;
-    current_stream_sync()?;
+    unsafe { sync_stream(stream)? };
     Ok(MerkleTreeGpu {
         backing_matrix,
         digest_layers,
@@ -228,6 +248,7 @@ pub fn transport_merkle_tree_h2d<F, Digest: Clone>(
 pub fn transport_pcs_data_h2d<D: Copy + Clone + PartialEq + Send + Sync + 'static>(
     pcs_data: &StackedPcsData<F, D>,
     prover_config: &GpuProverConfig,
+    stream: cudaStream_t,
 ) -> Result<StackedPcsDataGpu<F, D>, ProverError> {
     let _span = info_span!("transport_pcs_data_h2d").entered();
     let StackedPcsData {
@@ -240,9 +261,9 @@ pub fn transport_pcs_data_h2d<D: Copy + Clone + PartialEq + Send + Sync + 'stati
     let d_matrix_evals = matrix.values.to_device()?;
     let d_matrix = prover_config
         .cache_stacked_matrix
-        .then(|| PleMatrix::from_evals(layout.l_skip(), d_matrix_evals, height, width));
-    let d_tree = transport_merkle_tree_h2d(tree, prover_config.cache_rs_code_matrix)?;
-    current_stream_sync().map_err(ProverError::CurrentStreamSync)?;
+        .then(|| PleMatrix::from_evals(layout.l_skip(), d_matrix_evals, height, width, stream));
+    let d_tree = transport_merkle_tree_h2d(tree, prover_config.cache_rs_code_matrix, stream)?;
+    unsafe { sync_stream(stream) }.map_err(ProverError::CurrentStreamSync)?;
 
     Ok(StackedPcsDataGpu {
         layout: layout.clone(),
@@ -253,13 +274,14 @@ pub fn transport_pcs_data_h2d<D: Copy + Clone + PartialEq + Send + Sync + 'stati
 
 pub fn transport_air_proving_ctx_to_device<HS: GpuHashScheme>(
     cpu_ctx: AirProvingContext<CpuColMajorBackend<SC>>,
+    stream: cudaStream_t,
 ) -> AirProvingContext<GenericGpuBackend<HS>> {
     let _span = info_span!("transport_air_ctx_h2d").entered();
     assert!(
         cpu_ctx.cached_mains.is_empty(),
         "CPU to GPU transfer of cached traces not supported"
     );
-    let trace = transport_matrix_h2d_col_major(&cpu_ctx.common_main).unwrap();
+    let trace = transport_matrix_h2d_col_major(&cpu_ctx.common_main, stream).unwrap();
     AirProvingContext {
         cached_mains: vec![],
         common_main: trace,
@@ -270,11 +292,12 @@ pub fn transport_air_proving_ctx_to_device<HS: GpuHashScheme>(
 pub fn transport_proving_ctx_to_host(
     gpu_ctx: ProvingContext<GpuBackend>,
     l_skip: usize,
+    stream: cudaStream_t,
 ) -> ProvingContext<CpuColMajorBackend<SC>> {
     let per_trace = gpu_ctx
         .per_trace
         .into_iter()
-        .map(|(i, ctx)| (i, transport_air_proving_ctx_to_host(ctx, l_skip)))
+        .map(|(i, ctx)| (i, transport_air_proving_ctx_to_host(ctx, l_skip, stream)))
         .collect_vec();
     ProvingContext { per_trace }
 }
@@ -282,6 +305,7 @@ pub fn transport_proving_ctx_to_host(
 pub fn transport_air_proving_ctx_to_host(
     gpu_ctx: AirProvingContext<GpuBackend>,
     l_skip: usize,
+    stream: cudaStream_t,
 ) -> AirProvingContext<CpuColMajorBackend<SC>> {
     let trace = transport_matrix_d2h_col_major(&gpu_ctx.common_main).unwrap();
     let cached_mains = gpu_ctx
@@ -291,7 +315,13 @@ pub fn transport_air_proving_ctx_to_host(
             // WARNING: By default this matrix isn't cached. For this to work, ensure that
             // GpuProverConfig fields cache_stacked_matrix and cache_rs_code_matrix are set
             // to be true.
-            let evals_matrix = mat.data.matrix.as_ref().unwrap().to_evals(l_skip).unwrap();
+            let evals_matrix = mat
+                .data
+                .matrix
+                .as_ref()
+                .unwrap()
+                .to_evals(l_skip, stream)
+                .unwrap();
             CommittedTraceData {
                 commitment: mat.commitment,
                 trace: transport_matrix_d2h_col_major(&mat.trace).unwrap(),
@@ -319,6 +349,7 @@ pub fn transport_matrix_d2h_col_major<T>(
 
 pub fn transport_matrix_d2h_row_major(
     matrix: &DeviceMatrix<F>,
+    stream: cudaStream_t,
 ) -> Result<RowMajorMatrix<F>, MemCopyError> {
     let matrix_buffer = DeviceBuffer::<F>::with_capacity(matrix.height() * matrix.width());
     unsafe {
@@ -327,7 +358,7 @@ pub fn transport_matrix_d2h_row_major(
             matrix.buffer(),
             matrix.height(),
             matrix.width(),
-            cudaStreamPerThread,
+            stream,
         )?;
     }
     Ok(RowMajorMatrix::<F>::new(

--- a/crates/cuda-backend/src/data_transporter.rs
+++ b/crates/cuda-backend/src/data_transporter.rs
@@ -5,7 +5,7 @@ use openvm_cuda_common::{
     copy::{cuda_memcpy_on, MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     error::MemCopyError,
-    stream::{sync_stream, DeviceContext},
+    stream::{sync_stream, GpuDeviceCtx},
 };
 use openvm_stark_backend::{
     keygen::types::MultiStarkProvingKey,
@@ -97,7 +97,7 @@ impl<HS: GpuHashScheme> DeviceDataTransporter<HS::SC, GenericGpuBackend<HS>> for
 
 pub fn transport_matrix_h2d_col_major<T>(
     matrix: &ColMajorMatrix<T>,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<DeviceMatrix<T>, MemCopyError> {
     // matrix is already col-major, so this is just H2D buffer transfer
     let buffer = matrix.values.to_device_on(device_ctx)?;
@@ -111,7 +111,7 @@ pub fn transport_matrix_h2d_col_major<T>(
 
 pub fn transport_matrix_h2d_row(
     matrix: &RowMajorMatrix<F>,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<DeviceMatrix<F>, MemCopyError> {
     let data = matrix.values.as_slice();
     let input_buffer = data.to_device_on(device_ctx).unwrap();
@@ -140,7 +140,7 @@ pub fn transport_matrix_h2d_row(
 pub fn transport_and_unstack_single_data_h2d<HS: GpuHashScheme>(
     d: &StackedPcsData<F, HS::Digest>,
     prover_config: &GpuProverConfig,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<CommittedTraceData<GenericGpuBackend<HS>>, ProverError> {
     let _span = info_span!("transport_unstack_h2d").entered();
     debug_assert!(d
@@ -227,7 +227,7 @@ pub fn transport_and_unstack_single_data_h2d<HS: GpuHashScheme>(
 pub fn transport_merkle_tree_h2d<F, Digest: Clone>(
     tree: &MerkleTree<F, Digest>,
     cache_backing_matrix: bool,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<MerkleTreeGpu<F, Digest>, MemCopyError> {
     let backing_matrix = if cache_backing_matrix {
         Some(transport_matrix_h2d_col_major(
@@ -254,7 +254,7 @@ pub fn transport_merkle_tree_h2d<F, Digest: Clone>(
 pub fn transport_pcs_data_h2d<D: Copy + Clone + PartialEq + Send + Sync + 'static>(
     pcs_data: &StackedPcsData<F, D>,
     prover_config: &GpuProverConfig,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<StackedPcsDataGpu<F, D>, ProverError> {
     let _span = info_span!("transport_pcs_data_h2d").entered();
     let StackedPcsData {
@@ -280,7 +280,7 @@ pub fn transport_pcs_data_h2d<D: Copy + Clone + PartialEq + Send + Sync + 'stati
 
 pub fn transport_air_proving_ctx_to_device<HS: GpuHashScheme>(
     cpu_ctx: AirProvingContext<CpuColMajorBackend<SC>>,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> AirProvingContext<GenericGpuBackend<HS>> {
     let _span = info_span!("transport_air_ctx_h2d").entered();
     assert!(
@@ -298,7 +298,7 @@ pub fn transport_air_proving_ctx_to_device<HS: GpuHashScheme>(
 pub fn transport_proving_ctx_to_host(
     gpu_ctx: ProvingContext<GpuBackend>,
     l_skip: usize,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> ProvingContext<CpuColMajorBackend<SC>> {
     let per_trace = gpu_ctx
         .per_trace
@@ -316,7 +316,7 @@ pub fn transport_proving_ctx_to_host(
 pub fn transport_air_proving_ctx_to_host(
     gpu_ctx: AirProvingContext<GpuBackend>,
     l_skip: usize,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> AirProvingContext<CpuColMajorBackend<SC>> {
     let trace = transport_matrix_d2h_col_major(&gpu_ctx.common_main, device_ctx).unwrap();
     let cached_mains = gpu_ctx
@@ -353,7 +353,7 @@ pub fn transport_air_proving_ctx_to_host(
 
 pub fn transport_matrix_d2h_col_major<T>(
     matrix: &DeviceMatrix<T>,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<ColMajorMatrix<T>, MemCopyError> {
     let values_host = matrix.buffer().to_host_on(device_ctx)?;
     Ok(ColMajorMatrix::new(values_host, matrix.width()))
@@ -361,7 +361,7 @@ pub fn transport_matrix_d2h_col_major<T>(
 
 pub fn transport_matrix_d2h_row_major(
     matrix: &DeviceMatrix<F>,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<RowMajorMatrix<F>, MemCopyError> {
     let matrix_buffer =
         DeviceBuffer::<F>::with_capacity_on(matrix.height() * matrix.width(), device_ctx);
@@ -386,7 +386,7 @@ pub fn transport_matrix_d2h_row_major(
 /// If `tree.backing_matrix` is `None`.
 pub fn transport_merkle_tree_to_host(
     tree: &MerkleTreeGpu<F, Digest>,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> MerkleTree<F, Digest> {
     let backing_matrix =
         transport_matrix_d2h_col_major(tree.backing_matrix.as_ref().unwrap(), device_ctx).unwrap();
@@ -405,7 +405,7 @@ pub fn transport_merkle_tree_to_host(
 pub fn assert_eq_host_and_device_matrix_col_maj<T: Clone + Send + Sync + PartialEq + Debug>(
     cpu: &ColMajorMatrix<T>,
     gpu: &DeviceMatrix<T>,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) {
     assert_eq!(gpu.width(), cpu.width());
     assert_eq!(gpu.height(), cpu.height());
@@ -426,7 +426,7 @@ pub fn assert_eq_host_and_device_matrix_col_maj<T: Clone + Send + Sync + Partial
 pub fn assert_eq_device_matrix<T: Clone + Send + Sync + PartialEq + Debug>(
     a: &DeviceMatrix<T>,
     b: &DeviceMatrix<T>,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) {
     assert_eq!(a.height(), b.height());
     assert_eq!(a.width(), b.width());
@@ -449,7 +449,7 @@ pub fn assert_eq_device_matrix<T: Clone + Send + Sync + PartialEq + Debug>(
 pub fn assert_eq_host_and_device_matrix<T: Clone + Send + Sync + PartialEq + Debug>(
     cpu: Arc<RowMajorMatrix<T>>,
     gpu: &DeviceMatrix<T>,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) {
     assert_eq!(gpu.width(), Matrix::width(cpu.as_ref()));
     assert_eq!(gpu.height(), Matrix::height(cpu.as_ref()));

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -1,5 +1,8 @@
 use getset::{CopyGetters, Getters, MutGetters};
-use openvm_cuda_common::common::get_device;
+use openvm_cuda_common::{
+    common::get_device,
+    stream::{CudaStream, DeviceContext, StreamGuard},
+};
 use openvm_stark_backend::SystemParams;
 
 use crate::cuda::{
@@ -7,8 +10,10 @@ use crate::cuda::{
     device_info::get_sm_count,
 };
 
+/// Pure device configuration — no stream, no CUDA runtime state.
+/// Renamed from the old `GpuDevice`.
 #[derive(Clone, Getters, CopyGetters, MutGetters)]
-pub struct GpuDevice {
+pub struct GpuDeviceConfig {
     #[getset(get = "pub")]
     pub(crate) config: SystemParams,
     #[getset(get = "pub", get_mut = "pub")]
@@ -25,34 +30,71 @@ pub struct GpuProverConfig {
     pub zerocheck_save_memory: bool,
 }
 
+/// Stream-owning device handle. Wraps [`GpuDeviceConfig`] with a
+/// [`DeviceContext`] that carries the explicit CUDA stream.
+#[derive(Clone)]
+pub struct GpuDevice {
+    pub config: GpuDeviceConfig,
+    pub ctx: DeviceContext,
+}
+
 impl GpuDevice {
-    pub fn new(config: SystemParams) -> Self {
-        validate_gpu_l_skip(config.l_skip)
+    pub fn new(params: SystemParams) -> Result<Self, openvm_cuda_common::error::CudaError> {
+        validate_gpu_l_skip(params.l_skip)
             .expect("GPU backend requires l_skip <= 10 for current CUDA kernels");
         ensure_device_ntt_twiddles_initialized()
             .expect("failed to initialize small-NTT twiddles for current CUDA device");
 
         let prover_config = GpuProverConfig {
-            zerocheck_save_memory: config.log_blowup == 1,
+            zerocheck_save_memory: params.log_blowup == 1,
             ..Default::default()
         };
         let id = get_device().unwrap() as u32;
         let sm_count = get_sm_count(id).expect("failed to get SM count");
-        Self {
-            config,
+        let config = GpuDeviceConfig {
+            config: params,
             prover_config,
             id,
             sm_count,
-        }
+        };
+
+        let stream = CudaStream::new_non_blocking()?;
+        let ctx = DeviceContext {
+            device_id: id,
+            stream: StreamGuard::new(stream),
+        };
+
+        Ok(Self { config, ctx })
+    }
+
+    // Delegate accessors to inner config
+    pub fn config(&self) -> &SystemParams {
+        &self.config.config
+    }
+
+    pub fn prover_config(&self) -> &GpuProverConfig {
+        &self.config.prover_config
+    }
+
+    pub fn prover_config_mut(&mut self) -> &mut GpuProverConfig {
+        &mut self.config.prover_config
+    }
+
+    pub fn sm_count(&self) -> u32 {
+        self.config.sm_count
+    }
+
+    pub fn id(&self) -> u32 {
+        self.config.id
     }
 
     pub fn with_cache_rs_code_matrix(mut self, cache_rs_code_matrix: bool) -> Self {
-        self.prover_config.cache_rs_code_matrix = cache_rs_code_matrix;
+        self.config.prover_config.cache_rs_code_matrix = cache_rs_code_matrix;
         self
     }
 
     pub fn set_cache_rs_code_matrix(&mut self, cache_rs_code_matrix: bool) {
-        self.prover_config.cache_rs_code_matrix = cache_rs_code_matrix;
+        self.config.prover_config.cache_rs_code_matrix = cache_rs_code_matrix;
     }
 }
 

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -1,5 +1,5 @@
 use getset::{CopyGetters, Getters, MutGetters};
-use openvm_cuda_common::{common::get_device, stream::DeviceContext};
+use openvm_cuda_common::{common::get_device, stream::GpuDeviceCtx};
 use openvm_stark_backend::SystemParams;
 
 use crate::cuda::{
@@ -28,11 +28,11 @@ pub struct GpuProverConfig {
 }
 
 /// Stream-owning device handle. Wraps [`GpuDeviceConfig`] with a
-/// [`DeviceContext`] that carries the explicit CUDA stream.
+/// [`GpuDeviceCtx`] that carries the explicit CUDA stream.
 #[derive(Clone)]
 pub struct GpuDevice {
     pub config: GpuDeviceConfig,
-    pub device_ctx: DeviceContext,
+    pub device_ctx: GpuDeviceCtx,
 }
 
 impl GpuDevice {
@@ -47,7 +47,7 @@ impl GpuDevice {
             ..Default::default()
         };
         let id = get_device().unwrap() as u32;
-        let device_ctx = DeviceContext::for_device(id)?;
+        let device_ctx = GpuDeviceCtx::for_device(id)?;
         let sm_count =
             get_sm_count(id, device_ctx.stream.as_raw()).expect("failed to get SM count");
         let config = GpuDeviceConfig {

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -1,7 +1,7 @@
 use getset::{CopyGetters, Getters, MutGetters};
 use openvm_cuda_common::{
     common::get_device,
-    stream::{cudaStreamPerThread, CudaStream, DeviceContext, StreamGuard},
+    stream::{CudaStream, DeviceContext, StreamGuard},
 };
 use openvm_stark_backend::SystemParams;
 
@@ -50,21 +50,16 @@ impl GpuDevice {
             ..Default::default()
         };
         let id = get_device().unwrap() as u32;
-        let sm_count = get_sm_count(id, cudaStreamPerThread).expect("failed to get SM count");
+        let ctx = DeviceContext {
+            device_id: id,
+            stream: StreamGuard::new(CudaStream::new_non_blocking()?),
+        };
+        let sm_count = get_sm_count(id, ctx.stream.as_raw()).expect("failed to get SM count");
         let config = GpuDeviceConfig {
             config: params,
             prover_config,
             id,
             sm_count,
-        };
-
-        // During the transition (Phases 0–7) allocation/copy paths still use
-        // PTDS. Using the same PTDS handle here ensures kernel launches and
-        // allocations share a single stream, preventing races.
-        // Phase 8 replaces this with CudaStream::new_non_blocking().
-        let ctx = DeviceContext {
-            device_id: id,
-            stream: StreamGuard::new(CudaStream::ptds()),
         };
 
         Ok(Self { config, ctx })

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -12,7 +12,7 @@ use crate::cuda::{
 #[derive(Clone, Getters, CopyGetters, MutGetters)]
 pub struct GpuDeviceConfig {
     #[getset(get = "pub")]
-    pub(crate) config: SystemParams,
+    pub(crate) params: SystemParams,
     #[getset(get = "pub", get_mut = "pub")]
     pub(crate) prover_config: GpuProverConfig,
     pub id: u32,
@@ -50,7 +50,7 @@ impl GpuDevice {
         let ctx = DeviceContext::for_device(id)?;
         let sm_count = get_sm_count(id, ctx.stream.as_raw()).expect("failed to get SM count");
         let config = GpuDeviceConfig {
-            config: params,
+            params,
             prover_config,
             id,
             sm_count,
@@ -60,8 +60,8 @@ impl GpuDevice {
     }
 
     // Delegate accessors to inner config
-    pub fn config(&self) -> &SystemParams {
-        &self.config.config
+    pub fn params(&self) -> &SystemParams {
+        &self.config.params
     }
 
     pub fn prover_config(&self) -> &GpuProverConfig {

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -58,10 +58,13 @@ impl GpuDevice {
             sm_count,
         };
 
-        let stream = CudaStream::new_non_blocking()?;
+        // During the transition (Phases 0–7) allocation/copy paths still use
+        // PTDS. Using the same PTDS handle here ensures kernel launches and
+        // allocations share a single stream, preventing races.
+        // Phase 8 replaces this with CudaStream::new_non_blocking().
         let ctx = DeviceContext {
             device_id: id,
-            stream: StreamGuard::new(stream),
+            stream: StreamGuard::new(CudaStream::ptds()),
         };
 
         Ok(Self { config, ctx })

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -32,7 +32,7 @@ pub struct GpuProverConfig {
 #[derive(Clone)]
 pub struct GpuDevice {
     pub config: GpuDeviceConfig,
-    pub ctx: DeviceContext,
+    pub device_ctx: DeviceContext,
 }
 
 impl GpuDevice {
@@ -47,8 +47,9 @@ impl GpuDevice {
             ..Default::default()
         };
         let id = get_device().unwrap() as u32;
-        let ctx = DeviceContext::for_device(id)?;
-        let sm_count = get_sm_count(id, ctx.stream.as_raw()).expect("failed to get SM count");
+        let device_ctx = DeviceContext::for_device(id)?;
+        let sm_count =
+            get_sm_count(id, device_ctx.stream.as_raw()).expect("failed to get SM count");
         let config = GpuDeviceConfig {
             params,
             prover_config,
@@ -56,7 +57,7 @@ impl GpuDevice {
             sm_count,
         };
 
-        Ok(Self { config, ctx })
+        Ok(Self { config, device_ctx })
     }
 
     // Delegate accessors to inner config

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -1,8 +1,5 @@
 use getset::{CopyGetters, Getters, MutGetters};
-use openvm_cuda_common::{
-    common::get_device,
-    stream::{CudaStream, DeviceContext, StreamGuard},
-};
+use openvm_cuda_common::{common::get_device, stream::DeviceContext};
 use openvm_stark_backend::SystemParams;
 
 use crate::cuda::{
@@ -50,10 +47,7 @@ impl GpuDevice {
             ..Default::default()
         };
         let id = get_device().unwrap() as u32;
-        let ctx = DeviceContext {
-            device_id: id,
-            stream: StreamGuard::new(CudaStream::new_non_blocking()?),
-        };
+        let ctx = DeviceContext::for_device(id)?;
         let sm_count = get_sm_count(id, ctx.stream.as_raw()).expect("failed to get SM count");
         let config = GpuDeviceConfig {
             config: params,

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -1,7 +1,7 @@
 use getset::{CopyGetters, Getters, MutGetters};
 use openvm_cuda_common::{
     common::get_device,
-    stream::{CudaStream, DeviceContext, StreamGuard},
+    stream::{cudaStreamPerThread, CudaStream, DeviceContext, StreamGuard},
 };
 use openvm_stark_backend::SystemParams;
 
@@ -50,7 +50,7 @@ impl GpuDevice {
             ..Default::default()
         };
         let id = get_device().unwrap() as u32;
-        let sm_count = get_sm_count(id).expect("failed to get SM count");
+        let sm_count = get_sm_count(id, cudaStreamPerThread).expect("failed to get SM count");
         let config = GpuDeviceConfig {
             config: params,
             prover_config,

--- a/crates/cuda-backend/src/engine.rs
+++ b/crates/cuda-backend/src/engine.rs
@@ -37,7 +37,7 @@ impl<HS: GpuHashScheme> GpuEngine<HS> {
     pub fn new(params: SystemParams) -> Self {
         let config = HS::default_config(params.clone());
         Self {
-            device: GpuDevice::new(params),
+            device: GpuDevice::new(params).expect("failed to create GpuDevice"),
             config,
         }
     }

--- a/crates/cuda-backend/src/error.rs
+++ b/crates/cuda-backend/src/error.rs
@@ -12,7 +12,7 @@ use crate::{
 pub enum ProverError {
     #[error("MemCopy: {0}")]
     MemCopy(#[from] MemCopyError),
-    #[error("current_stream_sync: {0}")]
+    #[error("stream_synchronize: {0}")]
     CurrentStreamSync(CudaError),
     #[error("collapse_strided_matrix: {0}")]
     CollapseStrided(CudaError),

--- a/crates/cuda-backend/src/error.rs
+++ b/crates/cuda-backend/src/error.rs
@@ -13,7 +13,7 @@ pub enum ProverError {
     #[error("MemCopy: {0}")]
     MemCopy(#[from] MemCopyError),
     #[error("stream_synchronize: {0}")]
-    CurrentStreamSync(CudaError),
+    StreamSynchronize(CudaError),
     #[error("collapse_strided_matrix: {0}")]
     CollapseStrided(CudaError),
     #[error("Stack traces: {0}")]

--- a/crates/cuda-backend/src/gpu_backend.rs
+++ b/crates/cuda-backend/src/gpu_backend.rs
@@ -82,6 +82,11 @@ where
     HS::Digest: MerkleProofQueryDigest,
 {
     type Error = ProverError;
+    type DeviceCtx = openvm_cuda_common::stream::GpuDeviceCtx;
+
+    fn device_ctx(&self) -> &openvm_cuda_common::stream::GpuDeviceCtx {
+        &self.device_ctx
+    }
 }
 
 impl<HS: GpuHashScheme, TS: GpuFiatShamirTranscript<HS::SC>>

--- a/crates/cuda-backend/src/gpu_backend.rs
+++ b/crates/cuda-backend/src/gpu_backend.rs
@@ -62,13 +62,14 @@ where
         &self,
         traces: &[&DeviceMatrix<F>],
     ) -> Result<(HS::Digest, StackedPcsDataGpu<F, HS::Digest>), Self::Error> {
+        let cfg = self.config();
         stacked_commit::<HS::MerkleHash>(
-            self.config.l_skip,
-            self.config.n_stack,
-            self.config.log_blowup,
-            self.config.k_whir(),
+            cfg.l_skip,
+            cfg.n_stack,
+            cfg.log_blowup,
+            cfg.k_whir(),
             traces,
-            self.prover_config,
+            *self.prover_config(),
         )
     }
 }
@@ -101,18 +102,22 @@ impl<HS: GpuHashScheme, TS: GpuFiatShamirTranscript<HS::SC>>
         _common_main_pcs_data: &StackedPcsDataGpu<F, HS::Digest>,
     ) -> Result<((GkrProof<HS::SC>, BatchConstraintProof<HS::SC>), Vec<EF>), Self::Error> {
         let mem = MemTracker::start_and_reset_peak("prover.rap_constraints");
-        let save_memory = self.prover_config.zerocheck_save_memory;
+        let save_memory = self.prover_config().zerocheck_save_memory;
         // Threshold for monomial evaluation path based on proof type:
         // - App proofs (log_blowup=1): higher threshold (512)
         // - Recursion proofs: lower threshold (64)
-        let monomial_num_y_threshold = if self.config.log_blowup == 1 { 512 } else { 64 };
+        let monomial_num_y_threshold = if self.config().log_blowup == 1 {
+            512
+        } else {
+            64
+        };
         let (gkr_proof, batch_constraint_proof, r) = prove_zerocheck_and_logup_gpu::<HS, TS>(
             transcript,
             mpk,
             ctx,
             save_memory,
             monomial_num_y_threshold,
-            self.sm_count,
+            self.sm_count(),
         )?;
         mem.emit_metrics();
         Ok(((gkr_proof, batch_constraint_proof), r))

--- a/crates/cuda-backend/src/gpu_backend.rs
+++ b/crates/cuda-backend/src/gpu_backend.rs
@@ -62,7 +62,7 @@ where
         &self,
         traces: &[&DeviceMatrix<F>],
     ) -> Result<(HS::Digest, StackedPcsDataGpu<F, HS::Digest>), Self::Error> {
-        let cfg = self.config();
+        let cfg = self.params();
         stacked_commit::<HS::MerkleHash>(
             cfg.l_skip,
             cfg.n_stack,
@@ -107,7 +107,7 @@ impl<HS: GpuHashScheme, TS: GpuFiatShamirTranscript<HS::SC>>
         // Threshold for monomial evaluation path based on proof type:
         // - App proofs (log_blowup=1): higher threshold (512)
         // - Recursion proofs: lower threshold (64)
-        let monomial_num_y_threshold = if self.config().log_blowup == 1 {
+        let monomial_num_y_threshold = if self.params().log_blowup == 1 {
             512
         } else {
             64
@@ -147,7 +147,7 @@ where
         r: Vec<EF>,
     ) -> Result<Self::OpeningProof, Self::Error> {
         let mut mem = MemTracker::start_and_reset_peak("prover.openings");
-        let params = self.config();
+        let params = self.params();
         #[cfg(debug_assertions)]
         {
             let total_stacked_width: usize = std::iter::once(common_main_pcs_data.layout().width())

--- a/crates/cuda-backend/src/gpu_backend.rs
+++ b/crates/cuda-backend/src/gpu_backend.rs
@@ -62,6 +62,7 @@ where
         &self,
         traces: &[&DeviceMatrix<F>],
     ) -> Result<(HS::Digest, StackedPcsDataGpu<F, HS::Digest>), Self::Error> {
+        let stream = self.ctx.stream.as_raw();
         let cfg = self.config();
         stacked_commit::<HS::MerkleHash>(
             cfg.l_skip,
@@ -70,6 +71,7 @@ where
             cfg.k_whir(),
             traces,
             *self.prover_config(),
+            stream,
         )
     }
 }
@@ -101,6 +103,7 @@ impl<HS: GpuHashScheme, TS: GpuFiatShamirTranscript<HS::SC>>
         ctx: &ProvingContext<GenericGpuBackend<HS>>,
         _common_main_pcs_data: &StackedPcsDataGpu<F, HS::Digest>,
     ) -> Result<((GkrProof<HS::SC>, BatchConstraintProof<HS::SC>), Vec<EF>), Self::Error> {
+        let stream = self.ctx.stream.as_raw();
         let mem = MemTracker::start_and_reset_peak("prover.rap_constraints");
         let save_memory = self.prover_config().zerocheck_save_memory;
         // Threshold for monomial evaluation path based on proof type:
@@ -118,6 +121,7 @@ impl<HS: GpuHashScheme, TS: GpuFiatShamirTranscript<HS::SC>>
             save_memory,
             monomial_num_y_threshold,
             self.sm_count(),
+            stream,
         )?;
         mem.emit_metrics();
         Ok(((gkr_proof, batch_constraint_proof), r))
@@ -144,6 +148,7 @@ where
         common_main_pcs_data: StackedPcsDataGpu<F, HS::Digest>,
         r: Vec<EF>,
     ) -> Result<Self::OpeningProof, Self::Error> {
+        let stream = self.ctx.stream.as_raw();
         let mut mem = MemTracker::start_and_reset_peak("prover.openings");
         let params = self.config();
         #[cfg(debug_assertions)]
@@ -185,8 +190,13 @@ where
             .chain(u_rest.iter().copied())
             .collect_vec();
 
-        let whir_proof =
-            prove_whir_opening_gpu::<HS, TS>(params, transcript, stacked_per_commit, &u_cube)?;
+        let whir_proof = prove_whir_opening_gpu::<HS, TS>(
+            params,
+            transcript,
+            stacked_per_commit,
+            &u_cube,
+            stream,
+        )?;
         mem.emit_metrics();
         mem.reset_peak();
         Ok((stacking_proof, whir_proof))

--- a/crates/cuda-backend/src/gpu_backend.rs
+++ b/crates/cuda-backend/src/gpu_backend.rs
@@ -62,7 +62,6 @@ where
         &self,
         traces: &[&DeviceMatrix<F>],
     ) -> Result<(HS::Digest, StackedPcsDataGpu<F, HS::Digest>), Self::Error> {
-        let stream = self.ctx.stream.as_raw();
         let cfg = self.config();
         stacked_commit::<HS::MerkleHash>(
             cfg.l_skip,
@@ -71,7 +70,7 @@ where
             cfg.k_whir(),
             traces,
             *self.prover_config(),
-            stream,
+            &self.ctx,
         )
     }
 }
@@ -103,7 +102,6 @@ impl<HS: GpuHashScheme, TS: GpuFiatShamirTranscript<HS::SC>>
         ctx: &ProvingContext<GenericGpuBackend<HS>>,
         _common_main_pcs_data: &StackedPcsDataGpu<F, HS::Digest>,
     ) -> Result<((GkrProof<HS::SC>, BatchConstraintProof<HS::SC>), Vec<EF>), Self::Error> {
-        let stream = self.ctx.stream.as_raw();
         let mem = MemTracker::start_and_reset_peak("prover.rap_constraints");
         let save_memory = self.prover_config().zerocheck_save_memory;
         // Threshold for monomial evaluation path based on proof type:
@@ -121,7 +119,7 @@ impl<HS: GpuHashScheme, TS: GpuFiatShamirTranscript<HS::SC>>
             save_memory,
             monomial_num_y_threshold,
             self.sm_count(),
-            stream,
+            &self.ctx,
         )?;
         mem.emit_metrics();
         Ok(((gkr_proof, batch_constraint_proof), r))
@@ -148,7 +146,6 @@ where
         common_main_pcs_data: StackedPcsDataGpu<F, HS::Digest>,
         r: Vec<EF>,
     ) -> Result<Self::OpeningProof, Self::Error> {
-        let stream = self.ctx.stream.as_raw();
         let mut mem = MemTracker::start_and_reset_peak("prover.openings");
         let params = self.config();
         #[cfg(debug_assertions)]
@@ -195,7 +192,7 @@ where
             transcript,
             stacked_per_commit,
             &u_cube,
-            stream,
+            &self.ctx,
         )?;
         mem.emit_metrics();
         mem.reset_peak();

--- a/crates/cuda-backend/src/gpu_backend.rs
+++ b/crates/cuda-backend/src/gpu_backend.rs
@@ -70,7 +70,7 @@ where
             cfg.k_whir(),
             traces,
             *self.prover_config(),
-            &self.ctx,
+            &self.device_ctx,
         )
     }
 }
@@ -119,7 +119,7 @@ impl<HS: GpuHashScheme, TS: GpuFiatShamirTranscript<HS::SC>>
             save_memory,
             monomial_num_y_threshold,
             self.sm_count(),
-            &self.ctx,
+            &self.device_ctx,
         )?;
         mem.emit_metrics();
         Ok(((gkr_proof, batch_constraint_proof), r))
@@ -192,7 +192,7 @@ where
             transcript,
             stacked_per_commit,
             &u_cube,
-            &self.ctx,
+            &self.device_ctx,
         )?;
         mem.emit_metrics();
         mem.reset_peak();

--- a/crates/cuda-backend/src/hash_scheme.rs
+++ b/crates/cuda-backend/src/hash_scheme.rs
@@ -1,4 +1,4 @@
-use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::cudaStream_t};
+use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::DeviceContext};
 use openvm_stark_backend::{StarkProtocolConfig, SystemParams};
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::{
@@ -56,7 +56,7 @@ pub trait GpuMerkleHash: Copy + Clone + Send + Sync + 'static {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<(), CudaError>;
 
     /// Compress rows of an extension-field matrix into digest leaves.
@@ -71,7 +71,7 @@ pub trait GpuMerkleHash: Copy + Clone + Send + Sync + 'static {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<(), CudaError>;
 
     /// Compress adjacent pairs of digests to build an inner Merkle layer.
@@ -85,7 +85,7 @@ pub trait GpuMerkleHash: Copy + Clone + Send + Sync + 'static {
         output: &mut DeviceBuffer<Self::Digest>,
         prev_layer: &DeviceBuffer<Self::Digest>,
         output_size: usize,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<(), CudaError>;
 }
 
@@ -127,7 +127,7 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<(), CudaError> {
         poseidon2_compressing_row_hashes(
             out,
@@ -135,7 +135,7 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
             width,
             query_stride,
             log_rows_per_query,
-            stream,
+            ctx.stream.as_raw(),
         )
     }
 
@@ -145,7 +145,7 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<(), CudaError> {
         poseidon2_compressing_row_hashes_ext(
             out,
@@ -153,7 +153,7 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
             width,
             query_stride,
             log_rows_per_query,
-            stream,
+            ctx.stream.as_raw(),
         )
     }
 
@@ -161,9 +161,9 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
         output: &mut DeviceBuffer<Self::Digest>,
         prev_layer: &DeviceBuffer<Self::Digest>,
         output_size: usize,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<(), CudaError> {
-        poseidon2_adjacent_compress_layer(output, prev_layer, output_size, stream)
+        poseidon2_adjacent_compress_layer(output, prev_layer, output_size, ctx.stream.as_raw())
     }
 }
 
@@ -210,7 +210,7 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<(), CudaError> {
         bn254_poseidon2_compressing_row_hashes(
             out,
@@ -218,7 +218,7 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
             width,
             query_stride,
             log_rows_per_query,
-            stream,
+            ctx.stream.as_raw(),
         )
     }
 
@@ -228,7 +228,7 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<(), CudaError> {
         bn254_poseidon2_compressing_row_hashes_ext(
             out,
@@ -236,7 +236,7 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
             width,
             query_stride,
             log_rows_per_query,
-            stream,
+            ctx.stream.as_raw(),
         )
     }
 
@@ -244,9 +244,14 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
         output: &mut DeviceBuffer<Self::Digest>,
         prev_layer: &DeviceBuffer<Self::Digest>,
         output_size: usize,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<(), CudaError> {
-        bn254_poseidon2_adjacent_compress_layer(output, prev_layer, output_size, stream)
+        bn254_poseidon2_adjacent_compress_layer(
+            output,
+            prev_layer,
+            output_size,
+            ctx.stream.as_raw(),
+        )
     }
 }
 

--- a/crates/cuda-backend/src/hash_scheme.rs
+++ b/crates/cuda-backend/src/hash_scheme.rs
@@ -1,4 +1,4 @@
-use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::DeviceContext};
+use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::GpuDeviceCtx};
 use openvm_stark_backend::{StarkProtocolConfig, SystemParams};
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::{
@@ -56,7 +56,7 @@ pub trait GpuMerkleHash: Copy + Clone + Send + Sync + 'static {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<(), CudaError>;
 
     /// Compress rows of an extension-field matrix into digest leaves.
@@ -71,7 +71,7 @@ pub trait GpuMerkleHash: Copy + Clone + Send + Sync + 'static {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<(), CudaError>;
 
     /// Compress adjacent pairs of digests to build an inner Merkle layer.
@@ -85,7 +85,7 @@ pub trait GpuMerkleHash: Copy + Clone + Send + Sync + 'static {
         output: &mut DeviceBuffer<Self::Digest>,
         prev_layer: &DeviceBuffer<Self::Digest>,
         output_size: usize,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<(), CudaError>;
 }
 
@@ -127,7 +127,7 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<(), CudaError> {
         poseidon2_compressing_row_hashes(
             out,
@@ -145,7 +145,7 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<(), CudaError> {
         poseidon2_compressing_row_hashes_ext(
             out,
@@ -161,7 +161,7 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
         output: &mut DeviceBuffer<Self::Digest>,
         prev_layer: &DeviceBuffer<Self::Digest>,
         output_size: usize,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<(), CudaError> {
         poseidon2_adjacent_compress_layer(
             output,
@@ -215,7 +215,7 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<(), CudaError> {
         bn254_poseidon2_compressing_row_hashes(
             out,
@@ -233,7 +233,7 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<(), CudaError> {
         bn254_poseidon2_compressing_row_hashes_ext(
             out,
@@ -249,7 +249,7 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
         output: &mut DeviceBuffer<Self::Digest>,
         prev_layer: &DeviceBuffer<Self::Digest>,
         output_size: usize,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<(), CudaError> {
         bn254_poseidon2_adjacent_compress_layer(
             output,

--- a/crates/cuda-backend/src/hash_scheme.rs
+++ b/crates/cuda-backend/src/hash_scheme.rs
@@ -1,4 +1,4 @@
-use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError};
+use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::cudaStreamPerThread};
 use openvm_stark_backend::{StarkProtocolConfig, SystemParams};
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::{
@@ -125,7 +125,14 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
         query_stride: usize,
         log_rows_per_query: usize,
     ) -> Result<(), CudaError> {
-        poseidon2_compressing_row_hashes(out, matrix, width, query_stride, log_rows_per_query)
+        poseidon2_compressing_row_hashes(
+            out,
+            matrix,
+            width,
+            query_stride,
+            log_rows_per_query,
+            cudaStreamPerThread,
+        )
     }
 
     unsafe fn compress_rows_ext(
@@ -135,7 +142,14 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
         query_stride: usize,
         log_rows_per_query: usize,
     ) -> Result<(), CudaError> {
-        poseidon2_compressing_row_hashes_ext(out, matrix, width, query_stride, log_rows_per_query)
+        poseidon2_compressing_row_hashes_ext(
+            out,
+            matrix,
+            width,
+            query_stride,
+            log_rows_per_query,
+            cudaStreamPerThread,
+        )
     }
 
     unsafe fn compress_layer(
@@ -143,7 +157,7 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
         prev_layer: &DeviceBuffer<Self::Digest>,
         output_size: usize,
     ) -> Result<(), CudaError> {
-        poseidon2_adjacent_compress_layer(output, prev_layer, output_size)
+        poseidon2_adjacent_compress_layer(output, prev_layer, output_size, cudaStreamPerThread)
     }
 }
 
@@ -191,7 +205,14 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
         query_stride: usize,
         log_rows_per_query: usize,
     ) -> Result<(), CudaError> {
-        bn254_poseidon2_compressing_row_hashes(out, matrix, width, query_stride, log_rows_per_query)
+        bn254_poseidon2_compressing_row_hashes(
+            out,
+            matrix,
+            width,
+            query_stride,
+            log_rows_per_query,
+            cudaStreamPerThread,
+        )
     }
 
     unsafe fn compress_rows_ext(
@@ -207,6 +228,7 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
             width,
             query_stride,
             log_rows_per_query,
+            cudaStreamPerThread,
         )
     }
 
@@ -215,7 +237,12 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
         prev_layer: &DeviceBuffer<Self::Digest>,
         output_size: usize,
     ) -> Result<(), CudaError> {
-        bn254_poseidon2_adjacent_compress_layer(output, prev_layer, output_size)
+        bn254_poseidon2_adjacent_compress_layer(
+            output,
+            prev_layer,
+            output_size,
+            cudaStreamPerThread,
+        )
     }
 }
 

--- a/crates/cuda-backend/src/hash_scheme.rs
+++ b/crates/cuda-backend/src/hash_scheme.rs
@@ -56,7 +56,7 @@ pub trait GpuMerkleHash: Copy + Clone + Send + Sync + 'static {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<(), CudaError>;
 
     /// Compress rows of an extension-field matrix into digest leaves.
@@ -71,7 +71,7 @@ pub trait GpuMerkleHash: Copy + Clone + Send + Sync + 'static {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<(), CudaError>;
 
     /// Compress adjacent pairs of digests to build an inner Merkle layer.
@@ -85,7 +85,7 @@ pub trait GpuMerkleHash: Copy + Clone + Send + Sync + 'static {
         output: &mut DeviceBuffer<Self::Digest>,
         prev_layer: &DeviceBuffer<Self::Digest>,
         output_size: usize,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<(), CudaError>;
 }
 
@@ -127,7 +127,7 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<(), CudaError> {
         poseidon2_compressing_row_hashes(
             out,
@@ -135,7 +135,7 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
             width,
             query_stride,
             log_rows_per_query,
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )
     }
 
@@ -145,7 +145,7 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<(), CudaError> {
         poseidon2_compressing_row_hashes_ext(
             out,
@@ -153,7 +153,7 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
             width,
             query_stride,
             log_rows_per_query,
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )
     }
 
@@ -161,9 +161,14 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
         output: &mut DeviceBuffer<Self::Digest>,
         prev_layer: &DeviceBuffer<Self::Digest>,
         output_size: usize,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<(), CudaError> {
-        poseidon2_adjacent_compress_layer(output, prev_layer, output_size, ctx.stream.as_raw())
+        poseidon2_adjacent_compress_layer(
+            output,
+            prev_layer,
+            output_size,
+            device_ctx.stream.as_raw(),
+        )
     }
 }
 
@@ -210,7 +215,7 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<(), CudaError> {
         bn254_poseidon2_compressing_row_hashes(
             out,
@@ -218,7 +223,7 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
             width,
             query_stride,
             log_rows_per_query,
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )
     }
 
@@ -228,7 +233,7 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<(), CudaError> {
         bn254_poseidon2_compressing_row_hashes_ext(
             out,
@@ -236,7 +241,7 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
             width,
             query_stride,
             log_rows_per_query,
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )
     }
 
@@ -244,13 +249,13 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
         output: &mut DeviceBuffer<Self::Digest>,
         prev_layer: &DeviceBuffer<Self::Digest>,
         output_size: usize,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<(), CudaError> {
         bn254_poseidon2_adjacent_compress_layer(
             output,
             prev_layer,
             output_size,
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )
     }
 }

--- a/crates/cuda-backend/src/hash_scheme.rs
+++ b/crates/cuda-backend/src/hash_scheme.rs
@@ -1,4 +1,4 @@
-use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::cudaStreamPerThread};
+use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::cudaStream_t};
 use openvm_stark_backend::{StarkProtocolConfig, SystemParams};
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::{
@@ -56,6 +56,7 @@ pub trait GpuMerkleHash: Copy + Clone + Send + Sync + 'static {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError>;
 
     /// Compress rows of an extension-field matrix into digest leaves.
@@ -70,6 +71,7 @@ pub trait GpuMerkleHash: Copy + Clone + Send + Sync + 'static {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError>;
 
     /// Compress adjacent pairs of digests to build an inner Merkle layer.
@@ -83,6 +85,7 @@ pub trait GpuMerkleHash: Copy + Clone + Send + Sync + 'static {
         output: &mut DeviceBuffer<Self::Digest>,
         prev_layer: &DeviceBuffer<Self::Digest>,
         output_size: usize,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError>;
 }
 
@@ -124,6 +127,7 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError> {
         poseidon2_compressing_row_hashes(
             out,
@@ -131,7 +135,7 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
             width,
             query_stride,
             log_rows_per_query,
-            cudaStreamPerThread,
+            stream,
         )
     }
 
@@ -141,6 +145,7 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError> {
         poseidon2_compressing_row_hashes_ext(
             out,
@@ -148,7 +153,7 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
             width,
             query_stride,
             log_rows_per_query,
-            cudaStreamPerThread,
+            stream,
         )
     }
 
@@ -156,8 +161,9 @@ impl GpuMerkleHash for Poseidon2MerkleHash {
         output: &mut DeviceBuffer<Self::Digest>,
         prev_layer: &DeviceBuffer<Self::Digest>,
         output_size: usize,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError> {
-        poseidon2_adjacent_compress_layer(output, prev_layer, output_size, cudaStreamPerThread)
+        poseidon2_adjacent_compress_layer(output, prev_layer, output_size, stream)
     }
 }
 
@@ -204,6 +210,7 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError> {
         bn254_poseidon2_compressing_row_hashes(
             out,
@@ -211,7 +218,7 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
             width,
             query_stride,
             log_rows_per_query,
-            cudaStreamPerThread,
+            stream,
         )
     }
 
@@ -221,6 +228,7 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
         width: usize,
         query_stride: usize,
         log_rows_per_query: usize,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError> {
         bn254_poseidon2_compressing_row_hashes_ext(
             out,
@@ -228,7 +236,7 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
             width,
             query_stride,
             log_rows_per_query,
-            cudaStreamPerThread,
+            stream,
         )
     }
 
@@ -236,13 +244,9 @@ impl GpuMerkleHash for Bn254Poseidon2MerkleHash {
         output: &mut DeviceBuffer<Self::Digest>,
         prev_layer: &DeviceBuffer<Self::Digest>,
         output_size: usize,
+        stream: cudaStream_t,
     ) -> Result<(), CudaError> {
-        bn254_poseidon2_adjacent_compress_layer(
-            output,
-            prev_layer,
-            output_size,
-            cudaStreamPerThread,
-        )
+        bn254_poseidon2_adjacent_compress_layer(output, prev_layer, output_size, stream)
     }
 }
 

--- a/crates/cuda-backend/src/lib.rs
+++ b/crates/cuda-backend/src/lib.rs
@@ -1,3 +1,8 @@
+// cudaStream_t is an opaque CUDA handle (*mut c_void) passed through to FFI.
+// Clippy's not_unsafe_ptr_arg_deref fires on functions that accept it, but the
+// "pointer" is never dereferenced in Rust — it is just forwarded to CUDA runtime calls.
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
 pub mod base;
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 pub mod bn254_sponge;

--- a/crates/cuda-backend/src/logup_zerocheck/batch_mle.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/batch_mle.rs
@@ -7,7 +7,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     error::MemCopyError,
-    stream::cudaStream_t,
+    stream::DeviceContext,
 };
 use openvm_stark_backend::prover::{fractional_sumcheck_gkr::Frac, DeviceMultiStarkProvingKey};
 
@@ -38,8 +38,9 @@ fn zerocheck_batch_mle_intermediates_buffer_bytes(
     buffer_size: u32,
     num_x: u32,
     num_y: u32,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> usize {
+    let stream = ctx.stream.as_raw();
     unsafe {
         _zerocheck_batch_mle_intermediates_buffer_size(buffer_size, num_x, num_y, stream)
             * std::mem::size_of::<EF>()
@@ -51,8 +52,9 @@ fn logup_batch_mle_intermediates_buffer_bytes(
     buffer_size: u32,
     num_x: u32,
     num_y: u32,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> usize {
+    let stream = ctx.stream.as_raw();
     unsafe {
         _logup_batch_mle_intermediates_buffer_size(buffer_size, num_x, num_y, stream)
             * std::mem::size_of::<EF>()
@@ -124,7 +126,7 @@ pub(crate) struct ZerocheckMleBatchBuilder<'a> {
     air_offsets: DeviceBuffer<u32>,
     threads_per_block: u32,
     _intermediates_keepalive: Vec<DeviceBuffer<EF>>,
-    stream: cudaStream_t,
+    ctx: DeviceContext,
 }
 
 impl<'a> ZerocheckMleBatchBuilder<'a> {
@@ -136,7 +138,7 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
         traces: impl Iterator<Item = &'a TraceCtx>,
         pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
         num_x: u32,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<&TraceCtx> = traces.filter(|t| t.has_constraints).collect();
 
@@ -148,7 +150,7 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
                 air_offsets: DeviceBuffer::new(),
                 threads_per_block: 0,
                 _intermediates_keepalive: vec![],
-                stream,
+                ctx: ctx.clone(),
             });
         }
 
@@ -186,10 +188,10 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
                         buffer_size,
                         num_x,
                         t.num_y,
-                        stream,
+                        ctx.stream.as_raw(),
                     )
                 };
-                let buf = DeviceBuffer::<EF>::with_capacity(intermediates_len);
+                let buf = DeviceBuffer::<EF>::with_capacity_on(intermediates_len, ctx);
                 let ptr = buf.as_mut_ptr();
                 intermediates_keepalive.push(buf);
                 ptr
@@ -218,9 +220,9 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
         }
 
         // Upload to device
-        let d_block_ctxs = block_ctxs_h.to_device()?;
-        let d_zc_ctxs = zc_ctxs_h.to_device()?;
-        let air_offsets = air_offsets.to_device()?;
+        let d_block_ctxs = block_ctxs_h.to_device_on(ctx)?;
+        let d_zc_ctxs = zc_ctxs_h.to_device_on(ctx)?;
+        let air_offsets = air_offsets.to_device_on(ctx)?;
 
         Ok(Self {
             traces,
@@ -229,7 +231,7 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
             air_offsets,
             threads_per_block,
             _intermediates_keepalive: intermediates_keepalive,
-            stream,
+            ctx: ctx.clone(),
         })
     }
 
@@ -265,7 +267,7 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
             lambda_pows.len(),
             num_x,
             self.threads_per_block,
-            self.stream,
+            &self.ctx,
         )
     }
 }
@@ -280,7 +282,7 @@ pub(crate) struct LogupMleBatchBuilder<'a> {
     air_offsets: DeviceBuffer<u32>,
     threads_per_block: u32,
     _intermediates_keepalive: Vec<DeviceBuffer<EF>>,
-    stream: cudaStream_t,
+    ctx: DeviceContext,
 }
 
 impl<'a> LogupMleBatchBuilder<'a> {
@@ -293,7 +295,7 @@ impl<'a> LogupMleBatchBuilder<'a> {
         pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
         d_challenges_ptr: *const EF,
         num_x: u32,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<&TraceCtx> = traces.filter(|t| t.has_interactions).collect();
 
@@ -305,7 +307,7 @@ impl<'a> LogupMleBatchBuilder<'a> {
                 air_offsets: DeviceBuffer::new(),
                 threads_per_block: 0,
                 _intermediates_keepalive: vec![],
-                stream,
+                ctx: ctx.clone(),
             });
         }
 
@@ -339,9 +341,14 @@ impl<'a> LogupMleBatchBuilder<'a> {
 
             let d_intermediates = if buffer_size > 0 {
                 let intermediates_len = unsafe {
-                    _logup_batch_mle_intermediates_buffer_size(buffer_size, num_x, t.num_y, stream)
+                    _logup_batch_mle_intermediates_buffer_size(
+                        buffer_size,
+                        num_x,
+                        t.num_y,
+                        ctx.stream.as_raw(),
+                    )
                 };
-                let buf = DeviceBuffer::<EF>::with_capacity(intermediates_len);
+                let buf = DeviceBuffer::<EF>::with_capacity_on(intermediates_len, ctx);
                 let ptr = buf.as_mut_ptr();
                 intermediates_keepalive.push(buf);
                 ptr
@@ -383,9 +390,9 @@ impl<'a> LogupMleBatchBuilder<'a> {
         }
 
         // Upload to device
-        let d_block_ctxs = block_ctxs_h.to_device()?;
-        let d_logup_ctxs = logup_ctxs_h.to_device()?;
-        let air_offsets = air_offsets.to_device()?;
+        let d_block_ctxs = block_ctxs_h.to_device_on(ctx)?;
+        let d_logup_ctxs = logup_ctxs_h.to_device_on(ctx)?;
+        let air_offsets = air_offsets.to_device_on(ctx)?;
 
         Ok(Self {
             traces,
@@ -394,7 +401,7 @@ impl<'a> LogupMleBatchBuilder<'a> {
             air_offsets,
             threads_per_block,
             _intermediates_keepalive: intermediates_keepalive,
-            stream,
+            ctx: ctx.clone(),
         })
     }
 
@@ -424,7 +431,7 @@ impl<'a> LogupMleBatchBuilder<'a> {
             &self.air_offsets,
             num_x,
             self.threads_per_block,
-            self.stream,
+            &self.ctx,
         )
     }
 }
@@ -441,7 +448,7 @@ pub(crate) fn evaluate_zerocheck_batched<'a, HS: GpuHashScheme>(
     num_x: u32,
     zc_out: &mut [Vec<EF>],
     memory_limit_bytes: usize,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<(), KernelError> {
     // Collect traces with constraints and their buffer sizes
     let mut zc_traces_with_size: Vec<(&TraceCtx, usize)> = traces
@@ -454,7 +461,7 @@ pub(crate) fn evaluate_zerocheck_batched<'a, HS: GpuHashScheme>(
                 .inner
                 .buffer_size;
             let mem =
-                zerocheck_batch_mle_intermediates_buffer_bytes(buffer_size, num_x, t.num_y, stream);
+                zerocheck_batch_mle_intermediates_buffer_bytes(buffer_size, num_x, t.num_y, ctx);
             (t, mem)
         })
         .collect();
@@ -501,9 +508,9 @@ pub(crate) fn evaluate_zerocheck_batched<'a, HS: GpuHashScheme>(
                 rules,
                 t.num_y,
                 num_x,
-                stream,
+                ctx,
             )?;
-            let out_host = out.to_host()?;
+            let out_host = out.to_host_on(ctx)?;
             zc_out[t.trace_idx].copy_from_slice(&out_host);
         } else {
             // Normal batch using ZerocheckMleBatchBuilder
@@ -513,9 +520,9 @@ pub(crate) fn evaluate_zerocheck_batched<'a, HS: GpuHashScheme>(
                 memory_limit_bytes,
                 "zerocheck: batching traces"
             );
-            let builder = ZerocheckMleBatchBuilder::new(batch.iter().copied(), pk, num_x, stream)?;
+            let builder = ZerocheckMleBatchBuilder::new(batch.iter().copied(), pk, num_x, ctx)?;
             let out = builder.evaluate(lambda_pows, num_x)?;
-            let host = out.to_host()?;
+            let host = out.to_host_on(ctx)?;
 
             for (i, trace_idx) in builder.trace_indices().enumerate() {
                 let evals = &host[(i * num_x_usize)..((i + 1) * num_x_usize)];
@@ -538,7 +545,7 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
     logup_out: &mut [[Vec<EF>; 2]],
     logup_tilde_evals: &mut [[EF; 2]],
     memory_limit_bytes: usize,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<(), KernelError> {
     let (low_traces, high_traces): (Vec<&TraceCtx>, Vec<&TraceCtx>) = traces
         .iter()
@@ -550,9 +557,9 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
             .iter()
             .map(|t| logup_combinations[t.trace_idx].as_ref().unwrap())
             .collect();
-        let batch = LogupMonomialBatch::new(low_traces.iter().copied(), pk, &logup_combs, stream)?;
+        let batch = LogupMonomialBatch::new(low_traces.iter().copied(), pk, &logup_combs, ctx)?;
         let out = batch.evaluate(num_x)?;
-        let host = out.to_host()?;
+        let host = out.to_host_on(ctx)?;
         let num_x_usize = num_x as usize;
         for (i, trace_idx) in batch.trace_indices().enumerate() {
             let fracs = &host[(i * num_x_usize)..((i + 1) * num_x_usize)];
@@ -583,8 +590,7 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
                 .interaction_rules
                 .inner
                 .buffer_size;
-            let mem =
-                logup_batch_mle_intermediates_buffer_bytes(buffer_size, num_x, t.num_y, stream);
+            let mem = logup_batch_mle_intermediates_buffer_bytes(buffer_size, num_x, t.num_y, ctx);
             (t, mem)
         })
         .collect();
@@ -622,7 +628,7 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
                 num_x,
                 &mut logup_out[t.trace_idx],
                 &mut logup_tilde_evals[t.trace_idx],
-                stream,
+                ctx,
             )?;
         } else {
             // Normal batch using LogupMleBatchBuilder
@@ -632,15 +638,10 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
                 memory_limit_bytes,
                 "logup: batching traces"
             );
-            let builder = LogupMleBatchBuilder::new(
-                batch.iter().copied(),
-                pk,
-                d_challenges_ptr,
-                num_x,
-                stream,
-            )?;
+            let builder =
+                LogupMleBatchBuilder::new(batch.iter().copied(), pk, d_challenges_ptr, num_x, ctx)?;
             let out = builder.evaluate(num_x)?;
-            let host = out.to_host()?;
+            let host = out.to_host_on(ctx)?;
 
             for (i, (trace_idx, norm_factor)) in builder.trace_info().enumerate() {
                 let fracs = &host[(i * num_x_usize)..((i + 1) * num_x_usize)];
@@ -668,7 +669,7 @@ fn evaluate_single_logup<HS: GpuHashScheme>(
     num_x: u32,
     logup_out: &mut [Vec<EF>; 2],
     logup_tilde_eval: &mut [EF; 2],
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<(), KernelError> {
     let air_pk = &pk.per_air[t.air_idx];
     let out = evaluate_mle_interactions_gpu(
@@ -682,9 +683,9 @@ fn evaluate_single_logup<HS: GpuHashScheme>(
         &air_pk.other_data.interaction_rules,
         t.num_y,
         num_x,
-        stream,
+        ctx,
     )?;
-    let fracs = out.to_host()?;
+    let fracs = out.to_host_on(ctx)?;
 
     if num_x == 1 {
         logup_tilde_eval[0] = fracs[0].p * t.norm_factor;
@@ -712,7 +713,7 @@ fn evaluate_mle_constraints_gpu_batch(
     lambda_len: usize,
     num_x: u32,
     threads_per_block: u32,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<DeviceBuffer<EF>, KernelError> {
     let num_blocks = block_ctxs.len();
     let num_airs = zc_ctxs.len();
@@ -724,8 +725,9 @@ fn evaluate_mle_constraints_gpu_batch(
         "zerocheck_batch_eval_mle"
     );
     // Need one buffer slot per block
-    let mut tmp_sums_buffer = DeviceBuffer::<EF>::with_capacity(num_blocks * num_x as usize);
-    let mut output = DeviceBuffer::<EF>::with_capacity(num_airs * num_x as usize);
+    let mut tmp_sums_buffer =
+        DeviceBuffer::<EF>::with_capacity_on(num_blocks * num_x as usize, ctx);
+    let mut output = DeviceBuffer::<EF>::with_capacity_on(num_airs * num_x as usize, ctx);
     unsafe {
         zerocheck_batch_eval_mle(
             &mut tmp_sums_buffer,
@@ -739,7 +741,7 @@ fn evaluate_mle_constraints_gpu_batch(
             num_x,
             num_airs as u32,
             threads_per_block,
-            stream,
+            ctx.stream.as_raw(),
         )?;
     }
     Ok(output)
@@ -752,13 +754,14 @@ fn evaluate_mle_interactions_gpu_batch(
     air_block_offsets: &DeviceBuffer<u32>,
     num_x: u32,
     threads_per_block: u32,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<DeviceBuffer<Frac<EF>>, KernelError> {
     let num_blocks = block_ctxs.len();
     let num_airs = logup_ctxs.len();
     // Need one buffer slot per block
-    let mut tmp_sums_buffer = DeviceBuffer::<Frac<EF>>::with_capacity(num_blocks * num_x as usize);
-    let mut output = DeviceBuffer::<Frac<EF>>::with_capacity(num_airs * num_x as usize);
+    let mut tmp_sums_buffer =
+        DeviceBuffer::<Frac<EF>>::with_capacity_on(num_blocks * num_x as usize, ctx);
+    let mut output = DeviceBuffer::<Frac<EF>>::with_capacity_on(num_airs * num_x as usize, ctx);
     unsafe {
         logup_batch_eval_mle(
             &mut tmp_sums_buffer,
@@ -770,7 +773,7 @@ fn evaluate_mle_interactions_gpu_batch(
             num_x,
             num_airs as u32,
             threads_per_block,
-            stream,
+            ctx.stream.as_raw(),
         )?;
     }
     Ok(output)

--- a/crates/cuda-backend/src/logup_zerocheck/batch_mle.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/batch_mle.rs
@@ -7,6 +7,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     error::MemCopyError,
+    stream::cudaStreamPerThread,
 };
 use openvm_stark_backend::prover::{fractional_sumcheck_gkr::Frac, DeviceMultiStarkProvingKey};
 
@@ -39,7 +40,7 @@ fn zerocheck_batch_mle_intermediates_buffer_bytes(
     num_y: u32,
 ) -> usize {
     unsafe {
-        _zerocheck_batch_mle_intermediates_buffer_size(buffer_size, num_x, num_y)
+        _zerocheck_batch_mle_intermediates_buffer_size(buffer_size, num_x, num_y, cudaStreamPerThread)
             * std::mem::size_of::<EF>()
     }
 }
@@ -47,7 +48,7 @@ fn zerocheck_batch_mle_intermediates_buffer_bytes(
 /// Computes logup intermediate buffer memory in bytes for a trace.
 fn logup_batch_mle_intermediates_buffer_bytes(buffer_size: u32, num_x: u32, num_y: u32) -> usize {
     unsafe {
-        _logup_batch_mle_intermediates_buffer_size(buffer_size, num_x, num_y)
+        _logup_batch_mle_intermediates_buffer_size(buffer_size, num_x, num_y, cudaStreamPerThread)
             * std::mem::size_of::<EF>()
     }
 }
@@ -172,7 +173,7 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
 
             let d_intermediates = if buffer_size > 0 {
                 let intermediates_len = unsafe {
-                    _zerocheck_batch_mle_intermediates_buffer_size(buffer_size, num_x, t.num_y)
+                    _zerocheck_batch_mle_intermediates_buffer_size(buffer_size, num_x, t.num_y, cudaStreamPerThread)
                 };
                 let buf = DeviceBuffer::<EF>::with_capacity(intermediates_len);
                 let ptr = buf.as_mut_ptr();
@@ -319,7 +320,7 @@ impl<'a> LogupMleBatchBuilder<'a> {
 
             let d_intermediates = if buffer_size > 0 {
                 let intermediates_len = unsafe {
-                    _logup_batch_mle_intermediates_buffer_size(buffer_size, num_x, t.num_y)
+                    _logup_batch_mle_intermediates_buffer_size(buffer_size, num_x, t.num_y, cudaStreamPerThread)
                 };
                 let buf = DeviceBuffer::<EF>::with_capacity(intermediates_len);
                 let ptr = buf.as_mut_ptr();

--- a/crates/cuda-backend/src/logup_zerocheck/batch_mle.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/batch_mle.rs
@@ -7,7 +7,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     error::MemCopyError,
-    stream::cudaStreamPerThread,
+    stream::cudaStream_t,
 };
 use openvm_stark_backend::prover::{fractional_sumcheck_gkr::Frac, DeviceMultiStarkProvingKey};
 
@@ -38,21 +38,23 @@ fn zerocheck_batch_mle_intermediates_buffer_bytes(
     buffer_size: u32,
     num_x: u32,
     num_y: u32,
+    stream: cudaStream_t,
 ) -> usize {
     unsafe {
-        _zerocheck_batch_mle_intermediates_buffer_size(
-            buffer_size,
-            num_x,
-            num_y,
-            cudaStreamPerThread,
-        ) * std::mem::size_of::<EF>()
+        _zerocheck_batch_mle_intermediates_buffer_size(buffer_size, num_x, num_y, stream)
+            * std::mem::size_of::<EF>()
     }
 }
 
 /// Computes logup intermediate buffer memory in bytes for a trace.
-fn logup_batch_mle_intermediates_buffer_bytes(buffer_size: u32, num_x: u32, num_y: u32) -> usize {
+fn logup_batch_mle_intermediates_buffer_bytes(
+    buffer_size: u32,
+    num_x: u32,
+    num_y: u32,
+    stream: cudaStream_t,
+) -> usize {
     unsafe {
-        _logup_batch_mle_intermediates_buffer_size(buffer_size, num_x, num_y, cudaStreamPerThread)
+        _logup_batch_mle_intermediates_buffer_size(buffer_size, num_x, num_y, stream)
             * std::mem::size_of::<EF>()
     }
 }
@@ -122,6 +124,7 @@ pub(crate) struct ZerocheckMleBatchBuilder<'a> {
     air_offsets: DeviceBuffer<u32>,
     threads_per_block: u32,
     _intermediates_keepalive: Vec<DeviceBuffer<EF>>,
+    stream: cudaStream_t,
 }
 
 impl<'a> ZerocheckMleBatchBuilder<'a> {
@@ -133,6 +136,7 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
         traces: impl Iterator<Item = &'a TraceCtx>,
         pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
         num_x: u32,
+        stream: cudaStream_t,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<&TraceCtx> = traces.filter(|t| t.has_constraints).collect();
 
@@ -144,6 +148,7 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
                 air_offsets: DeviceBuffer::new(),
                 threads_per_block: 0,
                 _intermediates_keepalive: vec![],
+                stream,
             });
         }
 
@@ -181,7 +186,7 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
                         buffer_size,
                         num_x,
                         t.num_y,
-                        cudaStreamPerThread,
+                        stream,
                     )
                 };
                 let buf = DeviceBuffer::<EF>::with_capacity(intermediates_len);
@@ -224,6 +229,7 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
             air_offsets,
             threads_per_block,
             _intermediates_keepalive: intermediates_keepalive,
+            stream,
         })
     }
 
@@ -259,6 +265,7 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
             lambda_pows.len(),
             num_x,
             self.threads_per_block,
+            self.stream,
         )
     }
 }
@@ -273,6 +280,7 @@ pub(crate) struct LogupMleBatchBuilder<'a> {
     air_offsets: DeviceBuffer<u32>,
     threads_per_block: u32,
     _intermediates_keepalive: Vec<DeviceBuffer<EF>>,
+    stream: cudaStream_t,
 }
 
 impl<'a> LogupMleBatchBuilder<'a> {
@@ -285,6 +293,7 @@ impl<'a> LogupMleBatchBuilder<'a> {
         pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
         d_challenges_ptr: *const EF,
         num_x: u32,
+        stream: cudaStream_t,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<&TraceCtx> = traces.filter(|t| t.has_interactions).collect();
 
@@ -296,6 +305,7 @@ impl<'a> LogupMleBatchBuilder<'a> {
                 air_offsets: DeviceBuffer::new(),
                 threads_per_block: 0,
                 _intermediates_keepalive: vec![],
+                stream,
             });
         }
 
@@ -329,12 +339,7 @@ impl<'a> LogupMleBatchBuilder<'a> {
 
             let d_intermediates = if buffer_size > 0 {
                 let intermediates_len = unsafe {
-                    _logup_batch_mle_intermediates_buffer_size(
-                        buffer_size,
-                        num_x,
-                        t.num_y,
-                        cudaStreamPerThread,
-                    )
+                    _logup_batch_mle_intermediates_buffer_size(buffer_size, num_x, t.num_y, stream)
                 };
                 let buf = DeviceBuffer::<EF>::with_capacity(intermediates_len);
                 let ptr = buf.as_mut_ptr();
@@ -389,6 +394,7 @@ impl<'a> LogupMleBatchBuilder<'a> {
             air_offsets,
             threads_per_block,
             _intermediates_keepalive: intermediates_keepalive,
+            stream,
         })
     }
 
@@ -418,6 +424,7 @@ impl<'a> LogupMleBatchBuilder<'a> {
             &self.air_offsets,
             num_x,
             self.threads_per_block,
+            self.stream,
         )
     }
 }
@@ -426,6 +433,7 @@ impl<'a> LogupMleBatchBuilder<'a> {
 // Memory-aware batched evaluation
 // ============================================================================
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn evaluate_zerocheck_batched<'a, HS: GpuHashScheme>(
     traces: impl IntoIterator<Item = &'a TraceCtx>,
     pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
@@ -433,6 +441,7 @@ pub(crate) fn evaluate_zerocheck_batched<'a, HS: GpuHashScheme>(
     num_x: u32,
     zc_out: &mut [Vec<EF>],
     memory_limit_bytes: usize,
+    stream: cudaStream_t,
 ) -> Result<(), KernelError> {
     // Collect traces with constraints and their buffer sizes
     let mut zc_traces_with_size: Vec<(&TraceCtx, usize)> = traces
@@ -444,7 +453,8 @@ pub(crate) fn evaluate_zerocheck_batched<'a, HS: GpuHashScheme>(
                 .zerocheck_mle
                 .inner
                 .buffer_size;
-            let mem = zerocheck_batch_mle_intermediates_buffer_bytes(buffer_size, num_x, t.num_y);
+            let mem =
+                zerocheck_batch_mle_intermediates_buffer_bytes(buffer_size, num_x, t.num_y, stream);
             (t, mem)
         })
         .collect();
@@ -491,6 +501,7 @@ pub(crate) fn evaluate_zerocheck_batched<'a, HS: GpuHashScheme>(
                 rules,
                 t.num_y,
                 num_x,
+                stream,
             )?;
             let out_host = out.to_host()?;
             zc_out[t.trace_idx].copy_from_slice(&out_host);
@@ -502,7 +513,7 @@ pub(crate) fn evaluate_zerocheck_batched<'a, HS: GpuHashScheme>(
                 memory_limit_bytes,
                 "zerocheck: batching traces"
             );
-            let builder = ZerocheckMleBatchBuilder::new(batch.iter().copied(), pk, num_x)?;
+            let builder = ZerocheckMleBatchBuilder::new(batch.iter().copied(), pk, num_x, stream)?;
             let out = builder.evaluate(lambda_pows, num_x)?;
             let host = out.to_host()?;
 
@@ -527,6 +538,7 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
     logup_out: &mut [[Vec<EF>; 2]],
     logup_tilde_evals: &mut [[EF; 2]],
     memory_limit_bytes: usize,
+    stream: cudaStream_t,
 ) -> Result<(), KernelError> {
     let (low_traces, high_traces): (Vec<&TraceCtx>, Vec<&TraceCtx>) = traces
         .iter()
@@ -538,7 +550,7 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
             .iter()
             .map(|t| logup_combinations[t.trace_idx].as_ref().unwrap())
             .collect();
-        let batch = LogupMonomialBatch::new(low_traces.iter().copied(), pk, &logup_combs)?;
+        let batch = LogupMonomialBatch::new(low_traces.iter().copied(), pk, &logup_combs, stream)?;
         let out = batch.evaluate(num_x)?;
         let host = out.to_host()?;
         let num_x_usize = num_x as usize;
@@ -571,7 +583,8 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
                 .interaction_rules
                 .inner
                 .buffer_size;
-            let mem = logup_batch_mle_intermediates_buffer_bytes(buffer_size, num_x, t.num_y);
+            let mem =
+                logup_batch_mle_intermediates_buffer_bytes(buffer_size, num_x, t.num_y, stream);
             (t, mem)
         })
         .collect();
@@ -609,6 +622,7 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
                 num_x,
                 &mut logup_out[t.trace_idx],
                 &mut logup_tilde_evals[t.trace_idx],
+                stream,
             )?;
         } else {
             // Normal batch using LogupMleBatchBuilder
@@ -618,8 +632,13 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
                 memory_limit_bytes,
                 "logup: batching traces"
             );
-            let builder =
-                LogupMleBatchBuilder::new(batch.iter().copied(), pk, d_challenges_ptr, num_x)?;
+            let builder = LogupMleBatchBuilder::new(
+                batch.iter().copied(),
+                pk,
+                d_challenges_ptr,
+                num_x,
+                stream,
+            )?;
             let out = builder.evaluate(num_x)?;
             let host = out.to_host()?;
 
@@ -641,6 +660,7 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
 }
 
 /// Evaluate logup for a single trace using non-batch kernel.
+#[allow(clippy::too_many_arguments)]
 fn evaluate_single_logup<HS: GpuHashScheme>(
     t: &TraceCtx,
     pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
@@ -648,6 +668,7 @@ fn evaluate_single_logup<HS: GpuHashScheme>(
     num_x: u32,
     logup_out: &mut [Vec<EF>; 2],
     logup_tilde_eval: &mut [EF; 2],
+    stream: cudaStream_t,
 ) -> Result<(), KernelError> {
     let air_pk = &pk.per_air[t.air_idx];
     let out = evaluate_mle_interactions_gpu(
@@ -661,6 +682,7 @@ fn evaluate_single_logup<HS: GpuHashScheme>(
         &air_pk.other_data.interaction_rules,
         t.num_y,
         num_x,
+        stream,
     )?;
     let fracs = out.to_host()?;
 
@@ -681,6 +703,7 @@ fn evaluate_single_logup<HS: GpuHashScheme>(
 // ============================================================================
 
 /// See [`crate::logup_zerocheck`] module docs for async-free/peak memory behavior.
+#[allow(clippy::too_many_arguments)]
 fn evaluate_mle_constraints_gpu_batch(
     block_ctxs: &DeviceBuffer<BlockCtx>,
     zc_ctxs: &DeviceBuffer<ZerocheckCtx>,
@@ -689,6 +712,7 @@ fn evaluate_mle_constraints_gpu_batch(
     lambda_len: usize,
     num_x: u32,
     threads_per_block: u32,
+    stream: cudaStream_t,
 ) -> Result<DeviceBuffer<EF>, KernelError> {
     let num_blocks = block_ctxs.len();
     let num_airs = zc_ctxs.len();
@@ -715,7 +739,7 @@ fn evaluate_mle_constraints_gpu_batch(
             num_x,
             num_airs as u32,
             threads_per_block,
-            cudaStreamPerThread,
+            stream,
         )?;
     }
     Ok(output)
@@ -728,6 +752,7 @@ fn evaluate_mle_interactions_gpu_batch(
     air_block_offsets: &DeviceBuffer<u32>,
     num_x: u32,
     threads_per_block: u32,
+    stream: cudaStream_t,
 ) -> Result<DeviceBuffer<Frac<EF>>, KernelError> {
     let num_blocks = block_ctxs.len();
     let num_airs = logup_ctxs.len();
@@ -745,7 +770,7 @@ fn evaluate_mle_interactions_gpu_batch(
             num_x,
             num_airs as u32,
             threads_per_block,
-            cudaStreamPerThread,
+            stream,
         )?;
     }
     Ok(output)

--- a/crates/cuda-backend/src/logup_zerocheck/batch_mle.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/batch_mle.rs
@@ -38,9 +38,9 @@ fn zerocheck_batch_mle_intermediates_buffer_bytes(
     buffer_size: u32,
     num_x: u32,
     num_y: u32,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> usize {
-    let stream = ctx.stream.as_raw();
+    let stream = device_ctx.stream.as_raw();
     unsafe {
         _zerocheck_batch_mle_intermediates_buffer_size(buffer_size, num_x, num_y, stream)
             * std::mem::size_of::<EF>()
@@ -52,9 +52,9 @@ fn logup_batch_mle_intermediates_buffer_bytes(
     buffer_size: u32,
     num_x: u32,
     num_y: u32,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> usize {
-    let stream = ctx.stream.as_raw();
+    let stream = device_ctx.stream.as_raw();
     unsafe {
         _logup_batch_mle_intermediates_buffer_size(buffer_size, num_x, num_y, stream)
             * std::mem::size_of::<EF>()
@@ -126,7 +126,8 @@ pub(crate) struct ZerocheckMleBatchBuilder<'a> {
     air_offsets: DeviceBuffer<u32>,
     threads_per_block: u32,
     _intermediates_keepalive: Vec<DeviceBuffer<EF>>,
-    ctx: DeviceContext,
+    /// Cheap clone: just `(device_id, Arc<CudaStream>)`.
+    device_ctx: DeviceContext,
 }
 
 impl<'a> ZerocheckMleBatchBuilder<'a> {
@@ -138,7 +139,7 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
         traces: impl Iterator<Item = &'a TraceCtx>,
         pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
         num_x: u32,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<&TraceCtx> = traces.filter(|t| t.has_constraints).collect();
 
@@ -150,7 +151,7 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
                 air_offsets: DeviceBuffer::new(),
                 threads_per_block: 0,
                 _intermediates_keepalive: vec![],
-                ctx: ctx.clone(),
+                device_ctx: device_ctx.clone(),
             });
         }
 
@@ -188,10 +189,10 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
                         buffer_size,
                         num_x,
                         t.num_y,
-                        ctx.stream.as_raw(),
+                        device_ctx.stream.as_raw(),
                     )
                 };
-                let buf = DeviceBuffer::<EF>::with_capacity_on(intermediates_len, ctx);
+                let buf = DeviceBuffer::<EF>::with_capacity_on(intermediates_len, device_ctx);
                 let ptr = buf.as_mut_ptr();
                 intermediates_keepalive.push(buf);
                 ptr
@@ -220,9 +221,9 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
         }
 
         // Upload to device
-        let d_block_ctxs = block_ctxs_h.to_device_on(ctx)?;
-        let d_zc_ctxs = zc_ctxs_h.to_device_on(ctx)?;
-        let air_offsets = air_offsets.to_device_on(ctx)?;
+        let d_block_ctxs = block_ctxs_h.to_device_on(device_ctx)?;
+        let d_zc_ctxs = zc_ctxs_h.to_device_on(device_ctx)?;
+        let air_offsets = air_offsets.to_device_on(device_ctx)?;
 
         Ok(Self {
             traces,
@@ -231,7 +232,7 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
             air_offsets,
             threads_per_block,
             _intermediates_keepalive: intermediates_keepalive,
-            ctx: ctx.clone(),
+            device_ctx: device_ctx.clone(),
         })
     }
 
@@ -267,7 +268,7 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
             lambda_pows.len(),
             num_x,
             self.threads_per_block,
-            &self.ctx,
+            &self.device_ctx,
         )
     }
 }
@@ -282,7 +283,7 @@ pub(crate) struct LogupMleBatchBuilder<'a> {
     air_offsets: DeviceBuffer<u32>,
     threads_per_block: u32,
     _intermediates_keepalive: Vec<DeviceBuffer<EF>>,
-    ctx: DeviceContext,
+    device_ctx: DeviceContext,
 }
 
 impl<'a> LogupMleBatchBuilder<'a> {
@@ -295,7 +296,7 @@ impl<'a> LogupMleBatchBuilder<'a> {
         pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
         d_challenges_ptr: *const EF,
         num_x: u32,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<&TraceCtx> = traces.filter(|t| t.has_interactions).collect();
 
@@ -307,7 +308,7 @@ impl<'a> LogupMleBatchBuilder<'a> {
                 air_offsets: DeviceBuffer::new(),
                 threads_per_block: 0,
                 _intermediates_keepalive: vec![],
-                ctx: ctx.clone(),
+                device_ctx: device_ctx.clone(),
             });
         }
 
@@ -345,10 +346,10 @@ impl<'a> LogupMleBatchBuilder<'a> {
                         buffer_size,
                         num_x,
                         t.num_y,
-                        ctx.stream.as_raw(),
+                        device_ctx.stream.as_raw(),
                     )
                 };
-                let buf = DeviceBuffer::<EF>::with_capacity_on(intermediates_len, ctx);
+                let buf = DeviceBuffer::<EF>::with_capacity_on(intermediates_len, device_ctx);
                 let ptr = buf.as_mut_ptr();
                 intermediates_keepalive.push(buf);
                 ptr
@@ -390,9 +391,9 @@ impl<'a> LogupMleBatchBuilder<'a> {
         }
 
         // Upload to device
-        let d_block_ctxs = block_ctxs_h.to_device_on(ctx)?;
-        let d_logup_ctxs = logup_ctxs_h.to_device_on(ctx)?;
-        let air_offsets = air_offsets.to_device_on(ctx)?;
+        let d_block_ctxs = block_ctxs_h.to_device_on(device_ctx)?;
+        let d_logup_ctxs = logup_ctxs_h.to_device_on(device_ctx)?;
+        let air_offsets = air_offsets.to_device_on(device_ctx)?;
 
         Ok(Self {
             traces,
@@ -401,7 +402,7 @@ impl<'a> LogupMleBatchBuilder<'a> {
             air_offsets,
             threads_per_block,
             _intermediates_keepalive: intermediates_keepalive,
-            ctx: ctx.clone(),
+            device_ctx: device_ctx.clone(),
         })
     }
 
@@ -431,7 +432,7 @@ impl<'a> LogupMleBatchBuilder<'a> {
             &self.air_offsets,
             num_x,
             self.threads_per_block,
-            &self.ctx,
+            &self.device_ctx,
         )
     }
 }
@@ -448,7 +449,7 @@ pub(crate) fn evaluate_zerocheck_batched<'a, HS: GpuHashScheme>(
     num_x: u32,
     zc_out: &mut [Vec<EF>],
     memory_limit_bytes: usize,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<(), KernelError> {
     // Collect traces with constraints and their buffer sizes
     let mut zc_traces_with_size: Vec<(&TraceCtx, usize)> = traces
@@ -460,8 +461,12 @@ pub(crate) fn evaluate_zerocheck_batched<'a, HS: GpuHashScheme>(
                 .zerocheck_mle
                 .inner
                 .buffer_size;
-            let mem =
-                zerocheck_batch_mle_intermediates_buffer_bytes(buffer_size, num_x, t.num_y, ctx);
+            let mem = zerocheck_batch_mle_intermediates_buffer_bytes(
+                buffer_size,
+                num_x,
+                t.num_y,
+                device_ctx,
+            );
             (t, mem)
         })
         .collect();
@@ -508,9 +513,9 @@ pub(crate) fn evaluate_zerocheck_batched<'a, HS: GpuHashScheme>(
                 rules,
                 t.num_y,
                 num_x,
-                ctx,
+                device_ctx,
             )?;
-            let out_host = out.to_host_on(ctx)?;
+            let out_host = out.to_host_on(device_ctx)?;
             zc_out[t.trace_idx].copy_from_slice(&out_host);
         } else {
             // Normal batch using ZerocheckMleBatchBuilder
@@ -520,9 +525,10 @@ pub(crate) fn evaluate_zerocheck_batched<'a, HS: GpuHashScheme>(
                 memory_limit_bytes,
                 "zerocheck: batching traces"
             );
-            let builder = ZerocheckMleBatchBuilder::new(batch.iter().copied(), pk, num_x, ctx)?;
+            let builder =
+                ZerocheckMleBatchBuilder::new(batch.iter().copied(), pk, num_x, device_ctx)?;
             let out = builder.evaluate(lambda_pows, num_x)?;
-            let host = out.to_host_on(ctx)?;
+            let host = out.to_host_on(device_ctx)?;
 
             for (i, trace_idx) in builder.trace_indices().enumerate() {
                 let evals = &host[(i * num_x_usize)..((i + 1) * num_x_usize)];
@@ -545,7 +551,7 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
     logup_out: &mut [[Vec<EF>; 2]],
     logup_tilde_evals: &mut [[EF; 2]],
     memory_limit_bytes: usize,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<(), KernelError> {
     let (low_traces, high_traces): (Vec<&TraceCtx>, Vec<&TraceCtx>) = traces
         .iter()
@@ -557,9 +563,10 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
             .iter()
             .map(|t| logup_combinations[t.trace_idx].as_ref().unwrap())
             .collect();
-        let batch = LogupMonomialBatch::new(low_traces.iter().copied(), pk, &logup_combs, ctx)?;
+        let batch =
+            LogupMonomialBatch::new(low_traces.iter().copied(), pk, &logup_combs, device_ctx)?;
         let out = batch.evaluate(num_x)?;
-        let host = out.to_host_on(ctx)?;
+        let host = out.to_host_on(device_ctx)?;
         let num_x_usize = num_x as usize;
         for (i, trace_idx) in batch.trace_indices().enumerate() {
             let fracs = &host[(i * num_x_usize)..((i + 1) * num_x_usize)];
@@ -590,7 +597,8 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
                 .interaction_rules
                 .inner
                 .buffer_size;
-            let mem = logup_batch_mle_intermediates_buffer_bytes(buffer_size, num_x, t.num_y, ctx);
+            let mem =
+                logup_batch_mle_intermediates_buffer_bytes(buffer_size, num_x, t.num_y, device_ctx);
             (t, mem)
         })
         .collect();
@@ -628,7 +636,7 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
                 num_x,
                 &mut logup_out[t.trace_idx],
                 &mut logup_tilde_evals[t.trace_idx],
-                ctx,
+                device_ctx,
             )?;
         } else {
             // Normal batch using LogupMleBatchBuilder
@@ -638,10 +646,15 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
                 memory_limit_bytes,
                 "logup: batching traces"
             );
-            let builder =
-                LogupMleBatchBuilder::new(batch.iter().copied(), pk, d_challenges_ptr, num_x, ctx)?;
+            let builder = LogupMleBatchBuilder::new(
+                batch.iter().copied(),
+                pk,
+                d_challenges_ptr,
+                num_x,
+                device_ctx,
+            )?;
             let out = builder.evaluate(num_x)?;
-            let host = out.to_host_on(ctx)?;
+            let host = out.to_host_on(device_ctx)?;
 
             for (i, (trace_idx, norm_factor)) in builder.trace_info().enumerate() {
                 let fracs = &host[(i * num_x_usize)..((i + 1) * num_x_usize)];
@@ -669,7 +682,7 @@ fn evaluate_single_logup<HS: GpuHashScheme>(
     num_x: u32,
     logup_out: &mut [Vec<EF>; 2],
     logup_tilde_eval: &mut [EF; 2],
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<(), KernelError> {
     let air_pk = &pk.per_air[t.air_idx];
     let out = evaluate_mle_interactions_gpu(
@@ -683,9 +696,9 @@ fn evaluate_single_logup<HS: GpuHashScheme>(
         &air_pk.other_data.interaction_rules,
         t.num_y,
         num_x,
-        ctx,
+        device_ctx,
     )?;
-    let fracs = out.to_host_on(ctx)?;
+    let fracs = out.to_host_on(device_ctx)?;
 
     if num_x == 1 {
         logup_tilde_eval[0] = fracs[0].p * t.norm_factor;
@@ -713,7 +726,7 @@ fn evaluate_mle_constraints_gpu_batch(
     lambda_len: usize,
     num_x: u32,
     threads_per_block: u32,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<DeviceBuffer<EF>, KernelError> {
     let num_blocks = block_ctxs.len();
     let num_airs = zc_ctxs.len();
@@ -726,8 +739,8 @@ fn evaluate_mle_constraints_gpu_batch(
     );
     // Need one buffer slot per block
     let mut tmp_sums_buffer =
-        DeviceBuffer::<EF>::with_capacity_on(num_blocks * num_x as usize, ctx);
-    let mut output = DeviceBuffer::<EF>::with_capacity_on(num_airs * num_x as usize, ctx);
+        DeviceBuffer::<EF>::with_capacity_on(num_blocks * num_x as usize, device_ctx);
+    let mut output = DeviceBuffer::<EF>::with_capacity_on(num_airs * num_x as usize, device_ctx);
     unsafe {
         zerocheck_batch_eval_mle(
             &mut tmp_sums_buffer,
@@ -741,7 +754,7 @@ fn evaluate_mle_constraints_gpu_batch(
             num_x,
             num_airs as u32,
             threads_per_block,
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )?;
     }
     Ok(output)
@@ -754,14 +767,15 @@ fn evaluate_mle_interactions_gpu_batch(
     air_block_offsets: &DeviceBuffer<u32>,
     num_x: u32,
     threads_per_block: u32,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<DeviceBuffer<Frac<EF>>, KernelError> {
     let num_blocks = block_ctxs.len();
     let num_airs = logup_ctxs.len();
     // Need one buffer slot per block
     let mut tmp_sums_buffer =
-        DeviceBuffer::<Frac<EF>>::with_capacity_on(num_blocks * num_x as usize, ctx);
-    let mut output = DeviceBuffer::<Frac<EF>>::with_capacity_on(num_airs * num_x as usize, ctx);
+        DeviceBuffer::<Frac<EF>>::with_capacity_on(num_blocks * num_x as usize, device_ctx);
+    let mut output =
+        DeviceBuffer::<Frac<EF>>::with_capacity_on(num_airs * num_x as usize, device_ctx);
     unsafe {
         logup_batch_eval_mle(
             &mut tmp_sums_buffer,
@@ -773,7 +787,7 @@ fn evaluate_mle_interactions_gpu_batch(
             num_x,
             num_airs as u32,
             threads_per_block,
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )?;
     }
     Ok(output)

--- a/crates/cuda-backend/src/logup_zerocheck/batch_mle.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/batch_mle.rs
@@ -7,7 +7,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     error::MemCopyError,
-    stream::DeviceContext,
+    stream::GpuDeviceCtx,
 };
 use openvm_stark_backend::prover::{fractional_sumcheck_gkr::Frac, DeviceMultiStarkProvingKey};
 
@@ -38,7 +38,7 @@ fn zerocheck_batch_mle_intermediates_buffer_bytes(
     buffer_size: u32,
     num_x: u32,
     num_y: u32,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> usize {
     let stream = device_ctx.stream.as_raw();
     unsafe {
@@ -52,7 +52,7 @@ fn logup_batch_mle_intermediates_buffer_bytes(
     buffer_size: u32,
     num_x: u32,
     num_y: u32,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> usize {
     let stream = device_ctx.stream.as_raw();
     unsafe {
@@ -127,7 +127,7 @@ pub(crate) struct ZerocheckMleBatchBuilder<'a> {
     threads_per_block: u32,
     _intermediates_keepalive: Vec<DeviceBuffer<EF>>,
     /// Cheap clone: just `(device_id, Arc<CudaStream>)`.
-    device_ctx: DeviceContext,
+    device_ctx: GpuDeviceCtx,
 }
 
 impl<'a> ZerocheckMleBatchBuilder<'a> {
@@ -139,7 +139,7 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
         traces: impl Iterator<Item = &'a TraceCtx>,
         pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
         num_x: u32,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<&TraceCtx> = traces.filter(|t| t.has_constraints).collect();
 
@@ -283,7 +283,7 @@ pub(crate) struct LogupMleBatchBuilder<'a> {
     air_offsets: DeviceBuffer<u32>,
     threads_per_block: u32,
     _intermediates_keepalive: Vec<DeviceBuffer<EF>>,
-    device_ctx: DeviceContext,
+    device_ctx: GpuDeviceCtx,
 }
 
 impl<'a> LogupMleBatchBuilder<'a> {
@@ -296,7 +296,7 @@ impl<'a> LogupMleBatchBuilder<'a> {
         pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
         d_challenges_ptr: *const EF,
         num_x: u32,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<&TraceCtx> = traces.filter(|t| t.has_interactions).collect();
 
@@ -449,7 +449,7 @@ pub(crate) fn evaluate_zerocheck_batched<'a, HS: GpuHashScheme>(
     num_x: u32,
     zc_out: &mut [Vec<EF>],
     memory_limit_bytes: usize,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(), KernelError> {
     // Collect traces with constraints and their buffer sizes
     let mut zc_traces_with_size: Vec<(&TraceCtx, usize)> = traces
@@ -551,7 +551,7 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
     logup_out: &mut [[Vec<EF>; 2]],
     logup_tilde_evals: &mut [[EF; 2]],
     memory_limit_bytes: usize,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(), KernelError> {
     let (low_traces, high_traces): (Vec<&TraceCtx>, Vec<&TraceCtx>) = traces
         .iter()
@@ -682,7 +682,7 @@ fn evaluate_single_logup<HS: GpuHashScheme>(
     num_x: u32,
     logup_out: &mut [Vec<EF>; 2],
     logup_tilde_eval: &mut [EF; 2],
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(), KernelError> {
     let air_pk = &pk.per_air[t.air_idx];
     let out = evaluate_mle_interactions_gpu(
@@ -726,7 +726,7 @@ fn evaluate_mle_constraints_gpu_batch(
     lambda_len: usize,
     num_x: u32,
     threads_per_block: u32,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<DeviceBuffer<EF>, KernelError> {
     let num_blocks = block_ctxs.len();
     let num_airs = zc_ctxs.len();
@@ -767,7 +767,7 @@ fn evaluate_mle_interactions_gpu_batch(
     air_block_offsets: &DeviceBuffer<u32>,
     num_x: u32,
     threads_per_block: u32,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<DeviceBuffer<Frac<EF>>, KernelError> {
     let num_blocks = block_ctxs.len();
     let num_airs = logup_ctxs.len();

--- a/crates/cuda-backend/src/logup_zerocheck/batch_mle.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/batch_mle.rs
@@ -40,8 +40,12 @@ fn zerocheck_batch_mle_intermediates_buffer_bytes(
     num_y: u32,
 ) -> usize {
     unsafe {
-        _zerocheck_batch_mle_intermediates_buffer_size(buffer_size, num_x, num_y, cudaStreamPerThread)
-            * std::mem::size_of::<EF>()
+        _zerocheck_batch_mle_intermediates_buffer_size(
+            buffer_size,
+            num_x,
+            num_y,
+            cudaStreamPerThread,
+        ) * std::mem::size_of::<EF>()
     }
 }
 
@@ -173,7 +177,12 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
 
             let d_intermediates = if buffer_size > 0 {
                 let intermediates_len = unsafe {
-                    _zerocheck_batch_mle_intermediates_buffer_size(buffer_size, num_x, t.num_y, cudaStreamPerThread)
+                    _zerocheck_batch_mle_intermediates_buffer_size(
+                        buffer_size,
+                        num_x,
+                        t.num_y,
+                        cudaStreamPerThread,
+                    )
                 };
                 let buf = DeviceBuffer::<EF>::with_capacity(intermediates_len);
                 let ptr = buf.as_mut_ptr();
@@ -320,7 +329,12 @@ impl<'a> LogupMleBatchBuilder<'a> {
 
             let d_intermediates = if buffer_size > 0 {
                 let intermediates_len = unsafe {
-                    _logup_batch_mle_intermediates_buffer_size(buffer_size, num_x, t.num_y, cudaStreamPerThread)
+                    _logup_batch_mle_intermediates_buffer_size(
+                        buffer_size,
+                        num_x,
+                        t.num_y,
+                        cudaStreamPerThread,
+                    )
                 };
                 let buf = DeviceBuffer::<EF>::with_capacity(intermediates_len);
                 let ptr = buf.as_mut_ptr();
@@ -701,6 +715,7 @@ fn evaluate_mle_constraints_gpu_batch(
             num_x,
             num_airs as u32,
             threads_per_block,
+            cudaStreamPerThread,
         )?;
     }
     Ok(output)
@@ -730,6 +745,7 @@ fn evaluate_mle_interactions_gpu_batch(
             num_x,
             num_airs as u32,
             threads_per_block,
+            cudaStreamPerThread,
         )?;
     }
     Ok(output)

--- a/crates/cuda-backend/src/logup_zerocheck/batch_mle_monomial.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/batch_mle_monomial.rs
@@ -81,14 +81,15 @@ pub(crate) fn compute_lambda_combinations<HS: GpuHashScheme>(
     pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
     air_idx: usize,
     lambda_pows: &DeviceBuffer<EF>,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<DeviceBuffer<EF>, CudaError> {
     let monomials = pk.per_air[air_idx]
         .other_data
         .zerocheck_monomials
         .as_ref()
         .expect("AIR must have monomials");
-    let mut buf = DeviceBuffer::<EF>::with_capacity_on(monomials.num_monomials as usize, ctx);
+    let mut buf =
+        DeviceBuffer::<EF>::with_capacity_on(monomials.num_monomials as usize, device_ctx);
     unsafe {
         precompute_lambda_combinations(
             &mut buf,
@@ -96,7 +97,7 @@ pub(crate) fn compute_lambda_combinations<HS: GpuHashScheme>(
             monomials.d_lambda_terms.as_ptr(),
             lambda_pows,
             monomials.num_monomials,
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )?;
     }
     Ok(buf)
@@ -116,7 +117,8 @@ pub(crate) struct ZerocheckMonomialBatch<'a> {
     block_ctxs: DeviceBuffer<BlockCtx>,
     air_ctxs: DeviceBuffer<MonomialAirCtx>,
     air_offsets: DeviceBuffer<u32>,
-    ctx: DeviceContext,
+    /// Cheap clone: just `(device_id, Arc<CudaStream>)`.
+    device_ctx: DeviceContext,
 }
 
 impl<'a> ZerocheckMonomialBatch<'a> {
@@ -132,7 +134,7 @@ impl<'a> ZerocheckMonomialBatch<'a> {
         traces: impl IntoIterator<Item = &'a TraceCtx>,
         pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
         lambda_combinations: &[&DeviceBuffer<EF>],
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<_> = traces.into_iter().collect();
         assert!(
@@ -203,9 +205,9 @@ impl<'a> ZerocheckMonomialBatch<'a> {
             .collect();
 
         // Upload to device
-        let block_ctxs = block_ctxs_h.to_device_on(ctx)?;
-        let air_ctxs = air_ctxs_h.to_device_on(ctx)?;
-        let air_offsets = air_offsets.to_device_on(ctx)?;
+        let block_ctxs = block_ctxs_h.to_device_on(device_ctx)?;
+        let air_ctxs = air_ctxs_h.to_device_on(device_ctx)?;
+        let air_offsets = air_offsets.to_device_on(device_ctx)?;
 
         debug!(
             num_airs = traces.len(),
@@ -218,7 +220,7 @@ impl<'a> ZerocheckMonomialBatch<'a> {
             block_ctxs,
             air_ctxs,
             air_offsets,
-            ctx: ctx.clone(),
+            device_ctx: device_ctx.clone(),
         })
     }
 
@@ -244,8 +246,9 @@ impl<'a> ZerocheckMonomialBatch<'a> {
         );
 
         let mut tmp_sums =
-            DeviceBuffer::<EF>::with_capacity_on(num_blocks * num_x as usize, &self.ctx);
-        let mut output = DeviceBuffer::<EF>::with_capacity_on(num_airs * num_x as usize, &self.ctx);
+            DeviceBuffer::<EF>::with_capacity_on(num_blocks * num_x as usize, &self.device_ctx);
+        let mut output =
+            DeviceBuffer::<EF>::with_capacity_on(num_airs * num_x as usize, &self.device_ctx);
 
         debug_assert_eq!(
             self.air_offsets.len(),
@@ -266,7 +269,7 @@ impl<'a> ZerocheckMonomialBatch<'a> {
                 num_x,
                 num_airs as u32,
                 THREADS_PER_BLOCK,
-                self.ctx.stream.as_raw(),
+                self.device_ctx.stream.as_raw(),
             )?;
         }
 
@@ -293,7 +296,8 @@ pub(crate) struct ZerocheckMonomialParYBatch<'a> {
     air_offsets: DeviceBuffer<u32>,
     num_blocks: u32,
     chunk_size: u32,
-    ctx: DeviceContext,
+    /// Cheap clone: just `(device_id, Arc<CudaStream>)`.
+    device_ctx: DeviceContext,
 }
 
 impl<'a> ZerocheckMonomialParYBatch<'a> {
@@ -316,7 +320,7 @@ impl<'a> ZerocheckMonomialParYBatch<'a> {
         sm_count: u32,
         num_x: u32,
         max_monomials_per_thread: Option<u32>,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<_> = traces.into_iter().collect();
         assert!(
@@ -431,9 +435,9 @@ impl<'a> ZerocheckMonomialParYBatch<'a> {
             .collect();
 
         // Upload to device
-        let block_ctxs = block_ctxs_h.to_device_on(ctx)?;
-        let air_ctxs = air_ctxs_h.to_device_on(ctx)?;
-        let air_offsets = air_offsets.to_device_on(ctx)?;
+        let block_ctxs = block_ctxs_h.to_device_on(device_ctx)?;
+        let air_ctxs = air_ctxs_h.to_device_on(device_ctx)?;
+        let air_offsets = air_offsets.to_device_on(device_ctx)?;
 
         debug!(
             num_airs = traces.len(),
@@ -447,7 +451,7 @@ impl<'a> ZerocheckMonomialParYBatch<'a> {
             air_offsets,
             num_blocks,
             chunk_size,
-            ctx: ctx.clone(),
+            device_ctx: device_ctx.clone(),
         })
     }
 
@@ -474,9 +478,10 @@ impl<'a> ZerocheckMonomialParYBatch<'a> {
 
         let mut tmp_sums = DeviceBuffer::<EF>::with_capacity_on(
             self.num_blocks as usize * num_x as usize,
-            &self.ctx,
+            &self.device_ctx,
         );
-        let mut output = DeviceBuffer::<EF>::with_capacity_on(num_airs * num_x as usize, &self.ctx);
+        let mut output =
+            DeviceBuffer::<EF>::with_capacity_on(num_airs * num_x as usize, &self.device_ctx);
 
         debug_assert_eq!(
             self.air_offsets.len(),
@@ -498,7 +503,7 @@ impl<'a> ZerocheckMonomialParYBatch<'a> {
                 num_airs as u32,
                 self.chunk_size,
                 THREADS_PER_BLOCK_PAR_Y,
-                self.ctx.stream.as_raw(),
+                self.device_ctx.stream.as_raw(),
             )?;
         }
 
@@ -528,7 +533,7 @@ pub(crate) fn compute_logup_combinations<HS: GpuHashScheme>(
     d_eq_3bs: &DeviceBuffer<EF>,
     eq_3bs_host: &[EF],
     beta_pows_host: &[EF],
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<LogupCombinations, CudaError> {
     let monomials = pk.per_air[air_idx]
         .other_data
@@ -536,10 +541,10 @@ pub(crate) fn compute_logup_combinations<HS: GpuHashScheme>(
         .as_ref()
         .expect("AIR must have interaction monomials");
 
-    let stream = ctx.stream.as_raw();
+    let stream = device_ctx.stream.as_raw();
     // Precompute numerator combinations: sum_i(coeff_i * eq_3bs[interaction_idx_i])
     let mut d_numer_combinations = if monomials.num_numer_monomials > 0 {
-        DeviceBuffer::<EF>::with_capacity_on(monomials.num_numer_monomials as usize, ctx)
+        DeviceBuffer::<EF>::with_capacity_on(monomials.num_numer_monomials as usize, device_ctx)
     } else {
         DeviceBuffer::new()
     };
@@ -559,7 +564,7 @@ pub(crate) fn compute_logup_combinations<HS: GpuHashScheme>(
     // Precompute denominator combinations: sum_i(coeff_i * beta_pows[field_idx_i] *
     // eq_3bs[interaction_idx_i])
     let mut d_denom_combinations = if monomials.num_denom_monomials > 0 {
-        DeviceBuffer::<EF>::with_capacity_on(monomials.num_denom_monomials as usize, ctx)
+        DeviceBuffer::<EF>::with_capacity_on(monomials.num_denom_monomials as usize, device_ctx)
     } else {
         DeviceBuffer::new()
     };
@@ -612,7 +617,7 @@ pub(crate) struct LogupMonomialBatch<'a> {
     denom_ctxs: DeviceBuffer<LogupMonomialCtx>,
     air_offsets: DeviceBuffer<u32>,
     num_blocks: u32,
-    ctx: DeviceContext,
+    device_ctx: DeviceContext,
 }
 
 impl<'a> LogupMonomialBatch<'a> {
@@ -628,7 +633,7 @@ impl<'a> LogupMonomialBatch<'a> {
         traces: impl IntoIterator<Item = &'a TraceCtx>,
         pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
         logup_combinations: &[&LogupCombinations],
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<_> = traces.into_iter().collect();
         assert!(
@@ -739,11 +744,11 @@ impl<'a> LogupMonomialBatch<'a> {
             .collect();
 
         // Upload to device
-        let block_ctxs = block_ctxs_h.to_device_on(ctx)?;
-        let common_ctxs = common_ctxs_h.to_device_on(ctx)?;
-        let numer_ctxs = numer_ctxs_h.to_device_on(ctx)?;
-        let denom_ctxs = denom_ctxs_h.to_device_on(ctx)?;
-        let air_offsets = air_offsets.to_device_on(ctx)?;
+        let block_ctxs = block_ctxs_h.to_device_on(device_ctx)?;
+        let common_ctxs = common_ctxs_h.to_device_on(device_ctx)?;
+        let numer_ctxs = numer_ctxs_h.to_device_on(device_ctx)?;
+        let denom_ctxs = denom_ctxs_h.to_device_on(device_ctx)?;
+        let air_offsets = air_offsets.to_device_on(device_ctx)?;
 
         debug!(
             num_airs = traces.len(),
@@ -758,7 +763,7 @@ impl<'a> LogupMonomialBatch<'a> {
             denom_ctxs,
             air_offsets,
             num_blocks,
-            ctx: ctx.clone(),
+            device_ctx: device_ctx.clone(),
         })
     }
 
@@ -784,10 +789,10 @@ impl<'a> LogupMonomialBatch<'a> {
 
         let mut tmp_sums = DeviceBuffer::<Frac<EF>>::with_capacity_on(
             self.num_blocks as usize * num_x as usize,
-            &self.ctx,
+            &self.device_ctx,
         );
         let mut output =
-            DeviceBuffer::<Frac<EF>>::with_capacity_on(num_airs * num_x as usize, &self.ctx);
+            DeviceBuffer::<Frac<EF>>::with_capacity_on(num_airs * num_x as usize, &self.device_ctx);
 
         debug_assert_eq!(
             self.air_offsets.len(),
@@ -810,7 +815,7 @@ impl<'a> LogupMonomialBatch<'a> {
                 num_x,
                 num_airs as u32,
                 THREADS_PER_BLOCK_LOGUP,
-                self.ctx.stream.as_raw(),
+                self.device_ctx.stream.as_raw(),
             )?;
         }
 

--- a/crates/cuda-backend/src/logup_zerocheck/batch_mle_monomial.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/batch_mle_monomial.rs
@@ -7,7 +7,7 @@ use openvm_cuda_common::{
     copy::MemCopyH2D,
     d_buffer::DeviceBuffer,
     error::{CudaError, MemCopyError},
-    stream::DeviceContext,
+    stream::GpuDeviceCtx,
 };
 use openvm_stark_backend::prover::{fractional_sumcheck_gkr::Frac, DeviceMultiStarkProvingKey};
 use p3_field::PrimeCharacteristicRing;
@@ -81,7 +81,7 @@ pub(crate) fn compute_lambda_combinations<HS: GpuHashScheme>(
     pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
     air_idx: usize,
     lambda_pows: &DeviceBuffer<EF>,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<DeviceBuffer<EF>, CudaError> {
     let monomials = pk.per_air[air_idx]
         .other_data
@@ -118,7 +118,7 @@ pub(crate) struct ZerocheckMonomialBatch<'a> {
     air_ctxs: DeviceBuffer<MonomialAirCtx>,
     air_offsets: DeviceBuffer<u32>,
     /// Cheap clone: just `(device_id, Arc<CudaStream>)`.
-    device_ctx: DeviceContext,
+    device_ctx: GpuDeviceCtx,
 }
 
 impl<'a> ZerocheckMonomialBatch<'a> {
@@ -134,7 +134,7 @@ impl<'a> ZerocheckMonomialBatch<'a> {
         traces: impl IntoIterator<Item = &'a TraceCtx>,
         pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
         lambda_combinations: &[&DeviceBuffer<EF>],
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<_> = traces.into_iter().collect();
         assert!(
@@ -297,7 +297,7 @@ pub(crate) struct ZerocheckMonomialParYBatch<'a> {
     num_blocks: u32,
     chunk_size: u32,
     /// Cheap clone: just `(device_id, Arc<CudaStream>)`.
-    device_ctx: DeviceContext,
+    device_ctx: GpuDeviceCtx,
 }
 
 impl<'a> ZerocheckMonomialParYBatch<'a> {
@@ -320,7 +320,7 @@ impl<'a> ZerocheckMonomialParYBatch<'a> {
         sm_count: u32,
         num_x: u32,
         max_monomials_per_thread: Option<u32>,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<_> = traces.into_iter().collect();
         assert!(
@@ -533,7 +533,7 @@ pub(crate) fn compute_logup_combinations<HS: GpuHashScheme>(
     d_eq_3bs: &DeviceBuffer<EF>,
     eq_3bs_host: &[EF],
     beta_pows_host: &[EF],
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<LogupCombinations, CudaError> {
     let monomials = pk.per_air[air_idx]
         .other_data
@@ -617,7 +617,7 @@ pub(crate) struct LogupMonomialBatch<'a> {
     denom_ctxs: DeviceBuffer<LogupMonomialCtx>,
     air_offsets: DeviceBuffer<u32>,
     num_blocks: u32,
-    device_ctx: DeviceContext,
+    device_ctx: GpuDeviceCtx,
 }
 
 impl<'a> LogupMonomialBatch<'a> {
@@ -633,7 +633,7 @@ impl<'a> LogupMonomialBatch<'a> {
         traces: impl IntoIterator<Item = &'a TraceCtx>,
         pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
         logup_combinations: &[&LogupCombinations],
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<_> = traces.into_iter().collect();
         assert!(

--- a/crates/cuda-backend/src/logup_zerocheck/batch_mle_monomial.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/batch_mle_monomial.rs
@@ -7,7 +7,7 @@ use openvm_cuda_common::{
     copy::MemCopyH2D,
     d_buffer::DeviceBuffer,
     error::{CudaError, MemCopyError},
-    stream::cudaStream_t,
+    stream::DeviceContext,
 };
 use openvm_stark_backend::prover::{fractional_sumcheck_gkr::Frac, DeviceMultiStarkProvingKey};
 use p3_field::PrimeCharacteristicRing;
@@ -81,14 +81,14 @@ pub(crate) fn compute_lambda_combinations<HS: GpuHashScheme>(
     pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
     air_idx: usize,
     lambda_pows: &DeviceBuffer<EF>,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<DeviceBuffer<EF>, CudaError> {
     let monomials = pk.per_air[air_idx]
         .other_data
         .zerocheck_monomials
         .as_ref()
         .expect("AIR must have monomials");
-    let mut buf = DeviceBuffer::<EF>::with_capacity(monomials.num_monomials as usize);
+    let mut buf = DeviceBuffer::<EF>::with_capacity_on(monomials.num_monomials as usize, ctx);
     unsafe {
         precompute_lambda_combinations(
             &mut buf,
@@ -96,7 +96,7 @@ pub(crate) fn compute_lambda_combinations<HS: GpuHashScheme>(
             monomials.d_lambda_terms.as_ptr(),
             lambda_pows,
             monomials.num_monomials,
-            stream,
+            ctx.stream.as_raw(),
         )?;
     }
     Ok(buf)
@@ -116,7 +116,7 @@ pub(crate) struct ZerocheckMonomialBatch<'a> {
     block_ctxs: DeviceBuffer<BlockCtx>,
     air_ctxs: DeviceBuffer<MonomialAirCtx>,
     air_offsets: DeviceBuffer<u32>,
-    stream: cudaStream_t,
+    ctx: DeviceContext,
 }
 
 impl<'a> ZerocheckMonomialBatch<'a> {
@@ -132,7 +132,7 @@ impl<'a> ZerocheckMonomialBatch<'a> {
         traces: impl IntoIterator<Item = &'a TraceCtx>,
         pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
         lambda_combinations: &[&DeviceBuffer<EF>],
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<_> = traces.into_iter().collect();
         assert!(
@@ -203,9 +203,9 @@ impl<'a> ZerocheckMonomialBatch<'a> {
             .collect();
 
         // Upload to device
-        let block_ctxs = block_ctxs_h.to_device()?;
-        let air_ctxs = air_ctxs_h.to_device()?;
-        let air_offsets = air_offsets.to_device()?;
+        let block_ctxs = block_ctxs_h.to_device_on(ctx)?;
+        let air_ctxs = air_ctxs_h.to_device_on(ctx)?;
+        let air_offsets = air_offsets.to_device_on(ctx)?;
 
         debug!(
             num_airs = traces.len(),
@@ -218,7 +218,7 @@ impl<'a> ZerocheckMonomialBatch<'a> {
             block_ctxs,
             air_ctxs,
             air_offsets,
-            stream,
+            ctx: ctx.clone(),
         })
     }
 
@@ -243,8 +243,9 @@ impl<'a> ZerocheckMonomialBatch<'a> {
             "zerocheck_monomial_batched"
         );
 
-        let mut tmp_sums = DeviceBuffer::<EF>::with_capacity(num_blocks * num_x as usize);
-        let mut output = DeviceBuffer::<EF>::with_capacity(num_airs * num_x as usize);
+        let mut tmp_sums =
+            DeviceBuffer::<EF>::with_capacity_on(num_blocks * num_x as usize, &self.ctx);
+        let mut output = DeviceBuffer::<EF>::with_capacity_on(num_airs * num_x as usize, &self.ctx);
 
         debug_assert_eq!(
             self.air_offsets.len(),
@@ -265,7 +266,7 @@ impl<'a> ZerocheckMonomialBatch<'a> {
                 num_x,
                 num_airs as u32,
                 THREADS_PER_BLOCK,
-                self.stream,
+                self.ctx.stream.as_raw(),
             )?;
         }
 
@@ -292,7 +293,7 @@ pub(crate) struct ZerocheckMonomialParYBatch<'a> {
     air_offsets: DeviceBuffer<u32>,
     num_blocks: u32,
     chunk_size: u32,
-    stream: cudaStream_t,
+    ctx: DeviceContext,
 }
 
 impl<'a> ZerocheckMonomialParYBatch<'a> {
@@ -315,7 +316,7 @@ impl<'a> ZerocheckMonomialParYBatch<'a> {
         sm_count: u32,
         num_x: u32,
         max_monomials_per_thread: Option<u32>,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<_> = traces.into_iter().collect();
         assert!(
@@ -430,9 +431,9 @@ impl<'a> ZerocheckMonomialParYBatch<'a> {
             .collect();
 
         // Upload to device
-        let block_ctxs = block_ctxs_h.to_device()?;
-        let air_ctxs = air_ctxs_h.to_device()?;
-        let air_offsets = air_offsets.to_device()?;
+        let block_ctxs = block_ctxs_h.to_device_on(ctx)?;
+        let air_ctxs = air_ctxs_h.to_device_on(ctx)?;
+        let air_offsets = air_offsets.to_device_on(ctx)?;
 
         debug!(
             num_airs = traces.len(),
@@ -446,7 +447,7 @@ impl<'a> ZerocheckMonomialParYBatch<'a> {
             air_offsets,
             num_blocks,
             chunk_size,
-            stream,
+            ctx: ctx.clone(),
         })
     }
 
@@ -471,9 +472,11 @@ impl<'a> ZerocheckMonomialParYBatch<'a> {
             "zerocheck_monomial_par_y_batched"
         );
 
-        let mut tmp_sums =
-            DeviceBuffer::<EF>::with_capacity(self.num_blocks as usize * num_x as usize);
-        let mut output = DeviceBuffer::<EF>::with_capacity(num_airs * num_x as usize);
+        let mut tmp_sums = DeviceBuffer::<EF>::with_capacity_on(
+            self.num_blocks as usize * num_x as usize,
+            &self.ctx,
+        );
+        let mut output = DeviceBuffer::<EF>::with_capacity_on(num_airs * num_x as usize, &self.ctx);
 
         debug_assert_eq!(
             self.air_offsets.len(),
@@ -495,7 +498,7 @@ impl<'a> ZerocheckMonomialParYBatch<'a> {
                 num_airs as u32,
                 self.chunk_size,
                 THREADS_PER_BLOCK_PAR_Y,
-                self.stream,
+                self.ctx.stream.as_raw(),
             )?;
         }
 
@@ -525,7 +528,7 @@ pub(crate) fn compute_logup_combinations<HS: GpuHashScheme>(
     d_eq_3bs: &DeviceBuffer<EF>,
     eq_3bs_host: &[EF],
     beta_pows_host: &[EF],
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<LogupCombinations, CudaError> {
     let monomials = pk.per_air[air_idx]
         .other_data
@@ -533,9 +536,10 @@ pub(crate) fn compute_logup_combinations<HS: GpuHashScheme>(
         .as_ref()
         .expect("AIR must have interaction monomials");
 
+    let stream = ctx.stream.as_raw();
     // Precompute numerator combinations: sum_i(coeff_i * eq_3bs[interaction_idx_i])
     let mut d_numer_combinations = if monomials.num_numer_monomials > 0 {
-        DeviceBuffer::<EF>::with_capacity(monomials.num_numer_monomials as usize)
+        DeviceBuffer::<EF>::with_capacity_on(monomials.num_numer_monomials as usize, ctx)
     } else {
         DeviceBuffer::new()
     };
@@ -555,7 +559,7 @@ pub(crate) fn compute_logup_combinations<HS: GpuHashScheme>(
     // Precompute denominator combinations: sum_i(coeff_i * beta_pows[field_idx_i] *
     // eq_3bs[interaction_idx_i])
     let mut d_denom_combinations = if monomials.num_denom_monomials > 0 {
-        DeviceBuffer::<EF>::with_capacity(monomials.num_denom_monomials as usize)
+        DeviceBuffer::<EF>::with_capacity_on(monomials.num_denom_monomials as usize, ctx)
     } else {
         DeviceBuffer::new()
     };
@@ -608,7 +612,7 @@ pub(crate) struct LogupMonomialBatch<'a> {
     denom_ctxs: DeviceBuffer<LogupMonomialCtx>,
     air_offsets: DeviceBuffer<u32>,
     num_blocks: u32,
-    stream: cudaStream_t,
+    ctx: DeviceContext,
 }
 
 impl<'a> LogupMonomialBatch<'a> {
@@ -624,7 +628,7 @@ impl<'a> LogupMonomialBatch<'a> {
         traces: impl IntoIterator<Item = &'a TraceCtx>,
         pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
         logup_combinations: &[&LogupCombinations],
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<_> = traces.into_iter().collect();
         assert!(
@@ -735,11 +739,11 @@ impl<'a> LogupMonomialBatch<'a> {
             .collect();
 
         // Upload to device
-        let block_ctxs = block_ctxs_h.to_device()?;
-        let common_ctxs = common_ctxs_h.to_device()?;
-        let numer_ctxs = numer_ctxs_h.to_device()?;
-        let denom_ctxs = denom_ctxs_h.to_device()?;
-        let air_offsets = air_offsets.to_device()?;
+        let block_ctxs = block_ctxs_h.to_device_on(ctx)?;
+        let common_ctxs = common_ctxs_h.to_device_on(ctx)?;
+        let numer_ctxs = numer_ctxs_h.to_device_on(ctx)?;
+        let denom_ctxs = denom_ctxs_h.to_device_on(ctx)?;
+        let air_offsets = air_offsets.to_device_on(ctx)?;
 
         debug!(
             num_airs = traces.len(),
@@ -754,7 +758,7 @@ impl<'a> LogupMonomialBatch<'a> {
             denom_ctxs,
             air_offsets,
             num_blocks,
-            stream,
+            ctx: ctx.clone(),
         })
     }
 
@@ -778,9 +782,12 @@ impl<'a> LogupMonomialBatch<'a> {
             "logup_monomial_batched"
         );
 
-        let mut tmp_sums =
-            DeviceBuffer::<Frac<EF>>::with_capacity(self.num_blocks as usize * num_x as usize);
-        let mut output = DeviceBuffer::<Frac<EF>>::with_capacity(num_airs * num_x as usize);
+        let mut tmp_sums = DeviceBuffer::<Frac<EF>>::with_capacity_on(
+            self.num_blocks as usize * num_x as usize,
+            &self.ctx,
+        );
+        let mut output =
+            DeviceBuffer::<Frac<EF>>::with_capacity_on(num_airs * num_x as usize, &self.ctx);
 
         debug_assert_eq!(
             self.air_offsets.len(),
@@ -803,7 +810,7 @@ impl<'a> LogupMonomialBatch<'a> {
                 num_x,
                 num_airs as u32,
                 THREADS_PER_BLOCK_LOGUP,
-                self.stream,
+                self.ctx.stream.as_raw(),
             )?;
         }
 

--- a/crates/cuda-backend/src/logup_zerocheck/batch_mle_monomial.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/batch_mle_monomial.rs
@@ -7,7 +7,7 @@ use openvm_cuda_common::{
     copy::MemCopyH2D,
     d_buffer::DeviceBuffer,
     error::{CudaError, MemCopyError},
-    stream::cudaStreamPerThread,
+    stream::cudaStream_t,
 };
 use openvm_stark_backend::prover::{fractional_sumcheck_gkr::Frac, DeviceMultiStarkProvingKey};
 use p3_field::PrimeCharacteristicRing;
@@ -81,6 +81,7 @@ pub(crate) fn compute_lambda_combinations<HS: GpuHashScheme>(
     pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
     air_idx: usize,
     lambda_pows: &DeviceBuffer<EF>,
+    stream: cudaStream_t,
 ) -> Result<DeviceBuffer<EF>, CudaError> {
     let monomials = pk.per_air[air_idx]
         .other_data
@@ -95,7 +96,7 @@ pub(crate) fn compute_lambda_combinations<HS: GpuHashScheme>(
             monomials.d_lambda_terms.as_ptr(),
             lambda_pows,
             monomials.num_monomials,
-            cudaStreamPerThread,
+            stream,
         )?;
     }
     Ok(buf)
@@ -115,6 +116,7 @@ pub(crate) struct ZerocheckMonomialBatch<'a> {
     block_ctxs: DeviceBuffer<BlockCtx>,
     air_ctxs: DeviceBuffer<MonomialAirCtx>,
     air_offsets: DeviceBuffer<u32>,
+    stream: cudaStream_t,
 }
 
 impl<'a> ZerocheckMonomialBatch<'a> {
@@ -130,6 +132,7 @@ impl<'a> ZerocheckMonomialBatch<'a> {
         traces: impl IntoIterator<Item = &'a TraceCtx>,
         pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
         lambda_combinations: &[&DeviceBuffer<EF>],
+        stream: cudaStream_t,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<_> = traces.into_iter().collect();
         assert!(
@@ -215,6 +218,7 @@ impl<'a> ZerocheckMonomialBatch<'a> {
             block_ctxs,
             air_ctxs,
             air_offsets,
+            stream,
         })
     }
 
@@ -261,7 +265,7 @@ impl<'a> ZerocheckMonomialBatch<'a> {
                 num_x,
                 num_airs as u32,
                 THREADS_PER_BLOCK,
-                cudaStreamPerThread,
+                self.stream,
             )?;
         }
 
@@ -288,6 +292,7 @@ pub(crate) struct ZerocheckMonomialParYBatch<'a> {
     air_offsets: DeviceBuffer<u32>,
     num_blocks: u32,
     chunk_size: u32,
+    stream: cudaStream_t,
 }
 
 impl<'a> ZerocheckMonomialParYBatch<'a> {
@@ -310,6 +315,7 @@ impl<'a> ZerocheckMonomialParYBatch<'a> {
         sm_count: u32,
         num_x: u32,
         max_monomials_per_thread: Option<u32>,
+        stream: cudaStream_t,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<_> = traces.into_iter().collect();
         assert!(
@@ -440,6 +446,7 @@ impl<'a> ZerocheckMonomialParYBatch<'a> {
             air_offsets,
             num_blocks,
             chunk_size,
+            stream,
         })
     }
 
@@ -488,7 +495,7 @@ impl<'a> ZerocheckMonomialParYBatch<'a> {
                 num_airs as u32,
                 self.chunk_size,
                 THREADS_PER_BLOCK_PAR_Y,
-                cudaStreamPerThread,
+                self.stream,
             )?;
         }
 
@@ -510,6 +517,7 @@ pub struct LogupCombinations {
 /// Precompute logup combinations for a single AIR's interaction monomials.
 ///
 /// The AIR must have nonempty interaction monomials.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn compute_logup_combinations<HS: GpuHashScheme>(
     pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
     air_idx: usize,
@@ -517,6 +525,7 @@ pub(crate) fn compute_logup_combinations<HS: GpuHashScheme>(
     d_eq_3bs: &DeviceBuffer<EF>,
     eq_3bs_host: &[EF],
     beta_pows_host: &[EF],
+    stream: cudaStream_t,
 ) -> Result<LogupCombinations, CudaError> {
     let monomials = pk.per_air[air_idx]
         .other_data
@@ -538,7 +547,7 @@ pub(crate) fn compute_logup_combinations<HS: GpuHashScheme>(
                 monomials.d_numer_terms.as_ptr(),
                 d_eq_3bs,
                 monomials.num_numer_monomials,
-                cudaStreamPerThread,
+                stream,
             )?;
         }
     }
@@ -559,7 +568,7 @@ pub(crate) fn compute_logup_combinations<HS: GpuHashScheme>(
                 d_beta_pows,
                 d_eq_3bs,
                 monomials.num_denom_monomials,
-                cudaStreamPerThread,
+                stream,
             )?;
         }
     }
@@ -599,6 +608,7 @@ pub(crate) struct LogupMonomialBatch<'a> {
     denom_ctxs: DeviceBuffer<LogupMonomialCtx>,
     air_offsets: DeviceBuffer<u32>,
     num_blocks: u32,
+    stream: cudaStream_t,
 }
 
 impl<'a> LogupMonomialBatch<'a> {
@@ -614,6 +624,7 @@ impl<'a> LogupMonomialBatch<'a> {
         traces: impl IntoIterator<Item = &'a TraceCtx>,
         pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
         logup_combinations: &[&LogupCombinations],
+        stream: cudaStream_t,
     ) -> Result<Self, MemCopyError> {
         let traces: Vec<_> = traces.into_iter().collect();
         assert!(
@@ -743,6 +754,7 @@ impl<'a> LogupMonomialBatch<'a> {
             denom_ctxs,
             air_offsets,
             num_blocks,
+            stream,
         })
     }
 
@@ -791,7 +803,7 @@ impl<'a> LogupMonomialBatch<'a> {
                 num_x,
                 num_airs as u32,
                 THREADS_PER_BLOCK_LOGUP,
-                cudaStreamPerThread,
+                self.stream,
             )?;
         }
 

--- a/crates/cuda-backend/src/logup_zerocheck/batch_mle_monomial.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/batch_mle_monomial.rs
@@ -7,6 +7,7 @@ use openvm_cuda_common::{
     copy::MemCopyH2D,
     d_buffer::DeviceBuffer,
     error::{CudaError, MemCopyError},
+    stream::cudaStreamPerThread,
 };
 use openvm_stark_backend::prover::{fractional_sumcheck_gkr::Frac, DeviceMultiStarkProvingKey};
 use p3_field::PrimeCharacteristicRing;
@@ -94,6 +95,7 @@ pub(crate) fn compute_lambda_combinations<HS: GpuHashScheme>(
             monomials.d_lambda_terms.as_ptr(),
             lambda_pows,
             monomials.num_monomials,
+            cudaStreamPerThread,
         )?;
     }
     Ok(buf)
@@ -259,6 +261,7 @@ impl<'a> ZerocheckMonomialBatch<'a> {
                 num_x,
                 num_airs as u32,
                 THREADS_PER_BLOCK,
+                cudaStreamPerThread,
             )?;
         }
 
@@ -485,6 +488,7 @@ impl<'a> ZerocheckMonomialParYBatch<'a> {
                 num_airs as u32,
                 self.chunk_size,
                 THREADS_PER_BLOCK_PAR_Y,
+                cudaStreamPerThread,
             )?;
         }
 
@@ -534,6 +538,7 @@ pub(crate) fn compute_logup_combinations<HS: GpuHashScheme>(
                 monomials.d_numer_terms.as_ptr(),
                 d_eq_3bs,
                 monomials.num_numer_monomials,
+                cudaStreamPerThread,
             )?;
         }
     }
@@ -554,6 +559,7 @@ pub(crate) fn compute_logup_combinations<HS: GpuHashScheme>(
                 d_beta_pows,
                 d_eq_3bs,
                 monomials.num_denom_monomials,
+                cudaStreamPerThread,
             )?;
         }
     }
@@ -785,6 +791,7 @@ impl<'a> LogupMonomialBatch<'a> {
                 num_x,
                 num_airs as u32,
                 THREADS_PER_BLOCK_LOGUP,
+                cudaStreamPerThread,
             )?;
         }
 

--- a/crates/cuda-backend/src/logup_zerocheck/fold_ple.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fold_ple.rs
@@ -1,6 +1,6 @@
 use std::{cmp::max, sync::Arc};
 
-use openvm_cuda_common::{d_buffer::DeviceBuffer, stream::cudaStreamPerThread};
+use openvm_cuda_common::{d_buffer::DeviceBuffer, stream::cudaStream_t};
 use openvm_stark_backend::prover::MatrixDimensions;
 
 use super::errors::FoldPleError;
@@ -19,6 +19,7 @@ pub fn fold_ple_evals_rotate(
     trace_evals: &DeviceMatrix<F>,
     d_inv_lagrange_denoms_r0: &DeviceBuffer<EF>,
     need_rot: bool,
+    stream: cudaStream_t,
 ) -> Result<DeviceMatrix<EF>, FoldPleError> {
     validate_gpu_l_skip(l_skip)?;
     let width = trace_evals.width();
@@ -37,6 +38,7 @@ pub fn fold_ple_evals_rotate(
             folded_buf.as_mut_ptr(),
             d_inv_lagrange_denoms_r0,
             false,
+            stream,
         )?;
 
         if need_rot {
@@ -48,6 +50,7 @@ pub fn fold_ple_evals_rotate(
                 folded_buf.as_mut_ptr().add(num_x * width),
                 d_inv_lagrange_denoms_r0,
                 true,
+                stream,
             )?;
         }
     }
@@ -72,6 +75,7 @@ pub unsafe fn fold_ple_evals_gpu(
     output: *mut EF,
     d_inv_lagrange_denoms_r0: &DeviceBuffer<EF>,
     rotate: bool,
+    stream: cudaStream_t,
 ) -> Result<(), FoldPleError> {
     validate_gpu_l_skip(l_skip)?;
     let height = mat.height();
@@ -98,7 +102,7 @@ pub unsafe fn fold_ple_evals_gpu(
             l_skip as u32,
             num_x as u32,
             rotate,
-            cudaStreamPerThread,
+            stream,
         )?;
     }
     Ok(())

--- a/crates/cuda-backend/src/logup_zerocheck/fold_ple.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fold_ple.rs
@@ -1,6 +1,6 @@
 use std::{cmp::max, sync::Arc};
 
-use openvm_cuda_common::d_buffer::DeviceBuffer;
+use openvm_cuda_common::{d_buffer::DeviceBuffer, stream::cudaStreamPerThread};
 use openvm_stark_backend::prover::MatrixDimensions;
 
 use super::errors::FoldPleError;
@@ -98,6 +98,7 @@ pub unsafe fn fold_ple_evals_gpu(
             l_skip as u32,
             num_x as u32,
             rotate,
+            cudaStreamPerThread,
         )?;
     }
     Ok(())

--- a/crates/cuda-backend/src/logup_zerocheck/fold_ple.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fold_ple.rs
@@ -1,6 +1,6 @@
 use std::{cmp::max, sync::Arc};
 
-use openvm_cuda_common::{d_buffer::DeviceBuffer, stream::cudaStream_t};
+use openvm_cuda_common::{d_buffer::DeviceBuffer, stream::DeviceContext};
 use openvm_stark_backend::prover::MatrixDimensions;
 
 use super::errors::FoldPleError;
@@ -19,14 +19,14 @@ pub fn fold_ple_evals_rotate(
     trace_evals: &DeviceMatrix<F>,
     d_inv_lagrange_denoms_r0: &DeviceBuffer<EF>,
     need_rot: bool,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<DeviceMatrix<EF>, FoldPleError> {
     validate_gpu_l_skip(l_skip)?;
     let width = trace_evals.width();
     let height = trace_evals.height();
     let num_x = max(height >> l_skip, 1);
     let out_width = width * if need_rot { 2 } else { 1 };
-    let folded_buf = DeviceBuffer::<EF>::with_capacity(num_x * out_width);
+    let folded_buf = DeviceBuffer::<EF>::with_capacity_on(num_x * out_width, ctx);
     // SAFETY:
     // - We allocated `folded_buf` for `num_x * width * (1 or 2)` elements.
     // - `trace_evals` is `height x width` unlighted matrix
@@ -38,7 +38,7 @@ pub fn fold_ple_evals_rotate(
             folded_buf.as_mut_ptr(),
             d_inv_lagrange_denoms_r0,
             false,
-            stream,
+            ctx,
         )?;
 
         if need_rot {
@@ -50,7 +50,7 @@ pub fn fold_ple_evals_rotate(
                 folded_buf.as_mut_ptr().add(num_x * width),
                 d_inv_lagrange_denoms_r0,
                 true,
-                stream,
+                ctx,
             )?;
         }
     }
@@ -75,7 +75,7 @@ pub unsafe fn fold_ple_evals_gpu(
     output: *mut EF,
     d_inv_lagrange_denoms_r0: &DeviceBuffer<EF>,
     rotate: bool,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<(), FoldPleError> {
     validate_gpu_l_skip(l_skip)?;
     let height = mat.height();
@@ -102,7 +102,7 @@ pub unsafe fn fold_ple_evals_gpu(
             l_skip as u32,
             num_x as u32,
             rotate,
-            stream,
+            ctx.stream.as_raw(),
         )?;
     }
     Ok(())

--- a/crates/cuda-backend/src/logup_zerocheck/fold_ple.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fold_ple.rs
@@ -19,14 +19,14 @@ pub fn fold_ple_evals_rotate(
     trace_evals: &DeviceMatrix<F>,
     d_inv_lagrange_denoms_r0: &DeviceBuffer<EF>,
     need_rot: bool,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<DeviceMatrix<EF>, FoldPleError> {
     validate_gpu_l_skip(l_skip)?;
     let width = trace_evals.width();
     let height = trace_evals.height();
     let num_x = max(height >> l_skip, 1);
     let out_width = width * if need_rot { 2 } else { 1 };
-    let folded_buf = DeviceBuffer::<EF>::with_capacity_on(num_x * out_width, ctx);
+    let folded_buf = DeviceBuffer::<EF>::with_capacity_on(num_x * out_width, device_ctx);
     // SAFETY:
     // - We allocated `folded_buf` for `num_x * width * (1 or 2)` elements.
     // - `trace_evals` is `height x width` unlighted matrix
@@ -38,7 +38,7 @@ pub fn fold_ple_evals_rotate(
             folded_buf.as_mut_ptr(),
             d_inv_lagrange_denoms_r0,
             false,
-            ctx,
+            device_ctx,
         )?;
 
         if need_rot {
@@ -50,7 +50,7 @@ pub fn fold_ple_evals_rotate(
                 folded_buf.as_mut_ptr().add(num_x * width),
                 d_inv_lagrange_denoms_r0,
                 true,
-                ctx,
+                device_ctx,
             )?;
         }
     }
@@ -75,7 +75,7 @@ pub unsafe fn fold_ple_evals_gpu(
     output: *mut EF,
     d_inv_lagrange_denoms_r0: &DeviceBuffer<EF>,
     rotate: bool,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<(), FoldPleError> {
     validate_gpu_l_skip(l_skip)?;
     let height = mat.height();
@@ -102,7 +102,7 @@ pub unsafe fn fold_ple_evals_gpu(
             l_skip as u32,
             num_x as u32,
             rotate,
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )?;
     }
     Ok(())

--- a/crates/cuda-backend/src/logup_zerocheck/fold_ple.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fold_ple.rs
@@ -1,6 +1,6 @@
 use std::{cmp::max, sync::Arc};
 
-use openvm_cuda_common::{d_buffer::DeviceBuffer, stream::DeviceContext};
+use openvm_cuda_common::{d_buffer::DeviceBuffer, stream::GpuDeviceCtx};
 use openvm_stark_backend::prover::MatrixDimensions;
 
 use super::errors::FoldPleError;
@@ -19,7 +19,7 @@ pub fn fold_ple_evals_rotate(
     trace_evals: &DeviceMatrix<F>,
     d_inv_lagrange_denoms_r0: &DeviceBuffer<EF>,
     need_rot: bool,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<DeviceMatrix<EF>, FoldPleError> {
     validate_gpu_l_skip(l_skip)?;
     let width = trace_evals.width();
@@ -75,7 +75,7 @@ pub unsafe fn fold_ple_evals_gpu(
     output: *mut EF,
     d_inv_lagrange_denoms_r0: &DeviceBuffer<EF>,
     rotate: bool,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(), FoldPleError> {
     validate_gpu_l_skip(l_skip)?;
     let height = mat.height();

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -1,10 +1,10 @@
 use std::{array::from_fn, convert::TryInto, env, ffi::c_void, mem::transmute};
 
 use openvm_cuda_common::{
-    copy::{cuda_memcpy, MemCopyD2H},
+    copy::{cuda_memcpy_on, MemCopyD2H},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
-    stream::cudaStream_t,
+    stream::DeviceContext,
 };
 use openvm_stark_backend::{
     poly_common::{eval_eq_mle, interpolate_linear_at_01, interpolate_quadratic_at_012},
@@ -300,15 +300,20 @@ fn eq_tail_ptrs(
     }
 }
 
-fn copy_to_device_ptr<T: Copy>(dst: *mut T, src: &[T]) -> Result<(), FractionalSumcheckError> {
+fn copy_to_device_ptr<T: Copy>(
+    dst: *mut T,
+    src: &[T],
+    ctx: &DeviceContext,
+) -> Result<(), FractionalSumcheckError> {
     if src.is_empty() {
         return Ok(());
     }
     unsafe {
-        cuda_memcpy::<false, true>(
+        cuda_memcpy_on::<false, true>(
             dst as *mut c_void,
             src.as_ptr() as *const c_void,
             std::mem::size_of_val(src),
+            ctx,
         )?;
     }
     Ok(())
@@ -324,12 +329,13 @@ fn observe_and_update<SC, TS>(
     prev_s_eval: &mut EF,
     xi_j: EF,
     eq_r_acc: &mut EF,
+    ctx: &DeviceContext,
 ) -> Result<EF, FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
     TS: FiatShamirTranscript<SC>,
 {
-    let (s_evals, sp_evals) = reconstruct_s_evals(d_sum_evals, *prev_s_eval, xi_j, *eq_r_acc)?;
+    let (s_evals, sp_evals) = reconstruct_s_evals(d_sum_evals, *prev_s_eval, xi_j, *eq_r_acc, ctx)?;
 
     for &eval in &s_evals {
         transcript.observe_ext(eval);
@@ -363,12 +369,13 @@ fn do_sumcheck_round_and_revert<SC, TS>(
     prev_s_eval: &mut EF,
     xi_j: EF,
     eq_r_acc: &mut EF,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<EF, FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
     TS: FiatShamirTranscript<SC>,
 {
+    let stream = ctx.stream.as_raw();
     unsafe {
         frac_compute_round_and_revert(
             eq_buffer,
@@ -390,6 +397,7 @@ where
         prev_s_eval,
         xi_j,
         eq_r_acc,
+        ctx,
     )
 }
 
@@ -413,12 +421,13 @@ fn do_fused_sumcheck_round<SC, TS>(
     prev_s_eval: &mut EF,
     xi_j: EF,
     eq_r_acc: &mut EF,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<EF, FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
     TS: FiatShamirTranscript<SC>,
 {
+    let stream = ctx.stream.as_raw();
     unsafe {
         frac_compute_round_and_fold(
             eq_buffer,
@@ -442,6 +451,7 @@ where
         prev_s_eval,
         xi_j,
         eq_r_acc,
+        ctx,
     )
 }
 
@@ -461,12 +471,13 @@ fn do_fused_sumcheck_round_inplace<SC, TS>(
     prev_s_eval: &mut EF,
     xi_j: EF,
     eq_r_acc: &mut EF,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<EF, FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
     TS: FiatShamirTranscript<SC>,
 {
+    let stream = ctx.stream.as_raw();
     unsafe {
         frac_compute_round_and_fold_inplace(
             eq_buffer,
@@ -489,6 +500,7 @@ where
         prev_s_eval,
         xi_j,
         eq_r_acc,
+        ctx,
     )
 }
 
@@ -501,7 +513,7 @@ pub fn fractional_sumcheck_gpu<SC, TS>(
     alpha: EF,
     assert_zero: bool,
     mem: &mut MemTracker,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<(FracSumcheckProof<SC>, Vec<EF>), FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
@@ -518,6 +530,7 @@ where
             vec![],
         ));
     };
+    let stream = ctx.stream.as_raw();
     let total_leaves = layer.len();
     // total_rounds = l_skip + n_logup
     let total_rounds = log2_strict_usize(total_leaves);
@@ -591,8 +604,8 @@ where
     }
     mem.emit_metrics_with_label("frac_sumcheck.segment_tree");
     mem.tracing_info("fractional_sumcheck_gkr: after building segment tree");
-    let mut copy_scratch = DeviceBuffer::<Frac<EF>>::with_capacity(1);
-    let root = copy_from_device(&layer, 0, &mut copy_scratch)?;
+    let mut copy_scratch = DeviceBuffer::<Frac<EF>>::with_capacity_on(1, ctx);
+    let root = copy_from_device(&layer, 0, &mut copy_scratch, ctx)?;
     unsafe {
         frac_build_tree_layer(&mut layer, 2, true, EF::ZERO, false, stream)
             .map_err(FractionalSumcheckError::SegmentTree)?;
@@ -612,8 +625,8 @@ where
     let mut claims_per_layer = Vec::with_capacity(total_rounds);
     let mut sumcheck_polys = Vec::with_capacity(total_rounds);
 
-    let first_left = copy_from_device(&layer, 0, &mut copy_scratch)?;
-    let first_right = copy_from_device(&layer, 1, &mut copy_scratch)?;
+    let first_left = copy_from_device(&layer, 0, &mut copy_scratch, ctx)?;
+    let first_right = copy_from_device(&layer, 1, &mut copy_scratch, ctx)?;
     claims_per_layer.push(GkrLayerClaims {
         p_xi_0: first_left.p,
         q_xi_0: first_left.q,
@@ -630,7 +643,7 @@ where
     }
     let mu_1 = transcript.sample_ext();
     let mut xi_prev = vec![mu_1];
-    let mut d_sum_evals = DeviceBuffer::<EF>::with_capacity(2);
+    let mut d_sum_evals = DeviceBuffer::<EF>::with_capacity_on(2, ctx);
 
     let precompute_m_env = precompute_m_enabled();
 
@@ -649,7 +662,7 @@ where
         0
     };
     let mut work_buffer = if max_work_size > 0 {
-        DeviceBuffer::<Frac<EF>>::with_capacity(max_work_size)
+        DeviceBuffer::<Frac<EF>>::with_capacity_on(max_work_size, ctx)
     } else {
         DeviceBuffer::new()
     };
@@ -660,7 +673,7 @@ where
         0
     };
     let mut tmp_block_sums = if max_tmp_buffer_capacity > 0 {
-        DeviceBuffer::<EF>::with_capacity(max_tmp_buffer_capacity)
+        DeviceBuffer::<EF>::with_capacity_on(max_tmp_buffer_capacity, ctx)
     } else {
         DeviceBuffer::new()
     };
@@ -672,6 +685,7 @@ where
     let mut m_partial_buffer = DeviceBuffer::<EF>::new();
     let mut eq_r_prefix_buffer = DeviceBuffer::<EF>::new();
     let mut eq_suffix_buffer = DeviceBuffer::<EF>::new();
+    // Note: `stream` local variable is used for FFI calls throughout the loop.
 
     for round in 1..total_rounds {
         let gkr_round_span = debug_span!("GKR", round).entered();
@@ -681,7 +695,7 @@ where
         debug_assert_eq!(xi_prev.len(), round);
         // eq_buffer stores eq(xi_prev[j..], x) for x in H_{xi_prev.len()-j} for
         // j=1,...,xi_prev.len()-1.
-        let mut eq_buffer = SqrtEqLayers::from_xi(&xi_prev[1..], stream)
+        let mut eq_buffer = SqrtEqLayers::from_xi(&xi_prev[1..], ctx)
             .map_err(FractionalSumcheckError::EvalEqHypercube)?;
 
         let mut round_polys_eval = Vec::with_capacity(round);
@@ -693,7 +707,7 @@ where
         let tmp_buffer_capacity =
             unsafe { _frac_compute_round_temp_buffer_size((1 << round) as u32, stream) } as usize;
         if tmp_buffer_capacity > tmp_block_sums.len() {
-            tmp_block_sums = DeviceBuffer::<EF>::with_capacity(tmp_buffer_capacity);
+            tmp_block_sums = DeviceBuffer::<EF>::with_capacity_on(tmp_buffer_capacity, ctx);
         }
 
         let last_outer_round = round == total_rounds - 1;
@@ -729,7 +743,7 @@ where
             &mut prev_s_eval,
             xi_prev[0],
             &mut eq_r_acc,
-            stream,
+            ctx,
         )?;
 
         // Fused rounds 1..(round-1): compute + fold using prev_r.
@@ -760,7 +774,7 @@ where
                             &mut prev_s_eval,
                             xi_j,
                             &mut eq_r_acc,
-                            stream,
+                            ctx,
                         )?,
                         BufferTarget::WorkToLayer => do_fused_sumcheck_round(
                             &mut eq_buffer,
@@ -777,7 +791,7 @@ where
                             &mut prev_s_eval,
                             xi_j,
                             &mut eq_r_acc,
-                            stream,
+                            ctx,
                         )?,
                         BufferTarget::InPlaceLayer => do_fused_sumcheck_round_inplace(
                             &mut eq_buffer,
@@ -793,7 +807,7 @@ where
                             &mut prev_s_eval,
                             xi_j,
                             &mut eq_r_acc,
-                            stream,
+                            ctx,
                         )?,
                         BufferTarget::InPlaceWork => do_fused_sumcheck_round_inplace(
                             &mut eq_buffer,
@@ -809,7 +823,7 @@ where
                             &mut prev_s_eval,
                             xi_j,
                             &mut eq_r_acc,
-                            stream,
+                            ctx,
                         )?,
                     };
 
@@ -869,10 +883,11 @@ where
 
                 if eq_r_prefix_buffer.is_empty() {
                     eq_r_prefix_buffer =
-                        DeviceBuffer::<EF>::with_capacity(1usize << GKR_WINDOW_SIZE);
+                        DeviceBuffer::<EF>::with_capacity_on(1usize << GKR_WINDOW_SIZE, ctx);
                 }
                 if eq_suffix_buffer.is_empty() {
-                    eq_suffix_buffer = DeviceBuffer::<EF>::with_capacity(1usize << GKR_WINDOW_SIZE);
+                    eq_suffix_buffer =
+                        DeviceBuffer::<EF>::with_capacity_on(1usize << GKR_WINDOW_SIZE, ctx);
                 }
 
                 let mut base = base;
@@ -891,7 +906,7 @@ where
                     };
                     if m_buffer.is_empty() {
                         let max_m_len = 1usize << (2 * GKR_WINDOW_SIZE);
-                        m_buffer = DeviceBuffer::<EF>::with_capacity(max_m_len);
+                        m_buffer = DeviceBuffer::<EF>::with_capacity_on(max_m_len, ctx);
                     }
                     let m_ptr = m_buffer.as_mut_ptr();
                     // Reuse tmp_block_sums for eq_r_window upload.
@@ -920,7 +935,7 @@ where
                     let m_len = (1usize << w) * (1usize << w);
                     let partial_len = num_blocks * m_len;
                     if partial_len > m_partial_buffer.len() {
-                        m_partial_buffer = DeviceBuffer::<EF>::with_capacity(partial_len);
+                        m_partial_buffer = DeviceBuffer::<EF>::with_capacity_on(partial_len, ctx);
                     }
 
                     let (eq_tail_low, eq_tail_high, eq_low_cap, _) =
@@ -962,10 +977,12 @@ where
                         copy_to_device_ptr(
                             eq_r_prefix_buffer.as_mut_ptr(),
                             &eq_r_prefix_host[..(1usize << prefix_bits)],
+                            ctx,
                         )?;
                         copy_to_device_ptr(
                             eq_suffix_buffer.as_mut_ptr(),
                             &eq_suffix_host[..(1usize << suffix_bits)],
+                            ctx,
                         )?;
                         unsafe {
                             frac_precompute_m_eval_round_raw(
@@ -988,6 +1005,7 @@ where
                             &mut prev_s_eval,
                             xi_prev[base + t],
                             &mut eq_r_acc,
+                            ctx,
                         )?;
                         prev_r = r;
                         window_rs.push(r);
@@ -999,11 +1017,15 @@ where
                         all_rs.push(r_fold);
                         all_rs.extend_from_slice(&window_rs);
                         eval_mle_table(&all_rs, &mut eq_r_window_host);
-                        copy_to_device_ptr(d_eq_r_window, &eq_r_window_host[..(1 << (w + 1))])?;
+                        copy_to_device_ptr(
+                            d_eq_r_window,
+                            &eq_r_window_host[..(1 << (w + 1))],
+                            ctx,
+                        )?;
                         (rem_n + 1, w + 1)
                     } else {
                         eval_mle_table(&window_rs, &mut eq_r_window_host);
-                        copy_to_device_ptr(d_eq_r_window, &eq_r_window_host[..(1 << w)])?;
+                        copy_to_device_ptr(d_eq_r_window, &eq_r_window_host[..(1 << w)], ctx)?;
                         (rem_n, w)
                     };
 
@@ -1052,6 +1074,7 @@ where
                         &mut prev_s_eval,
                         xi_prev[base],
                         &mut eq_r_acc,
+                        ctx,
                     )?;
 
                     for &xi_j in xi_prev.iter().skip(base + 1) {
@@ -1070,7 +1093,7 @@ where
                             &mut prev_s_eval,
                             xi_j,
                             &mut eq_r_acc,
-                            stream,
+                            ctx,
                         )?;
                         pq_size >>= 1;
                     }
@@ -1086,8 +1109,8 @@ where
         }
 
         let pq_host = [
-            copy_from_device(active, 0, &mut copy_scratch)?,
-            copy_from_device(active, pq_size / 2, &mut copy_scratch)?,
+            copy_from_device(active, 0, &mut copy_scratch, ctx)?,
+            copy_from_device(active, pq_size / 2, &mut copy_scratch, ctx)?,
         ];
 
         claims_per_layer.push(GkrLayerClaims {
@@ -1125,16 +1148,18 @@ fn copy_from_device<T: Copy>(
     buf: &DeviceBuffer<T>,
     index: usize,
     scratch: &mut DeviceBuffer<T>,
+    ctx: &DeviceContext,
 ) -> Result<T, FractionalSumcheckError> {
     debug_assert!(!scratch.is_empty());
     unsafe {
-        cuda_memcpy::<true, true>(
+        cuda_memcpy_on::<true, true>(
             scratch.as_mut_raw_ptr(),
             buf.as_ptr().add(index) as *const std::ffi::c_void,
             std::mem::size_of::<T>(),
+            ctx,
         )?;
     }
-    let host = scratch.to_host()?;
+    let host = scratch.to_host_on(ctx)?;
     Ok(host[0])
 }
 
@@ -1159,8 +1184,9 @@ fn reconstruct_s_evals(
     prev_s_eval: EF,
     xi_j: EF,
     eq_r_acc: EF,
+    ctx: &DeviceContext,
 ) -> Result<([EF; GKR_S_DEG], [EF; GKR_S_DEG]), FractionalSumcheckError> {
-    let sp_vec = d_sum_evals.to_host()?;
+    let sp_vec = d_sum_evals.to_host_on(ctx)?;
     debug_assert_eq!(sp_vec.len(), GKR_S_DEG - 1);
 
     // sp_evals holds evaluations of degree 2 poly `eq(xi_{j+1..}, r_{j+1..}) * s'(X)` at {0,1,2}
@@ -1194,8 +1220,11 @@ fn reconstruct_s_evals(
 }
 
 /// Generate random fractional leaves on device for benchmarking.
-pub fn make_synthetic_leaves(n: usize) -> Result<DeviceBuffer<Frac<EF>>, FractionalSumcheckError> {
-    use openvm_cuda_common::copy::cuda_memcpy;
+pub fn make_synthetic_leaves(
+    n: usize,
+    ctx: &DeviceContext,
+) -> Result<DeviceBuffer<Frac<EF>>, FractionalSumcheckError> {
+    use openvm_cuda_common::copy::cuda_memcpy_on;
     use rand::{rngs::StdRng, Rng, SeedableRng};
 
     let size = 1usize << n;
@@ -1203,12 +1232,13 @@ pub fn make_synthetic_leaves(n: usize) -> Result<DeviceBuffer<Frac<EF>>, Fractio
     let host: Vec<(EF, EF)> = (0..size)
         .map(|_| (rng.random::<EF>(), rng.random::<EF>()))
         .collect();
-    let d_leaves = DeviceBuffer::<Frac<EF>>::with_capacity(size);
+    let d_leaves = DeviceBuffer::<Frac<EF>>::with_capacity_on(size, ctx);
     unsafe {
-        cuda_memcpy::<false, true>(
+        cuda_memcpy_on::<false, true>(
             d_leaves.as_mut_raw_ptr(),
             host.as_ptr() as *const std::ffi::c_void,
             std::mem::size_of_val(host.as_slice()),
+            ctx,
         )?;
     }
     Ok(d_leaves)
@@ -1217,8 +1247,9 @@ pub fn make_synthetic_leaves(n: usize) -> Result<DeviceBuffer<Frac<EF>>, Fractio
 #[cfg(test)]
 mod tests {
     use openvm_cuda_common::{
+        common::get_device,
         memory_manager::MemTracker,
-        stream::{cudaStreamPerThread, current_stream_sync},
+        stream::{CudaStream, DeviceContext, StreamGuard},
     };
     use p3_field::PrimeCharacteristicRing;
 
@@ -1227,6 +1258,13 @@ mod tests {
         EF,
     };
     use crate::{prelude::SC, sponge::DuplexSpongeGpu};
+
+    fn test_ctx() -> DeviceContext {
+        DeviceContext {
+            device_id: get_device().unwrap() as u32,
+            stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
+        }
+    }
 
     /// Run fractional sumcheck with a given round strategy and return the proof + final randomness.
     fn run_with_strategy(
@@ -1241,18 +1279,13 @@ mod tests {
                 if enable_precompute_m { "1" } else { "0" },
             );
         }
+        let ctx = test_ctx();
         let mut transcript = DuplexSpongeGpu::default();
-        let leaves = make_synthetic_leaves(n)?;
+        let leaves = make_synthetic_leaves(n, &ctx)?;
         let mut mem = MemTracker::start("test.precompute_m");
-        let result = fractional_sumcheck_gpu(
-            &mut transcript,
-            leaves,
-            EF::ZERO,
-            false,
-            &mut mem,
-            cudaStreamPerThread,
-        )?;
-        current_stream_sync().expect("sync");
+        let result =
+            fractional_sumcheck_gpu(&mut transcript, leaves, EF::ZERO, false, &mut mem, &ctx)?;
+        ctx.stream.synchronize().expect("sync");
         Ok(result)
     }
 

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -303,7 +303,7 @@ fn eq_tail_ptrs(
 fn copy_to_device_ptr<T: Copy>(
     dst: *mut T,
     src: &[T],
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<(), FractionalSumcheckError> {
     if src.is_empty() {
         return Ok(());
@@ -313,7 +313,7 @@ fn copy_to_device_ptr<T: Copy>(
             dst as *mut c_void,
             src.as_ptr() as *const c_void,
             std::mem::size_of_val(src),
-            ctx,
+            device_ctx,
         )?;
     }
     Ok(())
@@ -329,13 +329,14 @@ fn observe_and_update<SC, TS>(
     prev_s_eval: &mut EF,
     xi_j: EF,
     eq_r_acc: &mut EF,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<EF, FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
     TS: FiatShamirTranscript<SC>,
 {
-    let (s_evals, sp_evals) = reconstruct_s_evals(d_sum_evals, *prev_s_eval, xi_j, *eq_r_acc, ctx)?;
+    let (s_evals, sp_evals) =
+        reconstruct_s_evals(d_sum_evals, *prev_s_eval, xi_j, *eq_r_acc, device_ctx)?;
 
     for &eval in &s_evals {
         transcript.observe_ext(eval);
@@ -369,13 +370,13 @@ fn do_sumcheck_round_and_revert<SC, TS>(
     prev_s_eval: &mut EF,
     xi_j: EF,
     eq_r_acc: &mut EF,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<EF, FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
     TS: FiatShamirTranscript<SC>,
 {
-    let stream = ctx.stream.as_raw();
+    let stream = device_ctx.stream.as_raw();
     unsafe {
         frac_compute_round_and_revert(
             eq_buffer,
@@ -397,7 +398,7 @@ where
         prev_s_eval,
         xi_j,
         eq_r_acc,
-        ctx,
+        device_ctx,
     )
 }
 
@@ -421,13 +422,13 @@ fn do_fused_sumcheck_round<SC, TS>(
     prev_s_eval: &mut EF,
     xi_j: EF,
     eq_r_acc: &mut EF,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<EF, FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
     TS: FiatShamirTranscript<SC>,
 {
-    let stream = ctx.stream.as_raw();
+    let stream = device_ctx.stream.as_raw();
     unsafe {
         frac_compute_round_and_fold(
             eq_buffer,
@@ -451,7 +452,7 @@ where
         prev_s_eval,
         xi_j,
         eq_r_acc,
-        ctx,
+        device_ctx,
     )
 }
 
@@ -471,13 +472,13 @@ fn do_fused_sumcheck_round_inplace<SC, TS>(
     prev_s_eval: &mut EF,
     xi_j: EF,
     eq_r_acc: &mut EF,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<EF, FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
     TS: FiatShamirTranscript<SC>,
 {
-    let stream = ctx.stream.as_raw();
+    let stream = device_ctx.stream.as_raw();
     unsafe {
         frac_compute_round_and_fold_inplace(
             eq_buffer,
@@ -500,7 +501,7 @@ where
         prev_s_eval,
         xi_j,
         eq_r_acc,
-        ctx,
+        device_ctx,
     )
 }
 
@@ -513,7 +514,7 @@ pub fn fractional_sumcheck_gpu<SC, TS>(
     alpha: EF,
     assert_zero: bool,
     mem: &mut MemTracker,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<(FracSumcheckProof<SC>, Vec<EF>), FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
@@ -530,7 +531,7 @@ where
             vec![],
         ));
     };
-    let stream = ctx.stream.as_raw();
+    let stream = device_ctx.stream.as_raw();
     let total_leaves = layer.len();
     // total_rounds = l_skip + n_logup
     let total_rounds = log2_strict_usize(total_leaves);
@@ -604,8 +605,8 @@ where
     }
     mem.emit_metrics_with_label("frac_sumcheck.segment_tree");
     mem.tracing_info("fractional_sumcheck_gkr: after building segment tree");
-    let mut copy_scratch = DeviceBuffer::<Frac<EF>>::with_capacity_on(1, ctx);
-    let root = copy_from_device(&layer, 0, &mut copy_scratch, ctx)?;
+    let mut copy_scratch = DeviceBuffer::<Frac<EF>>::with_capacity_on(1, device_ctx);
+    let root = copy_from_device(&layer, 0, &mut copy_scratch, device_ctx)?;
     unsafe {
         frac_build_tree_layer(&mut layer, 2, true, EF::ZERO, false, stream)
             .map_err(FractionalSumcheckError::SegmentTree)?;
@@ -625,8 +626,8 @@ where
     let mut claims_per_layer = Vec::with_capacity(total_rounds);
     let mut sumcheck_polys = Vec::with_capacity(total_rounds);
 
-    let first_left = copy_from_device(&layer, 0, &mut copy_scratch, ctx)?;
-    let first_right = copy_from_device(&layer, 1, &mut copy_scratch, ctx)?;
+    let first_left = copy_from_device(&layer, 0, &mut copy_scratch, device_ctx)?;
+    let first_right = copy_from_device(&layer, 1, &mut copy_scratch, device_ctx)?;
     claims_per_layer.push(GkrLayerClaims {
         p_xi_0: first_left.p,
         q_xi_0: first_left.q,
@@ -643,7 +644,7 @@ where
     }
     let mu_1 = transcript.sample_ext();
     let mut xi_prev = vec![mu_1];
-    let mut d_sum_evals = DeviceBuffer::<EF>::with_capacity_on(2, ctx);
+    let mut d_sum_evals = DeviceBuffer::<EF>::with_capacity_on(2, device_ctx);
 
     let precompute_m_env = precompute_m_enabled();
 
@@ -662,7 +663,7 @@ where
         0
     };
     let mut work_buffer = if max_work_size > 0 {
-        DeviceBuffer::<Frac<EF>>::with_capacity_on(max_work_size, ctx)
+        DeviceBuffer::<Frac<EF>>::with_capacity_on(max_work_size, device_ctx)
     } else {
         DeviceBuffer::new()
     };
@@ -673,7 +674,7 @@ where
         0
     };
     let mut tmp_block_sums = if max_tmp_buffer_capacity > 0 {
-        DeviceBuffer::<EF>::with_capacity_on(max_tmp_buffer_capacity, ctx)
+        DeviceBuffer::<EF>::with_capacity_on(max_tmp_buffer_capacity, device_ctx)
     } else {
         DeviceBuffer::new()
     };
@@ -695,7 +696,7 @@ where
         debug_assert_eq!(xi_prev.len(), round);
         // eq_buffer stores eq(xi_prev[j..], x) for x in H_{xi_prev.len()-j} for
         // j=1,...,xi_prev.len()-1.
-        let mut eq_buffer = SqrtEqLayers::from_xi(&xi_prev[1..], ctx)
+        let mut eq_buffer = SqrtEqLayers::from_xi(&xi_prev[1..], device_ctx)
             .map_err(FractionalSumcheckError::EvalEqHypercube)?;
 
         let mut round_polys_eval = Vec::with_capacity(round);
@@ -707,7 +708,7 @@ where
         let tmp_buffer_capacity =
             unsafe { _frac_compute_round_temp_buffer_size((1 << round) as u32, stream) } as usize;
         if tmp_buffer_capacity > tmp_block_sums.len() {
-            tmp_block_sums = DeviceBuffer::<EF>::with_capacity_on(tmp_buffer_capacity, ctx);
+            tmp_block_sums = DeviceBuffer::<EF>::with_capacity_on(tmp_buffer_capacity, device_ctx);
         }
 
         let last_outer_round = round == total_rounds - 1;
@@ -743,7 +744,7 @@ where
             &mut prev_s_eval,
             xi_prev[0],
             &mut eq_r_acc,
-            ctx,
+            device_ctx,
         )?;
 
         // Fused rounds 1..(round-1): compute + fold using prev_r.
@@ -774,7 +775,7 @@ where
                             &mut prev_s_eval,
                             xi_j,
                             &mut eq_r_acc,
-                            ctx,
+                            device_ctx,
                         )?,
                         BufferTarget::WorkToLayer => do_fused_sumcheck_round(
                             &mut eq_buffer,
@@ -791,7 +792,7 @@ where
                             &mut prev_s_eval,
                             xi_j,
                             &mut eq_r_acc,
-                            ctx,
+                            device_ctx,
                         )?,
                         BufferTarget::InPlaceLayer => do_fused_sumcheck_round_inplace(
                             &mut eq_buffer,
@@ -807,7 +808,7 @@ where
                             &mut prev_s_eval,
                             xi_j,
                             &mut eq_r_acc,
-                            ctx,
+                            device_ctx,
                         )?,
                         BufferTarget::InPlaceWork => do_fused_sumcheck_round_inplace(
                             &mut eq_buffer,
@@ -823,7 +824,7 @@ where
                             &mut prev_s_eval,
                             xi_j,
                             &mut eq_r_acc,
-                            ctx,
+                            device_ctx,
                         )?,
                     };
 
@@ -883,11 +884,11 @@ where
 
                 if eq_r_prefix_buffer.is_empty() {
                     eq_r_prefix_buffer =
-                        DeviceBuffer::<EF>::with_capacity_on(1usize << GKR_WINDOW_SIZE, ctx);
+                        DeviceBuffer::<EF>::with_capacity_on(1usize << GKR_WINDOW_SIZE, device_ctx);
                 }
                 if eq_suffix_buffer.is_empty() {
                     eq_suffix_buffer =
-                        DeviceBuffer::<EF>::with_capacity_on(1usize << GKR_WINDOW_SIZE, ctx);
+                        DeviceBuffer::<EF>::with_capacity_on(1usize << GKR_WINDOW_SIZE, device_ctx);
                 }
 
                 let mut base = base;
@@ -906,7 +907,7 @@ where
                     };
                     if m_buffer.is_empty() {
                         let max_m_len = 1usize << (2 * GKR_WINDOW_SIZE);
-                        m_buffer = DeviceBuffer::<EF>::with_capacity_on(max_m_len, ctx);
+                        m_buffer = DeviceBuffer::<EF>::with_capacity_on(max_m_len, device_ctx);
                     }
                     let m_ptr = m_buffer.as_mut_ptr();
                     // Reuse tmp_block_sums for eq_r_window upload.
@@ -935,7 +936,8 @@ where
                     let m_len = (1usize << w) * (1usize << w);
                     let partial_len = num_blocks * m_len;
                     if partial_len > m_partial_buffer.len() {
-                        m_partial_buffer = DeviceBuffer::<EF>::with_capacity_on(partial_len, ctx);
+                        m_partial_buffer =
+                            DeviceBuffer::<EF>::with_capacity_on(partial_len, device_ctx);
                     }
 
                     let (eq_tail_low, eq_tail_high, eq_low_cap, _) =
@@ -977,12 +979,12 @@ where
                         copy_to_device_ptr(
                             eq_r_prefix_buffer.as_mut_ptr(),
                             &eq_r_prefix_host[..(1usize << prefix_bits)],
-                            ctx,
+                            device_ctx,
                         )?;
                         copy_to_device_ptr(
                             eq_suffix_buffer.as_mut_ptr(),
                             &eq_suffix_host[..(1usize << suffix_bits)],
-                            ctx,
+                            device_ctx,
                         )?;
                         unsafe {
                             frac_precompute_m_eval_round_raw(
@@ -1005,7 +1007,7 @@ where
                             &mut prev_s_eval,
                             xi_prev[base + t],
                             &mut eq_r_acc,
-                            ctx,
+                            device_ctx,
                         )?;
                         prev_r = r;
                         window_rs.push(r);
@@ -1020,12 +1022,16 @@ where
                         copy_to_device_ptr(
                             d_eq_r_window,
                             &eq_r_window_host[..(1 << (w + 1))],
-                            ctx,
+                            device_ctx,
                         )?;
                         (rem_n + 1, w + 1)
                     } else {
                         eval_mle_table(&window_rs, &mut eq_r_window_host);
-                        copy_to_device_ptr(d_eq_r_window, &eq_r_window_host[..(1 << w)], ctx)?;
+                        copy_to_device_ptr(
+                            d_eq_r_window,
+                            &eq_r_window_host[..(1 << w)],
+                            device_ctx,
+                        )?;
                         (rem_n, w)
                     };
 
@@ -1074,7 +1080,7 @@ where
                         &mut prev_s_eval,
                         xi_prev[base],
                         &mut eq_r_acc,
-                        ctx,
+                        device_ctx,
                     )?;
 
                     for &xi_j in xi_prev.iter().skip(base + 1) {
@@ -1093,7 +1099,7 @@ where
                             &mut prev_s_eval,
                             xi_j,
                             &mut eq_r_acc,
-                            ctx,
+                            device_ctx,
                         )?;
                         pq_size >>= 1;
                     }
@@ -1109,8 +1115,8 @@ where
         }
 
         let pq_host = [
-            copy_from_device(active, 0, &mut copy_scratch, ctx)?,
-            copy_from_device(active, pq_size / 2, &mut copy_scratch, ctx)?,
+            copy_from_device(active, 0, &mut copy_scratch, device_ctx)?,
+            copy_from_device(active, pq_size / 2, &mut copy_scratch, device_ctx)?,
         ];
 
         claims_per_layer.push(GkrLayerClaims {
@@ -1148,7 +1154,7 @@ fn copy_from_device<T: Copy>(
     buf: &DeviceBuffer<T>,
     index: usize,
     scratch: &mut DeviceBuffer<T>,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<T, FractionalSumcheckError> {
     debug_assert!(!scratch.is_empty());
     unsafe {
@@ -1156,10 +1162,10 @@ fn copy_from_device<T: Copy>(
             scratch.as_mut_raw_ptr(),
             buf.as_ptr().add(index) as *const std::ffi::c_void,
             std::mem::size_of::<T>(),
-            ctx,
+            device_ctx,
         )?;
     }
-    let host = scratch.to_host_on(ctx)?;
+    let host = scratch.to_host_on(device_ctx)?;
     Ok(host[0])
 }
 
@@ -1184,9 +1190,9 @@ fn reconstruct_s_evals(
     prev_s_eval: EF,
     xi_j: EF,
     eq_r_acc: EF,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<([EF; GKR_S_DEG], [EF; GKR_S_DEG]), FractionalSumcheckError> {
-    let sp_vec = d_sum_evals.to_host_on(ctx)?;
+    let sp_vec = d_sum_evals.to_host_on(device_ctx)?;
     debug_assert_eq!(sp_vec.len(), GKR_S_DEG - 1);
 
     // sp_evals holds evaluations of degree 2 poly `eq(xi_{j+1..}, r_{j+1..}) * s'(X)` at {0,1,2}
@@ -1222,7 +1228,7 @@ fn reconstruct_s_evals(
 /// Generate random fractional leaves on device for benchmarking.
 pub fn make_synthetic_leaves(
     n: usize,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<DeviceBuffer<Frac<EF>>, FractionalSumcheckError> {
     use openvm_cuda_common::copy::cuda_memcpy_on;
     use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -1232,13 +1238,13 @@ pub fn make_synthetic_leaves(
     let host: Vec<(EF, EF)> = (0..size)
         .map(|_| (rng.random::<EF>(), rng.random::<EF>()))
         .collect();
-    let d_leaves = DeviceBuffer::<Frac<EF>>::with_capacity_on(size, ctx);
+    let d_leaves = DeviceBuffer::<Frac<EF>>::with_capacity_on(size, device_ctx);
     unsafe {
         cuda_memcpy_on::<false, true>(
             d_leaves.as_mut_raw_ptr(),
             host.as_ptr() as *const std::ffi::c_void,
             std::mem::size_of_val(host.as_slice()),
-            ctx,
+            device_ctx,
         )?;
     }
     Ok(d_leaves)
@@ -1279,13 +1285,19 @@ mod tests {
                 if enable_precompute_m { "1" } else { "0" },
             );
         }
-        let ctx = test_ctx();
+        let device_ctx = test_ctx();
         let mut transcript = DuplexSpongeGpu::default();
-        let leaves = make_synthetic_leaves(n, &ctx)?;
+        let leaves = make_synthetic_leaves(n, &device_ctx)?;
         let mut mem = MemTracker::start("test.precompute_m");
-        let result =
-            fractional_sumcheck_gpu(&mut transcript, leaves, EF::ZERO, false, &mut mem, &ctx)?;
-        ctx.stream.synchronize().expect("sync");
+        let result = fractional_sumcheck_gpu(
+            &mut transcript,
+            leaves,
+            EF::ZERO,
+            false,
+            &mut mem,
+            &device_ctx,
+        )?;
+        device_ctx.stream.synchronize().expect("sync");
         Ok(result)
     }
 

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -4,7 +4,7 @@ use openvm_cuda_common::{
     copy::{cuda_memcpy, MemCopyD2H},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
-    stream::cudaStreamPerThread,
+    stream::cudaStream_t,
 };
 use openvm_stark_backend::{
     poly_common::{eval_eq_mle, interpolate_linear_at_01, interpolate_quadratic_at_012},
@@ -363,6 +363,7 @@ fn do_sumcheck_round_and_revert<SC, TS>(
     prev_s_eval: &mut EF,
     xi_j: EF,
     eq_r_acc: &mut EF,
+    stream: cudaStream_t,
 ) -> Result<EF, FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
@@ -376,7 +377,7 @@ where
             lambda,
             d_sum_evals,
             tmp_block_sums,
-            cudaStreamPerThread,
+            stream,
         )
         .map_err(FractionalSumcheckError::ComputeRound)?;
     }
@@ -412,6 +413,7 @@ fn do_fused_sumcheck_round<SC, TS>(
     prev_s_eval: &mut EF,
     xi_j: EF,
     eq_r_acc: &mut EF,
+    stream: cudaStream_t,
 ) -> Result<EF, FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
@@ -427,7 +429,7 @@ where
             r_prev,
             d_sum_evals,
             tmp_block_sums,
-            cudaStreamPerThread,
+            stream,
         )
         .map_err(FractionalSumcheckError::ComputeRound)?;
     }
@@ -459,6 +461,7 @@ fn do_fused_sumcheck_round_inplace<SC, TS>(
     prev_s_eval: &mut EF,
     xi_j: EF,
     eq_r_acc: &mut EF,
+    stream: cudaStream_t,
 ) -> Result<EF, FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
@@ -473,7 +476,7 @@ where
             r_prev,
             d_sum_evals,
             tmp_block_sums,
-            cudaStreamPerThread,
+            stream,
         )
         .map_err(FractionalSumcheckError::ComputeRound)?;
     }
@@ -498,6 +501,7 @@ pub fn fractional_sumcheck_gpu<SC, TS>(
     alpha: EF,
     assert_zero: bool,
     mem: &mut MemTracker,
+    stream: cudaStream_t,
 ) -> Result<(FracSumcheckProof<SC>, Vec<EF>), FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
@@ -530,7 +534,7 @@ where
         unsafe {
             // SAFETY: Frac<EF> has exact same memory layout and alignment as (EF, EF).
             let buf = transmute::<&DeviceBuffer<Frac<EF>>, &DeviceBuffer<(EF, EF)>>(&layer);
-            bit_rev_frac_ext_build_k2(buf, total_rounds as u32, alpha, cudaStreamPerThread)
+            bit_rev_frac_ext_build_k2(buf, total_rounds as u32, alpha, stream)
                 .map_err(FractionalSumcheckError::BitReversal)?;
         }
         2 // layers 0+1 already done
@@ -544,24 +548,17 @@ where
                 total_rounds as u32,
                 total_leaves.try_into().unwrap(),
                 1,
-                cudaStreamPerThread,
+                stream,
             )
             .map_err(FractionalSumcheckError::BitReversal)?;
-            frac_build_tree_layer(
-                &mut layer,
-                total_leaves,
-                false,
-                alpha,
-                true,
-                cudaStreamPerThread,
-            )
-            .map_err(FractionalSumcheckError::SegmentTree)?;
+            frac_build_tree_layer(&mut layer, total_leaves, false, alpha, true, stream)
+                .map_err(FractionalSumcheckError::SegmentTree)?;
             use crate::cuda::logup_zerocheck::frac_add_alpha;
             let half = total_leaves / 2;
             let second_half_ptr = layer.as_mut_raw_ptr() as *mut Frac<EF>;
             let second_half_buf =
                 DeviceBuffer::<Frac<EF>>::from_raw_parts(second_half_ptr.add(half), half);
-            frac_add_alpha(&second_half_buf, alpha, cudaStreamPerThread)
+            frac_add_alpha(&second_half_buf, alpha, stream)
                 .map_err(FractionalSumcheckError::SegmentTree)?;
             std::mem::forget(second_half_buf);
         }
@@ -573,7 +570,7 @@ where
     while i + 1 < total_rounds {
         let half_i1 = total_leaves >> (i + 2);
         unsafe {
-            frac_build_tree_two_layers(&mut layer, half_i1, cudaStreamPerThread)
+            frac_build_tree_two_layers(&mut layer, half_i1, stream)
                 .map_err(FractionalSumcheckError::SegmentTree)?;
         }
         i += 2;
@@ -587,7 +584,7 @@ where
                 false,
                 EF::ZERO,
                 false,
-                cudaStreamPerThread,
+                stream,
             )
             .map_err(FractionalSumcheckError::SegmentTree)?;
         }
@@ -597,7 +594,7 @@ where
     let mut copy_scratch = DeviceBuffer::<Frac<EF>>::with_capacity(1);
     let root = copy_from_device(&layer, 0, &mut copy_scratch)?;
     unsafe {
-        frac_build_tree_layer(&mut layer, 2, true, EF::ZERO, false, cudaStreamPerThread)
+        frac_build_tree_layer(&mut layer, 2, true, EF::ZERO, false, stream)
             .map_err(FractionalSumcheckError::SegmentTree)?;
     }
     if assert_zero {
@@ -657,12 +654,8 @@ where
         DeviceBuffer::new()
     };
     let max_tmp_buffer_capacity = if total_rounds > 1 {
-        (unsafe {
-            _frac_compute_round_temp_buffer_size(
-                (1 << (total_rounds - 1)) as u32,
-                cudaStreamPerThread,
-            )
-        }) as usize
+        (unsafe { _frac_compute_round_temp_buffer_size((1 << (total_rounds - 1)) as u32, stream) })
+            as usize
     } else {
         0
     };
@@ -688,7 +681,7 @@ where
         debug_assert_eq!(xi_prev.len(), round);
         // eq_buffer stores eq(xi_prev[j..], x) for x in H_{xi_prev.len()-j} for
         // j=1,...,xi_prev.len()-1.
-        let mut eq_buffer = SqrtEqLayers::from_xi(&xi_prev[1..])
+        let mut eq_buffer = SqrtEqLayers::from_xi(&xi_prev[1..], stream)
             .map_err(FractionalSumcheckError::EvalEqHypercube)?;
 
         let mut round_polys_eval = Vec::with_capacity(round);
@@ -697,9 +690,8 @@ where
 
         let lambda = transcript.sample_ext();
 
-        let tmp_buffer_capacity = unsafe {
-            _frac_compute_round_temp_buffer_size((1 << round) as u32, cudaStreamPerThread)
-        } as usize;
+        let tmp_buffer_capacity =
+            unsafe { _frac_compute_round_temp_buffer_size((1 << round) as u32, stream) } as usize;
         if tmp_buffer_capacity > tmp_block_sums.len() {
             tmp_block_sums = DeviceBuffer::<EF>::with_capacity(tmp_buffer_capacity);
         }
@@ -737,6 +729,7 @@ where
             &mut prev_s_eval,
             xi_prev[0],
             &mut eq_r_acc,
+            stream,
         )?;
 
         // Fused rounds 1..(round-1): compute + fold using prev_r.
@@ -767,6 +760,7 @@ where
                             &mut prev_s_eval,
                             xi_j,
                             &mut eq_r_acc,
+                            stream,
                         )?,
                         BufferTarget::WorkToLayer => do_fused_sumcheck_round(
                             &mut eq_buffer,
@@ -783,6 +777,7 @@ where
                             &mut prev_s_eval,
                             xi_j,
                             &mut eq_r_acc,
+                            stream,
                         )?,
                         BufferTarget::InPlaceLayer => do_fused_sumcheck_round_inplace(
                             &mut eq_buffer,
@@ -798,6 +793,7 @@ where
                             &mut prev_s_eval,
                             xi_j,
                             &mut eq_r_acc,
+                            stream,
                         )?,
                         BufferTarget::InPlaceWork => do_fused_sumcheck_round_inplace(
                             &mut eq_buffer,
@@ -813,6 +809,7 @@ where
                             &mut prev_s_eval,
                             xi_j,
                             &mut eq_r_acc,
+                            stream,
                         )?,
                     };
 
@@ -824,38 +821,22 @@ where
                 active = match scheduler.final_fold_target(last_outer_round) {
                     BufferTarget::InPlaceWork => {
                         unsafe {
-                            fold_ef_frac_columns_inplace(
-                                &mut work_buffer,
-                                pq_size,
-                                prev_r,
-                                cudaStreamPerThread,
-                            )
-                            .map_err(FractionalSumcheckError::FoldColumns)?;
+                            fold_ef_frac_columns_inplace(&mut work_buffer, pq_size, prev_r, stream)
+                                .map_err(FractionalSumcheckError::FoldColumns)?;
                         }
                         &mut work_buffer
                     }
                     BufferTarget::InPlaceLayer => {
                         unsafe {
-                            fold_ef_frac_columns_inplace(
-                                &mut layer,
-                                pq_size,
-                                prev_r,
-                                cudaStreamPerThread,
-                            )
-                            .map_err(FractionalSumcheckError::FoldColumns)?;
+                            fold_ef_frac_columns_inplace(&mut layer, pq_size, prev_r, stream)
+                                .map_err(FractionalSumcheckError::FoldColumns)?;
                         }
                         &mut layer
                     }
                     BufferTarget::LayerToWork => {
                         unsafe {
-                            fold_ef_frac_columns(
-                                &layer,
-                                &mut work_buffer,
-                                pq_size,
-                                prev_r,
-                                cudaStreamPerThread,
-                            )
-                            .map_err(FractionalSumcheckError::FoldColumns)?;
+                            fold_ef_frac_columns(&layer, &mut work_buffer, pq_size, prev_r, stream)
+                                .map_err(FractionalSumcheckError::FoldColumns)?;
                         }
                         &mut work_buffer
                     }
@@ -966,7 +947,7 @@ where
                             m_partial_buffer.as_mut_ptr(),
                             partial_len,
                             m_ptr,
-                            cudaStreamPerThread,
+                            stream,
                         )
                         .map_err(FractionalSumcheckError::ComputeRound)?;
                     }
@@ -994,7 +975,7 @@ where
                                 eq_r_prefix_buffer.as_ptr(),
                                 eq_suffix_buffer.as_ptr(),
                                 d_sum_evals.as_mut_ptr(),
-                                cudaStreamPerThread,
+                                stream,
                             )
                             .map_err(FractionalSumcheckError::ComputeRound)?;
                         }
@@ -1038,7 +1019,7 @@ where
                             buf_vars,
                             w_fold,
                             d_eq_r_window,
-                            cudaStreamPerThread,
+                            stream,
                         )
                         .map_err(FractionalSumcheckError::FoldColumns)?;
                     }
@@ -1058,7 +1039,7 @@ where
                             lambda,
                             &mut d_sum_evals,
                             &mut tmp_block_sums,
-                            cudaStreamPerThread,
+                            stream,
                         )
                         .map_err(FractionalSumcheckError::ComputeRound)?;
                     }
@@ -1089,13 +1070,14 @@ where
                             &mut prev_s_eval,
                             xi_j,
                             &mut eq_r_acc,
+                            stream,
                         )?;
                         pq_size >>= 1;
                     }
                 }
 
                 unsafe {
-                    fold_ef_frac_columns_inplace(active_pq, pq_size, prev_r, cudaStreamPerThread)
+                    fold_ef_frac_columns_inplace(active_pq, pq_size, prev_r, stream)
                         .map_err(FractionalSumcheckError::FoldColumns)?;
                 }
                 active = active_pq;
@@ -1234,7 +1216,10 @@ pub fn make_synthetic_leaves(n: usize) -> Result<DeviceBuffer<Frac<EF>>, Fractio
 
 #[cfg(test)]
 mod tests {
-    use openvm_cuda_common::{memory_manager::MemTracker, stream::current_stream_sync};
+    use openvm_cuda_common::{
+        memory_manager::MemTracker,
+        stream::{cudaStreamPerThread, current_stream_sync},
+    };
     use p3_field::PrimeCharacteristicRing;
 
     use super::{
@@ -1259,7 +1244,14 @@ mod tests {
         let mut transcript = DuplexSpongeGpu::default();
         let leaves = make_synthetic_leaves(n)?;
         let mut mem = MemTracker::start("test.precompute_m");
-        let result = fractional_sumcheck_gpu(&mut transcript, leaves, EF::ZERO, false, &mut mem)?;
+        let result = fractional_sumcheck_gpu(
+            &mut transcript,
+            leaves,
+            EF::ZERO,
+            false,
+            &mut mem,
+            cudaStreamPerThread,
+        )?;
         current_stream_sync().expect("sync");
         Ok(result)
     }

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -4,7 +4,7 @@ use openvm_cuda_common::{
     copy::{cuda_memcpy_on, MemCopyD2H},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
-    stream::DeviceContext,
+    stream::GpuDeviceCtx,
 };
 use openvm_stark_backend::{
     poly_common::{eval_eq_mle, interpolate_linear_at_01, interpolate_quadratic_at_012},
@@ -303,7 +303,7 @@ fn eq_tail_ptrs(
 fn copy_to_device_ptr<T: Copy>(
     dst: *mut T,
     src: &[T],
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(), FractionalSumcheckError> {
     if src.is_empty() {
         return Ok(());
@@ -329,7 +329,7 @@ fn observe_and_update<SC, TS>(
     prev_s_eval: &mut EF,
     xi_j: EF,
     eq_r_acc: &mut EF,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<EF, FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
@@ -370,7 +370,7 @@ fn do_sumcheck_round_and_revert<SC, TS>(
     prev_s_eval: &mut EF,
     xi_j: EF,
     eq_r_acc: &mut EF,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<EF, FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
@@ -422,7 +422,7 @@ fn do_fused_sumcheck_round<SC, TS>(
     prev_s_eval: &mut EF,
     xi_j: EF,
     eq_r_acc: &mut EF,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<EF, FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
@@ -472,7 +472,7 @@ fn do_fused_sumcheck_round_inplace<SC, TS>(
     prev_s_eval: &mut EF,
     xi_j: EF,
     eq_r_acc: &mut EF,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<EF, FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
@@ -514,7 +514,7 @@ pub fn fractional_sumcheck_gpu<SC, TS>(
     alpha: EF,
     assert_zero: bool,
     mem: &mut MemTracker,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(FracSumcheckProof<SC>, Vec<EF>), FractionalSumcheckError>
 where
     SC: StarkProtocolConfig<EF = EF>,
@@ -1154,7 +1154,7 @@ fn copy_from_device<T: Copy>(
     buf: &DeviceBuffer<T>,
     index: usize,
     scratch: &mut DeviceBuffer<T>,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<T, FractionalSumcheckError> {
     debug_assert!(!scratch.is_empty());
     unsafe {
@@ -1190,7 +1190,7 @@ fn reconstruct_s_evals(
     prev_s_eval: EF,
     xi_j: EF,
     eq_r_acc: EF,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<([EF; GKR_S_DEG], [EF; GKR_S_DEG]), FractionalSumcheckError> {
     let sp_vec = d_sum_evals.to_host_on(device_ctx)?;
     debug_assert_eq!(sp_vec.len(), GKR_S_DEG - 1);
@@ -1228,7 +1228,7 @@ fn reconstruct_s_evals(
 /// Generate random fractional leaves on device for benchmarking.
 pub fn make_synthetic_leaves(
     n: usize,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<DeviceBuffer<Frac<EF>>, FractionalSumcheckError> {
     use openvm_cuda_common::copy::cuda_memcpy_on;
     use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -1255,7 +1255,7 @@ mod tests {
     use openvm_cuda_common::{
         common::get_device,
         memory_manager::MemTracker,
-        stream::{CudaStream, DeviceContext, StreamGuard},
+        stream::{CudaStream, GpuDeviceCtx, StreamGuard},
     };
     use p3_field::PrimeCharacteristicRing;
 
@@ -1265,8 +1265,8 @@ mod tests {
     };
     use crate::{prelude::SC, sponge::DuplexSpongeGpu};
 
-    fn test_ctx() -> DeviceContext {
-        DeviceContext {
+    fn test_ctx() -> GpuDeviceCtx {
+        GpuDeviceCtx {
             device_id: get_device().unwrap() as u32,
             stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
         }

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -376,6 +376,7 @@ where
             lambda,
             d_sum_evals,
             tmp_block_sums,
+            cudaStreamPerThread,
         )
         .map_err(FractionalSumcheckError::ComputeRound)?;
     }
@@ -426,6 +427,7 @@ where
             r_prev,
             d_sum_evals,
             tmp_block_sums,
+            cudaStreamPerThread,
         )
         .map_err(FractionalSumcheckError::ComputeRound)?;
     }
@@ -471,6 +473,7 @@ where
             r_prev,
             d_sum_evals,
             tmp_block_sums,
+            cudaStreamPerThread,
         )
         .map_err(FractionalSumcheckError::ComputeRound)?;
     }
@@ -527,7 +530,7 @@ where
         unsafe {
             // SAFETY: Frac<EF> has exact same memory layout and alignment as (EF, EF).
             let buf = transmute::<&DeviceBuffer<Frac<EF>>, &DeviceBuffer<(EF, EF)>>(&layer);
-            bit_rev_frac_ext_build_k2(buf, total_rounds as u32, alpha)
+            bit_rev_frac_ext_build_k2(buf, total_rounds as u32, alpha, cudaStreamPerThread)
                 .map_err(FractionalSumcheckError::BitReversal)?;
         }
         2 // layers 0+1 already done
@@ -541,16 +544,24 @@ where
                 total_rounds as u32,
                 total_leaves.try_into().unwrap(),
                 1,
+                cudaStreamPerThread,
             )
             .map_err(FractionalSumcheckError::BitReversal)?;
-            frac_build_tree_layer(&mut layer, total_leaves, false, alpha, true)
-                .map_err(FractionalSumcheckError::SegmentTree)?;
+            frac_build_tree_layer(
+                &mut layer,
+                total_leaves,
+                false,
+                alpha,
+                true,
+                cudaStreamPerThread,
+            )
+            .map_err(FractionalSumcheckError::SegmentTree)?;
             use crate::cuda::logup_zerocheck::frac_add_alpha;
             let half = total_leaves / 2;
             let second_half_ptr = layer.as_mut_raw_ptr() as *mut Frac<EF>;
             let second_half_buf =
                 DeviceBuffer::<Frac<EF>>::from_raw_parts(second_half_ptr.add(half), half);
-            frac_add_alpha(&second_half_buf, alpha)
+            frac_add_alpha(&second_half_buf, alpha, cudaStreamPerThread)
                 .map_err(FractionalSumcheckError::SegmentTree)?;
             std::mem::forget(second_half_buf);
         }
@@ -562,7 +573,7 @@ where
     while i + 1 < total_rounds {
         let half_i1 = total_leaves >> (i + 2);
         unsafe {
-            frac_build_tree_two_layers(&mut layer, half_i1)
+            frac_build_tree_two_layers(&mut layer, half_i1, cudaStreamPerThread)
                 .map_err(FractionalSumcheckError::SegmentTree)?;
         }
         i += 2;
@@ -570,8 +581,15 @@ where
     // Remaining single layer (if odd number of layers left).
     if i < total_rounds {
         unsafe {
-            frac_build_tree_layer(&mut layer, total_leaves >> i, false, EF::ZERO, false)
-                .map_err(FractionalSumcheckError::SegmentTree)?;
+            frac_build_tree_layer(
+                &mut layer,
+                total_leaves >> i,
+                false,
+                EF::ZERO,
+                false,
+                cudaStreamPerThread,
+            )
+            .map_err(FractionalSumcheckError::SegmentTree)?;
         }
     }
     mem.emit_metrics_with_label("frac_sumcheck.segment_tree");
@@ -579,7 +597,7 @@ where
     let mut copy_scratch = DeviceBuffer::<Frac<EF>>::with_capacity(1);
     let root = copy_from_device(&layer, 0, &mut copy_scratch)?;
     unsafe {
-        frac_build_tree_layer(&mut layer, 2, true, EF::ZERO, false)
+        frac_build_tree_layer(&mut layer, 2, true, EF::ZERO, false, cudaStreamPerThread)
             .map_err(FractionalSumcheckError::SegmentTree)?;
     }
     if assert_zero {
@@ -639,7 +657,12 @@ where
         DeviceBuffer::new()
     };
     let max_tmp_buffer_capacity = if total_rounds > 1 {
-        (unsafe { _frac_compute_round_temp_buffer_size((1 << (total_rounds - 1)) as u32, cudaStreamPerThread) }) as usize
+        (unsafe {
+            _frac_compute_round_temp_buffer_size(
+                (1 << (total_rounds - 1)) as u32,
+                cudaStreamPerThread,
+            )
+        }) as usize
     } else {
         0
     };
@@ -674,8 +697,9 @@ where
 
         let lambda = transcript.sample_ext();
 
-        let tmp_buffer_capacity =
-            unsafe { _frac_compute_round_temp_buffer_size((1 << round) as u32, cudaStreamPerThread) } as usize;
+        let tmp_buffer_capacity = unsafe {
+            _frac_compute_round_temp_buffer_size((1 << round) as u32, cudaStreamPerThread)
+        } as usize;
         if tmp_buffer_capacity > tmp_block_sums.len() {
             tmp_block_sums = DeviceBuffer::<EF>::with_capacity(tmp_buffer_capacity);
         }
@@ -800,22 +824,38 @@ where
                 active = match scheduler.final_fold_target(last_outer_round) {
                     BufferTarget::InPlaceWork => {
                         unsafe {
-                            fold_ef_frac_columns_inplace(&mut work_buffer, pq_size, prev_r)
-                                .map_err(FractionalSumcheckError::FoldColumns)?;
+                            fold_ef_frac_columns_inplace(
+                                &mut work_buffer,
+                                pq_size,
+                                prev_r,
+                                cudaStreamPerThread,
+                            )
+                            .map_err(FractionalSumcheckError::FoldColumns)?;
                         }
                         &mut work_buffer
                     }
                     BufferTarget::InPlaceLayer => {
                         unsafe {
-                            fold_ef_frac_columns_inplace(&mut layer, pq_size, prev_r)
-                                .map_err(FractionalSumcheckError::FoldColumns)?;
+                            fold_ef_frac_columns_inplace(
+                                &mut layer,
+                                pq_size,
+                                prev_r,
+                                cudaStreamPerThread,
+                            )
+                            .map_err(FractionalSumcheckError::FoldColumns)?;
                         }
                         &mut layer
                     }
                     BufferTarget::LayerToWork => {
                         unsafe {
-                            fold_ef_frac_columns(&layer, &mut work_buffer, pq_size, prev_r)
-                                .map_err(FractionalSumcheckError::FoldColumns)?;
+                            fold_ef_frac_columns(
+                                &layer,
+                                &mut work_buffer,
+                                pq_size,
+                                prev_r,
+                                cudaStreamPerThread,
+                            )
+                            .map_err(FractionalSumcheckError::FoldColumns)?;
                         }
                         &mut work_buffer
                     }
@@ -926,6 +966,7 @@ where
                             m_partial_buffer.as_mut_ptr(),
                             partial_len,
                             m_ptr,
+                            cudaStreamPerThread,
                         )
                         .map_err(FractionalSumcheckError::ComputeRound)?;
                     }
@@ -953,6 +994,7 @@ where
                                 eq_r_prefix_buffer.as_ptr(),
                                 eq_suffix_buffer.as_ptr(),
                                 d_sum_evals.as_mut_ptr(),
+                                cudaStreamPerThread,
                             )
                             .map_err(FractionalSumcheckError::ComputeRound)?;
                         }
@@ -996,6 +1038,7 @@ where
                             buf_vars,
                             w_fold,
                             d_eq_r_window,
+                            cudaStreamPerThread,
                         )
                         .map_err(FractionalSumcheckError::FoldColumns)?;
                     }
@@ -1015,6 +1058,7 @@ where
                             lambda,
                             &mut d_sum_evals,
                             &mut tmp_block_sums,
+                            cudaStreamPerThread,
                         )
                         .map_err(FractionalSumcheckError::ComputeRound)?;
                     }
@@ -1051,7 +1095,7 @@ where
                 }
 
                 unsafe {
-                    fold_ef_frac_columns_inplace(active_pq, pq_size, prev_r)
+                    fold_ef_frac_columns_inplace(active_pq, pq_size, prev_r, cudaStreamPerThread)
                         .map_err(FractionalSumcheckError::FoldColumns)?;
                 }
                 active = active_pq;

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -4,6 +4,7 @@ use openvm_cuda_common::{
     copy::{cuda_memcpy, MemCopyD2H},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
+    stream::cudaStreamPerThread,
 };
 use openvm_stark_backend::{
     poly_common::{eval_eq_mle, interpolate_linear_at_01, interpolate_quadratic_at_012},
@@ -638,7 +639,7 @@ where
         DeviceBuffer::new()
     };
     let max_tmp_buffer_capacity = if total_rounds > 1 {
-        (unsafe { _frac_compute_round_temp_buffer_size((1 << (total_rounds - 1)) as u32) }) as usize
+        (unsafe { _frac_compute_round_temp_buffer_size((1 << (total_rounds - 1)) as u32, cudaStreamPerThread) }) as usize
     } else {
         0
     };
@@ -674,7 +675,7 @@ where
         let lambda = transcript.sample_ext();
 
         let tmp_buffer_capacity =
-            unsafe { _frac_compute_round_temp_buffer_size((1 << round) as u32) } as usize;
+            unsafe { _frac_compute_round_temp_buffer_size((1 << round) as u32, cudaStreamPerThread) } as usize;
         if tmp_buffer_capacity > tmp_block_sums.len() {
             tmp_block_sums = DeviceBuffer::<EF>::with_capacity(tmp_buffer_capacity);
         }

--- a/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
@@ -1,7 +1,7 @@
 use std::cmp::max;
 
 use itertools::Itertools;
-use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer, stream::DeviceContext};
+use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer, stream::GpuDeviceCtx};
 use openvm_stark_backend::prover::{
     fractional_sumcheck_gkr::Frac,
     stacked_pcs::{StackedLayout, StackedSlice},
@@ -95,7 +95,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
     alpha_logup: EF,
     d_challenges: &DeviceBuffer<EF>,
     total_leaves: usize,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(DeviceBuffer<Frac<EF>>, EF), InteractionGpuError> {
     if trace_interactions.iter().all(|meta| meta.is_none()) {
         return Ok((DeviceBuffer::new(), alpha_logup));

--- a/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
@@ -95,17 +95,17 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
     alpha_logup: EF,
     d_challenges: &DeviceBuffer<EF>,
     total_leaves: usize,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<(DeviceBuffer<Frac<EF>>, EF), InteractionGpuError> {
     if trace_interactions.iter().all(|meta| meta.is_none()) {
         return Ok((DeviceBuffer::new(), alpha_logup));
     }
 
-    let leaves = DeviceBuffer::<Frac<EF>>::with_capacity_on(total_leaves, ctx);
-    leaves.fill_zero_on(ctx)?;
+    let leaves = DeviceBuffer::<Frac<EF>>::with_capacity_on(total_leaves, device_ctx);
+    leaves.fill_zero_on(device_ctx)?;
     let null_preprocessed = DeviceBuffer::<F>::new();
 
-    let stream = ctx.stream.as_raw();
+    let stream = device_ctx.stream.as_raw();
     let mut d_partition_ptrs = DeviceBuffer::<u64>::new();
     let mut tmp = DeviceBuffer::<Frac<EF>>::new();
     for meta in trace_interactions.iter().flatten() {
@@ -133,7 +133,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
         let d_public_values = if air_ctx.public_values.is_empty() {
             DeviceBuffer::<F>::new()
         } else {
-            air_ctx.public_values.to_device_on(ctx)?
+            air_ctx.public_values.to_device_on(device_ctx)?
         };
 
         let height = air_ctx.height();
@@ -143,17 +143,20 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
             .map(|m| m.buffer().as_ptr() as u64)
             .collect_vec();
         if partition_ptrs.len() > d_partition_ptrs.len() {
-            d_partition_ptrs = DeviceBuffer::with_capacity_on(partition_ptrs.len(), ctx);
+            d_partition_ptrs = DeviceBuffer::with_capacity_on(partition_ptrs.len(), device_ctx);
         }
-        partition_ptrs.copy_to_on(&mut d_partition_ptrs, ctx)?;
+        partition_ptrs.copy_to_on(&mut d_partition_ptrs, device_ctx)?;
 
         let buffer_size = rules.inner.buffer_size;
         // TODO[jpw]: remove magic 10
         let is_global = buffer_size > 10;
         let intermediates = if is_global {
-            DeviceBuffer::<EF>::with_capacity_on((TASK_SIZE as usize) * buffer_size as usize, ctx)
+            DeviceBuffer::<EF>::with_capacity_on(
+                (TASK_SIZE as usize) * buffer_size as usize,
+                device_ctx,
+            )
         } else {
-            DeviceBuffer::<EF>::with_capacity_on(1, ctx)
+            DeviceBuffer::<EF>::with_capacity_on(1, device_ctx)
         };
 
         let num_rows_per_tile = height.div_ceil(TASK_SIZE as usize).max(1);
@@ -171,7 +174,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
         let trace_output = if height != lifted_height {
             let required = height * num_interactions;
             if required > tmp.len() {
-                tmp = DeviceBuffer::with_capacity_on(required, ctx);
+                tmp = DeviceBuffer::with_capacity_on(required, device_ctx);
             }
             tmp.as_mut_ptr()
         } else {

--- a/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
@@ -145,7 +145,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
         if partition_ptrs.len() > d_partition_ptrs.len() {
             d_partition_ptrs = DeviceBuffer::with_capacity_on(partition_ptrs.len(), ctx);
         }
-        partition_ptrs.copy_to(&mut d_partition_ptrs)?;
+        partition_ptrs.copy_to_on(&mut d_partition_ptrs, ctx)?;
 
         let buffer_size = rules.inner.buffer_size;
         // TODO[jpw]: remove magic 10

--- a/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
@@ -1,7 +1,7 @@
 use std::cmp::max;
 
 use itertools::Itertools;
-use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer, stream::cudaStreamPerThread};
+use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer, stream::cudaStream_t};
 use openvm_stark_backend::prover::{
     fractional_sumcheck_gkr::Frac,
     stacked_pcs::{StackedLayout, StackedSlice},
@@ -86,6 +86,7 @@ pub fn collect_trace_interactions<HS: GpuHashScheme>(
 /// Evaluate interactions from trace evaluation matrices to get (p, q) fractional sumcheck input.
 /// Returns leaves buffer (WITHOUT alpha applied) and alpha value to be applied in first tree layer.
 #[instrument(name = "prover.rap_constraints.logup_gkr.input_evals", skip_all)]
+#[allow(clippy::too_many_arguments)]
 pub fn log_gkr_input_evals<HS: GpuHashScheme>(
     trace_interactions: &[Option<TraceInteractionMeta>],
     pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
@@ -94,6 +95,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
     alpha_logup: EF,
     d_challenges: &DeviceBuffer<EF>,
     total_leaves: usize,
+    stream: cudaStream_t,
 ) -> Result<(DeviceBuffer<Frac<EF>>, EF), InteractionGpuError> {
     if trace_interactions.iter().all(|meta| meta.is_none()) {
         return Ok((DeviceBuffer::new(), alpha_logup));
@@ -188,7 +190,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
                 &rules.d_pair_idxs,
                 height as u32,
                 num_rows_per_tile as u32,
-                cudaStreamPerThread,
+                stream,
             )?;
         }
         if height != lifted_height {
@@ -202,7 +204,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
                     tmp.as_mut_ptr(),
                     norm_factor,
                     tmp.len() as u32,
-                    cudaStreamPerThread,
+                    stream,
                 )?;
                 // SAFETY: stacked interaction layout is defined with respect to lifted height, and
                 // the vertical-repeat kernel guards rounded-up tail threads beyond lifted_height.
@@ -212,7 +214,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
                     num_interactions as u32,
                     lifted_height as u32,
                     height as u32,
-                    cudaStreamPerThread,
+                    stream,
                 )?;
             }
         }

--- a/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
@@ -1,7 +1,7 @@
 use std::cmp::max;
 
 use itertools::Itertools;
-use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer};
+use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer, stream::cudaStreamPerThread};
 use openvm_stark_backend::prover::{
     fractional_sumcheck_gkr::Frac,
     stacked_pcs::{StackedLayout, StackedSlice},
@@ -188,6 +188,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
                 &rules.d_pair_idxs,
                 height as u32,
                 num_rows_per_tile as u32,
+                cudaStreamPerThread,
             )?;
         }
         if height != lifted_height {
@@ -201,6 +202,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
                     tmp.as_mut_ptr(),
                     norm_factor,
                     tmp.len() as u32,
+                    cudaStreamPerThread,
                 )?;
                 // SAFETY: stacked interaction layout is defined with respect to lifted height, and
                 // the vertical-repeat kernel guards rounded-up tail threads beyond lifted_height.
@@ -210,6 +212,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
                     num_interactions as u32,
                     lifted_height as u32,
                     height as u32,
+                    cudaStreamPerThread,
                 )?;
             }
         }

--- a/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
@@ -1,7 +1,7 @@
 use std::cmp::max;
 
 use itertools::Itertools;
-use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer, stream::cudaStream_t};
+use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer, stream::DeviceContext};
 use openvm_stark_backend::prover::{
     fractional_sumcheck_gkr::Frac,
     stacked_pcs::{StackedLayout, StackedSlice},
@@ -90,25 +90,26 @@ pub fn collect_trace_interactions<HS: GpuHashScheme>(
 pub fn log_gkr_input_evals<HS: GpuHashScheme>(
     trace_interactions: &[Option<TraceInteractionMeta>],
     pk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
-    ctx: &ProvingContext<GenericGpuBackend<HS>>,
+    proving_ctx: &ProvingContext<GenericGpuBackend<HS>>,
     l_skip: usize,
     alpha_logup: EF,
     d_challenges: &DeviceBuffer<EF>,
     total_leaves: usize,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<(DeviceBuffer<Frac<EF>>, EF), InteractionGpuError> {
     if trace_interactions.iter().all(|meta| meta.is_none()) {
         return Ok((DeviceBuffer::new(), alpha_logup));
     }
 
-    let leaves = DeviceBuffer::<Frac<EF>>::with_capacity(total_leaves);
-    leaves.fill_zero()?;
+    let leaves = DeviceBuffer::<Frac<EF>>::with_capacity_on(total_leaves, ctx);
+    leaves.fill_zero_on(ctx)?;
     let null_preprocessed = DeviceBuffer::<F>::new();
 
+    let stream = ctx.stream.as_raw();
     let mut d_partition_ptrs = DeviceBuffer::<u64>::new();
     let mut tmp = DeviceBuffer::<Frac<EF>>::new();
     for meta in trace_interactions.iter().flatten() {
-        let air_ctx = &ctx.per_trace[meta.trace_idx].1;
+        let air_ctx = &proving_ctx.per_trace[meta.trace_idx].1;
         let pk_air = &pk.per_air[meta.air_idx];
 
         let preprocessed_matrix = pk_air
@@ -132,7 +133,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
         let d_public_values = if air_ctx.public_values.is_empty() {
             DeviceBuffer::<F>::new()
         } else {
-            air_ctx.public_values.to_device()?
+            air_ctx.public_values.to_device_on(ctx)?
         };
 
         let height = air_ctx.height();
@@ -142,7 +143,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
             .map(|m| m.buffer().as_ptr() as u64)
             .collect_vec();
         if partition_ptrs.len() > d_partition_ptrs.len() {
-            d_partition_ptrs = DeviceBuffer::with_capacity(partition_ptrs.len());
+            d_partition_ptrs = DeviceBuffer::with_capacity_on(partition_ptrs.len(), ctx);
         }
         partition_ptrs.copy_to(&mut d_partition_ptrs)?;
 
@@ -150,9 +151,9 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
         // TODO[jpw]: remove magic 10
         let is_global = buffer_size > 10;
         let intermediates = if is_global {
-            DeviceBuffer::<EF>::with_capacity((TASK_SIZE as usize) * buffer_size as usize)
+            DeviceBuffer::<EF>::with_capacity_on((TASK_SIZE as usize) * buffer_size as usize, ctx)
         } else {
-            DeviceBuffer::<EF>::with_capacity(1)
+            DeviceBuffer::<EF>::with_capacity_on(1, ctx)
         };
 
         let num_rows_per_tile = height.div_ceil(TASK_SIZE as usize).max(1);
@@ -170,7 +171,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
         let trace_output = if height != lifted_height {
             let required = height * num_interactions;
             if required > tmp.len() {
-                tmp = DeviceBuffer::with_capacity(required);
+                tmp = DeviceBuffer::with_capacity_on(required, ctx);
             }
             tmp.as_mut_ptr()
         } else {

--- a/crates/cuda-backend/src/logup_zerocheck/mle_round.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mle_round.rs
@@ -1,4 +1,4 @@
-use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::cudaStreamPerThread};
+use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::cudaStream_t};
 use openvm_stark_backend::prover::fractional_sumcheck_gkr::Frac;
 use tracing::debug;
 
@@ -39,12 +39,12 @@ pub fn evaluate_mle_constraints_gpu(
     rules: &ConstraintOnlyRules<ZEROCHECK_BUFFER_VARS>,
     num_y: u32,
     num_x: u32,
+    stream: cudaStream_t,
 ) -> Result<DeviceBuffer<EF>, KernelError> {
     validate_mle_num_x(num_x)?;
     let buffer_size = rules.inner.buffer_size;
-    let intermed_capacity = unsafe {
-        _zerocheck_mle_intermediates_buffer_size(buffer_size, num_x, num_y, cudaStreamPerThread)
-    };
+    let intermed_capacity =
+        unsafe { _zerocheck_mle_intermediates_buffer_size(buffer_size, num_x, num_y, stream) };
     let mut intermediates = if intermed_capacity > 0 {
         debug!("zerocheck:intermediates_capacity={intermed_capacity}");
         DeviceBuffer::<EF>::with_capacity(intermed_capacity)
@@ -52,7 +52,7 @@ pub fn evaluate_mle_constraints_gpu(
         DeviceBuffer::<EF>::new()
     };
     let temp_sums_buffer_capacity =
-        unsafe { _zerocheck_mle_temp_sums_buffer_size(num_x, num_y, cudaStreamPerThread) };
+        unsafe { _zerocheck_mle_temp_sums_buffer_size(num_x, num_y, stream) };
     debug!("zerocheck:temp_sums_buffer_capacity={temp_sums_buffer_capacity}");
     let mut temp_sums_buffer = DeviceBuffer::<EF>::with_capacity(temp_sums_buffer_capacity);
     let mut output = DeviceBuffer::<EF>::with_capacity(num_x as usize);
@@ -76,7 +76,7 @@ pub fn evaluate_mle_constraints_gpu(
             &mut intermediates,
             num_y,
             num_x,
-            cudaStreamPerThread,
+            stream,
         )?;
     }
     Ok(output)
@@ -98,12 +98,12 @@ pub fn evaluate_mle_interactions_gpu(
     rules: &InteractionEvalRules,
     num_y: u32,
     num_x: u32,
+    stream: cudaStream_t,
 ) -> Result<DeviceBuffer<Frac<EF>>, KernelError> {
     validate_mle_num_x(num_x)?;
     let buffer_size = rules.inner.buffer_size;
-    let intermed_capacity = unsafe {
-        _logup_mle_intermediates_buffer_size(buffer_size, num_x, num_y, cudaStreamPerThread)
-    };
+    let intermed_capacity =
+        unsafe { _logup_mle_intermediates_buffer_size(buffer_size, num_x, num_y, stream) };
     let mut intermediates = if intermed_capacity > 0 {
         debug!("logup:intermediates_capacity={intermed_capacity}");
         DeviceBuffer::<EF>::with_capacity(intermed_capacity)
@@ -111,7 +111,7 @@ pub fn evaluate_mle_interactions_gpu(
         DeviceBuffer::<EF>::new()
     };
     let temp_sums_buffer_capacity =
-        unsafe { _logup_mle_temp_sums_buffer_size(num_x, num_y, cudaStreamPerThread) };
+        unsafe { _logup_mle_temp_sums_buffer_size(num_x, num_y, stream) };
     debug!("logup:temp_sums_buffer_capacity={temp_sums_buffer_capacity}");
     let mut temp_sums_buffer = DeviceBuffer::<Frac<EF>>::with_capacity(temp_sums_buffer_capacity);
     let mut output = DeviceBuffer::<Frac<EF>>::with_capacity(num_x as usize);
@@ -135,7 +135,7 @@ pub fn evaluate_mle_interactions_gpu(
             &mut intermediates,
             num_y,
             num_x,
-            cudaStreamPerThread,
+            stream,
         )?;
     }
     Ok(output)

--- a/crates/cuda-backend/src/logup_zerocheck/mle_round.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mle_round.rs
@@ -1,4 +1,4 @@
-use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError};
+use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::cudaStreamPerThread};
 use openvm_stark_backend::prover::fractional_sumcheck_gkr::Frac;
 use tracing::debug;
 
@@ -43,14 +43,14 @@ pub fn evaluate_mle_constraints_gpu(
     validate_mle_num_x(num_x)?;
     let buffer_size = rules.inner.buffer_size;
     let intermed_capacity =
-        unsafe { _zerocheck_mle_intermediates_buffer_size(buffer_size, num_x, num_y) };
+        unsafe { _zerocheck_mle_intermediates_buffer_size(buffer_size, num_x, num_y, cudaStreamPerThread) };
     let mut intermediates = if intermed_capacity > 0 {
         debug!("zerocheck:intermediates_capacity={intermed_capacity}");
         DeviceBuffer::<EF>::with_capacity(intermed_capacity)
     } else {
         DeviceBuffer::<EF>::new()
     };
-    let temp_sums_buffer_capacity = unsafe { _zerocheck_mle_temp_sums_buffer_size(num_x, num_y) };
+    let temp_sums_buffer_capacity = unsafe { _zerocheck_mle_temp_sums_buffer_size(num_x, num_y, cudaStreamPerThread) };
     debug!("zerocheck:temp_sums_buffer_capacity={temp_sums_buffer_capacity}");
     let mut temp_sums_buffer = DeviceBuffer::<EF>::with_capacity(temp_sums_buffer_capacity);
     let mut output = DeviceBuffer::<EF>::with_capacity(num_x as usize);
@@ -99,14 +99,14 @@ pub fn evaluate_mle_interactions_gpu(
     validate_mle_num_x(num_x)?;
     let buffer_size = rules.inner.buffer_size;
     let intermed_capacity =
-        unsafe { _logup_mle_intermediates_buffer_size(buffer_size, num_x, num_y) };
+        unsafe { _logup_mle_intermediates_buffer_size(buffer_size, num_x, num_y, cudaStreamPerThread) };
     let mut intermediates = if intermed_capacity > 0 {
         debug!("logup:intermediates_capacity={intermed_capacity}");
         DeviceBuffer::<EF>::with_capacity(intermed_capacity)
     } else {
         DeviceBuffer::<EF>::new()
     };
-    let temp_sums_buffer_capacity = unsafe { _logup_mle_temp_sums_buffer_size(num_x, num_y) };
+    let temp_sums_buffer_capacity = unsafe { _logup_mle_temp_sums_buffer_size(num_x, num_y, cudaStreamPerThread) };
     debug!("logup:temp_sums_buffer_capacity={temp_sums_buffer_capacity}");
     let mut temp_sums_buffer = DeviceBuffer::<Frac<EF>>::with_capacity(temp_sums_buffer_capacity);
     let mut output = DeviceBuffer::<Frac<EF>>::with_capacity(num_x as usize);

--- a/crates/cuda-backend/src/logup_zerocheck/mle_round.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mle_round.rs
@@ -42,15 +42,17 @@ pub fn evaluate_mle_constraints_gpu(
 ) -> Result<DeviceBuffer<EF>, KernelError> {
     validate_mle_num_x(num_x)?;
     let buffer_size = rules.inner.buffer_size;
-    let intermed_capacity =
-        unsafe { _zerocheck_mle_intermediates_buffer_size(buffer_size, num_x, num_y, cudaStreamPerThread) };
+    let intermed_capacity = unsafe {
+        _zerocheck_mle_intermediates_buffer_size(buffer_size, num_x, num_y, cudaStreamPerThread)
+    };
     let mut intermediates = if intermed_capacity > 0 {
         debug!("zerocheck:intermediates_capacity={intermed_capacity}");
         DeviceBuffer::<EF>::with_capacity(intermed_capacity)
     } else {
         DeviceBuffer::<EF>::new()
     };
-    let temp_sums_buffer_capacity = unsafe { _zerocheck_mle_temp_sums_buffer_size(num_x, num_y, cudaStreamPerThread) };
+    let temp_sums_buffer_capacity =
+        unsafe { _zerocheck_mle_temp_sums_buffer_size(num_x, num_y, cudaStreamPerThread) };
     debug!("zerocheck:temp_sums_buffer_capacity={temp_sums_buffer_capacity}");
     let mut temp_sums_buffer = DeviceBuffer::<EF>::with_capacity(temp_sums_buffer_capacity);
     let mut output = DeviceBuffer::<EF>::with_capacity(num_x as usize);
@@ -74,6 +76,7 @@ pub fn evaluate_mle_constraints_gpu(
             &mut intermediates,
             num_y,
             num_x,
+            cudaStreamPerThread,
         )?;
     }
     Ok(output)
@@ -98,15 +101,17 @@ pub fn evaluate_mle_interactions_gpu(
 ) -> Result<DeviceBuffer<Frac<EF>>, KernelError> {
     validate_mle_num_x(num_x)?;
     let buffer_size = rules.inner.buffer_size;
-    let intermed_capacity =
-        unsafe { _logup_mle_intermediates_buffer_size(buffer_size, num_x, num_y, cudaStreamPerThread) };
+    let intermed_capacity = unsafe {
+        _logup_mle_intermediates_buffer_size(buffer_size, num_x, num_y, cudaStreamPerThread)
+    };
     let mut intermediates = if intermed_capacity > 0 {
         debug!("logup:intermediates_capacity={intermed_capacity}");
         DeviceBuffer::<EF>::with_capacity(intermed_capacity)
     } else {
         DeviceBuffer::<EF>::new()
     };
-    let temp_sums_buffer_capacity = unsafe { _logup_mle_temp_sums_buffer_size(num_x, num_y, cudaStreamPerThread) };
+    let temp_sums_buffer_capacity =
+        unsafe { _logup_mle_temp_sums_buffer_size(num_x, num_y, cudaStreamPerThread) };
     debug!("logup:temp_sums_buffer_capacity={temp_sums_buffer_capacity}");
     let mut temp_sums_buffer = DeviceBuffer::<Frac<EF>>::with_capacity(temp_sums_buffer_capacity);
     let mut output = DeviceBuffer::<Frac<EF>>::with_capacity(num_x as usize);
@@ -130,6 +135,7 @@ pub fn evaluate_mle_interactions_gpu(
             &mut intermediates,
             num_y,
             num_x,
+            cudaStreamPerThread,
         )?;
     }
     Ok(output)

--- a/crates/cuda-backend/src/logup_zerocheck/mle_round.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mle_round.rs
@@ -39,24 +39,25 @@ pub fn evaluate_mle_constraints_gpu(
     rules: &ConstraintOnlyRules<ZEROCHECK_BUFFER_VARS>,
     num_y: u32,
     num_x: u32,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<DeviceBuffer<EF>, KernelError> {
     validate_mle_num_x(num_x)?;
-    let stream = ctx.stream.as_raw();
+    let stream = device_ctx.stream.as_raw();
     let buffer_size = rules.inner.buffer_size;
     let intermed_capacity =
         unsafe { _zerocheck_mle_intermediates_buffer_size(buffer_size, num_x, num_y, stream) };
     let mut intermediates = if intermed_capacity > 0 {
         debug!("zerocheck:intermediates_capacity={intermed_capacity}");
-        DeviceBuffer::<EF>::with_capacity_on(intermed_capacity, ctx)
+        DeviceBuffer::<EF>::with_capacity_on(intermed_capacity, device_ctx)
     } else {
         DeviceBuffer::<EF>::new()
     };
     let temp_sums_buffer_capacity =
         unsafe { _zerocheck_mle_temp_sums_buffer_size(num_x, num_y, stream) };
     debug!("zerocheck:temp_sums_buffer_capacity={temp_sums_buffer_capacity}");
-    let mut temp_sums_buffer = DeviceBuffer::<EF>::with_capacity_on(temp_sums_buffer_capacity, ctx);
-    let mut output = DeviceBuffer::<EF>::with_capacity_on(num_x as usize, ctx);
+    let mut temp_sums_buffer =
+        DeviceBuffer::<EF>::with_capacity_on(temp_sums_buffer_capacity, device_ctx);
+    let mut output = DeviceBuffer::<EF>::with_capacity_on(num_x as usize, device_ctx);
 
     unsafe {
         zerocheck_eval_mle(
@@ -99,16 +100,16 @@ pub fn evaluate_mle_interactions_gpu(
     rules: &InteractionEvalRules,
     num_y: u32,
     num_x: u32,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<DeviceBuffer<Frac<EF>>, KernelError> {
     validate_mle_num_x(num_x)?;
-    let stream = ctx.stream.as_raw();
+    let stream = device_ctx.stream.as_raw();
     let buffer_size = rules.inner.buffer_size;
     let intermed_capacity =
         unsafe { _logup_mle_intermediates_buffer_size(buffer_size, num_x, num_y, stream) };
     let mut intermediates = if intermed_capacity > 0 {
         debug!("logup:intermediates_capacity={intermed_capacity}");
-        DeviceBuffer::<EF>::with_capacity_on(intermed_capacity, ctx)
+        DeviceBuffer::<EF>::with_capacity_on(intermed_capacity, device_ctx)
     } else {
         DeviceBuffer::<EF>::new()
     };
@@ -116,8 +117,8 @@ pub fn evaluate_mle_interactions_gpu(
         unsafe { _logup_mle_temp_sums_buffer_size(num_x, num_y, stream) };
     debug!("logup:temp_sums_buffer_capacity={temp_sums_buffer_capacity}");
     let mut temp_sums_buffer =
-        DeviceBuffer::<Frac<EF>>::with_capacity_on(temp_sums_buffer_capacity, ctx);
-    let mut output = DeviceBuffer::<Frac<EF>>::with_capacity_on(num_x as usize, ctx);
+        DeviceBuffer::<Frac<EF>>::with_capacity_on(temp_sums_buffer_capacity, device_ctx);
+    let mut output = DeviceBuffer::<Frac<EF>>::with_capacity_on(num_x as usize, device_ctx);
 
     unsafe {
         logup_eval_mle(

--- a/crates/cuda-backend/src/logup_zerocheck/mle_round.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mle_round.rs
@@ -1,4 +1,4 @@
-use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::cudaStream_t};
+use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::DeviceContext};
 use openvm_stark_backend::prover::fractional_sumcheck_gkr::Frac;
 use tracing::debug;
 
@@ -39,23 +39,24 @@ pub fn evaluate_mle_constraints_gpu(
     rules: &ConstraintOnlyRules<ZEROCHECK_BUFFER_VARS>,
     num_y: u32,
     num_x: u32,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<DeviceBuffer<EF>, KernelError> {
     validate_mle_num_x(num_x)?;
+    let stream = ctx.stream.as_raw();
     let buffer_size = rules.inner.buffer_size;
     let intermed_capacity =
         unsafe { _zerocheck_mle_intermediates_buffer_size(buffer_size, num_x, num_y, stream) };
     let mut intermediates = if intermed_capacity > 0 {
         debug!("zerocheck:intermediates_capacity={intermed_capacity}");
-        DeviceBuffer::<EF>::with_capacity(intermed_capacity)
+        DeviceBuffer::<EF>::with_capacity_on(intermed_capacity, ctx)
     } else {
         DeviceBuffer::<EF>::new()
     };
     let temp_sums_buffer_capacity =
         unsafe { _zerocheck_mle_temp_sums_buffer_size(num_x, num_y, stream) };
     debug!("zerocheck:temp_sums_buffer_capacity={temp_sums_buffer_capacity}");
-    let mut temp_sums_buffer = DeviceBuffer::<EF>::with_capacity(temp_sums_buffer_capacity);
-    let mut output = DeviceBuffer::<EF>::with_capacity(num_x as usize);
+    let mut temp_sums_buffer = DeviceBuffer::<EF>::with_capacity_on(temp_sums_buffer_capacity, ctx);
+    let mut output = DeviceBuffer::<EF>::with_capacity_on(num_x as usize, ctx);
 
     unsafe {
         zerocheck_eval_mle(
@@ -98,23 +99,25 @@ pub fn evaluate_mle_interactions_gpu(
     rules: &InteractionEvalRules,
     num_y: u32,
     num_x: u32,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<DeviceBuffer<Frac<EF>>, KernelError> {
     validate_mle_num_x(num_x)?;
+    let stream = ctx.stream.as_raw();
     let buffer_size = rules.inner.buffer_size;
     let intermed_capacity =
         unsafe { _logup_mle_intermediates_buffer_size(buffer_size, num_x, num_y, stream) };
     let mut intermediates = if intermed_capacity > 0 {
         debug!("logup:intermediates_capacity={intermed_capacity}");
-        DeviceBuffer::<EF>::with_capacity(intermed_capacity)
+        DeviceBuffer::<EF>::with_capacity_on(intermed_capacity, ctx)
     } else {
         DeviceBuffer::<EF>::new()
     };
     let temp_sums_buffer_capacity =
         unsafe { _logup_mle_temp_sums_buffer_size(num_x, num_y, stream) };
     debug!("logup:temp_sums_buffer_capacity={temp_sums_buffer_capacity}");
-    let mut temp_sums_buffer = DeviceBuffer::<Frac<EF>>::with_capacity(temp_sums_buffer_capacity);
-    let mut output = DeviceBuffer::<Frac<EF>>::with_capacity(num_x as usize);
+    let mut temp_sums_buffer =
+        DeviceBuffer::<Frac<EF>>::with_capacity_on(temp_sums_buffer_capacity, ctx);
+    let mut output = DeviceBuffer::<Frac<EF>>::with_capacity_on(num_x as usize, ctx);
 
     unsafe {
         logup_eval_mle(

--- a/crates/cuda-backend/src/logup_zerocheck/mle_round.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mle_round.rs
@@ -1,4 +1,4 @@
-use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::DeviceContext};
+use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError, stream::GpuDeviceCtx};
 use openvm_stark_backend::prover::fractional_sumcheck_gkr::Frac;
 use tracing::debug;
 
@@ -39,7 +39,7 @@ pub fn evaluate_mle_constraints_gpu(
     rules: &ConstraintOnlyRules<ZEROCHECK_BUFFER_VARS>,
     num_y: u32,
     num_x: u32,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<DeviceBuffer<EF>, KernelError> {
     validate_mle_num_x(num_x)?;
     let stream = device_ctx.stream.as_raw();
@@ -100,7 +100,7 @@ pub fn evaluate_mle_interactions_gpu(
     rules: &InteractionEvalRules,
     num_y: u32,
     num_x: u32,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<DeviceBuffer<Frac<EF>>, KernelError> {
     validate_mle_num_x(num_x)?;
     let stream = device_ctx.stream.as_raw();

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -112,7 +112,7 @@ pub fn prove_zerocheck_and_logup_gpu<HS, TS>(
     save_memory: bool,
     monomial_num_y_threshold: u32,
     sm_count: u32,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<(GkrProof<HS::SC>, BatchConstraintProof<HS::SC>, Vec<EF>), LogupZerocheckError>
 where
     HS: GpuHashScheme,
@@ -151,7 +151,7 @@ where
 
     // Grind to increase soundness of random sampling for LogUp
     let logup_pow_witness = transcript
-        .grind_gpu(mpk.params.logup.pow_bits, ctx)
+        .grind_gpu(mpk.params.logup.pow_bits, device_ctx)
         .map_err(LogupZerocheckError::Grind)?;
     let alpha_logup = transcript.sample_ext();
     let beta_logup = transcript.sample_ext();
@@ -168,7 +168,7 @@ where
         save_memory,
         monomial_num_y_threshold,
         sm_count,
-        ctx,
+        device_ctx,
     )?;
     let n_global = prover.n_global;
 
@@ -186,7 +186,7 @@ where
             alpha_logup,
             &prover.d_challenges,
             total_leaves,
-            ctx,
+            device_ctx,
         )?
     } else {
         (DeviceBuffer::new(), EF::ZERO)
@@ -207,7 +207,7 @@ where
     prover.mem.emit_metrics_with_label("prover.gkr_input_evals");
 
     let (frac_sum_proof, mut xi) =
-        fractional_sumcheck_gpu(transcript, inputs, alpha, true, &mut prover.mem, ctx)?;
+        fractional_sumcheck_gpu(transcript, inputs, alpha, true, &mut prover.mem, device_ctx)?;
     while xi.len() != l_skip + n_global {
         xi.push(transcript.sample_ext());
     }
@@ -470,7 +470,7 @@ pub struct LogupZerocheckGpu<'a, HS: GpuHashScheme> {
     gkr_mem_contribution: usize,
     /// Memory limit for batch MLE intermediate buffers (set after GKR input eval)
     memory_limit_bytes: usize,
-    ctx: DeviceContext,
+    device_ctx: DeviceContext,
 }
 
 impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
@@ -485,13 +485,13 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
         save_memory: bool,
         monomial_num_y_threshold: u32,
         sm_count: u32,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Self, LogupZerocheckError> {
         let mem = MemTracker::start("prover.logup_zerocheck_prover");
         let l_skip = pk.params.l_skip;
         let omega_skip = F::two_adic_generator(l_skip);
         let omega_skip_pows = omega_skip.powers().take(1 << l_skip).collect_vec();
-        let d_omega_skip_pows = omega_skip_pows.to_device_on(ctx)?;
+        let d_omega_skip_pows = omega_skip_pows.to_device_on(device_ctx)?;
         let num_airs_present = proving_ctx.per_trace.len();
 
         let constraint_degree = pk.max_constraint_degree;
@@ -507,8 +507,8 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
             .take(max_interaction_length + 1)
             .collect_vec();
         let challenges = [&[alpha_logup], &beta_pows[..]].concat();
-        let d_challenges = challenges.to_device_on(ctx)?;
-        let d_beta_pows = beta_pows.to_device_on(ctx)?;
+        let d_challenges = challenges.to_device_on(device_ctx)?;
+        let d_beta_pows = beta_pows.to_device_on(device_ctx)?;
 
         let n_per_trace: Vec<isize> = proving_ctx
             .common_main_traces()
@@ -574,7 +574,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                     if air_ctx.public_values.is_empty() {
                         Ok(DeviceBuffer::new())
                     } else {
-                        air_ctx.public_values.to_device_on(ctx)
+                        air_ctx.public_values.to_device_on(device_ctx)
                     }
                 })
                 .collect::<Result<Vec<_>, _>>()?,
@@ -596,7 +596,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
             gkr_mem_contribution: 0,
             memory_limit_bytes: 0, // Set after GKR input eval
             monomial_num_y_threshold,
-            ctx: ctx.clone(),
+            device_ctx: device_ctx.clone(),
         })
     }
 
@@ -616,7 +616,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
         let xi = &self.xi;
         let h_lambda_pows = lambda.powers().take(self.max_num_constraints).collect_vec();
         self.lambda_pows = Some(if !h_lambda_pows.is_empty() {
-            h_lambda_pows.to_device_on(&self.ctx)?
+            h_lambda_pows.to_device_on(&self.device_ctx)?
         } else {
             DeviceBuffer::new()
         });
@@ -625,8 +625,13 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
         for (air_idx, air_pk) in self.pk.per_air.iter().enumerate() {
             if air_pk.other_data.zerocheck_monomials.is_some() {
                 self.lambda_combinations[air_idx] = Some(
-                    compute_lambda_combinations(self.pk, air_idx, lambda_pows_ref, &self.ctx)
-                        .map_err(LogupZerocheckError::LambdaCombinations)?,
+                    compute_lambda_combinations(
+                        self.pk,
+                        air_idx,
+                        lambda_pows_ref,
+                        &self.device_ctx,
+                    )
+                    .map_err(LogupZerocheckError::LambdaCombinations)?,
                 );
             }
         }
@@ -673,7 +678,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 if eq_3bs.is_empty() {
                     Ok(DeviceBuffer::new())
                 } else {
-                    eq_3bs.to_device_on(&self.ctx)
+                    eq_3bs.to_device_on(&self.device_ctx)
                 }
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -692,7 +697,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         &self.d_eq_3b_per_trace[trace_idx],
                         &self.eq_3b_per_trace[trace_idx],
                         &self.beta_pows,
-                        &self.ctx,
+                        &self.device_ctx,
                     )
                     .map_err(LogupZerocheckError::LogupCombinations)?,
                 );
@@ -707,7 +712,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 let layers = EqEvalLayers::new_rev(
                     n_lift,
                     xi[l_skip..l_skip + n_lift].iter().rev(),
-                    &self.ctx,
+                    &self.device_ctx,
                 )
                 .map_err(LogupZerocheckError::EqEvalLayers)?;
                 entry.insert(layers);
@@ -724,7 +729,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 cols[height..2 * height - 1].fill(F::ONE); // is_transition
                 cols[0] = F::ONE; // is_first
                 cols[2 * height + height - 1] = F::ONE; // is_last
-                let d_cols = cols.to_device_on(&self.ctx)?;
+                let d_cols = cols.to_device_on(&self.device_ctx)?;
                 Ok(DeviceMatrix::new(Arc::new(d_cols), height, 3))
             })
             .collect::<Result<Vec<_>, MemCopyError>>()?;
@@ -777,7 +782,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 main_parts.push(committed.trace.buffer().as_ptr());
             }
             main_parts.push(air_ctx.common_main.buffer().as_ptr());
-            let d_main_parts = main_parts.to_device_on(&self.ctx)?;
+            let d_main_parts = main_parts.to_device_on(&self.device_ctx)?;
 
             let n_lift = n.max(0) as usize;
             let eq_xi_tree = &self.eq_xis[&n_lift];
@@ -799,10 +804,10 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 num_cosets_zc as u32,
                 omega_root,
                 max_temp_bytes,
-                &self.ctx,
+                &self.device_ctx,
             )?;
             if !sum_buffer.is_empty() {
-                let q_evals = sum_buffer.to_host_on(&self.ctx)?;
+                let q_evals = sum_buffer.to_host_on(&self.device_ctx)?;
                 let q = {
                     // Make q_evals row-major, with columns <> cosets
                     let mut values = EF::zero_vec(num_cosets_zc << l_skip);
@@ -856,10 +861,10 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 num_cosets_logup as u32,
                 omega_root,
                 max_temp_bytes,
-                &self.ctx,
+                &self.device_ctx,
             )?;
             if !sum.is_empty() {
-                let evals = sum.to_host_on(&self.ctx)?;
+                let evals = sum.to_host_on(&self.device_ctx)?;
                 let (mut numer, denom): (Vec<EF>, Vec<EF>) =
                     evals.into_iter().map(|frac| (frac.p, frac.q)).unzip();
                 if n.is_negative() {
@@ -907,7 +912,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
         let l_skip = self.l_skip;
         let inv_lagrange_denoms_r0 =
             compute_barycentric_inv_lagrange_denoms(l_skip, &self.omega_skip_pows, r_0);
-        let d_inv_lagrange_denoms_r0 = inv_lagrange_denoms_r0.to_device_on(&self.ctx)?;
+        let d_inv_lagrange_denoms_r0 = inv_lagrange_denoms_r0.to_device_on(&self.device_ctx)?;
 
         let mut mem_limit = self.gkr_mem_contribution;
         // GPU folding for mat_evals_per_trace
@@ -928,7 +933,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         trace,
                         &d_inv_lagrange_denoms_r0,
                         need_rot,
-                        &self.ctx,
+                        &self.device_ctx,
                     )?;
                     results.push(folded);
                 }
@@ -942,7 +947,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         trace,
                         &d_inv_lagrange_denoms_r0,
                         need_rot,
-                        &self.ctx,
+                        &self.device_ctx,
                     )?;
                     results.push(folded);
                 }
@@ -955,7 +960,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                     trace,
                     &d_inv_lagrange_denoms_r0,
                     need_rot,
-                    &self.ctx,
+                    &self.device_ctx,
                 )?;
                 mem_limit = mem_limit.saturating_sub(folded.buffer().len() * size_of::<EF>());
                 results.push(folded);
@@ -987,7 +992,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 let omega = F::two_adic_generator(l);
                 let is_first = eval_eq_uni_at_one(l, r);
                 let is_last = eval_eq_uni_at_one(l, r * omega);
-                let folded_buf = DeviceBuffer::<EF>::with_capacity_on(num_x * 3, &self.ctx);
+                let folded_buf = DeviceBuffer::<EF>::with_capacity_on(num_x * 3, &self.device_ctx);
                 unsafe {
                     fold_selectors_round0(
                         folded_buf.as_mut_ptr(),
@@ -995,7 +1000,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         is_first,
                         is_last,
                         num_x,
-                        self.ctx.stream.as_raw(),
+                        self.device_ctx.stream.as_raw(),
                     )
                     .map_err(LogupZerocheckError::FoldSelectorsRound0)?;
                 }
@@ -1094,7 +1099,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                             air_width: air_width_for_mat(need_rot, m.width()),
                         })
                         .collect_vec();
-                    let main_ptrs_dev = main_ptrs.to_device_on(&self.ctx)?;
+                    let main_ptrs_dev = main_ptrs.to_device_on(&self.device_ctx)?;
 
                     late_eval.push(TraceCtx {
                         trace_idx,
@@ -1145,16 +1150,19 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         })
                         .collect_vec(),
                 );
-                let interpolated =
-                    DeviceMatrix::<EF>::with_capacity_on(sp_deg * num_y, columns.len(), &self.ctx);
-                let d_columns = columns.to_device_on(&self.ctx)?;
+                let interpolated = DeviceMatrix::<EF>::with_capacity_on(
+                    sp_deg * num_y,
+                    columns.len(),
+                    &self.device_ctx,
+                );
+                let d_columns = columns.to_device_on(&self.device_ctx)?;
                 unsafe {
                     interpolate_columns_gpu(
                         interpolated.buffer(),
                         &d_columns,
                         sp_deg,
                         num_y,
-                        self.ctx.stream.as_raw(),
+                        self.device_ctx.stream.as_raw(),
                     )
                     .map_err(|e| LogupZerocheckError::InterpolateColumns(e.into()))?;
                 }
@@ -1198,7 +1206,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                     })
                     .collect_vec();
                 debug_assert_eq!(widths_so_far, interpolated.width());
-                let main_ptrs_dev = main_ptrs.to_device_on(&self.ctx)?;
+                let main_ptrs_dev = main_ptrs.to_device_on(&self.device_ctx)?;
 
                 _keepalive_interpolated.push(interpolated);
                 let eq_xi_ptr = eq_xi_tree.get_ptr(log_num_y);
@@ -1238,12 +1246,12 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 late_logup_traces.iter().copied(),
                 self.pk,
                 &logup_combs,
-                &self.ctx,
+                &self.device_ctx,
             )?;
             let out = batch
                 .evaluate(1)
                 .map_err(LogupZerocheckError::MleInteractionEval)?;
-            let host = out.to_host_on(&self.ctx)?;
+            let host = out.to_host_on(&self.device_ctx)?;
             for (i, trace_idx) in batch.trace_indices().enumerate() {
                 self.logup_tilde_evals[trace_idx][0] = host[i].p * late_logup_traces[i].norm_factor;
                 self.logup_tilde_evals[trace_idx][1] = host[i].q;
@@ -1258,12 +1266,16 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 .iter()
                 .map(|t| self.lambda_combinations[t.air_idx].as_ref().unwrap())
                 .collect();
-            let batch =
-                ZerocheckMonomialBatch::new(late_mono_traces, self.pk, &lambda_combs, &self.ctx)?;
+            let batch = ZerocheckMonomialBatch::new(
+                late_mono_traces,
+                self.pk,
+                &lambda_combs,
+                &self.device_ctx,
+            )?;
             let out = batch
                 .evaluate(1)
                 .map_err(LogupZerocheckError::MleConstraintEval)?;
-            let host = out.to_host_on(&self.ctx)?;
+            let host = out.to_host_on(&self.device_ctx)?;
             for (i, trace_idx) in batch.trace_indices().enumerate() {
                 self.zerocheck_tilde_evals[trace_idx] = host[i];
                 // zc_out not set for num_x=1, handled from tilde_eval in compute_batch_s
@@ -1282,7 +1294,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 &mut logup_out,
                 &mut self.logup_tilde_evals,
                 self.memory_limit_bytes,
-                &self.ctx,
+                &self.device_ctx,
             )
             .map_err(LogupZerocheckError::MleInteractionEval)?;
         }
@@ -1313,7 +1325,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 sp_deg as u32,
                 &mut zc_out,
                 self.memory_limit_bytes,
-                &self.ctx,
+                &self.device_ctx,
             )
             .map_err(LogupZerocheckError::MleConstraintEval)?;
         }
@@ -1331,12 +1343,12 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 self.sm_count,
                 sp_deg as u32,
                 None,
-                &self.ctx,
+                &self.device_ctx,
             )?;
             let out = batch
                 .evaluate(sp_deg as u32)
                 .map_err(LogupZerocheckError::MleConstraintEval)?;
-            let host = out.to_host_on(&self.ctx)?;
+            let host = out.to_host_on(&self.device_ctx)?;
             for (i, trace_idx) in batch.trace_indices().enumerate() {
                 zc_out[trace_idx].copy_from_slice(&host[(i * sp_deg)..((i + 1) * sp_deg)]);
             }
@@ -1349,12 +1361,16 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 .iter()
                 .map(|t| self.lambda_combinations[t.air_idx].as_ref().unwrap())
                 .collect();
-            let batch =
-                ZerocheckMonomialBatch::new(low_mono_traces, self.pk, &lambda_combs, &self.ctx)?;
+            let batch = ZerocheckMonomialBatch::new(
+                low_mono_traces,
+                self.pk,
+                &lambda_combs,
+                &self.device_ctx,
+            )?;
             let out = batch
                 .evaluate(sp_deg as u32)
                 .map_err(LogupZerocheckError::MleConstraintEval)?;
-            let host = out.to_host_on(&self.ctx)?;
+            let host = out.to_host_on(&self.device_ctx)?;
             for (i, trace_idx) in batch.trace_indices().enumerate() {
                 zc_out[trace_idx].copy_from_slice(&host[(i * sp_deg)..((i + 1) * sp_deg)]);
             }
@@ -1454,7 +1470,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         let output_height = height >> 1;
                         max_output_cells = max(max_output_cells, output_height * width);
                         let output_mat =
-                            DeviceMatrix::<EF>::with_capacity_on(output_height, width, &self.ctx);
+                            DeviceMatrix::<EF>::with_capacity_on(output_height, width, &self.device_ctx);
                         (output_height.ilog2() as u8, width as u32, output_mat)
                     })
                     .multiunzip();
@@ -1469,10 +1485,10 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 .map(|mat| mat.buffer().as_mut_ptr())
                 .collect_vec();
 
-            let d_input_ptrs = input_ptrs.to_device_on(&self.ctx)?;
-            let d_output_ptrs = output_ptrs.to_device_on(&self.ctx)?;
-            let d_log_output_heights = log_output_heights.to_device_on(&self.ctx)?;
-            let d_widths = widths.to_device_on(&self.ctx)?;
+            let d_input_ptrs = input_ptrs.to_device_on(&self.device_ctx)?;
+            let d_output_ptrs = output_ptrs.to_device_on(&self.device_ctx)?;
+            let d_log_output_heights = log_output_heights.to_device_on(&self.device_ctx)?;
+            let d_widths = widths.to_device_on(&self.device_ctx)?;
 
             unsafe {
                 batch_fold_mle(
@@ -1483,7 +1499,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                     &d_log_output_heights,
                     max_output_cells.try_into().unwrap(),
                     r_round,
-                    self.ctx.stream.as_raw(),
+                    self.device_ctx.stream.as_raw(),
                 )
                 .map_err(LogupZerocheckError::BatchFoldMle)?;
             }
@@ -1555,7 +1571,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
             let mut split_mats: Vec<Option<ColMajorMatrix<EF>>> = mat_evals
                 .into_iter()
                 .map(|mat| {
-                    let mat_host = transport_matrix_d2h_col_major(&mat, &self.ctx)?;
+                    let mat_host = transport_matrix_d2h_col_major(&mat, &self.device_ctx)?;
                     let width = mat_host.width();
                     let height = mat_host.height();
                     debug_assert_eq!(height, 1, "Matrices should have height=1 after folding");

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -20,6 +20,7 @@ use openvm_cuda_common::{
     d_buffer::DeviceBuffer,
     error::MemCopyError,
     memory_manager::MemTracker,
+    stream::cudaStreamPerThread,
 };
 use openvm_stark_backend::{
     air_builders::symbolic::SymbolicConstraints,
@@ -978,6 +979,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         is_first,
                         is_last,
                         num_x,
+                        cudaStreamPerThread,
                     )
                     .map_err(LogupZerocheckError::FoldSelectorsRound0)?;
                 }
@@ -1130,8 +1132,14 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 let interpolated = DeviceMatrix::<EF>::with_capacity(sp_deg * num_y, columns.len());
                 let d_columns = columns.to_device()?;
                 unsafe {
-                    interpolate_columns_gpu(interpolated.buffer(), &d_columns, sp_deg, num_y)
-                        .map_err(|e| LogupZerocheckError::InterpolateColumns(e.into()))?;
+                    interpolate_columns_gpu(
+                        interpolated.buffer(),
+                        &d_columns,
+                        sp_deg,
+                        num_y,
+                        cudaStreamPerThread,
+                    )
+                    .map_err(|e| LogupZerocheckError::InterpolateColumns(e.into()))?;
                 }
 
                 let interpolated_height = interpolated.height();
@@ -1448,6 +1456,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                     &d_log_output_heights,
                     max_output_cells.try_into().unwrap(),
                     r_round,
+                    cudaStreamPerThread,
                 )
                 .map_err(LogupZerocheckError::BatchFoldMle)?;
             }

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -20,7 +20,7 @@ use openvm_cuda_common::{
     d_buffer::DeviceBuffer,
     error::MemCopyError,
     memory_manager::MemTracker,
-    stream::cudaStreamPerThread,
+    stream::cudaStream_t,
 };
 use openvm_stark_backend::{
     air_builders::symbolic::SymbolicConstraints,
@@ -112,6 +112,7 @@ pub fn prove_zerocheck_and_logup_gpu<HS, TS>(
     save_memory: bool,
     monomial_num_y_threshold: u32,
     sm_count: u32,
+    stream: cudaStream_t,
 ) -> Result<(GkrProof<HS::SC>, BatchConstraintProof<HS::SC>, Vec<EF>), LogupZerocheckError>
 where
     HS: GpuHashScheme,
@@ -149,7 +150,7 @@ where
 
     // Grind to increase soundness of random sampling for LogUp
     let logup_pow_witness = transcript
-        .grind_gpu(mpk.params.logup.pow_bits)
+        .grind_gpu(mpk.params.logup.pow_bits, stream)
         .map_err(LogupZerocheckError::Grind)?;
     let alpha_logup = transcript.sample_ext();
     let beta_logup = transcript.sample_ext();
@@ -166,6 +167,7 @@ where
         save_memory,
         monomial_num_y_threshold,
         sm_count,
+        stream,
     )?;
     let n_global = prover.n_global;
 
@@ -183,6 +185,7 @@ where
             alpha_logup,
             &prover.d_challenges,
             total_leaves,
+            stream,
         )?
     } else {
         (DeviceBuffer::new(), EF::ZERO)
@@ -203,7 +206,7 @@ where
     prover.mem.emit_metrics_with_label("prover.gkr_input_evals");
 
     let (frac_sum_proof, mut xi) =
-        fractional_sumcheck_gpu(transcript, inputs, alpha, true, &mut prover.mem)?;
+        fractional_sumcheck_gpu(transcript, inputs, alpha, true, &mut prover.mem, stream)?;
     while xi.len() != l_skip + n_global {
         xi.push(transcript.sample_ext());
     }
@@ -466,6 +469,7 @@ pub struct LogupZerocheckGpu<'a, HS: GpuHashScheme> {
     gkr_mem_contribution: usize,
     /// Memory limit for batch MLE intermediate buffers (set after GKR input eval)
     memory_limit_bytes: usize,
+    stream: cudaStream_t,
 }
 
 impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
@@ -480,6 +484,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
         save_memory: bool,
         monomial_num_y_threshold: u32,
         sm_count: u32,
+        stream: cudaStream_t,
     ) -> Result<Self, LogupZerocheckError> {
         let mem = MemTracker::start("prover.logup_zerocheck_prover");
         let l_skip = pk.params.l_skip;
@@ -590,6 +595,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
             gkr_mem_contribution: 0,
             memory_limit_bytes: 0, // Set after GKR input eval
             monomial_num_y_threshold,
+            stream,
         })
     }
 
@@ -618,7 +624,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
         for (air_idx, air_pk) in self.pk.per_air.iter().enumerate() {
             if air_pk.other_data.zerocheck_monomials.is_some() {
                 self.lambda_combinations[air_idx] = Some(
-                    compute_lambda_combinations(self.pk, air_idx, lambda_pows_ref)
+                    compute_lambda_combinations(self.pk, air_idx, lambda_pows_ref, self.stream)
                         .map_err(LogupZerocheckError::LambdaCombinations)?,
                 );
             }
@@ -685,6 +691,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         &self.d_eq_3b_per_trace[trace_idx],
                         &self.eq_3b_per_trace[trace_idx],
                         &self.beta_pows,
+                        self.stream,
                     )
                     .map_err(LogupZerocheckError::LogupCombinations)?,
                 );
@@ -696,9 +703,12 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
         for &n in &self.n_per_trace {
             let n_lift = n.max(0) as usize;
             if let Entry::Vacant(entry) = self.eq_xis.entry(n_lift) {
-                let layers =
-                    EqEvalLayers::new_rev(n_lift, xi[l_skip..l_skip + n_lift].iter().rev())
-                        .map_err(LogupZerocheckError::EqEvalLayers)?;
+                let layers = EqEvalLayers::new_rev(
+                    n_lift,
+                    xi[l_skip..l_skip + n_lift].iter().rev(),
+                    self.stream,
+                )
+                .map_err(LogupZerocheckError::EqEvalLayers)?;
                 entry.insert(layers);
             }
         }
@@ -788,6 +798,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 num_cosets_zc as u32,
                 omega_root,
                 max_temp_bytes,
+                self.stream,
             )?;
             if !sum_buffer.is_empty() {
                 let q_evals = sum_buffer.to_host()?;
@@ -844,6 +855,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 num_cosets_logup as u32,
                 omega_root,
                 max_temp_bytes,
+                self.stream,
             )?;
             if !sum.is_empty() {
                 let evals = sum.to_host()?;
@@ -915,6 +927,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         trace,
                         &d_inv_lagrange_denoms_r0,
                         need_rot,
+                        self.stream,
                     )?;
                     results.push(folded);
                 }
@@ -928,6 +941,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         trace,
                         &d_inv_lagrange_denoms_r0,
                         need_rot,
+                        self.stream,
                     )?;
                     results.push(folded);
                 }
@@ -940,6 +954,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                     trace,
                     &d_inv_lagrange_denoms_r0,
                     need_rot,
+                    self.stream,
                 )?;
                 mem_limit = mem_limit.saturating_sub(folded.buffer().len() * size_of::<EF>());
                 results.push(folded);
@@ -979,7 +994,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         is_first,
                         is_last,
                         num_x,
-                        cudaStreamPerThread,
+                        self.stream,
                     )
                     .map_err(LogupZerocheckError::FoldSelectorsRound0)?;
                 }
@@ -1137,7 +1152,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         &d_columns,
                         sp_deg,
                         num_y,
-                        cudaStreamPerThread,
+                        self.stream,
                     )
                     .map_err(|e| LogupZerocheckError::InterpolateColumns(e.into()))?;
                 }
@@ -1217,8 +1232,12 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         .expect("missing logup monomial combinations for late trace")
                 })
                 .collect();
-            let batch =
-                LogupMonomialBatch::new(late_logup_traces.iter().copied(), self.pk, &logup_combs)?;
+            let batch = LogupMonomialBatch::new(
+                late_logup_traces.iter().copied(),
+                self.pk,
+                &logup_combs,
+                self.stream,
+            )?;
             let out = batch
                 .evaluate(1)
                 .map_err(LogupZerocheckError::MleInteractionEval)?;
@@ -1237,7 +1256,8 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 .iter()
                 .map(|t| self.lambda_combinations[t.air_idx].as_ref().unwrap())
                 .collect();
-            let batch = ZerocheckMonomialBatch::new(late_mono_traces, self.pk, &lambda_combs)?;
+            let batch =
+                ZerocheckMonomialBatch::new(late_mono_traces, self.pk, &lambda_combs, self.stream)?;
             let out = batch
                 .evaluate(1)
                 .map_err(LogupZerocheckError::MleConstraintEval)?;
@@ -1260,6 +1280,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 &mut logup_out,
                 &mut self.logup_tilde_evals,
                 self.memory_limit_bytes,
+                self.stream,
             )
             .map_err(LogupZerocheckError::MleInteractionEval)?;
         }
@@ -1290,6 +1311,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 sp_deg as u32,
                 &mut zc_out,
                 self.memory_limit_bytes,
+                self.stream,
             )
             .map_err(LogupZerocheckError::MleConstraintEval)?;
         }
@@ -1307,6 +1329,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 self.sm_count,
                 sp_deg as u32,
                 None,
+                self.stream,
             )?;
             let out = batch
                 .evaluate(sp_deg as u32)
@@ -1324,7 +1347,8 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 .iter()
                 .map(|t| self.lambda_combinations[t.air_idx].as_ref().unwrap())
                 .collect();
-            let batch = ZerocheckMonomialBatch::new(low_mono_traces, self.pk, &lambda_combs)?;
+            let batch =
+                ZerocheckMonomialBatch::new(low_mono_traces, self.pk, &lambda_combs, self.stream)?;
             let out = batch
                 .evaluate(sp_deg as u32)
                 .map_err(LogupZerocheckError::MleConstraintEval)?;
@@ -1456,7 +1480,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                     &d_log_output_heights,
                     max_output_cells.try_into().unwrap(),
                     r_round,
-                    cudaStreamPerThread,
+                    self.stream,
                 )
                 .map_err(LogupZerocheckError::BatchFoldMle)?;
             }

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -20,7 +20,7 @@ use openvm_cuda_common::{
     d_buffer::DeviceBuffer,
     error::MemCopyError,
     memory_manager::MemTracker,
-    stream::DeviceContext,
+    stream::GpuDeviceCtx,
 };
 use openvm_stark_backend::{
     air_builders::symbolic::SymbolicConstraints,
@@ -112,7 +112,7 @@ pub fn prove_zerocheck_and_logup_gpu<HS, TS>(
     save_memory: bool,
     monomial_num_y_threshold: u32,
     sm_count: u32,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(GkrProof<HS::SC>, BatchConstraintProof<HS::SC>, Vec<EF>), LogupZerocheckError>
 where
     HS: GpuHashScheme,
@@ -470,7 +470,7 @@ pub struct LogupZerocheckGpu<'a, HS: GpuHashScheme> {
     gkr_mem_contribution: usize,
     /// Memory limit for batch MLE intermediate buffers (set after GKR input eval)
     memory_limit_bytes: usize,
-    device_ctx: DeviceContext,
+    device_ctx: GpuDeviceCtx,
 }
 
 impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
@@ -485,7 +485,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
         save_memory: bool,
         monomial_num_y_threshold: u32,
         sm_count: u32,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, LogupZerocheckError> {
         let mem = MemTracker::start("prover.logup_zerocheck_prover");
         let l_skip = pk.params.l_skip;

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -20,7 +20,7 @@ use openvm_cuda_common::{
     d_buffer::DeviceBuffer,
     error::MemCopyError,
     memory_manager::MemTracker,
-    stream::cudaStream_t,
+    stream::DeviceContext,
 };
 use openvm_stark_backend::{
     air_builders::symbolic::SymbolicConstraints,
@@ -108,11 +108,11 @@ pub(crate) fn air_width_for_mat(need_rot: bool, mat_width: usize) -> u32 {
 pub fn prove_zerocheck_and_logup_gpu<HS, TS>(
     transcript: &mut TS,
     mpk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
-    ctx: &ProvingContext<GenericGpuBackend<HS>>,
+    proving_ctx: &ProvingContext<GenericGpuBackend<HS>>,
     save_memory: bool,
     monomial_num_y_threshold: u32,
     sm_count: u32,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<(GkrProof<HS::SC>, BatchConstraintProof<HS::SC>, Vec<EF>), LogupZerocheckError>
 where
     HS: GpuHashScheme,
@@ -121,14 +121,15 @@ where
     let logup_gkr_span = info_span!("prover.rap_constraints.logup_gkr", phase = "prover").entered();
     let l_skip = mpk.params.l_skip;
     let constraint_degree = mpk.max_constraint_degree;
-    let num_traces = ctx.per_trace.len();
+    let num_traces = proving_ctx.per_trace.len();
 
     // Traces are sorted
-    let n_max = log2_strict_usize(ctx.per_trace[0].1.common_main.height()).saturating_sub(l_skip);
+    let n_max =
+        log2_strict_usize(proving_ctx.per_trace[0].1.common_main.height()).saturating_sub(l_skip);
     // Gather interactions metadata, including interactions stacked layout which depends on trace
     // heights
     let mut total_interactions = 0u64;
-    let interactions_meta: Vec<_> = ctx
+    let interactions_meta: Vec<_> = proving_ctx
         .per_trace
         .iter()
         .map(|(air_idx, air_ctx)| {
@@ -150,7 +151,7 @@ where
 
     // Grind to increase soundness of random sampling for LogUp
     let logup_pow_witness = transcript
-        .grind_gpu(mpk.params.logup.pow_bits, stream)
+        .grind_gpu(mpk.params.logup.pow_bits, ctx)
         .map_err(LogupZerocheckError::Grind)?;
     let alpha_logup = transcript.sample_ext();
     let beta_logup = transcript.sample_ext();
@@ -159,7 +160,7 @@ where
     let has_interactions = !interactions_layout.sorted_cols.is_empty();
     let mut prover = LogupZerocheckGpu::new(
         mpk,
-        ctx,
+        proving_ctx,
         n_logup,
         interactions_layout,
         alpha_logup,
@@ -167,7 +168,7 @@ where
         save_memory,
         monomial_num_y_threshold,
         sm_count,
-        stream,
+        ctx,
     )?;
     let n_global = prover.n_global;
 
@@ -180,12 +181,12 @@ where
         log_gkr_input_evals(
             &prover.trace_interactions,
             mpk,
-            ctx,
+            proving_ctx,
             l_skip,
             alpha_logup,
             &prover.d_challenges,
             total_leaves,
-            stream,
+            ctx,
         )?
     } else {
         (DeviceBuffer::new(), EF::ZERO)
@@ -206,7 +207,7 @@ where
     prover.mem.emit_metrics_with_label("prover.gkr_input_evals");
 
     let (frac_sum_proof, mut xi) =
-        fractional_sumcheck_gpu(transcript, inputs, alpha, true, &mut prover.mem, stream)?;
+        fractional_sumcheck_gpu(transcript, inputs, alpha, true, &mut prover.mem, ctx)?;
     while xi.len() != l_skip + n_global {
         xi.push(transcript.sample_ext());
     }
@@ -225,7 +226,7 @@ where
     let lambda = transcript.sample_ext();
     debug!(%lambda);
 
-    let sp_0_polys = prover.sumcheck_uni_round0_polys(ctx, lambda)?;
+    let sp_0_polys = prover.sumcheck_uni_round0_polys(proving_ctx, lambda)?;
     let s_0_cpu_span = info_span!("s'_0 -> s_0 cpu interpolations").entered();
     let sp_0_deg = sumcheck_round0_deg(l_skip, constraint_degree);
     let s_deg = constraint_degree + 1;
@@ -334,7 +335,7 @@ where
     prover.prev_s_eval = s_0_poly.eval_at_point(r_0);
     debug!("s_0(r_0) = {}", prover.prev_s_eval);
 
-    prover.fold_ple_evals(ctx, r_0)?;
+    prover.fold_ple_evals(proving_ctx, r_0)?;
     drop(round0_span);
 
     // Sumcheck rounds:
@@ -370,7 +371,7 @@ where
 
     let column_openings = prover.into_column_openings()?;
 
-    let need_rot_per_trace = ctx
+    let need_rot_per_trace = proving_ctx
         .per_trace
         .iter()
         .map(|(air_idx, _)| mpk.per_air[*air_idx].vk.params.need_rot)
@@ -469,14 +470,14 @@ pub struct LogupZerocheckGpu<'a, HS: GpuHashScheme> {
     gkr_mem_contribution: usize,
     /// Memory limit for batch MLE intermediate buffers (set after GKR input eval)
     memory_limit_bytes: usize,
-    stream: cudaStream_t,
+    ctx: DeviceContext,
 }
 
 impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
     #[allow(clippy::too_many_arguments)]
     fn new(
         pk: &'a DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
-        ctx: &ProvingContext<GenericGpuBackend<HS>>,
+        proving_ctx: &ProvingContext<GenericGpuBackend<HS>>,
         n_logup: usize,
         interactions_layout: StackedLayout,
         alpha_logup: EF,
@@ -484,14 +485,14 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
         save_memory: bool,
         monomial_num_y_threshold: u32,
         sm_count: u32,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<Self, LogupZerocheckError> {
         let mem = MemTracker::start("prover.logup_zerocheck_prover");
         let l_skip = pk.params.l_skip;
         let omega_skip = F::two_adic_generator(l_skip);
         let omega_skip_pows = omega_skip.powers().take(1 << l_skip).collect_vec();
-        let d_omega_skip_pows = omega_skip_pows.to_device()?;
-        let num_airs_present = ctx.per_trace.len();
+        let d_omega_skip_pows = omega_skip_pows.to_device_on(ctx)?;
+        let num_airs_present = proving_ctx.per_trace.len();
 
         let constraint_degree = pk.max_constraint_degree;
 
@@ -506,10 +507,10 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
             .take(max_interaction_length + 1)
             .collect_vec();
         let challenges = [&[alpha_logup], &beta_pows[..]].concat();
-        let d_challenges = challenges.to_device()?;
-        let d_beta_pows = beta_pows.to_device()?;
+        let d_challenges = challenges.to_device_on(ctx)?;
+        let d_beta_pows = beta_pows.to_device_on(ctx)?;
 
-        let n_per_trace: Vec<isize> = ctx
+        let n_per_trace: Vec<isize> = proving_ctx
             .common_main_traces()
             .map(|(_, t)| log2_strict_usize(t.height()) as isize - l_skip as isize)
             .collect();
@@ -532,9 +533,9 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
             .unwrap_or(0);
 
         // Collect interaction metadata for GPU execution (evaluations still run on CPU for now).
-        let trace_interactions = collect_trace_interactions(pk, ctx, &interactions_layout);
+        let trace_interactions = collect_trace_interactions(pk, proving_ctx, &interactions_layout);
 
-        let needs_next_per_trace = ctx
+        let needs_next_per_trace = proving_ctx
             .per_trace
             .iter()
             .map(|(air_idx, _)| pk.per_air[*air_idx].vk.params.need_rot)
@@ -566,18 +567,18 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
             sels_per_trace_base: vec![],
             mat_evals_per_trace: vec![],
             sels_per_trace: vec![],
-            public_values_per_trace: ctx
+            public_values_per_trace: proving_ctx
                 .per_trace
                 .iter()
                 .map(|(_, air_ctx)| {
                     if air_ctx.public_values.is_empty() {
                         Ok(DeviceBuffer::new())
                     } else {
-                        air_ctx.public_values.to_device()
+                        air_ctx.public_values.to_device_on(ctx)
                     }
                 })
                 .collect::<Result<Vec<_>, _>>()?,
-            air_indices_per_trace: ctx
+            air_indices_per_trace: proving_ctx
                 .per_trace
                 .iter()
                 .map(|(air_idx, _)| *air_idx)
@@ -595,7 +596,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
             gkr_mem_contribution: 0,
             memory_limit_bytes: 0, // Set after GKR input eval
             monomial_num_y_threshold,
-            stream,
+            ctx: ctx.clone(),
         })
     }
 
@@ -615,7 +616,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
         let xi = &self.xi;
         let h_lambda_pows = lambda.powers().take(self.max_num_constraints).collect_vec();
         self.lambda_pows = Some(if !h_lambda_pows.is_empty() {
-            h_lambda_pows.to_device()?
+            h_lambda_pows.to_device_on(&self.ctx)?
         } else {
             DeviceBuffer::new()
         });
@@ -624,7 +625,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
         for (air_idx, air_pk) in self.pk.per_air.iter().enumerate() {
             if air_pk.other_data.zerocheck_monomials.is_some() {
                 self.lambda_combinations[air_idx] = Some(
-                    compute_lambda_combinations(self.pk, air_idx, lambda_pows_ref, self.stream)
+                    compute_lambda_combinations(self.pk, air_idx, lambda_pows_ref, &self.ctx)
                         .map_err(LogupZerocheckError::LambdaCombinations)?,
                 );
             }
@@ -672,7 +673,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 if eq_3bs.is_empty() {
                     Ok(DeviceBuffer::new())
                 } else {
-                    eq_3bs.to_device()
+                    eq_3bs.to_device_on(&self.ctx)
                 }
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -691,7 +692,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         &self.d_eq_3b_per_trace[trace_idx],
                         &self.eq_3b_per_trace[trace_idx],
                         &self.beta_pows,
-                        self.stream,
+                        &self.ctx,
                     )
                     .map_err(LogupZerocheckError::LogupCombinations)?,
                 );
@@ -706,7 +707,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 let layers = EqEvalLayers::new_rev(
                     n_lift,
                     xi[l_skip..l_skip + n_lift].iter().rev(),
-                    self.stream,
+                    &self.ctx,
                 )
                 .map_err(LogupZerocheckError::EqEvalLayers)?;
                 entry.insert(layers);
@@ -723,7 +724,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 cols[height..2 * height - 1].fill(F::ONE); // is_transition
                 cols[0] = F::ONE; // is_first
                 cols[2 * height + height - 1] = F::ONE; // is_last
-                let d_cols = cols.to_device()?;
+                let d_cols = cols.to_device_on(&self.ctx)?;
                 Ok(DeviceMatrix::new(Arc::new(d_cols), height, 3))
             })
             .collect::<Result<Vec<_>, MemCopyError>>()?;
@@ -776,7 +777,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 main_parts.push(committed.trace.buffer().as_ptr());
             }
             main_parts.push(air_ctx.common_main.buffer().as_ptr());
-            let d_main_parts = main_parts.to_device()?;
+            let d_main_parts = main_parts.to_device_on(&self.ctx)?;
 
             let n_lift = n.max(0) as usize;
             let eq_xi_tree = &self.eq_xis[&n_lift];
@@ -798,10 +799,10 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 num_cosets_zc as u32,
                 omega_root,
                 max_temp_bytes,
-                self.stream,
+                &self.ctx,
             )?;
             if !sum_buffer.is_empty() {
-                let q_evals = sum_buffer.to_host()?;
+                let q_evals = sum_buffer.to_host_on(&self.ctx)?;
                 let q = {
                     // Make q_evals row-major, with columns <> cosets
                     let mut values = EF::zero_vec(num_cosets_zc << l_skip);
@@ -855,10 +856,10 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 num_cosets_logup as u32,
                 omega_root,
                 max_temp_bytes,
-                self.stream,
+                &self.ctx,
             )?;
             if !sum.is_empty() {
-                let evals = sum.to_host()?;
+                let evals = sum.to_host_on(&self.ctx)?;
                 let (mut numer, denom): (Vec<EF>, Vec<EF>) =
                     evals.into_iter().map(|frac| (frac.p, frac.q)).unzip();
                 if n.is_negative() {
@@ -906,7 +907,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
         let l_skip = self.l_skip;
         let inv_lagrange_denoms_r0 =
             compute_barycentric_inv_lagrange_denoms(l_skip, &self.omega_skip_pows, r_0);
-        let d_inv_lagrange_denoms_r0 = inv_lagrange_denoms_r0.to_device()?;
+        let d_inv_lagrange_denoms_r0 = inv_lagrange_denoms_r0.to_device_on(&self.ctx)?;
 
         let mut mem_limit = self.gkr_mem_contribution;
         // GPU folding for mat_evals_per_trace
@@ -927,7 +928,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         trace,
                         &d_inv_lagrange_denoms_r0,
                         need_rot,
-                        self.stream,
+                        &self.ctx,
                     )?;
                     results.push(folded);
                 }
@@ -941,7 +942,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         trace,
                         &d_inv_lagrange_denoms_r0,
                         need_rot,
-                        self.stream,
+                        &self.ctx,
                     )?;
                     results.push(folded);
                 }
@@ -954,7 +955,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                     trace,
                     &d_inv_lagrange_denoms_r0,
                     need_rot,
-                    self.stream,
+                    &self.ctx,
                 )?;
                 mem_limit = mem_limit.saturating_sub(folded.buffer().len() * size_of::<EF>());
                 results.push(folded);
@@ -986,7 +987,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 let omega = F::two_adic_generator(l);
                 let is_first = eval_eq_uni_at_one(l, r);
                 let is_last = eval_eq_uni_at_one(l, r * omega);
-                let folded_buf = DeviceBuffer::<EF>::with_capacity(num_x * 3);
+                let folded_buf = DeviceBuffer::<EF>::with_capacity_on(num_x * 3, &self.ctx);
                 unsafe {
                     fold_selectors_round0(
                         folded_buf.as_mut_ptr(),
@@ -994,7 +995,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         is_first,
                         is_last,
                         num_x,
-                        self.stream,
+                        self.ctx.stream.as_raw(),
                     )
                     .map_err(LogupZerocheckError::FoldSelectorsRound0)?;
                 }
@@ -1093,7 +1094,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                             air_width: air_width_for_mat(need_rot, m.width()),
                         })
                         .collect_vec();
-                    let main_ptrs_dev = main_ptrs.to_device()?;
+                    let main_ptrs_dev = main_ptrs.to_device_on(&self.ctx)?;
 
                     late_eval.push(TraceCtx {
                         trace_idx,
@@ -1144,15 +1145,16 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         })
                         .collect_vec(),
                 );
-                let interpolated = DeviceMatrix::<EF>::with_capacity(sp_deg * num_y, columns.len());
-                let d_columns = columns.to_device()?;
+                let interpolated =
+                    DeviceMatrix::<EF>::with_capacity_on(sp_deg * num_y, columns.len(), &self.ctx);
+                let d_columns = columns.to_device_on(&self.ctx)?;
                 unsafe {
                     interpolate_columns_gpu(
                         interpolated.buffer(),
                         &d_columns,
                         sp_deg,
                         num_y,
-                        self.stream,
+                        self.ctx.stream.as_raw(),
                     )
                     .map_err(|e| LogupZerocheckError::InterpolateColumns(e.into()))?;
                 }
@@ -1196,7 +1198,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                     })
                     .collect_vec();
                 debug_assert_eq!(widths_so_far, interpolated.width());
-                let main_ptrs_dev = main_ptrs.to_device()?;
+                let main_ptrs_dev = main_ptrs.to_device_on(&self.ctx)?;
 
                 _keepalive_interpolated.push(interpolated);
                 let eq_xi_ptr = eq_xi_tree.get_ptr(log_num_y);
@@ -1236,12 +1238,12 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 late_logup_traces.iter().copied(),
                 self.pk,
                 &logup_combs,
-                self.stream,
+                &self.ctx,
             )?;
             let out = batch
                 .evaluate(1)
                 .map_err(LogupZerocheckError::MleInteractionEval)?;
-            let host = out.to_host()?;
+            let host = out.to_host_on(&self.ctx)?;
             for (i, trace_idx) in batch.trace_indices().enumerate() {
                 self.logup_tilde_evals[trace_idx][0] = host[i].p * late_logup_traces[i].norm_factor;
                 self.logup_tilde_evals[trace_idx][1] = host[i].q;
@@ -1257,11 +1259,11 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 .map(|t| self.lambda_combinations[t.air_idx].as_ref().unwrap())
                 .collect();
             let batch =
-                ZerocheckMonomialBatch::new(late_mono_traces, self.pk, &lambda_combs, self.stream)?;
+                ZerocheckMonomialBatch::new(late_mono_traces, self.pk, &lambda_combs, &self.ctx)?;
             let out = batch
                 .evaluate(1)
                 .map_err(LogupZerocheckError::MleConstraintEval)?;
-            let host = out.to_host()?;
+            let host = out.to_host_on(&self.ctx)?;
             for (i, trace_idx) in batch.trace_indices().enumerate() {
                 self.zerocheck_tilde_evals[trace_idx] = host[i];
                 // zc_out not set for num_x=1, handled from tilde_eval in compute_batch_s
@@ -1280,7 +1282,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 &mut logup_out,
                 &mut self.logup_tilde_evals,
                 self.memory_limit_bytes,
-                self.stream,
+                &self.ctx,
             )
             .map_err(LogupZerocheckError::MleInteractionEval)?;
         }
@@ -1311,7 +1313,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 sp_deg as u32,
                 &mut zc_out,
                 self.memory_limit_bytes,
-                self.stream,
+                &self.ctx,
             )
             .map_err(LogupZerocheckError::MleConstraintEval)?;
         }
@@ -1329,12 +1331,12 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 self.sm_count,
                 sp_deg as u32,
                 None,
-                self.stream,
+                &self.ctx,
             )?;
             let out = batch
                 .evaluate(sp_deg as u32)
                 .map_err(LogupZerocheckError::MleConstraintEval)?;
-            let host = out.to_host()?;
+            let host = out.to_host_on(&self.ctx)?;
             for (i, trace_idx) in batch.trace_indices().enumerate() {
                 zc_out[trace_idx].copy_from_slice(&host[(i * sp_deg)..((i + 1) * sp_deg)]);
             }
@@ -1348,11 +1350,11 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 .map(|t| self.lambda_combinations[t.air_idx].as_ref().unwrap())
                 .collect();
             let batch =
-                ZerocheckMonomialBatch::new(low_mono_traces, self.pk, &lambda_combs, self.stream)?;
+                ZerocheckMonomialBatch::new(low_mono_traces, self.pk, &lambda_combs, &self.ctx)?;
             let out = batch
                 .evaluate(sp_deg as u32)
                 .map_err(LogupZerocheckError::MleConstraintEval)?;
-            let host = out.to_host()?;
+            let host = out.to_host_on(&self.ctx)?;
             for (i, trace_idx) in batch.trace_indices().enumerate() {
                 zc_out[trace_idx].copy_from_slice(&host[(i * sp_deg)..((i + 1) * sp_deg)]);
             }
@@ -1451,7 +1453,8 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                         let width = mat.width();
                         let output_height = height >> 1;
                         max_output_cells = max(max_output_cells, output_height * width);
-                        let output_mat = DeviceMatrix::<EF>::with_capacity(output_height, width);
+                        let output_mat =
+                            DeviceMatrix::<EF>::with_capacity_on(output_height, width, &self.ctx);
                         (output_height.ilog2() as u8, width as u32, output_mat)
                     })
                     .multiunzip();
@@ -1466,10 +1469,10 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 .map(|mat| mat.buffer().as_mut_ptr())
                 .collect_vec();
 
-            let d_input_ptrs = input_ptrs.to_device()?;
-            let d_output_ptrs = output_ptrs.to_device()?;
-            let d_log_output_heights = log_output_heights.to_device()?;
-            let d_widths = widths.to_device()?;
+            let d_input_ptrs = input_ptrs.to_device_on(&self.ctx)?;
+            let d_output_ptrs = output_ptrs.to_device_on(&self.ctx)?;
+            let d_log_output_heights = log_output_heights.to_device_on(&self.ctx)?;
+            let d_widths = widths.to_device_on(&self.ctx)?;
 
             unsafe {
                 batch_fold_mle(
@@ -1480,7 +1483,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                     &d_log_output_heights,
                     max_output_cells.try_into().unwrap(),
                     r_round,
-                    self.stream,
+                    self.ctx.stream.as_raw(),
                 )
                 .map_err(LogupZerocheckError::BatchFoldMle)?;
             }
@@ -1552,7 +1555,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
             let mut split_mats: Vec<Option<ColMajorMatrix<EF>>> = mat_evals
                 .into_iter()
                 .map(|mat| {
-                    let mat_host = transport_matrix_d2h_col_major(&mat)?;
+                    let mat_host = transport_matrix_d2h_col_major(&mat, &self.ctx)?;
                     let width = mat_host.width();
                     let height = mat_host.height();
                     debug_assert_eq!(height, 1, "Matrices should have height=1 after folding");

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -5,7 +5,7 @@
 //! new allocations happen before the current stream is synchronized, physical peak memory can
 //! temporarily include both the old and new buffers even though MemTracker only sees the logical
 //! max. Callers that care about physical peak should ensure a current-stream sync after use (e.g.
-//! by calling `to_host()` on outputs or `current_stream_sync()`).
+//! by calling `to_host_on()` on outputs or synchronizing the owning stream).
 
 use std::{
     cmp::max,

--- a/crates/cuda-backend/src/logup_zerocheck/round0.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/round0.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use openvm_cuda_common::{
-    copy::MemCopyH2D, d_buffer::DeviceBuffer, error::CudaError, stream::cudaStream_t,
+    copy::MemCopyH2D, d_buffer::DeviceBuffer, error::CudaError, stream::DeviceContext,
 };
 use openvm_stark_backend::{
     air_builders::symbolic::{
@@ -61,7 +61,7 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
     num_cosets: u32,
     g_shift: F,
     max_temp_bytes: usize,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<DeviceBuffer<EF>, Round0EvalError> {
     let constraints_dag = &pk.vk.symbolic_constraints;
     if constraints_dag.constraints.constraint_idx.is_empty() || num_cosets == 0 {
@@ -70,6 +70,7 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
     }
     validate_round0_num_cosets(num_x, skip_domain, num_cosets)?;
 
+    let stream = ctx.stream.as_raw();
     let rules = &pk.other_data.zerocheck_round0;
 
     let buffer_size: u32 = rules.inner.buffer_size;
@@ -85,7 +86,7 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
     };
     let mut intermediates = if intermed_capacity > 0 {
         debug!("zerocheck:intermediates_capacity={intermed_capacity}");
-        DeviceBuffer::<F>::with_capacity(intermed_capacity)
+        DeviceBuffer::<F>::with_capacity_on(intermed_capacity, ctx)
     } else {
         DeviceBuffer::<F>::new()
     };
@@ -101,7 +102,7 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
         )
     };
     debug!("zerocheck:temp_sums_buffer_capacity={temp_sums_buffer_capacity}");
-    let mut temp_sums_buffer = DeviceBuffer::<EF>::with_capacity(temp_sums_buffer_capacity);
+    let mut temp_sums_buffer = DeviceBuffer::<EF>::with_capacity_on(temp_sums_buffer_capacity, ctx);
     let used_temp_bytes =
         intermed_capacity * size_of::<F>() + temp_sums_buffer_capacity * size_of::<EF>();
     if used_temp_bytes > max_temp_bytes {
@@ -117,7 +118,7 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
         .unwrap_or(std::ptr::null());
 
     let mut sp_evals =
-        DeviceBuffer::<EF>::with_capacity(num_cosets as usize * skip_domain as usize);
+        DeviceBuffer::<EF>::with_capacity_on(num_cosets as usize * skip_domain as usize, ctx);
     // SAFETY:
     // - No bounds checks are done in this kernel. It fully assumes that the Rules are trusted and
     //   all nodes are valid.
@@ -169,13 +170,14 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
     num_cosets: u32,
     g_shift: F,
     max_temp_bytes: usize,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<DeviceBuffer<Frac<EF>>, Round0EvalError> {
     // Check if this trace has interactions
     if eq_3bs.is_empty() {
         return Ok(DeviceBuffer::new());
     }
     validate_round0_num_cosets(num_x, skip_domain, num_cosets)?;
+    let stream = ctx.stream.as_raw();
     let large_domain = num_cosets * skip_domain;
 
     // We create a new "interactions DAG" where the new .constraints are the interaction [count,
@@ -228,13 +230,13 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
                 denom_weights[message_rule_idx] += eq_3bs[interaction_idx] * beta_pows[message_idx];
             }
         }
-        let d_numer_weights = numer_weights.to_device()?;
-        let d_denom_weights = denom_weights.to_device()?;
+        let d_numer_weights = numer_weights.to_device_on(ctx)?;
+        let d_denom_weights = denom_weights.to_device_on(ctx)?;
         (rules, d_numer_weights, d_denom_weights, denom_sum_init)
     };
 
     let encoded_rules = rules.rules.iter().map(|c| c.encode()).collect_vec();
-    let d_rules = encoded_rules.to_device()?;
+    let d_rules = encoded_rules.to_device_on(ctx)?;
 
     let buffer_size: u32 = rules.buffer_size.try_into().unwrap();
     let intermed_capacity = unsafe {
@@ -249,7 +251,7 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
     };
     let mut intermediates = if intermed_capacity > 0 {
         debug!("logup_r0:intermediates_capacity={intermed_capacity}");
-        DeviceBuffer::<F>::with_capacity(intermed_capacity)
+        DeviceBuffer::<F>::with_capacity_on(intermed_capacity, ctx)
     } else {
         DeviceBuffer::<F>::new()
     };
@@ -265,7 +267,8 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
         )
     };
     debug!("logup_r0:tmp_sums_buffer_capacity={temp_sums_buffer_capacity}");
-    let mut temp_sums_buffer = DeviceBuffer::<Frac<EF>>::with_capacity(temp_sums_buffer_capacity);
+    let mut temp_sums_buffer =
+        DeviceBuffer::<Frac<EF>>::with_capacity_on(temp_sums_buffer_capacity, ctx);
     let used_temp_bytes =
         intermed_capacity * size_of::<F>() + temp_sums_buffer_capacity * size_of::<Frac<EF>>();
     if used_temp_bytes > max_temp_bytes {
@@ -280,7 +283,7 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
         .map(|cd| cd.trace.buffer().as_ptr())
         .unwrap_or(std::ptr::null());
 
-    let mut s_evals = DeviceBuffer::<Frac<EF>>::with_capacity(large_domain as usize);
+    let mut s_evals = DeviceBuffer::<Frac<EF>>::with_capacity_on(large_domain as usize, ctx);
 
     unsafe {
         logup_bary_eval_interactions_round0(

--- a/crates/cuda-backend/src/logup_zerocheck/round0.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/round0.rs
@@ -61,7 +61,7 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
     num_cosets: u32,
     g_shift: F,
     max_temp_bytes: usize,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<DeviceBuffer<EF>, Round0EvalError> {
     let constraints_dag = &pk.vk.symbolic_constraints;
     if constraints_dag.constraints.constraint_idx.is_empty() || num_cosets == 0 {
@@ -70,7 +70,7 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
     }
     validate_round0_num_cosets(num_x, skip_domain, num_cosets)?;
 
-    let stream = ctx.stream.as_raw();
+    let stream = device_ctx.stream.as_raw();
     let rules = &pk.other_data.zerocheck_round0;
 
     let buffer_size: u32 = rules.inner.buffer_size;
@@ -86,7 +86,7 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
     };
     let mut intermediates = if intermed_capacity > 0 {
         debug!("zerocheck:intermediates_capacity={intermed_capacity}");
-        DeviceBuffer::<F>::with_capacity_on(intermed_capacity, ctx)
+        DeviceBuffer::<F>::with_capacity_on(intermed_capacity, device_ctx)
     } else {
         DeviceBuffer::<F>::new()
     };
@@ -102,7 +102,8 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
         )
     };
     debug!("zerocheck:temp_sums_buffer_capacity={temp_sums_buffer_capacity}");
-    let mut temp_sums_buffer = DeviceBuffer::<EF>::with_capacity_on(temp_sums_buffer_capacity, ctx);
+    let mut temp_sums_buffer =
+        DeviceBuffer::<EF>::with_capacity_on(temp_sums_buffer_capacity, device_ctx);
     let used_temp_bytes =
         intermed_capacity * size_of::<F>() + temp_sums_buffer_capacity * size_of::<EF>();
     if used_temp_bytes > max_temp_bytes {
@@ -117,8 +118,10 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
         .map(|cd| cd.trace.buffer().as_ptr())
         .unwrap_or(std::ptr::null());
 
-    let mut sp_evals =
-        DeviceBuffer::<EF>::with_capacity_on(num_cosets as usize * skip_domain as usize, ctx);
+    let mut sp_evals = DeviceBuffer::<EF>::with_capacity_on(
+        num_cosets as usize * skip_domain as usize,
+        device_ctx,
+    );
     // SAFETY:
     // - No bounds checks are done in this kernel. It fully assumes that the Rules are trusted and
     //   all nodes are valid.
@@ -170,14 +173,14 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
     num_cosets: u32,
     g_shift: F,
     max_temp_bytes: usize,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<DeviceBuffer<Frac<EF>>, Round0EvalError> {
     // Check if this trace has interactions
     if eq_3bs.is_empty() {
         return Ok(DeviceBuffer::new());
     }
     validate_round0_num_cosets(num_x, skip_domain, num_cosets)?;
-    let stream = ctx.stream.as_raw();
+    let stream = device_ctx.stream.as_raw();
     let large_domain = num_cosets * skip_domain;
 
     // We create a new "interactions DAG" where the new .constraints are the interaction [count,
@@ -230,13 +233,13 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
                 denom_weights[message_rule_idx] += eq_3bs[interaction_idx] * beta_pows[message_idx];
             }
         }
-        let d_numer_weights = numer_weights.to_device_on(ctx)?;
-        let d_denom_weights = denom_weights.to_device_on(ctx)?;
+        let d_numer_weights = numer_weights.to_device_on(device_ctx)?;
+        let d_denom_weights = denom_weights.to_device_on(device_ctx)?;
         (rules, d_numer_weights, d_denom_weights, denom_sum_init)
     };
 
     let encoded_rules = rules.rules.iter().map(|c| c.encode()).collect_vec();
-    let d_rules = encoded_rules.to_device_on(ctx)?;
+    let d_rules = encoded_rules.to_device_on(device_ctx)?;
 
     let buffer_size: u32 = rules.buffer_size.try_into().unwrap();
     let intermed_capacity = unsafe {
@@ -251,7 +254,7 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
     };
     let mut intermediates = if intermed_capacity > 0 {
         debug!("logup_r0:intermediates_capacity={intermed_capacity}");
-        DeviceBuffer::<F>::with_capacity_on(intermed_capacity, ctx)
+        DeviceBuffer::<F>::with_capacity_on(intermed_capacity, device_ctx)
     } else {
         DeviceBuffer::<F>::new()
     };
@@ -268,7 +271,7 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
     };
     debug!("logup_r0:tmp_sums_buffer_capacity={temp_sums_buffer_capacity}");
     let mut temp_sums_buffer =
-        DeviceBuffer::<Frac<EF>>::with_capacity_on(temp_sums_buffer_capacity, ctx);
+        DeviceBuffer::<Frac<EF>>::with_capacity_on(temp_sums_buffer_capacity, device_ctx);
     let used_temp_bytes =
         intermed_capacity * size_of::<F>() + temp_sums_buffer_capacity * size_of::<Frac<EF>>();
     if used_temp_bytes > max_temp_bytes {
@@ -283,7 +286,7 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
         .map(|cd| cd.trace.buffer().as_ptr())
         .unwrap_or(std::ptr::null());
 
-    let mut s_evals = DeviceBuffer::<Frac<EF>>::with_capacity_on(large_domain as usize, ctx);
+    let mut s_evals = DeviceBuffer::<Frac<EF>>::with_capacity_on(large_domain as usize, device_ctx);
 
     unsafe {
         logup_bary_eval_interactions_round0(

--- a/crates/cuda-backend/src/logup_zerocheck/round0.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/round0.rs
@@ -1,9 +1,6 @@
 use itertools::Itertools;
 use openvm_cuda_common::{
-    copy::MemCopyH2D,
-    d_buffer::DeviceBuffer,
-    error::CudaError,
-    stream::cudaStreamPerThread,
+    copy::MemCopyH2D, d_buffer::DeviceBuffer, error::CudaError, stream::cudaStreamPerThread,
 };
 use openvm_stark_backend::{
     air_builders::symbolic::{
@@ -143,6 +140,7 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
             num_cosets,
             g_shift,
             max_temp_bytes,
+            cudaStreamPerThread,
         )?;
     }
 
@@ -255,7 +253,14 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
     };
 
     let temp_sums_buffer_capacity = unsafe {
-        _logup_r0_temp_sums_buffer_size(buffer_size, skip_domain, num_x, num_cosets, max_temp_bytes, cudaStreamPerThread)
+        _logup_r0_temp_sums_buffer_size(
+            buffer_size,
+            skip_domain,
+            num_x,
+            num_cosets,
+            max_temp_bytes,
+            cudaStreamPerThread,
+        )
     };
     debug!("logup_r0:tmp_sums_buffer_capacity={temp_sums_buffer_capacity}");
     let mut temp_sums_buffer = DeviceBuffer::<Frac<EF>>::with_capacity(temp_sums_buffer_capacity);
@@ -296,6 +301,7 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
             num_cosets,
             g_shift,
             max_temp_bytes,
+            cudaStreamPerThread,
         )?;
     }
 

--- a/crates/cuda-backend/src/logup_zerocheck/round0.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/round0.rs
@@ -1,5 +1,10 @@
 use itertools::Itertools;
-use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer, error::CudaError};
+use openvm_cuda_common::{
+    copy::MemCopyH2D,
+    d_buffer::DeviceBuffer,
+    error::CudaError,
+    stream::cudaStreamPerThread,
+};
 use openvm_stark_backend::{
     air_builders::symbolic::{
         symbolic_expression::SymbolicExpression, SymbolicConstraints, SymbolicDagBuilder,
@@ -77,6 +82,7 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
             num_x,
             num_cosets,
             max_temp_bytes,
+            cudaStreamPerThread,
         )
     };
     let mut intermediates = if intermed_capacity > 0 {
@@ -93,6 +99,7 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
             num_x,
             num_cosets,
             max_temp_bytes,
+            cudaStreamPerThread,
         )
     };
     debug!("zerocheck:temp_sums_buffer_capacity={temp_sums_buffer_capacity}");
@@ -237,6 +244,7 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
             num_x,
             num_cosets,
             max_temp_bytes,
+            cudaStreamPerThread,
         )
     };
     let mut intermediates = if intermed_capacity > 0 {
@@ -247,7 +255,7 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
     };
 
     let temp_sums_buffer_capacity = unsafe {
-        _logup_r0_temp_sums_buffer_size(buffer_size, skip_domain, num_x, num_cosets, max_temp_bytes)
+        _logup_r0_temp_sums_buffer_size(buffer_size, skip_domain, num_x, num_cosets, max_temp_bytes, cudaStreamPerThread)
     };
     debug!("logup_r0:tmp_sums_buffer_capacity={temp_sums_buffer_capacity}");
     let mut temp_sums_buffer = DeviceBuffer::<Frac<EF>>::with_capacity(temp_sums_buffer_capacity);

--- a/crates/cuda-backend/src/logup_zerocheck/round0.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/round0.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use openvm_cuda_common::{
-    copy::MemCopyH2D, d_buffer::DeviceBuffer, error::CudaError, stream::DeviceContext,
+    copy::MemCopyH2D, d_buffer::DeviceBuffer, error::CudaError, stream::GpuDeviceCtx,
 };
 use openvm_stark_backend::{
     air_builders::symbolic::{
@@ -61,7 +61,7 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
     num_cosets: u32,
     g_shift: F,
     max_temp_bytes: usize,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<DeviceBuffer<EF>, Round0EvalError> {
     let constraints_dag = &pk.vk.symbolic_constraints;
     if constraints_dag.constraints.constraint_idx.is_empty() || num_cosets == 0 {
@@ -173,7 +173,7 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
     num_cosets: u32,
     g_shift: F,
     max_temp_bytes: usize,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<DeviceBuffer<Frac<EF>>, Round0EvalError> {
     // Check if this trace has interactions
     if eq_3bs.is_empty() {

--- a/crates/cuda-backend/src/logup_zerocheck/round0.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/round0.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use openvm_cuda_common::{
-    copy::MemCopyH2D, d_buffer::DeviceBuffer, error::CudaError, stream::cudaStreamPerThread,
+    copy::MemCopyH2D, d_buffer::DeviceBuffer, error::CudaError, stream::cudaStream_t,
 };
 use openvm_stark_backend::{
     air_builders::symbolic::{
@@ -61,6 +61,7 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
     num_cosets: u32,
     g_shift: F,
     max_temp_bytes: usize,
+    stream: cudaStream_t,
 ) -> Result<DeviceBuffer<EF>, Round0EvalError> {
     let constraints_dag = &pk.vk.symbolic_constraints;
     if constraints_dag.constraints.constraint_idx.is_empty() || num_cosets == 0 {
@@ -79,7 +80,7 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
             num_x,
             num_cosets,
             max_temp_bytes,
-            cudaStreamPerThread,
+            stream,
         )
     };
     let mut intermediates = if intermed_capacity > 0 {
@@ -96,7 +97,7 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
             num_x,
             num_cosets,
             max_temp_bytes,
-            cudaStreamPerThread,
+            stream,
         )
     };
     debug!("zerocheck:temp_sums_buffer_capacity={temp_sums_buffer_capacity}");
@@ -140,7 +141,7 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
             num_cosets,
             g_shift,
             max_temp_bytes,
-            cudaStreamPerThread,
+            stream,
         )?;
     }
 
@@ -168,6 +169,7 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
     num_cosets: u32,
     g_shift: F,
     max_temp_bytes: usize,
+    stream: cudaStream_t,
 ) -> Result<DeviceBuffer<Frac<EF>>, Round0EvalError> {
     // Check if this trace has interactions
     if eq_3bs.is_empty() {
@@ -242,7 +244,7 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
             num_x,
             num_cosets,
             max_temp_bytes,
-            cudaStreamPerThread,
+            stream,
         )
     };
     let mut intermediates = if intermed_capacity > 0 {
@@ -259,7 +261,7 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
             num_x,
             num_cosets,
             max_temp_bytes,
-            cudaStreamPerThread,
+            stream,
         )
     };
     debug!("logup_r0:tmp_sums_buffer_capacity={temp_sums_buffer_capacity}");
@@ -301,7 +303,7 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
             num_cosets,
             g_shift,
             max_temp_bytes,
-            cudaStreamPerThread,
+            stream,
         )?;
     }
 

--- a/crates/cuda-backend/src/merkle_tree.rs
+++ b/crates/cuda-backend/src/merkle_tree.rs
@@ -5,7 +5,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
-    stream::cudaStream_t,
+    stream::DeviceContext,
 };
 use openvm_stark_backend::prover::MatrixDimensions;
 use p3_util::log2_strict_usize;
@@ -92,7 +92,7 @@ pub trait MerkleTreeConstructor: GpuMerkleHash {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<MerkleTreeGpu<F, Self::Digest>, MerkleTreeError>;
 }
 
@@ -100,7 +100,7 @@ pub trait MerkleProofQueryDigest: BatchQueryMerkle + Copy + Send + Sync + 'stati
     fn batch_query_merkle_proofs(
         trees: &[&MerkleTreeGpu<F, Self>],
         query_indices: &[usize],
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError>;
 }
 
@@ -132,23 +132,23 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<Self, MerkleTreeError> {
-        MH::new_merkle_tree(matrix, rows_per_query, cache_backing_matrix, stream)
+        MH::new_merkle_tree(matrix, rows_per_query, cache_backing_matrix, ctx)
     }
 
     fn new_generic_with_hash<MH: GpuMerkleHash<Digest = D>>(
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<Self, MerkleTreeError> {
         let mem = MemTracker::start("prover.merkle_tree");
         let height = matrix.height();
         assert!(height.is_power_of_two());
         let k = validate_merkle_rows_per_query(rows_per_query, height)?;
         let query_stride = height / rows_per_query;
-        let mut query_digest_layer = DeviceBuffer::<D>::with_capacity(query_stride);
+        let mut query_digest_layer = DeviceBuffer::<D>::with_capacity_on(query_stride, ctx);
         // SAFETY: query_digest_layer properly allocated
         unsafe {
             MH::compress_rows(
@@ -157,7 +157,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                 matrix.width(),
                 query_stride,
                 k,
-                stream,
+                ctx,
             )
             .map_err(MerkleTreeError::CompressingRowHashes)?;
         }
@@ -167,14 +167,14 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
         let mut digest_layers = vec![query_digest_layer];
         while digest_layers.last().unwrap().len() > 1 {
             let prev_layer = digest_layers.last().unwrap();
-            let mut layer = DeviceBuffer::<D>::with_capacity(prev_layer.len() / 2);
+            let mut layer = DeviceBuffer::<D>::with_capacity_on(prev_layer.len() / 2, ctx);
             let layer_len = layer.len();
             let layer_idx = digest_layers.len();
             // SAFETY:
             // - `layer` is properly allocated with half the size of `prev_layer` and does not
             //   overlap with it.
             unsafe {
-                MH::compress_layer(&mut layer, prev_layer, layer_len, stream).map_err(|error| {
+                MH::compress_layer(&mut layer, prev_layer, layer_len, ctx).map_err(|error| {
                     MerkleTreeError::AdjacentCompressLayer {
                         error,
                         layer: layer_idx,
@@ -185,7 +185,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
         }
         let d_root = digest_layers.last().unwrap();
         assert_eq!(d_root.len(), 1, "Only one root is supported");
-        let root = d_root.to_host()?.pop().unwrap();
+        let root = d_root.to_host_on(ctx)?.pop().unwrap();
 
         mem.emit_metrics();
         Ok(Self {
@@ -202,7 +202,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
         query_indices: &[usize],
         query_stride: usize,
         rows_per_query: usize,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<
         Vec<
             // per tree
@@ -224,7 +224,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                     .map(move |row_offset| (row_offset * query_stride + query_idx) as u32)
             })
             .collect_vec();
-        let d_row_idxs = row_idxs.to_device()?;
+        let d_row_idxs = row_idxs.to_device_on(ctx)?;
         // PERF[jpw]: I did not batch across trees into a single kernel call because widths are
         // different so it was inconvenient. Make a new kernel if slow.
         // NOTE: par_iter requires cross-stream waits, not worth the effort
@@ -232,7 +232,8 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
             .iter()
             .enumerate()
             .map(|(matrix_idx, matrix)| {
-                let d_out = DeviceBuffer::<F>::with_capacity(row_idxs.len() * matrix.width());
+                let d_out =
+                    DeviceBuffer::<F>::with_capacity_on(row_idxs.len() * matrix.width(), ctx);
                 // SAFETY:
                 // - `output_rows` is allocated with row_idxs.len() * width
                 // - row indices are within bounds
@@ -244,12 +245,12 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                         matrix.width() as u64,
                         matrix.height() as u64,
                         d_row_idxs.len(),
-                        stream,
+                        ctx.stream.as_raw(),
                     )
                     .map_err(|error| MerkleTreeError::MatrixGetRows { error, matrix_idx })?;
                 }
                 let width = matrix.width();
-                let out = info_span!("opened_rows_d2h").in_scope(|| d_out.to_host())?;
+                let out = info_span!("opened_rows_d2h").in_scope(|| d_out.to_host_on(ctx))?;
                 let opened_rows_per_query = out
                     .chunks_exact(rows_per_query * width)
                     .map(|rows| rows.to_vec())
@@ -265,13 +266,13 @@ impl MerkleTreeConstructor for Poseidon2MerkleHash {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<MerkleTreeGpu<F, Self::Digest>, MerkleTreeError> {
         MerkleTreeGpu::<F, Self::Digest>::new_generic_with_hash::<Self>(
             matrix,
             rows_per_query,
             cache_backing_matrix,
-            stream,
+            ctx,
         )
     }
 }
@@ -282,13 +283,13 @@ impl MerkleTreeConstructor for crate::hash_scheme::Bn254Poseidon2MerkleHash {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<MerkleTreeGpu<F, Self::Digest>, MerkleTreeError> {
         MerkleTreeGpu::<F, Self::Digest>::new_generic_with_hash::<Self>(
             matrix,
             rows_per_query,
             cache_backing_matrix,
-            stream,
+            ctx,
         )
     }
 }
@@ -302,13 +303,13 @@ impl MerkleTreeGpu<F, Digest> {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<Self, MerkleTreeError> {
         Self::new_with_hash::<Poseidon2MerkleHash>(
             matrix,
             rows_per_query,
             cache_backing_matrix,
-            stream,
+            ctx,
         )
     }
 }
@@ -318,7 +319,7 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
     fn batch_query_proofs(
         trees: &[&Self],
         query_indices: &[usize],
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<Vec<Vec<Vec<D>>>, MerkleTreeError> {
         if trees.is_empty() {
             return Ok(Vec::new());
@@ -348,7 +349,7 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                     .map(|layer| layer.as_ptr() as u64)
             })
             .collect_vec();
-        let d_layers_ptr = layers_ptr.to_device()?;
+        let d_layers_ptr = layers_ptr.to_device_on(ctx)?;
         debug_assert_eq!(d_layers_ptr.len(), num_trees * depth);
 
         // [query_idx] is the top level grouping
@@ -363,11 +364,13 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                 })
             })
             .collect_vec();
-        let d_indices = indices.to_device()?;
+        let d_indices = indices.to_device_on(ctx)?;
         debug_assert_eq!(d_indices.len(), d_layers_ptr.len() * num_queries);
 
-        let mut d_out =
-            DeviceBuffer::<F>::with_capacity(d_layers_ptr.len() * num_queries * DIGEST_SIZE);
+        let mut d_out = DeviceBuffer::<F>::with_capacity_on(
+            d_layers_ptr.len() * num_queries * DIGEST_SIZE,
+            ctx,
+        );
         // SAFETY:
         // - d_out has size num_trees * depth * num_queries * DIGEST_SIZE in `F` elements
         // - d_layers_ptr is size `num_trees * depth` device pointers
@@ -382,11 +385,11 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                 &d_indices,
                 num_queries,
                 d_layers_ptr.len(),
-                stream,
+                ctx.stream.as_raw(),
             )
             .map_err(MerkleTreeError::QueryDigestLayers)?;
         }
-        let out = d_out.to_host()?;
+        let out = d_out.to_host_on(ctx)?;
         // Chunk up the array using D::reconstruct_from_f
         let res = (0..num_trees)
             .map(|tree_idx| {
@@ -414,7 +417,7 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
     pub fn batch_query_merkle_proofs(
         trees: &[&Self],
         query_indices: &[usize],
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<
         Vec<
             // per tree
@@ -428,7 +431,7 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
     where
         D: MerkleProofQueryDigest,
     {
-        D::batch_query_merkle_proofs(trees, query_indices, stream)
+        D::batch_query_merkle_proofs(trees, query_indices, ctx)
     }
 }
 
@@ -436,9 +439,9 @@ impl MerkleProofQueryDigest for Digest {
     fn batch_query_merkle_proofs(
         trees: &[&MerkleTreeGpu<F, Self>],
         query_indices: &[usize],
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError> {
-        MerkleTreeGpu::<F, Self>::batch_query_proofs(trees, query_indices, stream)
+        MerkleTreeGpu::<F, Self>::batch_query_proofs(trees, query_indices, ctx)
     }
 }
 
@@ -447,9 +450,9 @@ impl MerkleProofQueryDigest for Bn254Digest {
     fn batch_query_merkle_proofs(
         trees: &[&MerkleTreeGpu<F, Self>],
         query_indices: &[usize],
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError> {
-        MerkleTreeGpu::<F, Self>::batch_query_proofs(trees, query_indices, stream)
+        MerkleTreeGpu::<F, Self>::batch_query_proofs(trees, query_indices, ctx)
     }
 }
 
@@ -461,13 +464,13 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<EF, D> {
         matrix: DeviceMatrix<EF>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<Self, MerkleTreeError> {
         let height = matrix.height();
         assert!(height.is_power_of_two());
         let k = validate_merkle_rows_per_query(rows_per_query, height)?;
         let query_stride = height / rows_per_query;
-        let mut query_digest_layer = DeviceBuffer::<D>::with_capacity(query_stride);
+        let mut query_digest_layer = DeviceBuffer::<D>::with_capacity_on(query_stride, ctx);
         // SAFETY: query_digest_layer properly allocated
         unsafe {
             MH::compress_rows_ext(
@@ -476,7 +479,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<EF, D> {
                 matrix.width(),
                 query_stride,
                 k,
-                stream,
+                ctx,
             )
             .map_err(MerkleTreeError::CompressingRowHashesExt)?;
         }
@@ -486,14 +489,14 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<EF, D> {
         let mut digest_layers = vec![query_digest_layer];
         while digest_layers.last().unwrap().len() > 1 {
             let prev_layer = digest_layers.last().unwrap();
-            let mut layer = DeviceBuffer::<D>::with_capacity(prev_layer.len() / 2);
+            let mut layer = DeviceBuffer::<D>::with_capacity_on(prev_layer.len() / 2, ctx);
             let layer_len = layer.len();
             let layer_idx = digest_layers.len();
             // SAFETY:
             // - `layer` is properly allocated with half the size of `prev_layer` and does not
             //   overlap with it.
             unsafe {
-                MH::compress_layer(&mut layer, prev_layer, layer_len, stream).map_err(|error| {
+                MH::compress_layer(&mut layer, prev_layer, layer_len, ctx).map_err(|error| {
                     MerkleTreeError::AdjacentCompressLayer {
                         error,
                         layer: layer_idx,
@@ -504,7 +507,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<EF, D> {
         }
         let d_root = digest_layers.last().unwrap();
         assert_eq!(d_root.len(), 1, "Only one root is supported");
-        let root = d_root.to_host()?.pop().unwrap();
+        let root = d_root.to_host_on(ctx)?.pop().unwrap();
 
         Ok(Self {
             backing_matrix,
@@ -525,13 +528,13 @@ impl MerkleTreeGpu<EF, Digest> {
         matrix: DeviceMatrix<EF>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<Self, MerkleTreeError> {
         Self::new_with_hash::<Poseidon2MerkleHash>(
             matrix,
             rows_per_query,
             cache_backing_matrix,
-            stream,
+            ctx,
         )
     }
 }

--- a/crates/cuda-backend/src/merkle_tree.rs
+++ b/crates/cuda-backend/src/merkle_tree.rs
@@ -5,7 +5,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
-    stream::cudaStreamPerThread,
+    stream::cudaStream_t,
 };
 use openvm_stark_backend::prover::MatrixDimensions;
 use p3_util::log2_strict_usize;
@@ -92,6 +92,7 @@ pub trait MerkleTreeConstructor: GpuMerkleHash {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
+        stream: cudaStream_t,
     ) -> Result<MerkleTreeGpu<F, Self::Digest>, MerkleTreeError>;
 }
 
@@ -99,6 +100,7 @@ pub trait MerkleProofQueryDigest: BatchQueryMerkle + Copy + Send + Sync + 'stati
     fn batch_query_merkle_proofs(
         trees: &[&MerkleTreeGpu<F, Self>],
         query_indices: &[usize],
+        stream: cudaStream_t,
     ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError>;
 }
 
@@ -130,14 +132,16 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
+        stream: cudaStream_t,
     ) -> Result<Self, MerkleTreeError> {
-        MH::new_merkle_tree(matrix, rows_per_query, cache_backing_matrix)
+        MH::new_merkle_tree(matrix, rows_per_query, cache_backing_matrix, stream)
     }
 
     fn new_generic_with_hash<MH: GpuMerkleHash<Digest = D>>(
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
+        stream: cudaStream_t,
     ) -> Result<Self, MerkleTreeError> {
         let mem = MemTracker::start("prover.merkle_tree");
         let height = matrix.height();
@@ -153,6 +157,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                 matrix.width(),
                 query_stride,
                 k,
+                stream,
             )
             .map_err(MerkleTreeError::CompressingRowHashes)?;
         }
@@ -169,7 +174,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
             // - `layer` is properly allocated with half the size of `prev_layer` and does not
             //   overlap with it.
             unsafe {
-                MH::compress_layer(&mut layer, prev_layer, layer_len).map_err(|error| {
+                MH::compress_layer(&mut layer, prev_layer, layer_len, stream).map_err(|error| {
                     MerkleTreeError::AdjacentCompressLayer {
                         error,
                         layer: layer_idx,
@@ -197,6 +202,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
         query_indices: &[usize],
         query_stride: usize,
         rows_per_query: usize,
+        stream: cudaStream_t,
     ) -> Result<
         Vec<
             // per tree
@@ -238,7 +244,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                         matrix.width() as u64,
                         matrix.height() as u64,
                         d_row_idxs.len(),
-                        cudaStreamPerThread,
+                        stream,
                     )
                     .map_err(|error| MerkleTreeError::MatrixGetRows { error, matrix_idx })?;
                 }
@@ -259,11 +265,13 @@ impl MerkleTreeConstructor for Poseidon2MerkleHash {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
+        stream: cudaStream_t,
     ) -> Result<MerkleTreeGpu<F, Self::Digest>, MerkleTreeError> {
         MerkleTreeGpu::<F, Self::Digest>::new_generic_with_hash::<Self>(
             matrix,
             rows_per_query,
             cache_backing_matrix,
+            stream,
         )
     }
 }
@@ -274,11 +282,13 @@ impl MerkleTreeConstructor for crate::hash_scheme::Bn254Poseidon2MerkleHash {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
+        stream: cudaStream_t,
     ) -> Result<MerkleTreeGpu<F, Self::Digest>, MerkleTreeError> {
         MerkleTreeGpu::<F, Self::Digest>::new_generic_with_hash::<Self>(
             matrix,
             rows_per_query,
             cache_backing_matrix,
+            stream,
         )
     }
 }
@@ -292,8 +302,14 @@ impl MerkleTreeGpu<F, Digest> {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
+        stream: cudaStream_t,
     ) -> Result<Self, MerkleTreeError> {
-        Self::new_with_hash::<Poseidon2MerkleHash>(matrix, rows_per_query, cache_backing_matrix)
+        Self::new_with_hash::<Poseidon2MerkleHash>(
+            matrix,
+            rows_per_query,
+            cache_backing_matrix,
+            stream,
+        )
     }
 }
 
@@ -302,6 +318,7 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
     fn batch_query_proofs(
         trees: &[&Self],
         query_indices: &[usize],
+        stream: cudaStream_t,
     ) -> Result<Vec<Vec<Vec<D>>>, MerkleTreeError> {
         if trees.is_empty() {
             return Ok(Vec::new());
@@ -365,7 +382,7 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                 &d_indices,
                 num_queries,
                 d_layers_ptr.len(),
-                cudaStreamPerThread,
+                stream,
             )
             .map_err(MerkleTreeError::QueryDigestLayers)?;
         }
@@ -397,6 +414,7 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
     pub fn batch_query_merkle_proofs(
         trees: &[&Self],
         query_indices: &[usize],
+        stream: cudaStream_t,
     ) -> Result<
         Vec<
             // per tree
@@ -410,7 +428,7 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
     where
         D: MerkleProofQueryDigest,
     {
-        D::batch_query_merkle_proofs(trees, query_indices)
+        D::batch_query_merkle_proofs(trees, query_indices, stream)
     }
 }
 
@@ -418,8 +436,9 @@ impl MerkleProofQueryDigest for Digest {
     fn batch_query_merkle_proofs(
         trees: &[&MerkleTreeGpu<F, Self>],
         query_indices: &[usize],
+        stream: cudaStream_t,
     ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError> {
-        MerkleTreeGpu::<F, Self>::batch_query_proofs(trees, query_indices)
+        MerkleTreeGpu::<F, Self>::batch_query_proofs(trees, query_indices, stream)
     }
 }
 
@@ -428,8 +447,9 @@ impl MerkleProofQueryDigest for Bn254Digest {
     fn batch_query_merkle_proofs(
         trees: &[&MerkleTreeGpu<F, Self>],
         query_indices: &[usize],
+        stream: cudaStream_t,
     ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError> {
-        MerkleTreeGpu::<F, Self>::batch_query_proofs(trees, query_indices)
+        MerkleTreeGpu::<F, Self>::batch_query_proofs(trees, query_indices, stream)
     }
 }
 
@@ -441,6 +461,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<EF, D> {
         matrix: DeviceMatrix<EF>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
+        stream: cudaStream_t,
     ) -> Result<Self, MerkleTreeError> {
         let height = matrix.height();
         assert!(height.is_power_of_two());
@@ -455,6 +476,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<EF, D> {
                 matrix.width(),
                 query_stride,
                 k,
+                stream,
             )
             .map_err(MerkleTreeError::CompressingRowHashesExt)?;
         }
@@ -471,7 +493,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<EF, D> {
             // - `layer` is properly allocated with half the size of `prev_layer` and does not
             //   overlap with it.
             unsafe {
-                MH::compress_layer(&mut layer, prev_layer, layer_len).map_err(|error| {
+                MH::compress_layer(&mut layer, prev_layer, layer_len, stream).map_err(|error| {
                     MerkleTreeError::AdjacentCompressLayer {
                         error,
                         layer: layer_idx,
@@ -503,7 +525,13 @@ impl MerkleTreeGpu<EF, Digest> {
         matrix: DeviceMatrix<EF>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
+        stream: cudaStream_t,
     ) -> Result<Self, MerkleTreeError> {
-        Self::new_with_hash::<Poseidon2MerkleHash>(matrix, rows_per_query, cache_backing_matrix)
+        Self::new_with_hash::<Poseidon2MerkleHash>(
+            matrix,
+            rows_per_query,
+            cache_backing_matrix,
+            stream,
+        )
     }
 }

--- a/crates/cuda-backend/src/merkle_tree.rs
+++ b/crates/cuda-backend/src/merkle_tree.rs
@@ -5,6 +5,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
+    stream::cudaStreamPerThread,
 };
 use openvm_stark_backend::prover::MatrixDimensions;
 use p3_util::log2_strict_usize;
@@ -237,6 +238,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                         matrix.width() as u64,
                         matrix.height() as u64,
                         d_row_idxs.len(),
+                        cudaStreamPerThread,
                     )
                     .map_err(|error| MerkleTreeError::MatrixGetRows { error, matrix_idx })?;
                 }
@@ -363,6 +365,7 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                 &d_indices,
                 num_queries,
                 d_layers_ptr.len(),
+                cudaStreamPerThread,
             )
             .map_err(MerkleTreeError::QueryDigestLayers)?;
         }

--- a/crates/cuda-backend/src/merkle_tree.rs
+++ b/crates/cuda-backend/src/merkle_tree.rs
@@ -92,7 +92,7 @@ pub trait MerkleTreeConstructor: GpuMerkleHash {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<MerkleTreeGpu<F, Self::Digest>, MerkleTreeError>;
 }
 
@@ -100,7 +100,7 @@ pub trait MerkleProofQueryDigest: BatchQueryMerkle + Copy + Send + Sync + 'stati
     fn batch_query_merkle_proofs(
         trees: &[&MerkleTreeGpu<F, Self>],
         query_indices: &[usize],
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError>;
 }
 
@@ -132,23 +132,23 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Self, MerkleTreeError> {
-        MH::new_merkle_tree(matrix, rows_per_query, cache_backing_matrix, ctx)
+        MH::new_merkle_tree(matrix, rows_per_query, cache_backing_matrix, device_ctx)
     }
 
     fn new_generic_with_hash<MH: GpuMerkleHash<Digest = D>>(
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Self, MerkleTreeError> {
         let mem = MemTracker::start("prover.merkle_tree");
         let height = matrix.height();
         assert!(height.is_power_of_two());
         let k = validate_merkle_rows_per_query(rows_per_query, height)?;
         let query_stride = height / rows_per_query;
-        let mut query_digest_layer = DeviceBuffer::<D>::with_capacity_on(query_stride, ctx);
+        let mut query_digest_layer = DeviceBuffer::<D>::with_capacity_on(query_stride, device_ctx);
         // SAFETY: query_digest_layer properly allocated
         unsafe {
             MH::compress_rows(
@@ -157,7 +157,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                 matrix.width(),
                 query_stride,
                 k,
-                ctx,
+                device_ctx,
             )
             .map_err(MerkleTreeError::CompressingRowHashes)?;
         }
@@ -167,25 +167,25 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
         let mut digest_layers = vec![query_digest_layer];
         while digest_layers.last().unwrap().len() > 1 {
             let prev_layer = digest_layers.last().unwrap();
-            let mut layer = DeviceBuffer::<D>::with_capacity_on(prev_layer.len() / 2, ctx);
+            let mut layer = DeviceBuffer::<D>::with_capacity_on(prev_layer.len() / 2, device_ctx);
             let layer_len = layer.len();
             let layer_idx = digest_layers.len();
             // SAFETY:
             // - `layer` is properly allocated with half the size of `prev_layer` and does not
             //   overlap with it.
             unsafe {
-                MH::compress_layer(&mut layer, prev_layer, layer_len, ctx).map_err(|error| {
-                    MerkleTreeError::AdjacentCompressLayer {
+                MH::compress_layer(&mut layer, prev_layer, layer_len, device_ctx).map_err(
+                    |error| MerkleTreeError::AdjacentCompressLayer {
                         error,
                         layer: layer_idx,
-                    }
-                })?;
+                    },
+                )?;
             }
             digest_layers.push(layer);
         }
         let d_root = digest_layers.last().unwrap();
         assert_eq!(d_root.len(), 1, "Only one root is supported");
-        let root = d_root.to_host_on(ctx)?.pop().unwrap();
+        let root = d_root.to_host_on(device_ctx)?.pop().unwrap();
 
         mem.emit_metrics();
         Ok(Self {
@@ -202,7 +202,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
         query_indices: &[usize],
         query_stride: usize,
         rows_per_query: usize,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<
         Vec<
             // per tree
@@ -224,7 +224,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                     .map(move |row_offset| (row_offset * query_stride + query_idx) as u32)
             })
             .collect_vec();
-        let d_row_idxs = row_idxs.to_device_on(ctx)?;
+        let d_row_idxs = row_idxs.to_device_on(device_ctx)?;
         // PERF[jpw]: I did not batch across trees into a single kernel call because widths are
         // different so it was inconvenient. Make a new kernel if slow.
         // NOTE: par_iter requires cross-stream waits, not worth the effort
@@ -232,8 +232,10 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
             .iter()
             .enumerate()
             .map(|(matrix_idx, matrix)| {
-                let d_out =
-                    DeviceBuffer::<F>::with_capacity_on(row_idxs.len() * matrix.width(), ctx);
+                let d_out = DeviceBuffer::<F>::with_capacity_on(
+                    row_idxs.len() * matrix.width(),
+                    device_ctx,
+                );
                 // SAFETY:
                 // - `output_rows` is allocated with row_idxs.len() * width
                 // - row indices are within bounds
@@ -245,12 +247,13 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                         matrix.width() as u64,
                         matrix.height() as u64,
                         d_row_idxs.len(),
-                        ctx.stream.as_raw(),
+                        device_ctx.stream.as_raw(),
                     )
                     .map_err(|error| MerkleTreeError::MatrixGetRows { error, matrix_idx })?;
                 }
                 let width = matrix.width();
-                let out = info_span!("opened_rows_d2h").in_scope(|| d_out.to_host_on(ctx))?;
+                let out =
+                    info_span!("opened_rows_d2h").in_scope(|| d_out.to_host_on(device_ctx))?;
                 let opened_rows_per_query = out
                     .chunks_exact(rows_per_query * width)
                     .map(|rows| rows.to_vec())
@@ -266,13 +269,13 @@ impl MerkleTreeConstructor for Poseidon2MerkleHash {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<MerkleTreeGpu<F, Self::Digest>, MerkleTreeError> {
         MerkleTreeGpu::<F, Self::Digest>::new_generic_with_hash::<Self>(
             matrix,
             rows_per_query,
             cache_backing_matrix,
-            ctx,
+            device_ctx,
         )
     }
 }
@@ -283,13 +286,13 @@ impl MerkleTreeConstructor for crate::hash_scheme::Bn254Poseidon2MerkleHash {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<MerkleTreeGpu<F, Self::Digest>, MerkleTreeError> {
         MerkleTreeGpu::<F, Self::Digest>::new_generic_with_hash::<Self>(
             matrix,
             rows_per_query,
             cache_backing_matrix,
-            ctx,
+            device_ctx,
         )
     }
 }
@@ -303,13 +306,13 @@ impl MerkleTreeGpu<F, Digest> {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Self, MerkleTreeError> {
         Self::new_with_hash::<Poseidon2MerkleHash>(
             matrix,
             rows_per_query,
             cache_backing_matrix,
-            ctx,
+            device_ctx,
         )
     }
 }
@@ -319,7 +322,7 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
     fn batch_query_proofs(
         trees: &[&Self],
         query_indices: &[usize],
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Vec<Vec<Vec<D>>>, MerkleTreeError> {
         if trees.is_empty() {
             return Ok(Vec::new());
@@ -349,7 +352,7 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                     .map(|layer| layer.as_ptr() as u64)
             })
             .collect_vec();
-        let d_layers_ptr = layers_ptr.to_device_on(ctx)?;
+        let d_layers_ptr = layers_ptr.to_device_on(device_ctx)?;
         debug_assert_eq!(d_layers_ptr.len(), num_trees * depth);
 
         // [query_idx] is the top level grouping
@@ -364,12 +367,12 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                 })
             })
             .collect_vec();
-        let d_indices = indices.to_device_on(ctx)?;
+        let d_indices = indices.to_device_on(device_ctx)?;
         debug_assert_eq!(d_indices.len(), d_layers_ptr.len() * num_queries);
 
         let mut d_out = DeviceBuffer::<F>::with_capacity_on(
             d_layers_ptr.len() * num_queries * DIGEST_SIZE,
-            ctx,
+            device_ctx,
         );
         // SAFETY:
         // - d_out has size num_trees * depth * num_queries * DIGEST_SIZE in `F` elements
@@ -385,11 +388,11 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
                 &d_indices,
                 num_queries,
                 d_layers_ptr.len(),
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
             .map_err(MerkleTreeError::QueryDigestLayers)?;
         }
-        let out = d_out.to_host_on(ctx)?;
+        let out = d_out.to_host_on(device_ctx)?;
         // Chunk up the array using D::reconstruct_from_f
         let res = (0..num_trees)
             .map(|tree_idx| {
@@ -417,7 +420,7 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
     pub fn batch_query_merkle_proofs(
         trees: &[&Self],
         query_indices: &[usize],
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<
         Vec<
             // per tree
@@ -431,7 +434,7 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
     where
         D: MerkleProofQueryDigest,
     {
-        D::batch_query_merkle_proofs(trees, query_indices, ctx)
+        D::batch_query_merkle_proofs(trees, query_indices, device_ctx)
     }
 }
 
@@ -439,9 +442,9 @@ impl MerkleProofQueryDigest for Digest {
     fn batch_query_merkle_proofs(
         trees: &[&MerkleTreeGpu<F, Self>],
         query_indices: &[usize],
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError> {
-        MerkleTreeGpu::<F, Self>::batch_query_proofs(trees, query_indices, ctx)
+        MerkleTreeGpu::<F, Self>::batch_query_proofs(trees, query_indices, device_ctx)
     }
 }
 
@@ -450,9 +453,9 @@ impl MerkleProofQueryDigest for Bn254Digest {
     fn batch_query_merkle_proofs(
         trees: &[&MerkleTreeGpu<F, Self>],
         query_indices: &[usize],
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError> {
-        MerkleTreeGpu::<F, Self>::batch_query_proofs(trees, query_indices, ctx)
+        MerkleTreeGpu::<F, Self>::batch_query_proofs(trees, query_indices, device_ctx)
     }
 }
 
@@ -464,13 +467,13 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<EF, D> {
         matrix: DeviceMatrix<EF>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Self, MerkleTreeError> {
         let height = matrix.height();
         assert!(height.is_power_of_two());
         let k = validate_merkle_rows_per_query(rows_per_query, height)?;
         let query_stride = height / rows_per_query;
-        let mut query_digest_layer = DeviceBuffer::<D>::with_capacity_on(query_stride, ctx);
+        let mut query_digest_layer = DeviceBuffer::<D>::with_capacity_on(query_stride, device_ctx);
         // SAFETY: query_digest_layer properly allocated
         unsafe {
             MH::compress_rows_ext(
@@ -479,7 +482,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<EF, D> {
                 matrix.width(),
                 query_stride,
                 k,
-                ctx,
+                device_ctx,
             )
             .map_err(MerkleTreeError::CompressingRowHashesExt)?;
         }
@@ -489,25 +492,25 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<EF, D> {
         let mut digest_layers = vec![query_digest_layer];
         while digest_layers.last().unwrap().len() > 1 {
             let prev_layer = digest_layers.last().unwrap();
-            let mut layer = DeviceBuffer::<D>::with_capacity_on(prev_layer.len() / 2, ctx);
+            let mut layer = DeviceBuffer::<D>::with_capacity_on(prev_layer.len() / 2, device_ctx);
             let layer_len = layer.len();
             let layer_idx = digest_layers.len();
             // SAFETY:
             // - `layer` is properly allocated with half the size of `prev_layer` and does not
             //   overlap with it.
             unsafe {
-                MH::compress_layer(&mut layer, prev_layer, layer_len, ctx).map_err(|error| {
-                    MerkleTreeError::AdjacentCompressLayer {
+                MH::compress_layer(&mut layer, prev_layer, layer_len, device_ctx).map_err(
+                    |error| MerkleTreeError::AdjacentCompressLayer {
                         error,
                         layer: layer_idx,
-                    }
-                })?;
+                    },
+                )?;
             }
             digest_layers.push(layer);
         }
         let d_root = digest_layers.last().unwrap();
         assert_eq!(d_root.len(), 1, "Only one root is supported");
-        let root = d_root.to_host_on(ctx)?.pop().unwrap();
+        let root = d_root.to_host_on(device_ctx)?.pop().unwrap();
 
         Ok(Self {
             backing_matrix,
@@ -528,13 +531,13 @@ impl MerkleTreeGpu<EF, Digest> {
         matrix: DeviceMatrix<EF>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Self, MerkleTreeError> {
         Self::new_with_hash::<Poseidon2MerkleHash>(
             matrix,
             rows_per_query,
             cache_backing_matrix,
-            ctx,
+            device_ctx,
         )
     }
 }

--- a/crates/cuda-backend/src/merkle_tree.rs
+++ b/crates/cuda-backend/src/merkle_tree.rs
@@ -5,7 +5,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
-    stream::DeviceContext,
+    stream::GpuDeviceCtx,
 };
 use openvm_stark_backend::prover::MatrixDimensions;
 use p3_util::log2_strict_usize;
@@ -92,7 +92,7 @@ pub trait MerkleTreeConstructor: GpuMerkleHash {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<MerkleTreeGpu<F, Self::Digest>, MerkleTreeError>;
 }
 
@@ -100,7 +100,7 @@ pub trait MerkleProofQueryDigest: BatchQueryMerkle + Copy + Send + Sync + 'stati
     fn batch_query_merkle_proofs(
         trees: &[&MerkleTreeGpu<F, Self>],
         query_indices: &[usize],
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError>;
 }
 
@@ -132,7 +132,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, MerkleTreeError> {
         MH::new_merkle_tree(matrix, rows_per_query, cache_backing_matrix, device_ctx)
     }
@@ -141,7 +141,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, MerkleTreeError> {
         let mem = MemTracker::start("prover.merkle_tree");
         let height = matrix.height();
@@ -202,7 +202,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<F, D> {
         query_indices: &[usize],
         query_stride: usize,
         rows_per_query: usize,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<
         Vec<
             // per tree
@@ -269,7 +269,7 @@ impl MerkleTreeConstructor for Poseidon2MerkleHash {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<MerkleTreeGpu<F, Self::Digest>, MerkleTreeError> {
         MerkleTreeGpu::<F, Self::Digest>::new_generic_with_hash::<Self>(
             matrix,
@@ -286,7 +286,7 @@ impl MerkleTreeConstructor for crate::hash_scheme::Bn254Poseidon2MerkleHash {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<MerkleTreeGpu<F, Self::Digest>, MerkleTreeError> {
         MerkleTreeGpu::<F, Self::Digest>::new_generic_with_hash::<Self>(
             matrix,
@@ -306,7 +306,7 @@ impl MerkleTreeGpu<F, Digest> {
         matrix: DeviceMatrix<F>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, MerkleTreeError> {
         Self::new_with_hash::<Poseidon2MerkleHash>(
             matrix,
@@ -322,7 +322,7 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
     fn batch_query_proofs(
         trees: &[&Self],
         query_indices: &[usize],
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Vec<Vec<Vec<D>>>, MerkleTreeError> {
         if trees.is_empty() {
             return Ok(Vec::new());
@@ -420,7 +420,7 @@ impl<D: BatchQueryMerkle + Send + Sync + 'static> MerkleTreeGpu<F, D> {
     pub fn batch_query_merkle_proofs(
         trees: &[&Self],
         query_indices: &[usize],
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<
         Vec<
             // per tree
@@ -442,7 +442,7 @@ impl MerkleProofQueryDigest for Digest {
     fn batch_query_merkle_proofs(
         trees: &[&MerkleTreeGpu<F, Self>],
         query_indices: &[usize],
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError> {
         MerkleTreeGpu::<F, Self>::batch_query_proofs(trees, query_indices, device_ctx)
     }
@@ -453,7 +453,7 @@ impl MerkleProofQueryDigest for Bn254Digest {
     fn batch_query_merkle_proofs(
         trees: &[&MerkleTreeGpu<F, Self>],
         query_indices: &[usize],
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Vec<Vec<Vec<Self>>>, MerkleTreeError> {
         MerkleTreeGpu::<F, Self>::batch_query_proofs(trees, query_indices, device_ctx)
     }
@@ -467,7 +467,7 @@ impl<D: Copy + Send + Sync + 'static> MerkleTreeGpu<EF, D> {
         matrix: DeviceMatrix<EF>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, MerkleTreeError> {
         let height = matrix.height();
         assert!(height.is_power_of_two());
@@ -531,7 +531,7 @@ impl MerkleTreeGpu<EF, Digest> {
         matrix: DeviceMatrix<EF>,
         rows_per_query: usize,
         cache_backing_matrix: bool,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, MerkleTreeError> {
         Self::new_with_hash::<Poseidon2MerkleHash>(
             matrix,

--- a/crates/cuda-backend/src/ntt.rs
+++ b/crates/cuda-backend/src/ntt.rs
@@ -6,7 +6,7 @@ use std::{
 use openvm_cuda_common::{
     common::{device_reset_epoch, get_device},
     d_buffer::DeviceBuffer,
-    stream::DeviceContext,
+    stream::GpuDeviceCtx,
 };
 
 use crate::{cuda::ntt, prelude::F};
@@ -34,7 +34,7 @@ fn ensure_initialized(inverse: bool) -> Result<(), openvm_cuda_common::error::Cu
     }
 
     {
-        let device_ctx = DeviceContext::for_device(device_key.0 as u32)?;
+        let device_ctx = GpuDeviceCtx::for_device(device_key.0 as u32)?;
         let partial_twiddles =
             DeviceBuffer::<[F; WINDOW_SIZE]>::with_capacity_on(WINDOW_NUM, &device_ctx);
         let twiddles = DeviceBuffer::<F>::with_capacity_on(RADIX_TWIDDLES_SIZE, &device_ctx);
@@ -56,7 +56,7 @@ struct NttImpl<'a> {
     poly_count: u32,
     is_intt: bool,
     stage: u32,
-    device_ctx: DeviceContext,
+    device_ctx: GpuDeviceCtx,
 }
 
 impl<'a> NttImpl<'a> {
@@ -66,7 +66,7 @@ impl<'a> NttImpl<'a> {
         padded_poly_size: u32,
         poly_count: u32,
         is_intt: bool,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Self {
         ensure_initialized(is_intt).expect("failed to initialize CUDA NTT twiddle tables");
         Self {
@@ -115,7 +115,7 @@ pub fn batch_ntt(
     width: u32,
     bit_reverse: bool,
     is_intt: bool,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) {
     if log_trace_height == 0 {
         return;

--- a/crates/cuda-backend/src/ntt.rs
+++ b/crates/cuda-backend/src/ntt.rs
@@ -6,7 +6,7 @@ use std::{
 use openvm_cuda_common::{
     common::{device_reset_epoch, get_device},
     d_buffer::DeviceBuffer,
-    stream::cudaStreamPerThread,
+    stream::{cudaStreamPerThread, cudaStream_t},
 };
 
 use crate::{cuda::ntt, prelude::F};
@@ -54,6 +54,7 @@ struct NttImpl<'a> {
     poly_count: u32,
     is_intt: bool,
     stage: u32,
+    stream: cudaStream_t,
 }
 
 impl<'a> NttImpl<'a> {
@@ -63,6 +64,7 @@ impl<'a> NttImpl<'a> {
         padded_poly_size: u32,
         poly_count: u32,
         is_intt: bool,
+        stream: cudaStream_t,
     ) -> Self {
         ensure_initialized(is_intt).expect("failed to initialize CUDA NTT twiddle tables");
         Self {
@@ -72,6 +74,7 @@ impl<'a> NttImpl<'a> {
             poly_count,
             is_intt,
             stage: 0,
+            stream,
         }
     }
 
@@ -88,7 +91,7 @@ impl<'a> NttImpl<'a> {
                 self.padded_poly_size,
                 self.poly_count,
                 self.is_intt,
-                cudaStreamPerThread,
+                self.stream,
             )
             .expect("failed to launch CUDA mixed-radix NTT step");
         }
@@ -110,6 +113,7 @@ pub fn batch_ntt(
     width: u32,
     bit_reverse: bool,
     is_intt: bool,
+    stream: cudaStream_t,
 ) {
     if log_trace_height == 0 {
         return;
@@ -130,13 +134,20 @@ pub fn batch_ntt(
                 log_trace_height,
                 padded_poly_size,
                 width,
-                cudaStreamPerThread,
+                stream,
             )
             .expect("failed to launch CUDA bit-reversal permutation");
         }
     }
 
-    let mut _impl = NttImpl::new(buffer, log_trace_height, padded_poly_size, width, is_intt);
+    let mut _impl = NttImpl::new(
+        buffer,
+        log_trace_height,
+        padded_poly_size,
+        width,
+        is_intt,
+        stream,
+    );
     if log_trace_height <= 10 {
         _impl.step(log_trace_height);
     } else if log_trace_height <= 17 {

--- a/crates/cuda-backend/src/ntt.rs
+++ b/crates/cuda-backend/src/ntt.rs
@@ -6,7 +6,7 @@ use std::{
 use openvm_cuda_common::{
     common::{device_reset_epoch, get_device},
     d_buffer::DeviceBuffer,
-    stream::{cudaStreamPerThread, cudaStream_t},
+    stream::{CudaStream, DeviceContext, StreamGuard},
 };
 
 use crate::{cuda::ntt, prelude::F};
@@ -34,13 +34,17 @@ fn ensure_initialized(inverse: bool) -> Result<(), openvm_cuda_common::error::Cu
     }
 
     {
-        let partial_twiddles = DeviceBuffer::<[F; WINDOW_SIZE]>::with_capacity(WINDOW_NUM);
-        let twiddles = DeviceBuffer::<F>::with_capacity(RADIX_TWIDDLES_SIZE);
+        let ctx = DeviceContext {
+            device_id: get_device()? as u32,
+            stream: StreamGuard::new(CudaStream::new_non_blocking()?),
+        };
+        let partial_twiddles = DeviceBuffer::<[F; WINDOW_SIZE]>::with_capacity_on(WINDOW_NUM, &ctx);
+        let twiddles = DeviceBuffer::<F>::with_capacity_on(RADIX_TWIDDLES_SIZE, &ctx);
         unsafe {
             // Both CUDA helpers upload into constant memory and synchronize before returning, so
             // these staging buffers are safe to free once the calls complete.
-            ntt::generate_all_twiddles(&twiddles, inverse, cudaStreamPerThread)?;
-            ntt::generate_partial_twiddles(&partial_twiddles, inverse, cudaStreamPerThread)?;
+            ntt::generate_all_twiddles(&twiddles, inverse, ctx.stream.as_raw())?;
+            ntt::generate_partial_twiddles(&partial_twiddles, inverse, ctx.stream.as_raw())?;
         }
     }
     initialized.insert(device_key);
@@ -54,7 +58,7 @@ struct NttImpl<'a> {
     poly_count: u32,
     is_intt: bool,
     stage: u32,
-    stream: cudaStream_t,
+    ctx: DeviceContext,
 }
 
 impl<'a> NttImpl<'a> {
@@ -64,7 +68,7 @@ impl<'a> NttImpl<'a> {
         padded_poly_size: u32,
         poly_count: u32,
         is_intt: bool,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Self {
         ensure_initialized(is_intt).expect("failed to initialize CUDA NTT twiddle tables");
         Self {
@@ -74,7 +78,7 @@ impl<'a> NttImpl<'a> {
             poly_count,
             is_intt,
             stage: 0,
-            stream,
+            ctx: ctx.clone(),
         }
     }
 
@@ -91,7 +95,7 @@ impl<'a> NttImpl<'a> {
                 self.padded_poly_size,
                 self.poly_count,
                 self.is_intt,
-                self.stream,
+                self.ctx.stream.as_raw(),
             )
             .expect("failed to launch CUDA mixed-radix NTT step");
         }
@@ -113,7 +117,7 @@ pub fn batch_ntt(
     width: u32,
     bit_reverse: bool,
     is_intt: bool,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) {
     if log_trace_height == 0 {
         return;
@@ -134,7 +138,7 @@ pub fn batch_ntt(
                 log_trace_height,
                 padded_poly_size,
                 width,
-                stream,
+                ctx.stream.as_raw(),
             )
             .expect("failed to launch CUDA bit-reversal permutation");
         }
@@ -146,7 +150,7 @@ pub fn batch_ntt(
         padded_poly_size,
         width,
         is_intt,
-        stream,
+        ctx,
     );
     if log_trace_height <= 10 {
         _impl.step(log_trace_height);

--- a/crates/cuda-backend/src/ntt.rs
+++ b/crates/cuda-backend/src/ntt.rs
@@ -6,7 +6,7 @@ use std::{
 use openvm_cuda_common::{
     common::{device_reset_epoch, get_device},
     d_buffer::DeviceBuffer,
-    stream::{CudaStream, DeviceContext, StreamGuard},
+    stream::DeviceContext,
 };
 
 use crate::{cuda::ntt, prelude::F};
@@ -34,10 +34,7 @@ fn ensure_initialized(inverse: bool) -> Result<(), openvm_cuda_common::error::Cu
     }
 
     {
-        let ctx = DeviceContext {
-            device_id: get_device()? as u32,
-            stream: StreamGuard::new(CudaStream::new_non_blocking()?),
-        };
+        let ctx = DeviceContext::for_device(device_key.0 as u32)?;
         let partial_twiddles = DeviceBuffer::<[F; WINDOW_SIZE]>::with_capacity_on(WINDOW_NUM, &ctx);
         let twiddles = DeviceBuffer::<F>::with_capacity_on(RADIX_TWIDDLES_SIZE, &ctx);
         unsafe {

--- a/crates/cuda-backend/src/ntt.rs
+++ b/crates/cuda-backend/src/ntt.rs
@@ -34,14 +34,15 @@ fn ensure_initialized(inverse: bool) -> Result<(), openvm_cuda_common::error::Cu
     }
 
     {
-        let ctx = DeviceContext::for_device(device_key.0 as u32)?;
-        let partial_twiddles = DeviceBuffer::<[F; WINDOW_SIZE]>::with_capacity_on(WINDOW_NUM, &ctx);
-        let twiddles = DeviceBuffer::<F>::with_capacity_on(RADIX_TWIDDLES_SIZE, &ctx);
+        let device_ctx = DeviceContext::for_device(device_key.0 as u32)?;
+        let partial_twiddles =
+            DeviceBuffer::<[F; WINDOW_SIZE]>::with_capacity_on(WINDOW_NUM, &device_ctx);
+        let twiddles = DeviceBuffer::<F>::with_capacity_on(RADIX_TWIDDLES_SIZE, &device_ctx);
         unsafe {
             // Both CUDA helpers upload into constant memory and synchronize before returning, so
             // these staging buffers are safe to free once the calls complete.
-            ntt::generate_all_twiddles(&twiddles, inverse, ctx.stream.as_raw())?;
-            ntt::generate_partial_twiddles(&partial_twiddles, inverse, ctx.stream.as_raw())?;
+            ntt::generate_all_twiddles(&twiddles, inverse, device_ctx.stream.as_raw())?;
+            ntt::generate_partial_twiddles(&partial_twiddles, inverse, device_ctx.stream.as_raw())?;
         }
     }
     initialized.insert(device_key);
@@ -55,7 +56,7 @@ struct NttImpl<'a> {
     poly_count: u32,
     is_intt: bool,
     stage: u32,
-    ctx: DeviceContext,
+    device_ctx: DeviceContext,
 }
 
 impl<'a> NttImpl<'a> {
@@ -65,7 +66,7 @@ impl<'a> NttImpl<'a> {
         padded_poly_size: u32,
         poly_count: u32,
         is_intt: bool,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Self {
         ensure_initialized(is_intt).expect("failed to initialize CUDA NTT twiddle tables");
         Self {
@@ -75,7 +76,7 @@ impl<'a> NttImpl<'a> {
             poly_count,
             is_intt,
             stage: 0,
-            ctx: ctx.clone(),
+            device_ctx: device_ctx.clone(),
         }
     }
 
@@ -92,7 +93,7 @@ impl<'a> NttImpl<'a> {
                 self.padded_poly_size,
                 self.poly_count,
                 self.is_intt,
-                self.ctx.stream.as_raw(),
+                self.device_ctx.stream.as_raw(),
             )
             .expect("failed to launch CUDA mixed-radix NTT step");
         }
@@ -114,7 +115,7 @@ pub fn batch_ntt(
     width: u32,
     bit_reverse: bool,
     is_intt: bool,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) {
     if log_trace_height == 0 {
         return;
@@ -135,7 +136,7 @@ pub fn batch_ntt(
                 log_trace_height,
                 padded_poly_size,
                 width,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
             .expect("failed to launch CUDA bit-reversal permutation");
         }
@@ -147,7 +148,7 @@ pub fn batch_ntt(
         padded_poly_size,
         width,
         is_intt,
-        ctx,
+        device_ctx,
     );
     if log_trace_height <= 10 {
         _impl.step(log_trace_height);

--- a/crates/cuda-backend/src/ntt.rs
+++ b/crates/cuda-backend/src/ntt.rs
@@ -6,6 +6,7 @@ use std::{
 use openvm_cuda_common::{
     common::{device_reset_epoch, get_device},
     d_buffer::DeviceBuffer,
+    stream::cudaStreamPerThread,
 };
 
 use crate::{cuda::ntt, prelude::F};
@@ -38,8 +39,8 @@ fn ensure_initialized(inverse: bool) -> Result<(), openvm_cuda_common::error::Cu
         unsafe {
             // Both CUDA helpers upload into constant memory and synchronize before returning, so
             // these staging buffers are safe to free once the calls complete.
-            ntt::generate_all_twiddles(&twiddles, inverse)?;
-            ntt::generate_partial_twiddles(&partial_twiddles, inverse)?;
+            ntt::generate_all_twiddles(&twiddles, inverse, cudaStreamPerThread)?;
+            ntt::generate_partial_twiddles(&partial_twiddles, inverse, cudaStreamPerThread)?;
         }
     }
     initialized.insert(device_key);
@@ -87,6 +88,7 @@ impl<'a> NttImpl<'a> {
                 self.padded_poly_size,
                 self.poly_count,
                 self.is_intt,
+                cudaStreamPerThread,
             )
             .expect("failed to launch CUDA mixed-radix NTT step");
         }
@@ -122,8 +124,15 @@ pub fn batch_ntt(
 
     if bit_reverse {
         unsafe {
-            ntt::bit_rev(buffer, buffer, log_trace_height, padded_poly_size, width)
-                .expect("failed to launch CUDA bit-reversal permutation");
+            ntt::bit_rev(
+                buffer,
+                buffer,
+                log_trace_height,
+                padded_poly_size,
+                width,
+                cudaStreamPerThread,
+            )
+            .expect("failed to launch CUDA bit-reversal permutation");
         }
     }
 

--- a/crates/cuda-backend/src/pkey.rs
+++ b/crates/cuda-backend/src/pkey.rs
@@ -76,35 +76,38 @@ pub struct InteractionMonomials {
     pub num_interactions: u32,
 }
 
-fn to_device_or_empty<T>(data: &[T], ctx: &DeviceContext) -> Result<DeviceBuffer<T>, MemCopyError> {
+fn to_device_or_empty<T>(
+    data: &[T],
+    device_ctx: &DeviceContext,
+) -> Result<DeviceBuffer<T>, MemCopyError> {
     if data.is_empty() {
         Ok(DeviceBuffer::new())
     } else {
-        data.to_device_on(ctx)
+        data.to_device_on(device_ctx)
     }
 }
 
 impl AirDataGpu {
     pub fn new<S: StarkProtocolConfig<F = F>>(
         pk: &StarkProvingKey<S>,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Self, MemCopyError> {
         let dag = &pk.vk.symbolic_constraints;
         let symbolic_constraints = SymbolicConstraints::from(dag);
-        let interaction_rules = InteractionEvalRules::new(&symbolic_constraints, ctx)?;
-        let zerocheck_round0 = ConstraintOnlyRules::<true>::new(&dag.constraints, ctx)?;
-        let zerocheck_mle = ConstraintOnlyRules::<false>::new(&dag.constraints, ctx)?;
+        let interaction_rules = InteractionEvalRules::new(&symbolic_constraints, device_ctx)?;
+        let zerocheck_round0 = ConstraintOnlyRules::<true>::new(&dag.constraints, device_ctx)?;
+        let zerocheck_mle = ConstraintOnlyRules::<false>::new(&dag.constraints, device_ctx)?;
 
         let zerocheck_monomials = if dag.constraints.num_constraints() > 0 {
             let expanded = ExpandedMonomials::from_dag(&dag.constraints);
-            Some(ZerocheckMonomials::from_expanded(&expanded, ctx)?)
+            Some(ZerocheckMonomials::from_expanded(&expanded, device_ctx)?)
         } else {
             None
         };
         let interaction_monomials = if !symbolic_constraints.interactions.is_empty() {
             let expanded =
                 ExpandedInteractionMonomials::from_symbolic_constraints(&symbolic_constraints);
-            Some(InteractionMonomials::from_expanded(&expanded, ctx)?)
+            Some(InteractionMonomials::from_expanded(&expanded, device_ctx)?)
         } else {
             None
         };
@@ -121,7 +124,7 @@ impl AirDataGpu {
 impl ZerocheckMonomials {
     pub fn from_expanded(
         expanded: &ExpandedMonomials<F>,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Self, MemCopyError> {
         // Validate bounds for all monomial headers to prevent out-of-bounds access in CUDA kernel
         let num_variables = expanded.variables.len();
@@ -144,9 +147,9 @@ impl ZerocheckMonomials {
         }
 
         Ok(Self {
-            d_headers: expanded.headers.to_device_on(ctx)?,
-            d_variables: expanded.variables.to_device_on(ctx)?,
-            d_lambda_terms: expanded.lambda_terms.to_device_on(ctx)?,
+            d_headers: expanded.headers.to_device_on(device_ctx)?,
+            d_variables: expanded.variables.to_device_on(device_ctx)?,
+            d_lambda_terms: expanded.lambda_terms.to_device_on(device_ctx)?,
             num_monomials: expanded.headers.len() as u32,
         })
     }
@@ -155,7 +158,7 @@ impl ZerocheckMonomials {
 impl InteractionMonomials {
     pub fn from_expanded(
         expanded: &ExpandedInteractionMonomials<F>,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Self, MemCopyError> {
         // Validate numerator monomial headers
         let num_numer_vars = expanded.numer_variables.len();
@@ -190,13 +193,13 @@ impl InteractionMonomials {
         }
 
         Ok(Self {
-            d_numer_headers: to_device_or_empty(&expanded.numer_headers, ctx)?,
-            d_numer_variables: to_device_or_empty(&expanded.numer_variables, ctx)?,
-            d_numer_terms: to_device_or_empty(&expanded.numer_terms, ctx)?,
+            d_numer_headers: to_device_or_empty(&expanded.numer_headers, device_ctx)?,
+            d_numer_variables: to_device_or_empty(&expanded.numer_variables, device_ctx)?,
+            d_numer_terms: to_device_or_empty(&expanded.numer_terms, device_ctx)?,
             num_numer_monomials: expanded.numer_headers.len() as u32,
-            d_denom_headers: to_device_or_empty(&expanded.denom_headers, ctx)?,
-            d_denom_variables: to_device_or_empty(&expanded.denom_variables, ctx)?,
-            d_denom_terms: to_device_or_empty(&expanded.denom_terms, ctx)?,
+            d_denom_headers: to_device_or_empty(&expanded.denom_headers, device_ctx)?,
+            d_denom_variables: to_device_or_empty(&expanded.denom_variables, device_ctx)?,
+            d_denom_terms: to_device_or_empty(&expanded.denom_terms, device_ctx)?,
             num_denom_monomials: expanded.denom_headers.len() as u32,
             max_fields_len: expanded.max_fields_len,
             num_interactions: expanded.num_interactions,
@@ -207,7 +210,7 @@ impl InteractionMonomials {
 impl InteractionEvalRules {
     pub fn new(
         symbolic_constraints: &SymbolicConstraints<F>,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Self, MemCopyError> {
         let interactions = &symbolic_constraints.interactions;
         let num_interactions = interactions.len();
@@ -270,9 +273,9 @@ impl InteractionEvalRules {
             .map(|&dag_idx| rules.dag_idx_to_rule_idx[&dag_idx])
             .collect_vec();
         let encoded_rules = rules.rules.iter().map(|c| c.encode()).collect_vec();
-        let d_rules = encoded_rules.to_device_on(ctx)?;
-        let d_used_nodes = used_nodes.to_device_on(ctx)?;
-        let d_pair_idxs = pair_idxs.to_device_on(ctx)?;
+        let d_rules = encoded_rules.to_device_on(device_ctx)?;
+        let d_used_nodes = used_nodes.to_device_on(device_ctx)?;
+        let d_pair_idxs = pair_idxs.to_device_on(device_ctx)?;
         assert_eq!(
             used_nodes.len(),
             2 * num_interactions,
@@ -297,7 +300,10 @@ impl InteractionEvalRules {
 }
 
 impl<const BUFFER_VARS: bool> ConstraintOnlyRules<BUFFER_VARS> {
-    pub fn new(dag: &SymbolicExpressionDag<F>, ctx: &DeviceContext) -> Result<Self, MemCopyError> {
+    pub fn new(
+        dag: &SymbolicExpressionDag<F>,
+        device_ctx: &DeviceContext,
+    ) -> Result<Self, MemCopyError> {
         if dag.num_constraints() == 0 {
             return Ok(Self {
                 inner: EvalRules::dummy(),
@@ -313,8 +319,8 @@ impl<const BUFFER_VARS: bool> ConstraintOnlyRules<BUFFER_VARS> {
             .collect_vec();
 
         let encoded_rules = rules.rules.iter().map(|c| c.encode()).collect_vec();
-        let d_rules = encoded_rules.to_device_on(ctx)?;
-        let d_used_nodes = used_nodes.to_device_on(ctx)?;
+        let d_rules = encoded_rules.to_device_on(device_ctx)?;
+        let d_used_nodes = used_nodes.to_device_on(device_ctx)?;
 
         let inner = EvalRules {
             d_rules,

--- a/crates/cuda-backend/src/pkey.rs
+++ b/crates/cuda-backend/src/pkey.rs
@@ -1,6 +1,8 @@
 //! Defines the symbolic rule data to precompute and store in the GPU proving key
 use itertools::Itertools;
-use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer, error::MemCopyError};
+use openvm_cuda_common::{
+    copy::MemCopyH2D, d_buffer::DeviceBuffer, error::MemCopyError, stream::DeviceContext,
+};
 use openvm_stark_backend::{
     air_builders::symbolic::{
         symbolic_expression::SymbolicExpression,
@@ -74,34 +76,35 @@ pub struct InteractionMonomials {
     pub num_interactions: u32,
 }
 
-fn to_device_or_empty<T>(data: &[T]) -> Result<DeviceBuffer<T>, MemCopyError> {
+fn to_device_or_empty<T>(data: &[T], ctx: &DeviceContext) -> Result<DeviceBuffer<T>, MemCopyError> {
     if data.is_empty() {
         Ok(DeviceBuffer::new())
     } else {
-        data.to_device()
+        data.to_device_on(ctx)
     }
 }
 
 impl AirDataGpu {
     pub fn new<S: StarkProtocolConfig<F = F>>(
         pk: &StarkProvingKey<S>,
+        ctx: &DeviceContext,
     ) -> Result<Self, MemCopyError> {
         let dag = &pk.vk.symbolic_constraints;
         let symbolic_constraints = SymbolicConstraints::from(dag);
-        let interaction_rules = InteractionEvalRules::new(&symbolic_constraints)?;
-        let zerocheck_round0 = ConstraintOnlyRules::<true>::new(&dag.constraints)?;
-        let zerocheck_mle = ConstraintOnlyRules::<false>::new(&dag.constraints)?;
+        let interaction_rules = InteractionEvalRules::new(&symbolic_constraints, ctx)?;
+        let zerocheck_round0 = ConstraintOnlyRules::<true>::new(&dag.constraints, ctx)?;
+        let zerocheck_mle = ConstraintOnlyRules::<false>::new(&dag.constraints, ctx)?;
 
         let zerocheck_monomials = if dag.constraints.num_constraints() > 0 {
             let expanded = ExpandedMonomials::from_dag(&dag.constraints);
-            Some(ZerocheckMonomials::from_expanded(&expanded)?)
+            Some(ZerocheckMonomials::from_expanded(&expanded, ctx)?)
         } else {
             None
         };
         let interaction_monomials = if !symbolic_constraints.interactions.is_empty() {
             let expanded =
                 ExpandedInteractionMonomials::from_symbolic_constraints(&symbolic_constraints);
-            Some(InteractionMonomials::from_expanded(&expanded)?)
+            Some(InteractionMonomials::from_expanded(&expanded, ctx)?)
         } else {
             None
         };
@@ -116,7 +119,10 @@ impl AirDataGpu {
 }
 
 impl ZerocheckMonomials {
-    pub fn from_expanded(expanded: &ExpandedMonomials<F>) -> Result<Self, MemCopyError> {
+    pub fn from_expanded(
+        expanded: &ExpandedMonomials<F>,
+        ctx: &DeviceContext,
+    ) -> Result<Self, MemCopyError> {
         // Validate bounds for all monomial headers to prevent out-of-bounds access in CUDA kernel
         let num_variables = expanded.variables.len();
         let num_lambda_terms = expanded.lambda_terms.len();
@@ -138,16 +144,19 @@ impl ZerocheckMonomials {
         }
 
         Ok(Self {
-            d_headers: expanded.headers.to_device()?,
-            d_variables: expanded.variables.to_device()?,
-            d_lambda_terms: expanded.lambda_terms.to_device()?,
+            d_headers: expanded.headers.to_device_on(ctx)?,
+            d_variables: expanded.variables.to_device_on(ctx)?,
+            d_lambda_terms: expanded.lambda_terms.to_device_on(ctx)?,
             num_monomials: expanded.headers.len() as u32,
         })
     }
 }
 
 impl InteractionMonomials {
-    pub fn from_expanded(expanded: &ExpandedInteractionMonomials<F>) -> Result<Self, MemCopyError> {
+    pub fn from_expanded(
+        expanded: &ExpandedInteractionMonomials<F>,
+        ctx: &DeviceContext,
+    ) -> Result<Self, MemCopyError> {
         // Validate numerator monomial headers
         let num_numer_vars = expanded.numer_variables.len();
         let num_numer_terms = expanded.numer_terms.len();
@@ -181,13 +190,13 @@ impl InteractionMonomials {
         }
 
         Ok(Self {
-            d_numer_headers: to_device_or_empty(&expanded.numer_headers)?,
-            d_numer_variables: to_device_or_empty(&expanded.numer_variables)?,
-            d_numer_terms: to_device_or_empty(&expanded.numer_terms)?,
+            d_numer_headers: to_device_or_empty(&expanded.numer_headers, ctx)?,
+            d_numer_variables: to_device_or_empty(&expanded.numer_variables, ctx)?,
+            d_numer_terms: to_device_or_empty(&expanded.numer_terms, ctx)?,
             num_numer_monomials: expanded.numer_headers.len() as u32,
-            d_denom_headers: to_device_or_empty(&expanded.denom_headers)?,
-            d_denom_variables: to_device_or_empty(&expanded.denom_variables)?,
-            d_denom_terms: to_device_or_empty(&expanded.denom_terms)?,
+            d_denom_headers: to_device_or_empty(&expanded.denom_headers, ctx)?,
+            d_denom_variables: to_device_or_empty(&expanded.denom_variables, ctx)?,
+            d_denom_terms: to_device_or_empty(&expanded.denom_terms, ctx)?,
             num_denom_monomials: expanded.denom_headers.len() as u32,
             max_fields_len: expanded.max_fields_len,
             num_interactions: expanded.num_interactions,
@@ -196,7 +205,10 @@ impl InteractionMonomials {
 }
 
 impl InteractionEvalRules {
-    pub fn new(symbolic_constraints: &SymbolicConstraints<F>) -> Result<Self, MemCopyError> {
+    pub fn new(
+        symbolic_constraints: &SymbolicConstraints<F>,
+        ctx: &DeviceContext,
+    ) -> Result<Self, MemCopyError> {
         let interactions = &symbolic_constraints.interactions;
         let num_interactions = interactions.len();
         if num_interactions == 0 {
@@ -258,9 +270,9 @@ impl InteractionEvalRules {
             .map(|&dag_idx| rules.dag_idx_to_rule_idx[&dag_idx])
             .collect_vec();
         let encoded_rules = rules.rules.iter().map(|c| c.encode()).collect_vec();
-        let d_rules = encoded_rules.to_device()?;
-        let d_used_nodes = used_nodes.to_device()?;
-        let d_pair_idxs = pair_idxs.to_device()?;
+        let d_rules = encoded_rules.to_device_on(ctx)?;
+        let d_used_nodes = used_nodes.to_device_on(ctx)?;
+        let d_pair_idxs = pair_idxs.to_device_on(ctx)?;
         assert_eq!(
             used_nodes.len(),
             2 * num_interactions,
@@ -285,7 +297,7 @@ impl InteractionEvalRules {
 }
 
 impl<const BUFFER_VARS: bool> ConstraintOnlyRules<BUFFER_VARS> {
-    pub fn new(dag: &SymbolicExpressionDag<F>) -> Result<Self, MemCopyError> {
+    pub fn new(dag: &SymbolicExpressionDag<F>, ctx: &DeviceContext) -> Result<Self, MemCopyError> {
         if dag.num_constraints() == 0 {
             return Ok(Self {
                 inner: EvalRules::dummy(),
@@ -301,8 +313,8 @@ impl<const BUFFER_VARS: bool> ConstraintOnlyRules<BUFFER_VARS> {
             .collect_vec();
 
         let encoded_rules = rules.rules.iter().map(|c| c.encode()).collect_vec();
-        let d_rules = encoded_rules.to_device()?;
-        let d_used_nodes = used_nodes.to_device()?;
+        let d_rules = encoded_rules.to_device_on(ctx)?;
+        let d_used_nodes = used_nodes.to_device_on(ctx)?;
 
         let inner = EvalRules {
             d_rules,

--- a/crates/cuda-backend/src/pkey.rs
+++ b/crates/cuda-backend/src/pkey.rs
@@ -1,7 +1,7 @@
 //! Defines the symbolic rule data to precompute and store in the GPU proving key
 use itertools::Itertools;
 use openvm_cuda_common::{
-    copy::MemCopyH2D, d_buffer::DeviceBuffer, error::MemCopyError, stream::DeviceContext,
+    copy::MemCopyH2D, d_buffer::DeviceBuffer, error::MemCopyError, stream::GpuDeviceCtx,
 };
 use openvm_stark_backend::{
     air_builders::symbolic::{
@@ -78,7 +78,7 @@ pub struct InteractionMonomials {
 
 fn to_device_or_empty<T>(
     data: &[T],
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<DeviceBuffer<T>, MemCopyError> {
     if data.is_empty() {
         Ok(DeviceBuffer::new())
@@ -90,7 +90,7 @@ fn to_device_or_empty<T>(
 impl AirDataGpu {
     pub fn new<S: StarkProtocolConfig<F = F>>(
         pk: &StarkProvingKey<S>,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, MemCopyError> {
         let dag = &pk.vk.symbolic_constraints;
         let symbolic_constraints = SymbolicConstraints::from(dag);
@@ -124,7 +124,7 @@ impl AirDataGpu {
 impl ZerocheckMonomials {
     pub fn from_expanded(
         expanded: &ExpandedMonomials<F>,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, MemCopyError> {
         // Validate bounds for all monomial headers to prevent out-of-bounds access in CUDA kernel
         let num_variables = expanded.variables.len();
@@ -158,7 +158,7 @@ impl ZerocheckMonomials {
 impl InteractionMonomials {
     pub fn from_expanded(
         expanded: &ExpandedInteractionMonomials<F>,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, MemCopyError> {
         // Validate numerator monomial headers
         let num_numer_vars = expanded.numer_variables.len();
@@ -210,7 +210,7 @@ impl InteractionMonomials {
 impl InteractionEvalRules {
     pub fn new(
         symbolic_constraints: &SymbolicConstraints<F>,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, MemCopyError> {
         let interactions = &symbolic_constraints.interactions;
         let num_interactions = interactions.len();
@@ -302,7 +302,7 @@ impl InteractionEvalRules {
 impl<const BUFFER_VARS: bool> ConstraintOnlyRules<BUFFER_VARS> {
     pub fn new(
         dag: &SymbolicExpressionDag<F>,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, MemCopyError> {
         if dag.num_constraints() == 0 {
             return Ok(Self {

--- a/crates/cuda-backend/src/poly.rs
+++ b/crates/cuda-backend/src/poly.rs
@@ -5,7 +5,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2D, MemCopyH2D},
     d_buffer::DeviceBuffer,
     error::CudaError,
-    stream::cudaStream_t,
+    stream::{cudaStream_t, DeviceContext},
 };
 use openvm_stark_backend::prover::MatrixDimensions;
 use p3_field::PrimeCharacteristicRing;
@@ -56,7 +56,7 @@ impl PleMatrix<F> {
         evals: DeviceBuffer<F>,
         height: usize,
         width: usize,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Self {
         validate_gpu_l_skip(l_skip).expect("GPU PleMatrix requires l_skip <= 10");
         let mut mixed = evals;
@@ -65,7 +65,8 @@ impl PleMatrix<F> {
             // (width cols) * (height / 2^l_skip chunks per col). Use natural ordering.
             let num_uni_poly = width * (height >> l_skip);
             unsafe {
-                batch_ntt_small(&mut mixed, l_skip, num_uni_poly, true, stream).unwrap();
+                batch_ntt_small(&mut mixed, l_skip, num_uni_poly, true, ctx.stream.as_raw())
+                    .unwrap();
             }
         }
         Self {
@@ -78,19 +79,20 @@ impl PleMatrix<F> {
     pub fn to_evals(
         &self,
         l_skip: usize,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<DeviceMatrix<F>, KernelError> {
         validate_gpu_l_skip(l_skip)?;
         let width = self.width();
         let height = self.height();
         // D2D copy so we can do in-place NTT
-        let mut evals = self.mixed.device_copy()?;
+        let mut evals = self.mixed.device_copy_on(ctx)?;
         if l_skip > 0 {
             // For univariate coordinate, perform NTT for each 2^l_skip chunk per column: (width
             // cols) * (height / 2^l_skip chunks per col). Use natural ordering.
             let num_uni_poly = width * (height >> l_skip);
             unsafe {
-                batch_ntt_small(&mut evals, l_skip, num_uni_poly, false, stream).unwrap();
+                batch_ntt_small(&mut evals, l_skip, num_uni_poly, false, ctx.stream.as_raw())
+                    .unwrap();
             }
         }
         Ok(DeviceMatrix::new(Arc::new(evals), height, width))
@@ -102,7 +104,7 @@ impl PleMatrix<F> {
 pub fn mle_evals_to_coeffs_inplace(
     evals: &mut DeviceBuffer<F>,
     n: usize,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<(), CudaError> {
     if n == 0 {
         return Ok(());
@@ -122,7 +124,7 @@ pub fn mle_evals_to_coeffs_inplace(
             n as u32 - 1,
             true,
             false,
-            stream,
+            ctx.stream.as_raw(),
         )
     }
 }
@@ -247,16 +249,19 @@ pub unsafe fn mle_interpolate_stages(
 pub unsafe fn evals_eq_hypercube(
     out: &mut DeviceBuffer<EF>,
     xs: &[EF],
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<(), KernelError> {
     let n = xs.len();
     assert!(out.len() >= 1 << n);
     // Use memcpy instead of memset since EF will be in Montgomery form.
-    [EF::ONE].copy_to(out).map_err(KernelError::MemCopy)?;
+    [EF::ONE]
+        .copy_to_on(out, ctx)
+        .map_err(KernelError::MemCopy)?;
 
     for (i, &x_i) in xs.iter().enumerate() {
         let step = 1 << i;
-        eq_hypercube_stage_ext(out.as_mut_ptr(), x_i, step, stream).map_err(KernelError::Kernel)?;
+        eq_hypercube_stage_ext(out.as_mut_ptr(), x_i, step, ctx.stream.as_raw())
+            .map_err(KernelError::Kernel)?;
     }
     Ok(())
 }
@@ -277,16 +282,18 @@ pub unsafe fn evals_eq_hypercube(
 pub unsafe fn evals_mobius_eq_hypercube(
     out: &mut DeviceBuffer<EF>,
     omega: &[EF],
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<(), KernelError> {
     let n = omega.len();
     assert!(out.len() >= 1 << n);
     // Use memcpy instead of memset since EF will be in Montgomery form.
-    [EF::ONE].copy_to(out).map_err(KernelError::MemCopy)?;
+    [EF::ONE]
+        .copy_to_on(out, ctx)
+        .map_err(KernelError::MemCopy)?;
 
     for (i, &omega_i) in omega.iter().enumerate() {
         let step = 1 << i;
-        mobius_eq_hypercube_stage_ext(out.as_mut_ptr(), omega_i, step, stream)
+        mobius_eq_hypercube_stage_ext(out.as_mut_ptr(), omega_i, step, ctx.stream.as_raw())
             .map_err(KernelError::Kernel)?;
     }
     Ok(())
@@ -323,13 +330,13 @@ impl<F> EqEvalSegments<F> {
 // Currently only implement kernels for EF.
 impl EqEvalSegments<EF> {
     /// Creates a new `EqEvalSegments` instance with `max_n = x.len()`.
-    pub fn new(x: &[EF], stream: cudaStream_t) -> Result<Self, KernelError> {
+    pub fn new(x: &[EF], ctx: &DeviceContext) -> Result<Self, KernelError> {
         let max_n = x.len();
-        let mut buffer = DeviceBuffer::with_capacity(2 << max_n);
+        let mut buffer = DeviceBuffer::with_capacity_on(2 << max_n, ctx);
         // Index 0 should never to be used, but we initialize it to zero.
         // Index 1 is set to eq_0 = 1 for initial state
         [EF::ZERO, EF::ONE]
-            .copy_to(&mut buffer)
+            .copy_to_on(&mut buffer, ctx)
             .map_err(KernelError::MemCopy)?;
         // At step i, we populate `eq_{i+1}` starting at offset `2^{i+1}`
         for (i, &x_i) in x.iter().enumerate() {
@@ -342,8 +349,14 @@ impl EqEvalSegments<EF> {
                 let dst = buffer.as_mut_ptr().add(2 * step);
                 // The `eq_i` segment starts at offset `2^i`
                 let src = buffer.as_ptr().add(step);
-                eq_hypercube_nonoverlapping_stage_ext(dst, src, x_i, step as u32, stream)
-                    .map_err(KernelError::Kernel)?;
+                eq_hypercube_nonoverlapping_stage_ext(
+                    dst,
+                    src,
+                    x_i,
+                    step as u32,
+                    ctx.stream.as_raw(),
+                )
+                .map_err(KernelError::Kernel)?;
             }
         }
         Ok(Self { buffer, max_n })
@@ -375,20 +388,20 @@ impl EqEvalLayers<EF> {
     pub fn new_rev<'a>(
         n: usize,
         x: impl IntoIterator<Item = &'a EF>,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<Self, KernelError> {
         let mut layers = Vec::with_capacity(n + 1);
-        let layer_0 = [EF::ONE].to_device().map_err(KernelError::MemCopy)?;
+        let layer_0 = [EF::ONE].to_device_on(ctx).map_err(KernelError::MemCopy)?;
         layers.push(layer_0);
         for (i, &x_i) in x.into_iter().enumerate() {
             let step = 1 << i;
-            let buffer = DeviceBuffer::with_capacity(2 * step);
+            let buffer = DeviceBuffer::with_capacity_on(2 * step, ctx);
             // SAFETY:
             // - `buffer` has length `2^{i+1}`
             unsafe {
                 let dst = buffer.as_mut_ptr();
                 let src = layers.last().unwrap().as_ptr();
-                eq_hypercube_interleaved_stage_ext(dst, src, x_i, step as u32, stream)
+                eq_hypercube_interleaved_stage_ext(dst, src, x_i, step as u32, ctx.stream.as_raw())
                     .map_err(KernelError::Kernel)?;
             }
             layers.push(buffer);
@@ -403,21 +416,27 @@ impl EqEvalLayers<EF> {
     pub fn new<'a>(
         n: usize,
         x: impl IntoIterator<Item = &'a EF>,
-        stream: cudaStream_t,
+        ctx: &DeviceContext,
     ) -> Result<Self, KernelError> {
         let mut layers = Vec::with_capacity(n + 1);
-        let layer_0 = [EF::ONE].to_device().map_err(KernelError::MemCopy)?;
+        let layer_0 = [EF::ONE].to_device_on(ctx).map_err(KernelError::MemCopy)?;
         layers.push(layer_0);
         for (i, &x_i) in x.into_iter().enumerate() {
             let step = 1 << i;
-            let buffer = DeviceBuffer::with_capacity(2 * step);
+            let buffer = DeviceBuffer::with_capacity_on(2 * step, ctx);
             // SAFETY:
             // - `buffer` has length `2^{i+1}`
             unsafe {
                 let dst = buffer.as_mut_ptr();
                 let src = layers.last().unwrap().as_ptr();
-                eq_hypercube_nonoverlapping_stage_ext(dst, src, x_i, step as u32, stream)
-                    .map_err(KernelError::Kernel)?;
+                eq_hypercube_nonoverlapping_stage_ext(
+                    dst,
+                    src,
+                    x_i,
+                    step as u32,
+                    ctx.stream.as_raw(),
+                )
+                .map_err(KernelError::Kernel)?;
             }
             layers.push(buffer);
         }
@@ -440,15 +459,15 @@ pub struct SqrtHyperBuffer {
 impl SqrtHyperBuffer {
     /// Build a buffer from `xi`. Note that last elements of `xi` correspond to the lowest index
     /// bits.
-    pub fn from_xi(xi: &[EF], stream: cudaStream_t) -> Result<Self, KernelError> {
+    pub fn from_xi(xi: &[EF], ctx: &DeviceContext) -> Result<Self, KernelError> {
         let low = {
-            let mut res = DeviceBuffer::with_capacity(1 << (xi.len() / 2));
-            unsafe { evals_eq_hypercube(&mut res, &xi[..xi.len() / 2], stream)? };
+            let mut res = DeviceBuffer::with_capacity_on(1 << (xi.len() / 2), ctx);
+            unsafe { evals_eq_hypercube(&mut res, &xi[..xi.len() / 2], ctx)? };
             res
         };
         let high = {
-            let mut res = DeviceBuffer::with_capacity(1 << xi.len().div_ceil(2));
-            unsafe { evals_eq_hypercube(&mut res, &xi[xi.len() / 2..], stream)? };
+            let mut res = DeviceBuffer::with_capacity_on(1 << xi.len().div_ceil(2), ctx);
+            unsafe { evals_eq_hypercube(&mut res, &xi[xi.len() / 2..], ctx)? };
             res
         };
         Ok(Self {
@@ -459,15 +478,20 @@ impl SqrtHyperBuffer {
         })
     }
 
-    pub fn fold_columns(&mut self, r: EF, stream: cudaStream_t) -> Result<(), CudaError> {
+    pub fn fold_columns(&mut self, r: EF, ctx: &DeviceContext) -> Result<(), CudaError> {
         assert!(self.size > 1);
         if self.size > self.low_capacity {
             unsafe {
-                fold_mle_column(&mut self.high, self.size / self.low_capacity, r, stream)?;
+                fold_mle_column(
+                    &mut self.high,
+                    self.size / self.low_capacity,
+                    r,
+                    ctx.stream.as_raw(),
+                )?;
             }
         } else {
             unsafe {
-                fold_mle_column(&mut self.low, self.size, r, stream)?;
+                fold_mle_column(&mut self.low, self.size, r, ctx.stream.as_raw())?;
             }
         };
         self.size /= 2;
@@ -494,13 +518,13 @@ impl SqrtEqLayers {
     /// This is meant to match behavior of [SqrtHyperBuffer::from_xi] but with layers.
     ///
     /// Example: This means `[a,b,c,d]` should be sent to `low: [[d], [d, c]], high: [[b], [b, a]]`.
-    pub fn from_xi(xi: &[EF], stream: cudaStream_t) -> Result<Self, KernelError> {
+    pub fn from_xi(xi: &[EF], ctx: &DeviceContext) -> Result<Self, KernelError> {
         let n = xi.len();
         let low_n = n / 2;
         let high_n = n - low_n;
 
-        let low = EqEvalLayers::new(low_n, xi[high_n..].iter().rev(), stream)?;
-        let high = EqEvalLayers::new(high_n, xi[..high_n].iter().rev(), stream)?;
+        let low = EqEvalLayers::new(low_n, xi[high_n..].iter().rev(), ctx)?;
+        let high = EqEvalLayers::new(high_n, xi[..high_n].iter().rev(), ctx)?;
 
         Ok(Self { low, high })
     }

--- a/crates/cuda-backend/src/poly.rs
+++ b/crates/cuda-backend/src/poly.rs
@@ -56,7 +56,7 @@ impl PleMatrix<F> {
         evals: DeviceBuffer<F>,
         height: usize,
         width: usize,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Self {
         validate_gpu_l_skip(l_skip).expect("GPU PleMatrix requires l_skip <= 10");
         let mut mixed = evals;
@@ -65,8 +65,14 @@ impl PleMatrix<F> {
             // (width cols) * (height / 2^l_skip chunks per col). Use natural ordering.
             let num_uni_poly = width * (height >> l_skip);
             unsafe {
-                batch_ntt_small(&mut mixed, l_skip, num_uni_poly, true, ctx.stream.as_raw())
-                    .unwrap();
+                batch_ntt_small(
+                    &mut mixed,
+                    l_skip,
+                    num_uni_poly,
+                    true,
+                    device_ctx.stream.as_raw(),
+                )
+                .unwrap();
             }
         }
         Self {
@@ -79,20 +85,26 @@ impl PleMatrix<F> {
     pub fn to_evals(
         &self,
         l_skip: usize,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<DeviceMatrix<F>, KernelError> {
         validate_gpu_l_skip(l_skip)?;
         let width = self.width();
         let height = self.height();
         // D2D copy so we can do in-place NTT
-        let mut evals = self.mixed.device_copy_on(ctx)?;
+        let mut evals = self.mixed.device_copy_on(device_ctx)?;
         if l_skip > 0 {
             // For univariate coordinate, perform NTT for each 2^l_skip chunk per column: (width
             // cols) * (height / 2^l_skip chunks per col). Use natural ordering.
             let num_uni_poly = width * (height >> l_skip);
             unsafe {
-                batch_ntt_small(&mut evals, l_skip, num_uni_poly, false, ctx.stream.as_raw())
-                    .unwrap();
+                batch_ntt_small(
+                    &mut evals,
+                    l_skip,
+                    num_uni_poly,
+                    false,
+                    device_ctx.stream.as_raw(),
+                )
+                .unwrap();
             }
         }
         Ok(DeviceMatrix::new(Arc::new(evals), height, width))
@@ -104,7 +116,7 @@ impl PleMatrix<F> {
 pub fn mle_evals_to_coeffs_inplace(
     evals: &mut DeviceBuffer<F>,
     n: usize,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<(), CudaError> {
     if n == 0 {
         return Ok(());
@@ -124,7 +136,7 @@ pub fn mle_evals_to_coeffs_inplace(
             n as u32 - 1,
             true,
             false,
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )
     }
 }
@@ -249,18 +261,18 @@ pub unsafe fn mle_interpolate_stages(
 pub unsafe fn evals_eq_hypercube(
     out: &mut DeviceBuffer<EF>,
     xs: &[EF],
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<(), KernelError> {
     let n = xs.len();
     assert!(out.len() >= 1 << n);
     // Use memcpy instead of memset since EF will be in Montgomery form.
     [EF::ONE]
-        .copy_to_on(out, ctx)
+        .copy_to_on(out, device_ctx)
         .map_err(KernelError::MemCopy)?;
 
     for (i, &x_i) in xs.iter().enumerate() {
         let step = 1 << i;
-        eq_hypercube_stage_ext(out.as_mut_ptr(), x_i, step, ctx.stream.as_raw())
+        eq_hypercube_stage_ext(out.as_mut_ptr(), x_i, step, device_ctx.stream.as_raw())
             .map_err(KernelError::Kernel)?;
     }
     Ok(())
@@ -282,18 +294,18 @@ pub unsafe fn evals_eq_hypercube(
 pub unsafe fn evals_mobius_eq_hypercube(
     out: &mut DeviceBuffer<EF>,
     omega: &[EF],
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<(), KernelError> {
     let n = omega.len();
     assert!(out.len() >= 1 << n);
     // Use memcpy instead of memset since EF will be in Montgomery form.
     [EF::ONE]
-        .copy_to_on(out, ctx)
+        .copy_to_on(out, device_ctx)
         .map_err(KernelError::MemCopy)?;
 
     for (i, &omega_i) in omega.iter().enumerate() {
         let step = 1 << i;
-        mobius_eq_hypercube_stage_ext(out.as_mut_ptr(), omega_i, step, ctx.stream.as_raw())
+        mobius_eq_hypercube_stage_ext(out.as_mut_ptr(), omega_i, step, device_ctx.stream.as_raw())
             .map_err(KernelError::Kernel)?;
     }
     Ok(())
@@ -330,13 +342,13 @@ impl<F> EqEvalSegments<F> {
 // Currently only implement kernels for EF.
 impl EqEvalSegments<EF> {
     /// Creates a new `EqEvalSegments` instance with `max_n = x.len()`.
-    pub fn new(x: &[EF], ctx: &DeviceContext) -> Result<Self, KernelError> {
+    pub fn new(x: &[EF], device_ctx: &DeviceContext) -> Result<Self, KernelError> {
         let max_n = x.len();
-        let mut buffer = DeviceBuffer::with_capacity_on(2 << max_n, ctx);
+        let mut buffer = DeviceBuffer::with_capacity_on(2 << max_n, device_ctx);
         // Index 0 should never to be used, but we initialize it to zero.
         // Index 1 is set to eq_0 = 1 for initial state
         [EF::ZERO, EF::ONE]
-            .copy_to_on(&mut buffer, ctx)
+            .copy_to_on(&mut buffer, device_ctx)
             .map_err(KernelError::MemCopy)?;
         // At step i, we populate `eq_{i+1}` starting at offset `2^{i+1}`
         for (i, &x_i) in x.iter().enumerate() {
@@ -354,7 +366,7 @@ impl EqEvalSegments<EF> {
                     src,
                     x_i,
                     step as u32,
-                    ctx.stream.as_raw(),
+                    device_ctx.stream.as_raw(),
                 )
                 .map_err(KernelError::Kernel)?;
             }
@@ -388,21 +400,29 @@ impl EqEvalLayers<EF> {
     pub fn new_rev<'a>(
         n: usize,
         x: impl IntoIterator<Item = &'a EF>,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Self, KernelError> {
         let mut layers = Vec::with_capacity(n + 1);
-        let layer_0 = [EF::ONE].to_device_on(ctx).map_err(KernelError::MemCopy)?;
+        let layer_0 = [EF::ONE]
+            .to_device_on(device_ctx)
+            .map_err(KernelError::MemCopy)?;
         layers.push(layer_0);
         for (i, &x_i) in x.into_iter().enumerate() {
             let step = 1 << i;
-            let buffer = DeviceBuffer::with_capacity_on(2 * step, ctx);
+            let buffer = DeviceBuffer::with_capacity_on(2 * step, device_ctx);
             // SAFETY:
             // - `buffer` has length `2^{i+1}`
             unsafe {
                 let dst = buffer.as_mut_ptr();
                 let src = layers.last().unwrap().as_ptr();
-                eq_hypercube_interleaved_stage_ext(dst, src, x_i, step as u32, ctx.stream.as_raw())
-                    .map_err(KernelError::Kernel)?;
+                eq_hypercube_interleaved_stage_ext(
+                    dst,
+                    src,
+                    x_i,
+                    step as u32,
+                    device_ctx.stream.as_raw(),
+                )
+                .map_err(KernelError::Kernel)?;
             }
             layers.push(buffer);
         }
@@ -416,14 +436,16 @@ impl EqEvalLayers<EF> {
     pub fn new<'a>(
         n: usize,
         x: impl IntoIterator<Item = &'a EF>,
-        ctx: &DeviceContext,
+        device_ctx: &DeviceContext,
     ) -> Result<Self, KernelError> {
         let mut layers = Vec::with_capacity(n + 1);
-        let layer_0 = [EF::ONE].to_device_on(ctx).map_err(KernelError::MemCopy)?;
+        let layer_0 = [EF::ONE]
+            .to_device_on(device_ctx)
+            .map_err(KernelError::MemCopy)?;
         layers.push(layer_0);
         for (i, &x_i) in x.into_iter().enumerate() {
             let step = 1 << i;
-            let buffer = DeviceBuffer::with_capacity_on(2 * step, ctx);
+            let buffer = DeviceBuffer::with_capacity_on(2 * step, device_ctx);
             // SAFETY:
             // - `buffer` has length `2^{i+1}`
             unsafe {
@@ -434,7 +456,7 @@ impl EqEvalLayers<EF> {
                     src,
                     x_i,
                     step as u32,
-                    ctx.stream.as_raw(),
+                    device_ctx.stream.as_raw(),
                 )
                 .map_err(KernelError::Kernel)?;
             }
@@ -459,15 +481,15 @@ pub struct SqrtHyperBuffer {
 impl SqrtHyperBuffer {
     /// Build a buffer from `xi`. Note that last elements of `xi` correspond to the lowest index
     /// bits.
-    pub fn from_xi(xi: &[EF], ctx: &DeviceContext) -> Result<Self, KernelError> {
+    pub fn from_xi(xi: &[EF], device_ctx: &DeviceContext) -> Result<Self, KernelError> {
         let low = {
-            let mut res = DeviceBuffer::with_capacity_on(1 << (xi.len() / 2), ctx);
-            unsafe { evals_eq_hypercube(&mut res, &xi[..xi.len() / 2], ctx)? };
+            let mut res = DeviceBuffer::with_capacity_on(1 << (xi.len() / 2), device_ctx);
+            unsafe { evals_eq_hypercube(&mut res, &xi[..xi.len() / 2], device_ctx)? };
             res
         };
         let high = {
-            let mut res = DeviceBuffer::with_capacity_on(1 << xi.len().div_ceil(2), ctx);
-            unsafe { evals_eq_hypercube(&mut res, &xi[xi.len() / 2..], ctx)? };
+            let mut res = DeviceBuffer::with_capacity_on(1 << xi.len().div_ceil(2), device_ctx);
+            unsafe { evals_eq_hypercube(&mut res, &xi[xi.len() / 2..], device_ctx)? };
             res
         };
         Ok(Self {
@@ -478,7 +500,7 @@ impl SqrtHyperBuffer {
         })
     }
 
-    pub fn fold_columns(&mut self, r: EF, ctx: &DeviceContext) -> Result<(), CudaError> {
+    pub fn fold_columns(&mut self, r: EF, device_ctx: &DeviceContext) -> Result<(), CudaError> {
         assert!(self.size > 1);
         if self.size > self.low_capacity {
             unsafe {
@@ -486,12 +508,12 @@ impl SqrtHyperBuffer {
                     &mut self.high,
                     self.size / self.low_capacity,
                     r,
-                    ctx.stream.as_raw(),
+                    device_ctx.stream.as_raw(),
                 )?;
             }
         } else {
             unsafe {
-                fold_mle_column(&mut self.low, self.size, r, ctx.stream.as_raw())?;
+                fold_mle_column(&mut self.low, self.size, r, device_ctx.stream.as_raw())?;
             }
         };
         self.size /= 2;
@@ -518,13 +540,13 @@ impl SqrtEqLayers {
     /// This is meant to match behavior of [SqrtHyperBuffer::from_xi] but with layers.
     ///
     /// Example: This means `[a,b,c,d]` should be sent to `low: [[d], [d, c]], high: [[b], [b, a]]`.
-    pub fn from_xi(xi: &[EF], ctx: &DeviceContext) -> Result<Self, KernelError> {
+    pub fn from_xi(xi: &[EF], device_ctx: &DeviceContext) -> Result<Self, KernelError> {
         let n = xi.len();
         let low_n = n / 2;
         let high_n = n - low_n;
 
-        let low = EqEvalLayers::new(low_n, xi[high_n..].iter().rev(), ctx)?;
-        let high = EqEvalLayers::new(high_n, xi[..high_n].iter().rev(), ctx)?;
+        let low = EqEvalLayers::new(low_n, xi[high_n..].iter().rev(), device_ctx)?;
+        let high = EqEvalLayers::new(high_n, xi[..high_n].iter().rev(), device_ctx)?;
 
         Ok(Self { low, high })
     }

--- a/crates/cuda-backend/src/poly.rs
+++ b/crates/cuda-backend/src/poly.rs
@@ -5,7 +5,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2D, MemCopyH2D},
     d_buffer::DeviceBuffer,
     error::CudaError,
-    stream::{cudaStream_t, DeviceContext},
+    stream::{cudaStream_t, GpuDeviceCtx},
 };
 use openvm_stark_backend::prover::MatrixDimensions;
 use p3_field::PrimeCharacteristicRing;
@@ -56,7 +56,7 @@ impl PleMatrix<F> {
         evals: DeviceBuffer<F>,
         height: usize,
         width: usize,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Self {
         validate_gpu_l_skip(l_skip).expect("GPU PleMatrix requires l_skip <= 10");
         let mut mixed = evals;
@@ -85,7 +85,7 @@ impl PleMatrix<F> {
     pub fn to_evals(
         &self,
         l_skip: usize,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<DeviceMatrix<F>, KernelError> {
         validate_gpu_l_skip(l_skip)?;
         let width = self.width();
@@ -116,7 +116,7 @@ impl PleMatrix<F> {
 pub fn mle_evals_to_coeffs_inplace(
     evals: &mut DeviceBuffer<F>,
     n: usize,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(), CudaError> {
     if n == 0 {
         return Ok(());
@@ -261,7 +261,7 @@ pub unsafe fn mle_interpolate_stages(
 pub unsafe fn evals_eq_hypercube(
     out: &mut DeviceBuffer<EF>,
     xs: &[EF],
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(), KernelError> {
     let n = xs.len();
     assert!(out.len() >= 1 << n);
@@ -294,7 +294,7 @@ pub unsafe fn evals_eq_hypercube(
 pub unsafe fn evals_mobius_eq_hypercube(
     out: &mut DeviceBuffer<EF>,
     omega: &[EF],
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(), KernelError> {
     let n = omega.len();
     assert!(out.len() >= 1 << n);
@@ -342,7 +342,7 @@ impl<F> EqEvalSegments<F> {
 // Currently only implement kernels for EF.
 impl EqEvalSegments<EF> {
     /// Creates a new `EqEvalSegments` instance with `max_n = x.len()`.
-    pub fn new(x: &[EF], device_ctx: &DeviceContext) -> Result<Self, KernelError> {
+    pub fn new(x: &[EF], device_ctx: &GpuDeviceCtx) -> Result<Self, KernelError> {
         let max_n = x.len();
         let mut buffer = DeviceBuffer::with_capacity_on(2 << max_n, device_ctx);
         // Index 0 should never to be used, but we initialize it to zero.
@@ -400,7 +400,7 @@ impl EqEvalLayers<EF> {
     pub fn new_rev<'a>(
         n: usize,
         x: impl IntoIterator<Item = &'a EF>,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, KernelError> {
         let mut layers = Vec::with_capacity(n + 1);
         let layer_0 = [EF::ONE]
@@ -436,7 +436,7 @@ impl EqEvalLayers<EF> {
     pub fn new<'a>(
         n: usize,
         x: impl IntoIterator<Item = &'a EF>,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, KernelError> {
         let mut layers = Vec::with_capacity(n + 1);
         let layer_0 = [EF::ONE]
@@ -481,7 +481,7 @@ pub struct SqrtHyperBuffer {
 impl SqrtHyperBuffer {
     /// Build a buffer from `xi`. Note that last elements of `xi` correspond to the lowest index
     /// bits.
-    pub fn from_xi(xi: &[EF], device_ctx: &DeviceContext) -> Result<Self, KernelError> {
+    pub fn from_xi(xi: &[EF], device_ctx: &GpuDeviceCtx) -> Result<Self, KernelError> {
         let low = {
             let mut res = DeviceBuffer::with_capacity_on(1 << (xi.len() / 2), device_ctx);
             unsafe { evals_eq_hypercube(&mut res, &xi[..xi.len() / 2], device_ctx)? };
@@ -500,7 +500,7 @@ impl SqrtHyperBuffer {
         })
     }
 
-    pub fn fold_columns(&mut self, r: EF, device_ctx: &DeviceContext) -> Result<(), CudaError> {
+    pub fn fold_columns(&mut self, r: EF, device_ctx: &GpuDeviceCtx) -> Result<(), CudaError> {
         assert!(self.size > 1);
         if self.size > self.low_capacity {
             unsafe {
@@ -540,7 +540,7 @@ impl SqrtEqLayers {
     /// This is meant to match behavior of [SqrtHyperBuffer::from_xi] but with layers.
     ///
     /// Example: This means `[a,b,c,d]` should be sent to `low: [[d], [d, c]], high: [[b], [b, a]]`.
-    pub fn from_xi(xi: &[EF], device_ctx: &DeviceContext) -> Result<Self, KernelError> {
+    pub fn from_xi(xi: &[EF], device_ctx: &GpuDeviceCtx) -> Result<Self, KernelError> {
         let n = xi.len();
         let low_n = n / 2;
         let high_n = n - low_n;

--- a/crates/cuda-backend/src/poly.rs
+++ b/crates/cuda-backend/src/poly.rs
@@ -5,6 +5,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2D, MemCopyH2D},
     d_buffer::DeviceBuffer,
     error::CudaError,
+    stream::cudaStreamPerThread,
 };
 use openvm_stark_backend::prover::MatrixDimensions;
 use p3_field::PrimeCharacteristicRing;
@@ -58,7 +59,8 @@ impl PleMatrix<F> {
             // (width cols) * (height / 2^l_skip chunks per col). Use natural ordering.
             let num_uni_poly = width * (height >> l_skip);
             unsafe {
-                batch_ntt_small(&mut mixed, l_skip, num_uni_poly, true).unwrap();
+                batch_ntt_small(&mut mixed, l_skip, num_uni_poly, true, cudaStreamPerThread)
+                    .unwrap();
             }
         }
         Self {
@@ -79,7 +81,8 @@ impl PleMatrix<F> {
             // cols) * (height / 2^l_skip chunks per col). Use natural ordering.
             let num_uni_poly = width * (height >> l_skip);
             unsafe {
-                batch_ntt_small(&mut evals, l_skip, num_uni_poly, false).unwrap();
+                batch_ntt_small(&mut evals, l_skip, num_uni_poly, false, cudaStreamPerThread)
+                    .unwrap();
             }
         }
         Ok(DeviceMatrix::new(Arc::new(evals), height, width))
@@ -162,6 +165,7 @@ pub unsafe fn mle_interpolate_stages(
             num_stages,
             is_eval_to_coeff,
             right_pad,
+            cudaStreamPerThread,
         )?;
 
         current_log_step = warp_end + 1;
@@ -184,6 +188,7 @@ pub unsafe fn mle_interpolate_stages(
             shared_end,
             is_eval_to_coeff,
             right_pad,
+            cudaStreamPerThread,
         )?;
 
         current_log_step = shared_end + 1;
@@ -198,7 +203,15 @@ pub unsafe fn mle_interpolate_stages(
     let height = padded_height >> log_blowup;
     while current_log_step <= end_log_step {
         let step = 1u32 << current_log_step;
-        mle_interpolate_stage_2d(buffer, width, height, padded_height, step, is_eval_to_coeff)?;
+        mle_interpolate_stage_2d(
+            buffer,
+            width,
+            height,
+            padded_height,
+            step,
+            is_eval_to_coeff,
+            cudaStreamPerThread,
+        )?;
         current_log_step += 1;
     }
 
@@ -225,7 +238,8 @@ pub unsafe fn evals_eq_hypercube(out: &mut DeviceBuffer<EF>, xs: &[EF]) -> Resul
 
     for (i, &x_i) in xs.iter().enumerate() {
         let step = 1 << i;
-        eq_hypercube_stage_ext(out.as_mut_ptr(), x_i, step).map_err(KernelError::Kernel)?;
+        eq_hypercube_stage_ext(out.as_mut_ptr(), x_i, step, cudaStreamPerThread)
+            .map_err(KernelError::Kernel)?;
     }
     Ok(())
 }
@@ -254,7 +268,7 @@ pub unsafe fn evals_mobius_eq_hypercube(
 
     for (i, &omega_i) in omega.iter().enumerate() {
         let step = 1 << i;
-        mobius_eq_hypercube_stage_ext(out.as_mut_ptr(), omega_i, step)
+        mobius_eq_hypercube_stage_ext(out.as_mut_ptr(), omega_i, step, cudaStreamPerThread)
             .map_err(KernelError::Kernel)?;
     }
     Ok(())
@@ -310,8 +324,14 @@ impl EqEvalSegments<EF> {
                 let dst = buffer.as_mut_ptr().add(2 * step);
                 // The `eq_i` segment starts at offset `2^i`
                 let src = buffer.as_ptr().add(step);
-                eq_hypercube_nonoverlapping_stage_ext(dst, src, x_i, step as u32)
-                    .map_err(KernelError::Kernel)?;
+                eq_hypercube_nonoverlapping_stage_ext(
+                    dst,
+                    src,
+                    x_i,
+                    step as u32,
+                    cudaStreamPerThread,
+                )
+                .map_err(KernelError::Kernel)?;
             }
         }
         Ok(Self { buffer, max_n })
@@ -352,7 +372,7 @@ impl EqEvalLayers<EF> {
             unsafe {
                 let dst = buffer.as_mut_ptr();
                 let src = layers.last().unwrap().as_ptr();
-                eq_hypercube_interleaved_stage_ext(dst, src, x_i, step as u32)
+                eq_hypercube_interleaved_stage_ext(dst, src, x_i, step as u32, cudaStreamPerThread)
                     .map_err(KernelError::Kernel)?;
             }
             layers.push(buffer);
@@ -376,8 +396,14 @@ impl EqEvalLayers<EF> {
             unsafe {
                 let dst = buffer.as_mut_ptr();
                 let src = layers.last().unwrap().as_ptr();
-                eq_hypercube_nonoverlapping_stage_ext(dst, src, x_i, step as u32)
-                    .map_err(KernelError::Kernel)?;
+                eq_hypercube_nonoverlapping_stage_ext(
+                    dst,
+                    src,
+                    x_i,
+                    step as u32,
+                    cudaStreamPerThread,
+                )
+                .map_err(KernelError::Kernel)?;
             }
             layers.push(buffer);
         }
@@ -423,11 +449,16 @@ impl SqrtHyperBuffer {
         assert!(self.size > 1);
         if self.size > self.low_capacity {
             unsafe {
-                fold_mle_column(&mut self.high, self.size / self.low_capacity, r)?;
+                fold_mle_column(
+                    &mut self.high,
+                    self.size / self.low_capacity,
+                    r,
+                    cudaStreamPerThread,
+                )?;
             }
         } else {
             unsafe {
-                fold_mle_column(&mut self.low, self.size, r)?;
+                fold_mle_column(&mut self.low, self.size, r, cudaStreamPerThread)?;
             }
         };
         self.size /= 2;

--- a/crates/cuda-backend/src/poly.rs
+++ b/crates/cuda-backend/src/poly.rs
@@ -5,7 +5,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2D, MemCopyH2D},
     d_buffer::DeviceBuffer,
     error::CudaError,
-    stream::cudaStreamPerThread,
+    stream::cudaStream_t,
 };
 use openvm_stark_backend::prover::MatrixDimensions;
 use p3_field::PrimeCharacteristicRing;
@@ -51,7 +51,13 @@ impl<F> MatrixDimensions for PleMatrix<F> {
 
 impl PleMatrix<F> {
     /// Creates a `PleMatrix`. This doubles the VRAM footprint to cache the `mixed` buffer.
-    pub fn from_evals(l_skip: usize, evals: DeviceBuffer<F>, height: usize, width: usize) -> Self {
+    pub fn from_evals(
+        l_skip: usize,
+        evals: DeviceBuffer<F>,
+        height: usize,
+        width: usize,
+        stream: cudaStream_t,
+    ) -> Self {
         validate_gpu_l_skip(l_skip).expect("GPU PleMatrix requires l_skip <= 10");
         let mut mixed = evals;
         if l_skip > 0 {
@@ -59,8 +65,7 @@ impl PleMatrix<F> {
             // (width cols) * (height / 2^l_skip chunks per col). Use natural ordering.
             let num_uni_poly = width * (height >> l_skip);
             unsafe {
-                batch_ntt_small(&mut mixed, l_skip, num_uni_poly, true, cudaStreamPerThread)
-                    .unwrap();
+                batch_ntt_small(&mut mixed, l_skip, num_uni_poly, true, stream).unwrap();
             }
         }
         Self {
@@ -70,7 +75,11 @@ impl PleMatrix<F> {
         }
     }
 
-    pub fn to_evals(&self, l_skip: usize) -> Result<DeviceMatrix<F>, KernelError> {
+    pub fn to_evals(
+        &self,
+        l_skip: usize,
+        stream: cudaStream_t,
+    ) -> Result<DeviceMatrix<F>, KernelError> {
         validate_gpu_l_skip(l_skip)?;
         let width = self.width();
         let height = self.height();
@@ -81,8 +90,7 @@ impl PleMatrix<F> {
             // cols) * (height / 2^l_skip chunks per col). Use natural ordering.
             let num_uni_poly = width * (height >> l_skip);
             unsafe {
-                batch_ntt_small(&mut evals, l_skip, num_uni_poly, false, cudaStreamPerThread)
-                    .unwrap();
+                batch_ntt_small(&mut evals, l_skip, num_uni_poly, false, stream).unwrap();
             }
         }
         Ok(DeviceMatrix::new(Arc::new(evals), height, width))
@@ -91,7 +99,11 @@ impl PleMatrix<F> {
 
 /// Assumes that `evals` is column-major matrix of evaluations on a hypercube `H_n`.
 /// In-place interpolates `evals` from evaluations to coefficient form.
-pub fn mle_evals_to_coeffs_inplace(evals: &mut DeviceBuffer<F>, n: usize) -> Result<(), CudaError> {
+pub fn mle_evals_to_coeffs_inplace(
+    evals: &mut DeviceBuffer<F>,
+    n: usize,
+    stream: cudaStream_t,
+) -> Result<(), CudaError> {
     if n == 0 {
         return Ok(());
     }
@@ -110,6 +122,7 @@ pub fn mle_evals_to_coeffs_inplace(evals: &mut DeviceBuffer<F>, n: usize) -> Res
             n as u32 - 1,
             true,
             false,
+            stream,
         )
     }
 }
@@ -141,6 +154,7 @@ pub unsafe fn mle_interpolate_stages(
     end_log_step: u32,
     is_eval_to_coeff: bool,
     right_pad: bool,
+    stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     if start_log_step > end_log_step {
         return Ok(());
@@ -165,7 +179,7 @@ pub unsafe fn mle_interpolate_stages(
             num_stages,
             is_eval_to_coeff,
             right_pad,
-            cudaStreamPerThread,
+            stream,
         )?;
 
         current_log_step = warp_end + 1;
@@ -188,7 +202,7 @@ pub unsafe fn mle_interpolate_stages(
             shared_end,
             is_eval_to_coeff,
             right_pad,
-            cudaStreamPerThread,
+            stream,
         )?;
 
         current_log_step = shared_end + 1;
@@ -210,7 +224,7 @@ pub unsafe fn mle_interpolate_stages(
             padded_height,
             step,
             is_eval_to_coeff,
-            cudaStreamPerThread,
+            stream,
         )?;
         current_log_step += 1;
     }
@@ -230,7 +244,11 @@ pub unsafe fn mle_interpolate_stages(
 /// # Safety
 /// - `n` is set to the length of `xs`.
 /// - `out` must have length `>= 2^n`.
-pub unsafe fn evals_eq_hypercube(out: &mut DeviceBuffer<EF>, xs: &[EF]) -> Result<(), KernelError> {
+pub unsafe fn evals_eq_hypercube(
+    out: &mut DeviceBuffer<EF>,
+    xs: &[EF],
+    stream: cudaStream_t,
+) -> Result<(), KernelError> {
     let n = xs.len();
     assert!(out.len() >= 1 << n);
     // Use memcpy instead of memset since EF will be in Montgomery form.
@@ -238,8 +256,7 @@ pub unsafe fn evals_eq_hypercube(out: &mut DeviceBuffer<EF>, xs: &[EF]) -> Resul
 
     for (i, &x_i) in xs.iter().enumerate() {
         let step = 1 << i;
-        eq_hypercube_stage_ext(out.as_mut_ptr(), x_i, step, cudaStreamPerThread)
-            .map_err(KernelError::Kernel)?;
+        eq_hypercube_stage_ext(out.as_mut_ptr(), x_i, step, stream).map_err(KernelError::Kernel)?;
     }
     Ok(())
 }
@@ -260,6 +277,7 @@ pub unsafe fn evals_eq_hypercube(out: &mut DeviceBuffer<EF>, xs: &[EF]) -> Resul
 pub unsafe fn evals_mobius_eq_hypercube(
     out: &mut DeviceBuffer<EF>,
     omega: &[EF],
+    stream: cudaStream_t,
 ) -> Result<(), KernelError> {
     let n = omega.len();
     assert!(out.len() >= 1 << n);
@@ -268,7 +286,7 @@ pub unsafe fn evals_mobius_eq_hypercube(
 
     for (i, &omega_i) in omega.iter().enumerate() {
         let step = 1 << i;
-        mobius_eq_hypercube_stage_ext(out.as_mut_ptr(), omega_i, step, cudaStreamPerThread)
+        mobius_eq_hypercube_stage_ext(out.as_mut_ptr(), omega_i, step, stream)
             .map_err(KernelError::Kernel)?;
     }
     Ok(())
@@ -305,7 +323,7 @@ impl<F> EqEvalSegments<F> {
 // Currently only implement kernels for EF.
 impl EqEvalSegments<EF> {
     /// Creates a new `EqEvalSegments` instance with `max_n = x.len()`.
-    pub fn new(x: &[EF]) -> Result<Self, KernelError> {
+    pub fn new(x: &[EF], stream: cudaStream_t) -> Result<Self, KernelError> {
         let max_n = x.len();
         let mut buffer = DeviceBuffer::with_capacity(2 << max_n);
         // Index 0 should never to be used, but we initialize it to zero.
@@ -324,14 +342,8 @@ impl EqEvalSegments<EF> {
                 let dst = buffer.as_mut_ptr().add(2 * step);
                 // The `eq_i` segment starts at offset `2^i`
                 let src = buffer.as_ptr().add(step);
-                eq_hypercube_nonoverlapping_stage_ext(
-                    dst,
-                    src,
-                    x_i,
-                    step as u32,
-                    cudaStreamPerThread,
-                )
-                .map_err(KernelError::Kernel)?;
+                eq_hypercube_nonoverlapping_stage_ext(dst, src, x_i, step as u32, stream)
+                    .map_err(KernelError::Kernel)?;
             }
         }
         Ok(Self { buffer, max_n })
@@ -360,7 +372,11 @@ impl EqEvalLayers<EF> {
     /// Creates a new `EqEvalLayers` instance with `layers.len() = x.len() + 1`.
     ///
     /// Inserts `x_i` from the front for each layer.
-    pub fn new_rev<'a>(n: usize, x: impl IntoIterator<Item = &'a EF>) -> Result<Self, KernelError> {
+    pub fn new_rev<'a>(
+        n: usize,
+        x: impl IntoIterator<Item = &'a EF>,
+        stream: cudaStream_t,
+    ) -> Result<Self, KernelError> {
         let mut layers = Vec::with_capacity(n + 1);
         let layer_0 = [EF::ONE].to_device().map_err(KernelError::MemCopy)?;
         layers.push(layer_0);
@@ -372,7 +388,7 @@ impl EqEvalLayers<EF> {
             unsafe {
                 let dst = buffer.as_mut_ptr();
                 let src = layers.last().unwrap().as_ptr();
-                eq_hypercube_interleaved_stage_ext(dst, src, x_i, step as u32, cudaStreamPerThread)
+                eq_hypercube_interleaved_stage_ext(dst, src, x_i, step as u32, stream)
                     .map_err(KernelError::Kernel)?;
             }
             layers.push(buffer);
@@ -384,7 +400,11 @@ impl EqEvalLayers<EF> {
     ///
     /// Inserts `x_i` from the back for each layer. This matches behavior of
     /// [`EqEvalSegments::new`].
-    pub fn new<'a>(n: usize, x: impl IntoIterator<Item = &'a EF>) -> Result<Self, KernelError> {
+    pub fn new<'a>(
+        n: usize,
+        x: impl IntoIterator<Item = &'a EF>,
+        stream: cudaStream_t,
+    ) -> Result<Self, KernelError> {
         let mut layers = Vec::with_capacity(n + 1);
         let layer_0 = [EF::ONE].to_device().map_err(KernelError::MemCopy)?;
         layers.push(layer_0);
@@ -396,14 +416,8 @@ impl EqEvalLayers<EF> {
             unsafe {
                 let dst = buffer.as_mut_ptr();
                 let src = layers.last().unwrap().as_ptr();
-                eq_hypercube_nonoverlapping_stage_ext(
-                    dst,
-                    src,
-                    x_i,
-                    step as u32,
-                    cudaStreamPerThread,
-                )
-                .map_err(KernelError::Kernel)?;
+                eq_hypercube_nonoverlapping_stage_ext(dst, src, x_i, step as u32, stream)
+                    .map_err(KernelError::Kernel)?;
             }
             layers.push(buffer);
         }
@@ -426,15 +440,15 @@ pub struct SqrtHyperBuffer {
 impl SqrtHyperBuffer {
     /// Build a buffer from `xi`. Note that last elements of `xi` correspond to the lowest index
     /// bits.
-    pub fn from_xi(xi: &[EF]) -> Result<Self, KernelError> {
+    pub fn from_xi(xi: &[EF], stream: cudaStream_t) -> Result<Self, KernelError> {
         let low = {
             let mut res = DeviceBuffer::with_capacity(1 << (xi.len() / 2));
-            unsafe { evals_eq_hypercube(&mut res, &xi[..xi.len() / 2])? };
+            unsafe { evals_eq_hypercube(&mut res, &xi[..xi.len() / 2], stream)? };
             res
         };
         let high = {
             let mut res = DeviceBuffer::with_capacity(1 << xi.len().div_ceil(2));
-            unsafe { evals_eq_hypercube(&mut res, &xi[xi.len() / 2..])? };
+            unsafe { evals_eq_hypercube(&mut res, &xi[xi.len() / 2..], stream)? };
             res
         };
         Ok(Self {
@@ -445,20 +459,15 @@ impl SqrtHyperBuffer {
         })
     }
 
-    pub fn fold_columns(&mut self, r: EF) -> Result<(), CudaError> {
+    pub fn fold_columns(&mut self, r: EF, stream: cudaStream_t) -> Result<(), CudaError> {
         assert!(self.size > 1);
         if self.size > self.low_capacity {
             unsafe {
-                fold_mle_column(
-                    &mut self.high,
-                    self.size / self.low_capacity,
-                    r,
-                    cudaStreamPerThread,
-                )?;
+                fold_mle_column(&mut self.high, self.size / self.low_capacity, r, stream)?;
             }
         } else {
             unsafe {
-                fold_mle_column(&mut self.low, self.size, r, cudaStreamPerThread)?;
+                fold_mle_column(&mut self.low, self.size, r, stream)?;
             }
         };
         self.size /= 2;
@@ -485,13 +494,13 @@ impl SqrtEqLayers {
     /// This is meant to match behavior of [SqrtHyperBuffer::from_xi] but with layers.
     ///
     /// Example: This means `[a,b,c,d]` should be sent to `low: [[d], [d, c]], high: [[b], [b, a]]`.
-    pub fn from_xi(xi: &[EF]) -> Result<Self, KernelError> {
+    pub fn from_xi(xi: &[EF], stream: cudaStream_t) -> Result<Self, KernelError> {
         let n = xi.len();
         let low_n = n / 2;
         let high_n = n - low_n;
 
-        let low = EqEvalLayers::new(low_n, xi[high_n..].iter().rev())?;
-        let high = EqEvalLayers::new(high_n, xi[..high_n].iter().rev())?;
+        let low = EqEvalLayers::new(low_n, xi[high_n..].iter().rev(), stream)?;
+        let high = EqEvalLayers::new(high_n, xi[..high_n].iter().rev(), stream)?;
 
         Ok(Self { low, high })
     }

--- a/crates/cuda-backend/src/sponge.rs
+++ b/crates/cuda-backend/src/sponge.rs
@@ -6,10 +6,10 @@
 use std::ffi::c_void;
 
 use openvm_cuda_common::{
-    copy::cuda_memcpy,
+    copy::cuda_memcpy_on,
     d_buffer::DeviceBuffer,
     error::{CudaError, MemCopyError},
-    stream::cudaStream_t,
+    stream::DeviceContext,
 };
 use openvm_stark_backend::{
     p3_challenger::{CanObserve, CanSample},
@@ -154,15 +154,12 @@ impl Default for DuplexSpongeGpu {
 
 impl Clone for DuplexSpongeGpu {
     fn clone(&self) -> Self {
-        let mut new = Self {
+        // Device buffer is not cloned — caller must explicitly sync_h2d with a
+        // DeviceContext after cloning if device state is needed.
+        Self {
             host: self.host.clone(),
             device: DeviceBuffer::new(),
-        };
-        // Sync cloned host state to device if device was allocated
-        if !self.device.is_empty() {
-            let _ = new.sync_h2d();
         }
-        new
     }
 }
 
@@ -181,9 +178,9 @@ impl DuplexSpongeGpu {
     }
 
     /// Ensure the device buffer is allocated.
-    fn ensure_device_allocated(&mut self) {
+    fn ensure_device_allocated(&mut self, ctx: &DeviceContext) {
         if self.device.is_empty() {
-            self.device = DeviceBuffer::with_capacity(1);
+            self.device = DeviceBuffer::with_capacity_on(1, ctx);
         }
     }
 
@@ -193,8 +190,8 @@ impl DuplexSpongeGpu {
     ///
     /// This converts from `DuplexChallenger`'s representation (with buffered input/output)
     /// to `DeviceSpongeState`'s representation (with indices pointing into state).
-    pub fn sync_h2d(&mut self) -> Result<(), MemCopyError> {
-        self.ensure_device_allocated();
+    pub fn sync_h2d(&mut self, ctx: &DeviceContext) -> Result<(), MemCopyError> {
+        self.ensure_device_allocated(ctx);
 
         // Convert DuplexChallenger state to DeviceSpongeState format:
         // - DuplexChallenger buffers input values before writing to sponge_state
@@ -218,10 +215,11 @@ impl DuplexSpongeGpu {
         // - Both pointers are valid and properly aligned
         // - The size matches the struct size
         unsafe {
-            cuda_memcpy::<false, true>(
+            cuda_memcpy_on::<false, true>(
                 self.device.as_mut_ptr() as *mut c_void,
                 &device_state as *const DeviceSpongeState as *const c_void,
                 std::mem::size_of::<DeviceSpongeState>(),
+                ctx,
             )
         }
     }
@@ -266,14 +264,14 @@ impl DuplexSpongeGpu {
     ///
     /// After this call, the host state will have observed the witness and sampled,
     /// matching the state after calling `check_witness(bits, witness)`.
-    pub fn grind_gpu(&mut self, bits: usize, stream: cudaStream_t) -> Result<F, GrindError> {
+    pub fn grind_gpu(&mut self, bits: usize, ctx: &DeviceContext) -> Result<F, GrindError> {
         validate_gpu_grind_bits(bits)?;
         // Trivial case: 0 bits mean no PoW is required and any witness is valid.
         if bits == 0 {
             return Ok(F::ZERO);
         }
         // 1. Sync host state to device
-        self.sync_h2d()?;
+        self.sync_h2d(ctx)?;
 
         // 2. Launch grinding kernel
         let witness_u32 = unsafe {
@@ -281,7 +279,7 @@ impl DuplexSpongeGpu {
                 self.device.as_ptr(),
                 bits as u32,
                 F::ORDER_U32 - 1,
-                stream,
+                ctx,
             )?
         };
 
@@ -343,12 +341,12 @@ pub trait GpuFiatShamirTranscript<Config: StarkProtocolConfig>:
     /// sampling, the result has `bits` trailing zero bits.  Implementations should sync
     /// host state to device, launch a CUDA grinding kernel, then update the host state
     /// to match (observe witness + consume one sample).
-    fn grind_gpu(&mut self, bits: usize, stream: cudaStream_t) -> Result<Config::F, GrindError>;
+    fn grind_gpu(&mut self, bits: usize, ctx: &DeviceContext) -> Result<Config::F, GrindError>;
 }
 
 impl GpuFiatShamirTranscript<SC> for DuplexSpongeGpu {
-    fn grind_gpu(&mut self, bits: usize, stream: cudaStream_t) -> Result<F, GrindError> {
-        DuplexSpongeGpu::grind_gpu(self, bits, stream)
+    fn grind_gpu(&mut self, bits: usize, ctx: &DeviceContext) -> Result<F, GrindError> {
+        DuplexSpongeGpu::grind_gpu(self, bits, ctx)
     }
 }
 
@@ -356,12 +354,22 @@ impl GpuFiatShamirTranscript<SC> for DuplexSpongeGpu {
 mod tests {
     use std::time::Instant;
 
-    use openvm_cuda_common::stream::cudaStreamPerThread;
+    use openvm_cuda_common::{
+        common::get_device,
+        stream::{CudaStream, DeviceContext, StreamGuard},
+    };
     use openvm_stark_sdk::config::baby_bear_poseidon2::default_duplex_sponge;
     use p3_field::PrimeCharacteristicRing;
 
     use super::*;
     use crate::prelude::SC;
+
+    fn test_ctx() -> DeviceContext {
+        DeviceContext {
+            device_id: get_device().unwrap() as u32,
+            stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
+        }
+    }
 
     #[test]
     fn test_device_sponge_state_size() {
@@ -468,10 +476,11 @@ mod tests {
     /// where parallelism amortizes the overhead.
     #[test]
     fn test_grind_cpu_vs_gpu() {
+        let ctx = test_ctx();
         // Warmup: run one GPU grind to initialize CUDA context
         {
             let mut warmup = DuplexSpongeGpu::default();
-            let _ = warmup.grind_gpu(8, cudaStreamPerThread);
+            let _ = warmup.grind_gpu(8, &ctx);
         }
 
         // Test multiple bit counts to see scaling
@@ -510,7 +519,7 @@ mod tests {
             // Time GPU grinding
             let gpu_start = Instant::now();
             let gpu_witness = gpu_sponge
-                .grind_gpu(bits, cudaStreamPerThread)
+                .grind_gpu(bits, &ctx)
                 .expect("GPU grinding failed");
             let gpu_time = gpu_start.elapsed();
 

--- a/crates/cuda-backend/src/sponge.rs
+++ b/crates/cuda-backend/src/sponge.rs
@@ -178,9 +178,9 @@ impl DuplexSpongeGpu {
     }
 
     /// Ensure the device buffer is allocated.
-    fn ensure_device_allocated(&mut self, ctx: &DeviceContext) {
+    fn ensure_device_allocated(&mut self, device_ctx: &DeviceContext) {
         if self.device.is_empty() {
-            self.device = DeviceBuffer::with_capacity_on(1, ctx);
+            self.device = DeviceBuffer::with_capacity_on(1, device_ctx);
         }
     }
 
@@ -190,8 +190,8 @@ impl DuplexSpongeGpu {
     ///
     /// This converts from `DuplexChallenger`'s representation (with buffered input/output)
     /// to `DeviceSpongeState`'s representation (with indices pointing into state).
-    pub fn sync_h2d(&mut self, ctx: &DeviceContext) -> Result<(), MemCopyError> {
-        self.ensure_device_allocated(ctx);
+    pub fn sync_h2d(&mut self, device_ctx: &DeviceContext) -> Result<(), MemCopyError> {
+        self.ensure_device_allocated(device_ctx);
 
         // Convert DuplexChallenger state to DeviceSpongeState format:
         // - DuplexChallenger buffers input values before writing to sponge_state
@@ -219,7 +219,7 @@ impl DuplexSpongeGpu {
                 self.device.as_mut_ptr() as *mut c_void,
                 &device_state as *const DeviceSpongeState as *const c_void,
                 std::mem::size_of::<DeviceSpongeState>(),
-                ctx,
+                device_ctx,
             )
         }
     }
@@ -264,14 +264,14 @@ impl DuplexSpongeGpu {
     ///
     /// After this call, the host state will have observed the witness and sampled,
     /// matching the state after calling `check_witness(bits, witness)`.
-    pub fn grind_gpu(&mut self, bits: usize, ctx: &DeviceContext) -> Result<F, GrindError> {
+    pub fn grind_gpu(&mut self, bits: usize, device_ctx: &DeviceContext) -> Result<F, GrindError> {
         validate_gpu_grind_bits(bits)?;
         // Trivial case: 0 bits mean no PoW is required and any witness is valid.
         if bits == 0 {
             return Ok(F::ZERO);
         }
         // 1. Sync host state to device
-        self.sync_h2d(ctx)?;
+        self.sync_h2d(device_ctx)?;
 
         // 2. Launch grinding kernel
         let witness_u32 = unsafe {
@@ -279,7 +279,7 @@ impl DuplexSpongeGpu {
                 self.device.as_ptr(),
                 bits as u32,
                 F::ORDER_U32 - 1,
-                ctx,
+                device_ctx,
             )?
         };
 
@@ -341,12 +341,16 @@ pub trait GpuFiatShamirTranscript<Config: StarkProtocolConfig>:
     /// sampling, the result has `bits` trailing zero bits.  Implementations should sync
     /// host state to device, launch a CUDA grinding kernel, then update the host state
     /// to match (observe witness + consume one sample).
-    fn grind_gpu(&mut self, bits: usize, ctx: &DeviceContext) -> Result<Config::F, GrindError>;
+    fn grind_gpu(
+        &mut self,
+        bits: usize,
+        device_ctx: &DeviceContext,
+    ) -> Result<Config::F, GrindError>;
 }
 
 impl GpuFiatShamirTranscript<SC> for DuplexSpongeGpu {
-    fn grind_gpu(&mut self, bits: usize, ctx: &DeviceContext) -> Result<F, GrindError> {
-        DuplexSpongeGpu::grind_gpu(self, bits, ctx)
+    fn grind_gpu(&mut self, bits: usize, device_ctx: &DeviceContext) -> Result<F, GrindError> {
+        DuplexSpongeGpu::grind_gpu(self, bits, device_ctx)
     }
 }
 
@@ -476,11 +480,11 @@ mod tests {
     /// where parallelism amortizes the overhead.
     #[test]
     fn test_grind_cpu_vs_gpu() {
-        let ctx = test_ctx();
+        let device_ctx = test_ctx();
         // Warmup: run one GPU grind to initialize CUDA context
         {
             let mut warmup = DuplexSpongeGpu::default();
-            let _ = warmup.grind_gpu(8, &ctx);
+            let _ = warmup.grind_gpu(8, &device_ctx);
         }
 
         // Test multiple bit counts to see scaling
@@ -519,7 +523,7 @@ mod tests {
             // Time GPU grinding
             let gpu_start = Instant::now();
             let gpu_witness = gpu_sponge
-                .grind_gpu(bits, &ctx)
+                .grind_gpu(bits, &device_ctx)
                 .expect("GPU grinding failed");
             let gpu_time = gpu_start.elapsed();
 

--- a/crates/cuda-backend/src/sponge.rs
+++ b/crates/cuda-backend/src/sponge.rs
@@ -9,6 +9,7 @@ use openvm_cuda_common::{
     copy::cuda_memcpy,
     d_buffer::DeviceBuffer,
     error::{CudaError, MemCopyError},
+    stream::cudaStreamPerThread,
 };
 use openvm_stark_backend::{
     p3_challenger::{CanObserve, CanSample},
@@ -276,7 +277,12 @@ impl DuplexSpongeGpu {
 
         // 2. Launch grinding kernel
         let witness_u32 = unsafe {
-            crate::cuda::sponge::sponge_grind(self.device.as_ptr(), bits as u32, F::ORDER_U32 - 1)?
+            crate::cuda::sponge::sponge_grind(
+                self.device.as_ptr(),
+                bits as u32,
+                F::ORDER_U32 - 1,
+                cudaStreamPerThread,
+            )?
         };
 
         let witness = F::from_u32(witness_u32);

--- a/crates/cuda-backend/src/sponge.rs
+++ b/crates/cuda-backend/src/sponge.rs
@@ -9,7 +9,7 @@ use openvm_cuda_common::{
     copy::cuda_memcpy,
     d_buffer::DeviceBuffer,
     error::{CudaError, MemCopyError},
-    stream::cudaStreamPerThread,
+    stream::cudaStream_t,
 };
 use openvm_stark_backend::{
     p3_challenger::{CanObserve, CanSample},
@@ -266,7 +266,7 @@ impl DuplexSpongeGpu {
     ///
     /// After this call, the host state will have observed the witness and sampled,
     /// matching the state after calling `check_witness(bits, witness)`.
-    pub fn grind_gpu(&mut self, bits: usize) -> Result<F, GrindError> {
+    pub fn grind_gpu(&mut self, bits: usize, stream: cudaStream_t) -> Result<F, GrindError> {
         validate_gpu_grind_bits(bits)?;
         // Trivial case: 0 bits mean no PoW is required and any witness is valid.
         if bits == 0 {
@@ -281,7 +281,7 @@ impl DuplexSpongeGpu {
                 self.device.as_ptr(),
                 bits as u32,
                 F::ORDER_U32 - 1,
-                cudaStreamPerThread,
+                stream,
             )?
         };
 
@@ -343,12 +343,12 @@ pub trait GpuFiatShamirTranscript<Config: StarkProtocolConfig>:
     /// sampling, the result has `bits` trailing zero bits.  Implementations should sync
     /// host state to device, launch a CUDA grinding kernel, then update the host state
     /// to match (observe witness + consume one sample).
-    fn grind_gpu(&mut self, bits: usize) -> Result<Config::F, GrindError>;
+    fn grind_gpu(&mut self, bits: usize, stream: cudaStream_t) -> Result<Config::F, GrindError>;
 }
 
 impl GpuFiatShamirTranscript<SC> for DuplexSpongeGpu {
-    fn grind_gpu(&mut self, bits: usize) -> Result<F, GrindError> {
-        DuplexSpongeGpu::grind_gpu(self, bits)
+    fn grind_gpu(&mut self, bits: usize, stream: cudaStream_t) -> Result<F, GrindError> {
+        DuplexSpongeGpu::grind_gpu(self, bits, stream)
     }
 }
 
@@ -356,6 +356,7 @@ impl GpuFiatShamirTranscript<SC> for DuplexSpongeGpu {
 mod tests {
     use std::time::Instant;
 
+    use openvm_cuda_common::stream::cudaStreamPerThread;
     use openvm_stark_sdk::config::baby_bear_poseidon2::default_duplex_sponge;
     use p3_field::PrimeCharacteristicRing;
 
@@ -470,7 +471,7 @@ mod tests {
         // Warmup: run one GPU grind to initialize CUDA context
         {
             let mut warmup = DuplexSpongeGpu::default();
-            let _ = warmup.grind_gpu(8);
+            let _ = warmup.grind_gpu(8, cudaStreamPerThread);
         }
 
         // Test multiple bit counts to see scaling
@@ -508,7 +509,9 @@ mod tests {
 
             // Time GPU grinding
             let gpu_start = Instant::now();
-            let gpu_witness = gpu_sponge.grind_gpu(bits).expect("GPU grinding failed");
+            let gpu_witness = gpu_sponge
+                .grind_gpu(bits, cudaStreamPerThread)
+                .expect("GPU grinding failed");
             let gpu_time = gpu_start.elapsed();
 
             // Verify both found valid witnesses (witnesses may differ but both should be valid)

--- a/crates/cuda-backend/src/sponge.rs
+++ b/crates/cuda-backend/src/sponge.rs
@@ -9,7 +9,7 @@ use openvm_cuda_common::{
     copy::cuda_memcpy_on,
     d_buffer::DeviceBuffer,
     error::{CudaError, MemCopyError},
-    stream::DeviceContext,
+    stream::GpuDeviceCtx,
 };
 use openvm_stark_backend::{
     p3_challenger::{CanObserve, CanSample},
@@ -155,7 +155,7 @@ impl Default for DuplexSpongeGpu {
 impl Clone for DuplexSpongeGpu {
     fn clone(&self) -> Self {
         // Device buffer is not cloned — caller must explicitly sync_h2d with a
-        // DeviceContext after cloning if device state is needed.
+        // GpuDeviceCtx after cloning if device state is needed.
         Self {
             host: self.host.clone(),
             device: DeviceBuffer::new(),
@@ -178,7 +178,7 @@ impl DuplexSpongeGpu {
     }
 
     /// Ensure the device buffer is allocated.
-    fn ensure_device_allocated(&mut self, device_ctx: &DeviceContext) {
+    fn ensure_device_allocated(&mut self, device_ctx: &GpuDeviceCtx) {
         if self.device.is_empty() {
             self.device = DeviceBuffer::with_capacity_on(1, device_ctx);
         }
@@ -190,7 +190,7 @@ impl DuplexSpongeGpu {
     ///
     /// This converts from `DuplexChallenger`'s representation (with buffered input/output)
     /// to `DeviceSpongeState`'s representation (with indices pointing into state).
-    pub fn sync_h2d(&mut self, device_ctx: &DeviceContext) -> Result<(), MemCopyError> {
+    pub fn sync_h2d(&mut self, device_ctx: &GpuDeviceCtx) -> Result<(), MemCopyError> {
         self.ensure_device_allocated(device_ctx);
 
         // Convert DuplexChallenger state to DeviceSpongeState format:
@@ -264,7 +264,7 @@ impl DuplexSpongeGpu {
     ///
     /// After this call, the host state will have observed the witness and sampled,
     /// matching the state after calling `check_witness(bits, witness)`.
-    pub fn grind_gpu(&mut self, bits: usize, device_ctx: &DeviceContext) -> Result<F, GrindError> {
+    pub fn grind_gpu(&mut self, bits: usize, device_ctx: &GpuDeviceCtx) -> Result<F, GrindError> {
         validate_gpu_grind_bits(bits)?;
         // Trivial case: 0 bits mean no PoW is required and any witness is valid.
         if bits == 0 {
@@ -344,12 +344,12 @@ pub trait GpuFiatShamirTranscript<Config: StarkProtocolConfig>:
     fn grind_gpu(
         &mut self,
         bits: usize,
-        device_ctx: &DeviceContext,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<Config::F, GrindError>;
 }
 
 impl GpuFiatShamirTranscript<SC> for DuplexSpongeGpu {
-    fn grind_gpu(&mut self, bits: usize, device_ctx: &DeviceContext) -> Result<F, GrindError> {
+    fn grind_gpu(&mut self, bits: usize, device_ctx: &GpuDeviceCtx) -> Result<F, GrindError> {
         DuplexSpongeGpu::grind_gpu(self, bits, device_ctx)
     }
 }
@@ -360,7 +360,7 @@ mod tests {
 
     use openvm_cuda_common::{
         common::get_device,
-        stream::{CudaStream, DeviceContext, StreamGuard},
+        stream::{CudaStream, GpuDeviceCtx, StreamGuard},
     };
     use openvm_stark_sdk::config::baby_bear_poseidon2::default_duplex_sponge;
     use p3_field::PrimeCharacteristicRing;
@@ -368,8 +368,8 @@ mod tests {
     use super::*;
     use crate::prelude::SC;
 
-    fn test_ctx() -> DeviceContext {
-        DeviceContext {
+    fn test_ctx() -> GpuDeviceCtx {
+        GpuDeviceCtx {
             device_id: get_device().unwrap() as u32,
             stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
         }

--- a/crates/cuda-backend/src/stacked_pcs.rs
+++ b/crates/cuda-backend/src/stacked_pcs.rs
@@ -3,7 +3,7 @@ use std::{ffi::c_void, sync::Arc};
 use getset::Getters;
 use itertools::Itertools;
 use openvm_cuda_common::{
-    copy::cuda_memcpy_on, d_buffer::DeviceBuffer, memory_manager::MemTracker, stream::DeviceContext,
+    copy::cuda_memcpy_on, d_buffer::DeviceBuffer, memory_manager::MemTracker, stream::GpuDeviceCtx,
 };
 use openvm_stark_backend::{
     p3_util::log2_strict_usize,
@@ -54,7 +54,7 @@ pub fn stacked_commit<MH: GpuMerkleHash + MerkleTreeConstructor>(
     k_whir: usize,
     traces: &[&DeviceMatrix<F>],
     prover_config: GpuProverConfig,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(MH::Digest, StackedPcsDataGpu<F, MH::Digest>), ProverError> {
     let mut mem = MemTracker::start("prover.stacked_commit");
     mem.tracing_info("before stacked_commit");
@@ -95,7 +95,7 @@ pub fn stacked_matrix(
     l_skip: usize,
     n_stack: usize,
     traces: &[&DeviceMatrix<F>],
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(PleMatrix<F>, StackedLayout), ProverError> {
     let layout = get_stacked_layout(l_skip, n_stack, traces);
     let matrix = stack_traces(&layout, traces, device_ctx)?;
@@ -122,7 +122,7 @@ pub(crate) fn get_stacked_layout(
 pub(crate) fn stack_traces(
     layout: &StackedLayout,
     traces: &[&DeviceMatrix<F>],
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<PleMatrix<F>, StackTracesError> {
     let mem = MemTracker::start("prover.stack_traces");
     let l_skip = layout.l_skip();
@@ -145,7 +145,7 @@ pub(crate) fn stack_traces_into_expanded(
     traces: &[&DeviceMatrix<F>],
     buffer: &mut DeviceBuffer<F>,
     padded_height: usize,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(), StackTracesError> {
     let l_skip = layout.l_skip();
     debug_assert_eq!(padded_height % layout.height(), 0);
@@ -212,7 +212,7 @@ pub fn rs_code_matrix(
     layout: &StackedLayout,
     traces: &[&DeviceMatrix<F>],
     stacked_matrix: &Option<PleMatrix<F>>,
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<DeviceMatrix<F>, RsCodeMatrixError> {
     let mem = MemTracker::start_and_reset_peak("prover.rs_code_matrix");
     let l_skip = layout.l_skip();
@@ -355,7 +355,7 @@ mod tests {
     use itertools::Itertools;
     use openvm_cuda_common::{
         common::get_device,
-        stream::{CudaStream, DeviceContext, StreamGuard},
+        stream::{CudaStream, GpuDeviceCtx, StreamGuard},
     };
     use openvm_stark_backend::{
         prover::ColMajorMatrix,
@@ -369,8 +369,8 @@ mod tests {
         prelude::{F, SC},
     };
 
-    fn test_ctx() -> DeviceContext {
-        DeviceContext {
+    fn test_ctx() -> GpuDeviceCtx {
+        GpuDeviceCtx {
             device_id: get_device().unwrap() as u32,
             stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
         }

--- a/crates/cuda-backend/src/stacked_pcs.rs
+++ b/crates/cuda-backend/src/stacked_pcs.rs
@@ -3,8 +3,7 @@ use std::{ffi::c_void, sync::Arc};
 use getset::Getters;
 use itertools::Itertools;
 use openvm_cuda_common::{
-    copy::cuda_memcpy, d_buffer::DeviceBuffer, memory_manager::MemTracker,
-    stream::cudaStreamPerThread,
+    copy::cuda_memcpy, d_buffer::DeviceBuffer, memory_manager::MemTracker, stream::cudaStream_t,
 };
 use openvm_stark_backend::{
     p3_util::log2_strict_usize,
@@ -55,6 +54,7 @@ pub fn stacked_commit<MH: GpuMerkleHash + MerkleTreeConstructor>(
     k_whir: usize,
     traces: &[&DeviceMatrix<F>],
     prover_config: GpuProverConfig,
+    stream: cudaStream_t,
 ) -> Result<(MH::Digest, StackedPcsDataGpu<F, MH::Digest>), ProverError> {
     let mut mem = MemTracker::start("prover.stacked_commit");
     mem.tracing_info("before stacked_commit");
@@ -66,15 +66,16 @@ pub fn stacked_commit<MH: GpuMerkleHash + MerkleTreeConstructor>(
         "stacked_matrix_dimensions"
     );
     let opt_stacked_matrix = if prover_config.cache_stacked_matrix {
-        Some(stack_traces(&layout, traces)?)
+        Some(stack_traces(&layout, traces, stream)?)
     } else {
         None
     };
-    let rs_matrix = rs_code_matrix(log_blowup, &layout, traces, &opt_stacked_matrix)?;
+    let rs_matrix = rs_code_matrix(log_blowup, &layout, traces, &opt_stacked_matrix, stream)?;
     let tree = MerkleTreeGpu::<F, MH::Digest>::new_with_hash::<MH>(
         rs_matrix,
         1 << k_whir,
         prover_config.cache_rs_code_matrix,
+        stream,
     )?;
     let root = tree.root();
     let data = StackedPcsDataGpu {
@@ -94,9 +95,10 @@ pub fn stacked_matrix(
     l_skip: usize,
     n_stack: usize,
     traces: &[&DeviceMatrix<F>],
+    stream: cudaStream_t,
 ) -> Result<(PleMatrix<F>, StackedLayout), ProverError> {
     let layout = get_stacked_layout(l_skip, n_stack, traces);
-    let matrix = stack_traces(&layout, traces)?;
+    let matrix = stack_traces(&layout, traces, stream)?;
     Ok((matrix, layout))
 }
 
@@ -120,15 +122,18 @@ pub(crate) fn get_stacked_layout(
 pub(crate) fn stack_traces(
     layout: &StackedLayout,
     traces: &[&DeviceMatrix<F>],
+    stream: cudaStream_t,
 ) -> Result<PleMatrix<F>, StackTracesError> {
     let mem = MemTracker::start("prover.stack_traces");
     let l_skip = layout.l_skip();
     let height = layout.height();
     let width = layout.width();
     let mut q_evals = DeviceBuffer::<F>::with_capacity(width.checked_mul(height).unwrap());
-    stack_traces_into_expanded(layout, traces, &mut q_evals, height)?;
+    stack_traces_into_expanded(layout, traces, &mut q_evals, height, stream)?;
     mem.emit_metrics();
-    Ok(PleMatrix::from_evals(l_skip, q_evals, height, width))
+    Ok(PleMatrix::from_evals(
+        l_skip, q_evals, height, width, stream,
+    ))
 }
 
 /// `buffer` should be the buffer to write the stacked traces into.
@@ -139,6 +144,7 @@ pub(crate) fn stack_traces_into_expanded(
     traces: &[&DeviceMatrix<F>],
     buffer: &mut DeviceBuffer<F>,
     padded_height: usize,
+    stream: cudaStream_t,
 ) -> Result<(), StackTracesError> {
     let l_skip = layout.l_skip();
     debug_assert_eq!(padded_height % layout.height(), 0);
@@ -175,15 +181,8 @@ pub(crate) fn stack_traces_into_expanded(
             unsafe {
                 let src = trace.buffer().as_ptr().add(*j * trace.height());
                 let dst = buffer.as_mut_ptr().add(start);
-                batch_expand_pad_wide(
-                    dst,
-                    src,
-                    trace.height() as u32,
-                    stride as u32,
-                    1,
-                    cudaStreamPerThread,
-                )
-                .map_err(StackTracesError::BatchExpandPadWide)?;
+                batch_expand_pad_wide(dst, src, trace.height() as u32, stride as u32, 1, stream)
+                    .map_err(StackTracesError::BatchExpandPadWide)?;
             }
         }
     }
@@ -202,6 +201,7 @@ pub fn rs_code_matrix(
     layout: &StackedLayout,
     traces: &[&DeviceMatrix<F>],
     stacked_matrix: &Option<PleMatrix<F>>,
+    stream: cudaStream_t,
 ) -> Result<DeviceMatrix<F>, RsCodeMatrixError> {
     let mem = MemTracker::start_and_reset_peak("prover.rs_code_matrix");
     let l_skip = layout.l_skip();
@@ -222,12 +222,12 @@ pub fn rs_code_matrix(
                 width as u32,
                 codeword_height as u32,
                 height as u32,
-                cudaStreamPerThread,
+                stream,
             )
             .map_err(RsCodeMatrixError::BatchExpandPad)?;
         }
     } else {
-        stack_traces_into_expanded(layout, traces, &mut codewords, codeword_height)
+        stack_traces_into_expanded(layout, traces, &mut codewords, codeword_height, stream)
             .map_err(RsCodeMatrixError::StackTraces)?;
         // Currently codewords has the stacked matrix, batch expanded, in evaluation form on
         // hyperprism. We convert it to mixed form, i.e., unroll `PleMatrix::from_evals`.
@@ -238,14 +238,8 @@ pub fn rs_code_matrix(
             // (width cols) * (codeword_height / 2^l_skip chunks per col). Use natural ordering.
             let num_uni_poly = width * (codeword_height >> l_skip);
             unsafe {
-                batch_ntt_small(
-                    &mut codewords,
-                    l_skip,
-                    num_uni_poly,
-                    true,
-                    cudaStreamPerThread,
-                )
-                .map_err(RsCodeMatrixError::CustomBatchIntt)?;
+                batch_ntt_small(&mut codewords, l_skip, num_uni_poly, true, stream)
+                    .map_err(RsCodeMatrixError::CustomBatchIntt)?;
             }
         }
     }
@@ -271,6 +265,7 @@ pub fn rs_code_matrix(
                 l_skip as u32 - 1, // end_log_step (inclusive)
                 false,             // coeffs to evals (NOT eval to coeff)
                 false,             // natural order
+                stream,
             )
             .map_err(|error| RsCodeMatrixError::MleInterpolateStage2d { error, step: 1 })?;
         }
@@ -284,7 +279,7 @@ pub fn rs_code_matrix(
             log_codeword_height as u32,
             codeword_height as u32,
             width as u32,
-            cudaStreamPerThread,
+            stream,
         )
         .map_err(RsCodeMatrixError::BitRev)?;
     }
@@ -297,6 +292,7 @@ pub fn rs_code_matrix(
         width as u32,
         false, // bit-reversal already done
         false,
+        stream,
     );
     let code_matrix = DeviceMatrix::new(Arc::new(codewords), codeword_height, width);
     mem.emit_metrics();
@@ -340,6 +336,7 @@ impl<F, Digest> StackedPcsDataGpu<F, Digest> {
 #[cfg(test)]
 mod tests {
     use itertools::Itertools;
+    use openvm_cuda_common::stream::cudaStreamPerThread;
     use openvm_stark_backend::{
         prover::ColMajorMatrix,
         test_utils::{InteractionsFixture11, TestFixture},
@@ -358,15 +355,20 @@ mod tests {
             .map(|v| v.into_iter().map(F::from_u32).collect_vec());
         let mats = columns
             .into_iter()
-            .map(|c| transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1)).unwrap())
+            .map(|c| {
+                transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1), cudaStreamPerThread)
+                    .unwrap()
+            })
             .collect_vec();
         let mat_refs = mats.iter().collect_vec();
         let l_skip = 0;
-        let (stacked_mat, _layout) = stacked_matrix(0, 2, &mat_refs).unwrap();
+        let (stacked_mat, _layout) = stacked_matrix(0, 2, &mat_refs, cudaStreamPerThread).unwrap();
         assert_eq!(stacked_mat.height(), 4);
         assert_eq!(stacked_mat.width(), 2);
-        let stacked_h_mat =
-            transport_matrix_d2h_col_major(&stacked_mat.to_evals(l_skip).unwrap()).unwrap();
+        let stacked_h_mat = transport_matrix_d2h_col_major(
+            &stacked_mat.to_evals(l_skip, cudaStreamPerThread).unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             stacked_h_mat.values,
             [1, 2, 3, 4, 5, 6, 7, 0].map(F::from_u32).to_vec()
@@ -376,16 +378,25 @@ mod tests {
     #[test]
     fn test_stacked_matrix_manual_1() {
         let ctx = TestFixture::<SC>::generate_proving_ctx(&InteractionsFixture11);
-        let [send_trace, rcv_trace] = [0, 1]
-            .map(|i| transport_matrix_h2d_col_major(&ctx.per_trace[i].1.common_main).unwrap());
+        let [send_trace, rcv_trace] = [0, 1].map(|i| {
+            transport_matrix_h2d_col_major(&ctx.per_trace[i].1.common_main, cudaStreamPerThread)
+                .unwrap()
+        });
         let l_skip = 2;
         let n_stack = 8;
-        let (stacked_mat, _layout) =
-            stacked_matrix(l_skip, n_stack, &[&rcv_trace, &send_trace]).unwrap();
+        let (stacked_mat, _layout) = stacked_matrix(
+            l_skip,
+            n_stack,
+            &[&rcv_trace, &send_trace],
+            cudaStreamPerThread,
+        )
+        .unwrap();
         assert_eq!(stacked_mat.height(), 1 << (l_skip + n_stack));
         assert_eq!(stacked_mat.width(), 1);
-        let stacked_h_mat =
-            transport_matrix_d2h_col_major(&stacked_mat.to_evals(l_skip).unwrap()).unwrap();
+        let stacked_h_mat = transport_matrix_d2h_col_major(
+            &stacked_mat.to_evals(l_skip, cudaStreamPerThread).unwrap(),
+        )
+        .unwrap();
         let mut expected = vec![F::ZERO; 1 << (l_skip + n_stack)];
         expected[..24].copy_from_slice(
             &[
@@ -403,15 +414,21 @@ mod tests {
             .map(|v| v.into_iter().map(F::from_u32).collect_vec());
         let mats = columns
             .into_iter()
-            .map(|c| transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1)).unwrap())
+            .map(|c| {
+                transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1), cudaStreamPerThread)
+                    .unwrap()
+            })
             .collect_vec();
         let mat_refs = mats.iter().collect_vec();
         let l_skip = 2;
-        let (stacked_mat, _layout) = stacked_matrix(l_skip, 0, &mat_refs).unwrap();
+        let (stacked_mat, _layout) =
+            stacked_matrix(l_skip, 0, &mat_refs, cudaStreamPerThread).unwrap();
         assert_eq!(stacked_mat.height(), 4);
         assert_eq!(stacked_mat.width(), 3);
-        let stacked_h_mat =
-            transport_matrix_d2h_col_major(&stacked_mat.to_evals(l_skip).unwrap()).unwrap();
+        let stacked_h_mat = transport_matrix_d2h_col_major(
+            &stacked_mat.to_evals(l_skip, cudaStreamPerThread).unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             stacked_h_mat.values,
             [1, 2, 3, 4, 5, 0, 6, 0, 7, 0, 0, 0]
@@ -426,15 +443,21 @@ mod tests {
             .map(|v| v.into_iter().map(F::from_u32).collect_vec());
         let mats = columns
             .into_iter()
-            .map(|c| transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1)).unwrap())
+            .map(|c| {
+                transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1), cudaStreamPerThread)
+                    .unwrap()
+            })
             .collect_vec();
         let mat_refs = mats.iter().collect_vec();
         let l_skip = 3;
-        let (stacked_mat, _layout) = stacked_matrix(l_skip, 0, &mat_refs).unwrap();
+        let (stacked_mat, _layout) =
+            stacked_matrix(l_skip, 0, &mat_refs, cudaStreamPerThread).unwrap();
         assert_eq!(stacked_mat.height(), 8);
         assert_eq!(stacked_mat.width(), 3);
-        let stacked_h_mat =
-            transport_matrix_d2h_col_major(&stacked_mat.to_evals(l_skip).unwrap()).unwrap();
+        let stacked_h_mat = transport_matrix_d2h_col_major(
+            &stacked_mat.to_evals(l_skip, cudaStreamPerThread).unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             stacked_h_mat.values,
             [

--- a/crates/cuda-backend/src/stacked_pcs.rs
+++ b/crates/cuda-backend/src/stacked_pcs.rs
@@ -3,7 +3,7 @@ use std::{ffi::c_void, sync::Arc};
 use getset::Getters;
 use itertools::Itertools;
 use openvm_cuda_common::{
-    copy::cuda_memcpy, d_buffer::DeviceBuffer, memory_manager::MemTracker, stream::cudaStream_t,
+    copy::cuda_memcpy_on, d_buffer::DeviceBuffer, memory_manager::MemTracker, stream::DeviceContext,
 };
 use openvm_stark_backend::{
     p3_util::log2_strict_usize,
@@ -54,7 +54,7 @@ pub fn stacked_commit<MH: GpuMerkleHash + MerkleTreeConstructor>(
     k_whir: usize,
     traces: &[&DeviceMatrix<F>],
     prover_config: GpuProverConfig,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<(MH::Digest, StackedPcsDataGpu<F, MH::Digest>), ProverError> {
     let mut mem = MemTracker::start("prover.stacked_commit");
     mem.tracing_info("before stacked_commit");
@@ -66,16 +66,16 @@ pub fn stacked_commit<MH: GpuMerkleHash + MerkleTreeConstructor>(
         "stacked_matrix_dimensions"
     );
     let opt_stacked_matrix = if prover_config.cache_stacked_matrix {
-        Some(stack_traces(&layout, traces, stream)?)
+        Some(stack_traces(&layout, traces, ctx)?)
     } else {
         None
     };
-    let rs_matrix = rs_code_matrix(log_blowup, &layout, traces, &opt_stacked_matrix, stream)?;
+    let rs_matrix = rs_code_matrix(log_blowup, &layout, traces, &opt_stacked_matrix, ctx)?;
     let tree = MerkleTreeGpu::<F, MH::Digest>::new_with_hash::<MH>(
         rs_matrix,
         1 << k_whir,
         prover_config.cache_rs_code_matrix,
-        stream,
+        ctx,
     )?;
     let root = tree.root();
     let data = StackedPcsDataGpu {
@@ -95,10 +95,10 @@ pub fn stacked_matrix(
     l_skip: usize,
     n_stack: usize,
     traces: &[&DeviceMatrix<F>],
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<(PleMatrix<F>, StackedLayout), ProverError> {
     let layout = get_stacked_layout(l_skip, n_stack, traces);
-    let matrix = stack_traces(&layout, traces, stream)?;
+    let matrix = stack_traces(&layout, traces, ctx)?;
     Ok((matrix, layout))
 }
 
@@ -122,18 +122,16 @@ pub(crate) fn get_stacked_layout(
 pub(crate) fn stack_traces(
     layout: &StackedLayout,
     traces: &[&DeviceMatrix<F>],
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<PleMatrix<F>, StackTracesError> {
     let mem = MemTracker::start("prover.stack_traces");
     let l_skip = layout.l_skip();
     let height = layout.height();
     let width = layout.width();
-    let mut q_evals = DeviceBuffer::<F>::with_capacity(width.checked_mul(height).unwrap());
-    stack_traces_into_expanded(layout, traces, &mut q_evals, height, stream)?;
+    let mut q_evals = DeviceBuffer::<F>::with_capacity_on(width.checked_mul(height).unwrap(), ctx);
+    stack_traces_into_expanded(layout, traces, &mut q_evals, height, ctx)?;
     mem.emit_metrics();
-    Ok(PleMatrix::from_evals(
-        l_skip, q_evals, height, width, stream,
-    ))
+    Ok(PleMatrix::from_evals(l_skip, q_evals, height, width, ctx))
 }
 
 /// `buffer` should be the buffer to write the stacked traces into.
@@ -144,13 +142,15 @@ pub(crate) fn stack_traces_into_expanded(
     traces: &[&DeviceMatrix<F>],
     buffer: &mut DeviceBuffer<F>,
     padded_height: usize,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<(), StackTracesError> {
     let l_skip = layout.l_skip();
     debug_assert_eq!(padded_height % layout.height(), 0);
     debug_assert_eq!(buffer.len() % padded_height, 0);
     debug_assert_eq!(buffer.len() / padded_height, layout.width());
-    buffer.fill_zero().map_err(StackTracesError::FillZero)?;
+    buffer
+        .fill_zero_on(ctx)
+        .map_err(StackTracesError::FillZero)?;
     for (mat_idx, j, s) in &layout.sorted_cols {
         let start = s.col_idx * padded_height + s.row_idx;
         let trace = traces[*mat_idx];
@@ -165,10 +165,11 @@ pub(crate) fn stack_traces_into_expanded(
                 let src = trace.buffer().as_ptr().add(*j * s_len);
                 let dst = buffer.as_mut_ptr().add(start);
                 // D2D memcpy
-                cuda_memcpy::<true, true>(
+                cuda_memcpy_on::<true, true>(
                     dst as *mut c_void,
                     src as *const c_void,
                     s_len * size_of::<F>(),
+                    ctx,
                 )?;
             }
         } else {
@@ -181,8 +182,15 @@ pub(crate) fn stack_traces_into_expanded(
             unsafe {
                 let src = trace.buffer().as_ptr().add(*j * trace.height());
                 let dst = buffer.as_mut_ptr().add(start);
-                batch_expand_pad_wide(dst, src, trace.height() as u32, stride as u32, 1, stream)
-                    .map_err(StackTracesError::BatchExpandPadWide)?;
+                batch_expand_pad_wide(
+                    dst,
+                    src,
+                    trace.height() as u32,
+                    stride as u32,
+                    1,
+                    ctx.stream.as_raw(),
+                )
+                .map_err(StackTracesError::BatchExpandPadWide)?;
             }
         }
     }
@@ -201,7 +209,7 @@ pub fn rs_code_matrix(
     layout: &StackedLayout,
     traces: &[&DeviceMatrix<F>],
     stacked_matrix: &Option<PleMatrix<F>>,
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<DeviceMatrix<F>, RsCodeMatrixError> {
     let mem = MemTracker::start_and_reset_peak("prover.rs_code_matrix");
     let l_skip = layout.l_skip();
@@ -209,7 +217,7 @@ pub fn rs_code_matrix(
     let width = layout.width();
     debug_assert!(height >= (1 << l_skip));
     let codeword_height = height.checked_shl(log_blowup as u32).unwrap();
-    let mut codewords = DeviceBuffer::<F>::with_capacity(codeword_height * width);
+    let mut codewords = DeviceBuffer::<F>::with_capacity_on(codeword_height * width, ctx);
     // The following kernels together perform MLE interpolation followed by coset NTT for
     // `width` polys from `height -> codeword_height` size domains.
     if let Some(stacked_matrix) = stacked_matrix.as_ref() {
@@ -222,12 +230,12 @@ pub fn rs_code_matrix(
                 width as u32,
                 codeword_height as u32,
                 height as u32,
-                stream,
+                ctx.stream.as_raw(),
             )
             .map_err(RsCodeMatrixError::BatchExpandPad)?;
         }
     } else {
-        stack_traces_into_expanded(layout, traces, &mut codewords, codeword_height, stream)
+        stack_traces_into_expanded(layout, traces, &mut codewords, codeword_height, ctx)
             .map_err(RsCodeMatrixError::StackTraces)?;
         // Currently codewords has the stacked matrix, batch expanded, in evaluation form on
         // hyperprism. We convert it to mixed form, i.e., unroll `PleMatrix::from_evals`.
@@ -238,8 +246,14 @@ pub fn rs_code_matrix(
             // (width cols) * (codeword_height / 2^l_skip chunks per col). Use natural ordering.
             let num_uni_poly = width * (codeword_height >> l_skip);
             unsafe {
-                batch_ntt_small(&mut codewords, l_skip, num_uni_poly, true, stream)
-                    .map_err(RsCodeMatrixError::CustomBatchIntt)?;
+                batch_ntt_small(
+                    &mut codewords,
+                    l_skip,
+                    num_uni_poly,
+                    true,
+                    ctx.stream.as_raw(),
+                )
+                .map_err(RsCodeMatrixError::CustomBatchIntt)?;
             }
         }
     }
@@ -265,7 +279,7 @@ pub fn rs_code_matrix(
                 l_skip as u32 - 1, // end_log_step (inclusive)
                 false,             // coeffs to evals (NOT eval to coeff)
                 false,             // natural order
-                stream,
+                ctx.stream.as_raw(),
             )
             .map_err(|error| RsCodeMatrixError::MleInterpolateStage2d { error, step: 1 })?;
         }
@@ -279,7 +293,7 @@ pub fn rs_code_matrix(
             log_codeword_height as u32,
             codeword_height as u32,
             width as u32,
-            stream,
+            ctx.stream.as_raw(),
         )
         .map_err(RsCodeMatrixError::BitRev)?;
     }
@@ -292,7 +306,7 @@ pub fn rs_code_matrix(
         width as u32,
         false, // bit-reversal already done
         false,
-        stream,
+        ctx,
     );
     let code_matrix = DeviceMatrix::new(Arc::new(codewords), codeword_height, width);
     mem.emit_metrics();
@@ -336,7 +350,10 @@ impl<F, Digest> StackedPcsDataGpu<F, Digest> {
 #[cfg(test)]
 mod tests {
     use itertools::Itertools;
-    use openvm_cuda_common::stream::cudaStreamPerThread;
+    use openvm_cuda_common::{
+        common::get_device,
+        stream::{CudaStream, DeviceContext, StreamGuard},
+    };
     use openvm_stark_backend::{
         prover::ColMajorMatrix,
         test_utils::{InteractionsFixture11, TestFixture},
@@ -349,26 +366,30 @@ mod tests {
         prelude::{F, SC},
     };
 
+    fn test_ctx() -> DeviceContext {
+        DeviceContext {
+            device_id: get_device().unwrap() as u32,
+            stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
+        }
+    }
+
     #[test]
     fn test_stacked_matrix_manual_0() {
+        let ctx = test_ctx();
         let columns = [vec![1, 2, 3, 4], vec![5, 6], vec![7]]
             .map(|v| v.into_iter().map(F::from_u32).collect_vec());
         let mats = columns
             .into_iter()
-            .map(|c| {
-                transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1), cudaStreamPerThread)
-                    .unwrap()
-            })
+            .map(|c| transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1), &ctx).unwrap())
             .collect_vec();
         let mat_refs = mats.iter().collect_vec();
         let l_skip = 0;
-        let (stacked_mat, _layout) = stacked_matrix(0, 2, &mat_refs, cudaStreamPerThread).unwrap();
+        let (stacked_mat, _layout) = stacked_matrix(0, 2, &mat_refs, &ctx).unwrap();
         assert_eq!(stacked_mat.height(), 4);
         assert_eq!(stacked_mat.width(), 2);
-        let stacked_h_mat = transport_matrix_d2h_col_major(
-            &stacked_mat.to_evals(l_skip, cudaStreamPerThread).unwrap(),
-        )
-        .unwrap();
+        let stacked_h_mat =
+            transport_matrix_d2h_col_major(&stacked_mat.to_evals(l_skip, &ctx).unwrap(), &ctx)
+                .unwrap();
         assert_eq!(
             stacked_h_mat.values,
             [1, 2, 3, 4, 5, 6, 7, 0].map(F::from_u32).to_vec()
@@ -377,24 +398,21 @@ mod tests {
 
     #[test]
     fn test_stacked_matrix_manual_1() {
-        let ctx = TestFixture::<SC>::generate_proving_ctx(&InteractionsFixture11);
+        let gpu_ctx = test_ctx();
+        let proving_ctx = TestFixture::<SC>::generate_proving_ctx(&InteractionsFixture11);
         let [send_trace, rcv_trace] = [0, 1].map(|i| {
-            transport_matrix_h2d_col_major(&ctx.per_trace[i].1.common_main, cudaStreamPerThread)
+            transport_matrix_h2d_col_major(&proving_ctx.per_trace[i].1.common_main, &gpu_ctx)
                 .unwrap()
         });
         let l_skip = 2;
         let n_stack = 8;
-        let (stacked_mat, _layout) = stacked_matrix(
-            l_skip,
-            n_stack,
-            &[&rcv_trace, &send_trace],
-            cudaStreamPerThread,
-        )
-        .unwrap();
+        let (stacked_mat, _layout) =
+            stacked_matrix(l_skip, n_stack, &[&rcv_trace, &send_trace], &gpu_ctx).unwrap();
         assert_eq!(stacked_mat.height(), 1 << (l_skip + n_stack));
         assert_eq!(stacked_mat.width(), 1);
         let stacked_h_mat = transport_matrix_d2h_col_major(
-            &stacked_mat.to_evals(l_skip, cudaStreamPerThread).unwrap(),
+            &stacked_mat.to_evals(l_skip, &gpu_ctx).unwrap(),
+            &gpu_ctx,
         )
         .unwrap();
         let mut expected = vec![F::ZERO; 1 << (l_skip + n_stack)];
@@ -410,25 +428,21 @@ mod tests {
 
     #[test]
     fn test_stacked_matrix_manual_strided_0() {
+        let ctx = test_ctx();
         let columns = [vec![1, 2, 3, 4], vec![5, 6], vec![7]]
             .map(|v| v.into_iter().map(F::from_u32).collect_vec());
         let mats = columns
             .into_iter()
-            .map(|c| {
-                transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1), cudaStreamPerThread)
-                    .unwrap()
-            })
+            .map(|c| transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1), &ctx).unwrap())
             .collect_vec();
         let mat_refs = mats.iter().collect_vec();
         let l_skip = 2;
-        let (stacked_mat, _layout) =
-            stacked_matrix(l_skip, 0, &mat_refs, cudaStreamPerThread).unwrap();
+        let (stacked_mat, _layout) = stacked_matrix(l_skip, 0, &mat_refs, &ctx).unwrap();
         assert_eq!(stacked_mat.height(), 4);
         assert_eq!(stacked_mat.width(), 3);
-        let stacked_h_mat = transport_matrix_d2h_col_major(
-            &stacked_mat.to_evals(l_skip, cudaStreamPerThread).unwrap(),
-        )
-        .unwrap();
+        let stacked_h_mat =
+            transport_matrix_d2h_col_major(&stacked_mat.to_evals(l_skip, &ctx).unwrap(), &ctx)
+                .unwrap();
         assert_eq!(
             stacked_h_mat.values,
             [1, 2, 3, 4, 5, 0, 6, 0, 7, 0, 0, 0]
@@ -439,25 +453,21 @@ mod tests {
 
     #[test]
     fn test_stacked_matrix_manual_strided_1() {
+        let ctx = test_ctx();
         let columns = [vec![1, 2, 3, 4], vec![5, 6], vec![7]]
             .map(|v| v.into_iter().map(F::from_u32).collect_vec());
         let mats = columns
             .into_iter()
-            .map(|c| {
-                transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1), cudaStreamPerThread)
-                    .unwrap()
-            })
+            .map(|c| transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1), &ctx).unwrap())
             .collect_vec();
         let mat_refs = mats.iter().collect_vec();
         let l_skip = 3;
-        let (stacked_mat, _layout) =
-            stacked_matrix(l_skip, 0, &mat_refs, cudaStreamPerThread).unwrap();
+        let (stacked_mat, _layout) = stacked_matrix(l_skip, 0, &mat_refs, &ctx).unwrap();
         assert_eq!(stacked_mat.height(), 8);
         assert_eq!(stacked_mat.width(), 3);
-        let stacked_h_mat = transport_matrix_d2h_col_major(
-            &stacked_mat.to_evals(l_skip, cudaStreamPerThread).unwrap(),
-        )
-        .unwrap();
+        let stacked_h_mat =
+            transport_matrix_d2h_col_major(&stacked_mat.to_evals(l_skip, &ctx).unwrap(), &ctx)
+                .unwrap();
         assert_eq!(
             stacked_h_mat.values,
             [

--- a/crates/cuda-backend/src/stacked_pcs.rs
+++ b/crates/cuda-backend/src/stacked_pcs.rs
@@ -2,7 +2,10 @@ use std::{ffi::c_void, sync::Arc};
 
 use getset::Getters;
 use itertools::Itertools;
-use openvm_cuda_common::{copy::cuda_memcpy, d_buffer::DeviceBuffer, memory_manager::MemTracker};
+use openvm_cuda_common::{
+    copy::cuda_memcpy, d_buffer::DeviceBuffer, memory_manager::MemTracker,
+    stream::cudaStreamPerThread,
+};
 use openvm_stark_backend::{
     p3_util::log2_strict_usize,
     prover::{stacked_pcs::StackedLayout, MatrixDimensions},
@@ -172,8 +175,15 @@ pub(crate) fn stack_traces_into_expanded(
             unsafe {
                 let src = trace.buffer().as_ptr().add(*j * trace.height());
                 let dst = buffer.as_mut_ptr().add(start);
-                batch_expand_pad_wide(dst, src, trace.height() as u32, stride as u32, 1)
-                    .map_err(StackTracesError::BatchExpandPadWide)?;
+                batch_expand_pad_wide(
+                    dst,
+                    src,
+                    trace.height() as u32,
+                    stride as u32,
+                    1,
+                    cudaStreamPerThread,
+                )
+                .map_err(StackTracesError::BatchExpandPadWide)?;
             }
         }
     }
@@ -212,6 +222,7 @@ pub fn rs_code_matrix(
                 width as u32,
                 codeword_height as u32,
                 height as u32,
+                cudaStreamPerThread,
             )
             .map_err(RsCodeMatrixError::BatchExpandPad)?;
         }
@@ -227,8 +238,14 @@ pub fn rs_code_matrix(
             // (width cols) * (codeword_height / 2^l_skip chunks per col). Use natural ordering.
             let num_uni_poly = width * (codeword_height >> l_skip);
             unsafe {
-                batch_ntt_small(&mut codewords, l_skip, num_uni_poly, true)
-                    .map_err(RsCodeMatrixError::CustomBatchIntt)?;
+                batch_ntt_small(
+                    &mut codewords,
+                    l_skip,
+                    num_uni_poly,
+                    true,
+                    cudaStreamPerThread,
+                )
+                .map_err(RsCodeMatrixError::CustomBatchIntt)?;
             }
         }
     }
@@ -267,6 +284,7 @@ pub fn rs_code_matrix(
             log_codeword_height as u32,
             codeword_height as u32,
             width as u32,
+            cudaStreamPerThread,
         )
         .map_err(RsCodeMatrixError::BitRev)?;
     }

--- a/crates/cuda-backend/src/stacked_pcs.rs
+++ b/crates/cuda-backend/src/stacked_pcs.rs
@@ -54,7 +54,7 @@ pub fn stacked_commit<MH: GpuMerkleHash + MerkleTreeConstructor>(
     k_whir: usize,
     traces: &[&DeviceMatrix<F>],
     prover_config: GpuProverConfig,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<(MH::Digest, StackedPcsDataGpu<F, MH::Digest>), ProverError> {
     let mut mem = MemTracker::start("prover.stacked_commit");
     mem.tracing_info("before stacked_commit");
@@ -66,16 +66,16 @@ pub fn stacked_commit<MH: GpuMerkleHash + MerkleTreeConstructor>(
         "stacked_matrix_dimensions"
     );
     let opt_stacked_matrix = if prover_config.cache_stacked_matrix {
-        Some(stack_traces(&layout, traces, ctx)?)
+        Some(stack_traces(&layout, traces, device_ctx)?)
     } else {
         None
     };
-    let rs_matrix = rs_code_matrix(log_blowup, &layout, traces, &opt_stacked_matrix, ctx)?;
+    let rs_matrix = rs_code_matrix(log_blowup, &layout, traces, &opt_stacked_matrix, device_ctx)?;
     let tree = MerkleTreeGpu::<F, MH::Digest>::new_with_hash::<MH>(
         rs_matrix,
         1 << k_whir,
         prover_config.cache_rs_code_matrix,
-        ctx,
+        device_ctx,
     )?;
     let root = tree.root();
     let data = StackedPcsDataGpu {
@@ -95,10 +95,10 @@ pub fn stacked_matrix(
     l_skip: usize,
     n_stack: usize,
     traces: &[&DeviceMatrix<F>],
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<(PleMatrix<F>, StackedLayout), ProverError> {
     let layout = get_stacked_layout(l_skip, n_stack, traces);
-    let matrix = stack_traces(&layout, traces, ctx)?;
+    let matrix = stack_traces(&layout, traces, device_ctx)?;
     Ok((matrix, layout))
 }
 
@@ -122,16 +122,19 @@ pub(crate) fn get_stacked_layout(
 pub(crate) fn stack_traces(
     layout: &StackedLayout,
     traces: &[&DeviceMatrix<F>],
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<PleMatrix<F>, StackTracesError> {
     let mem = MemTracker::start("prover.stack_traces");
     let l_skip = layout.l_skip();
     let height = layout.height();
     let width = layout.width();
-    let mut q_evals = DeviceBuffer::<F>::with_capacity_on(width.checked_mul(height).unwrap(), ctx);
-    stack_traces_into_expanded(layout, traces, &mut q_evals, height, ctx)?;
+    let mut q_evals =
+        DeviceBuffer::<F>::with_capacity_on(width.checked_mul(height).unwrap(), device_ctx);
+    stack_traces_into_expanded(layout, traces, &mut q_evals, height, device_ctx)?;
     mem.emit_metrics();
-    Ok(PleMatrix::from_evals(l_skip, q_evals, height, width, ctx))
+    Ok(PleMatrix::from_evals(
+        l_skip, q_evals, height, width, device_ctx,
+    ))
 }
 
 /// `buffer` should be the buffer to write the stacked traces into.
@@ -142,14 +145,14 @@ pub(crate) fn stack_traces_into_expanded(
     traces: &[&DeviceMatrix<F>],
     buffer: &mut DeviceBuffer<F>,
     padded_height: usize,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<(), StackTracesError> {
     let l_skip = layout.l_skip();
     debug_assert_eq!(padded_height % layout.height(), 0);
     debug_assert_eq!(buffer.len() % padded_height, 0);
     debug_assert_eq!(buffer.len() / padded_height, layout.width());
     buffer
-        .fill_zero_on(ctx)
+        .fill_zero_on(device_ctx)
         .map_err(StackTracesError::FillZero)?;
     for (mat_idx, j, s) in &layout.sorted_cols {
         let start = s.col_idx * padded_height + s.row_idx;
@@ -169,7 +172,7 @@ pub(crate) fn stack_traces_into_expanded(
                     dst as *mut c_void,
                     src as *const c_void,
                     s_len * size_of::<F>(),
-                    ctx,
+                    device_ctx,
                 )?;
             }
         } else {
@@ -188,7 +191,7 @@ pub(crate) fn stack_traces_into_expanded(
                     trace.height() as u32,
                     stride as u32,
                     1,
-                    ctx.stream.as_raw(),
+                    device_ctx.stream.as_raw(),
                 )
                 .map_err(StackTracesError::BatchExpandPadWide)?;
             }
@@ -209,7 +212,7 @@ pub fn rs_code_matrix(
     layout: &StackedLayout,
     traces: &[&DeviceMatrix<F>],
     stacked_matrix: &Option<PleMatrix<F>>,
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<DeviceMatrix<F>, RsCodeMatrixError> {
     let mem = MemTracker::start_and_reset_peak("prover.rs_code_matrix");
     let l_skip = layout.l_skip();
@@ -217,7 +220,7 @@ pub fn rs_code_matrix(
     let width = layout.width();
     debug_assert!(height >= (1 << l_skip));
     let codeword_height = height.checked_shl(log_blowup as u32).unwrap();
-    let mut codewords = DeviceBuffer::<F>::with_capacity_on(codeword_height * width, ctx);
+    let mut codewords = DeviceBuffer::<F>::with_capacity_on(codeword_height * width, device_ctx);
     // The following kernels together perform MLE interpolation followed by coset NTT for
     // `width` polys from `height -> codeword_height` size domains.
     if let Some(stacked_matrix) = stacked_matrix.as_ref() {
@@ -230,12 +233,12 @@ pub fn rs_code_matrix(
                 width as u32,
                 codeword_height as u32,
                 height as u32,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
             .map_err(RsCodeMatrixError::BatchExpandPad)?;
         }
     } else {
-        stack_traces_into_expanded(layout, traces, &mut codewords, codeword_height, ctx)
+        stack_traces_into_expanded(layout, traces, &mut codewords, codeword_height, device_ctx)
             .map_err(RsCodeMatrixError::StackTraces)?;
         // Currently codewords has the stacked matrix, batch expanded, in evaluation form on
         // hyperprism. We convert it to mixed form, i.e., unroll `PleMatrix::from_evals`.
@@ -251,7 +254,7 @@ pub fn rs_code_matrix(
                     l_skip,
                     num_uni_poly,
                     true,
-                    ctx.stream.as_raw(),
+                    device_ctx.stream.as_raw(),
                 )
                 .map_err(RsCodeMatrixError::CustomBatchIntt)?;
             }
@@ -279,7 +282,7 @@ pub fn rs_code_matrix(
                 l_skip as u32 - 1, // end_log_step (inclusive)
                 false,             // coeffs to evals (NOT eval to coeff)
                 false,             // natural order
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
             .map_err(|error| RsCodeMatrixError::MleInterpolateStage2d { error, step: 1 })?;
         }
@@ -293,7 +296,7 @@ pub fn rs_code_matrix(
             log_codeword_height as u32,
             codeword_height as u32,
             width as u32,
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )
         .map_err(RsCodeMatrixError::BitRev)?;
     }
@@ -306,7 +309,7 @@ pub fn rs_code_matrix(
         width as u32,
         false, // bit-reversal already done
         false,
-        ctx,
+        device_ctx,
     );
     let code_matrix = DeviceMatrix::new(Arc::new(codewords), codeword_height, width);
     mem.emit_metrics();
@@ -375,21 +378,25 @@ mod tests {
 
     #[test]
     fn test_stacked_matrix_manual_0() {
-        let ctx = test_ctx();
+        let device_ctx = test_ctx();
         let columns = [vec![1, 2, 3, 4], vec![5, 6], vec![7]]
             .map(|v| v.into_iter().map(F::from_u32).collect_vec());
         let mats = columns
             .into_iter()
-            .map(|c| transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1), &ctx).unwrap())
+            .map(|c| {
+                transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1), &device_ctx).unwrap()
+            })
             .collect_vec();
         let mat_refs = mats.iter().collect_vec();
         let l_skip = 0;
-        let (stacked_mat, _layout) = stacked_matrix(0, 2, &mat_refs, &ctx).unwrap();
+        let (stacked_mat, _layout) = stacked_matrix(0, 2, &mat_refs, &device_ctx).unwrap();
         assert_eq!(stacked_mat.height(), 4);
         assert_eq!(stacked_mat.width(), 2);
-        let stacked_h_mat =
-            transport_matrix_d2h_col_major(&stacked_mat.to_evals(l_skip, &ctx).unwrap(), &ctx)
-                .unwrap();
+        let stacked_h_mat = transport_matrix_d2h_col_major(
+            &stacked_mat.to_evals(l_skip, &device_ctx).unwrap(),
+            &device_ctx,
+        )
+        .unwrap();
         assert_eq!(
             stacked_h_mat.values,
             [1, 2, 3, 4, 5, 6, 7, 0].map(F::from_u32).to_vec()
@@ -428,21 +435,25 @@ mod tests {
 
     #[test]
     fn test_stacked_matrix_manual_strided_0() {
-        let ctx = test_ctx();
+        let device_ctx = test_ctx();
         let columns = [vec![1, 2, 3, 4], vec![5, 6], vec![7]]
             .map(|v| v.into_iter().map(F::from_u32).collect_vec());
         let mats = columns
             .into_iter()
-            .map(|c| transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1), &ctx).unwrap())
+            .map(|c| {
+                transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1), &device_ctx).unwrap()
+            })
             .collect_vec();
         let mat_refs = mats.iter().collect_vec();
         let l_skip = 2;
-        let (stacked_mat, _layout) = stacked_matrix(l_skip, 0, &mat_refs, &ctx).unwrap();
+        let (stacked_mat, _layout) = stacked_matrix(l_skip, 0, &mat_refs, &device_ctx).unwrap();
         assert_eq!(stacked_mat.height(), 4);
         assert_eq!(stacked_mat.width(), 3);
-        let stacked_h_mat =
-            transport_matrix_d2h_col_major(&stacked_mat.to_evals(l_skip, &ctx).unwrap(), &ctx)
-                .unwrap();
+        let stacked_h_mat = transport_matrix_d2h_col_major(
+            &stacked_mat.to_evals(l_skip, &device_ctx).unwrap(),
+            &device_ctx,
+        )
+        .unwrap();
         assert_eq!(
             stacked_h_mat.values,
             [1, 2, 3, 4, 5, 0, 6, 0, 7, 0, 0, 0]
@@ -453,21 +464,25 @@ mod tests {
 
     #[test]
     fn test_stacked_matrix_manual_strided_1() {
-        let ctx = test_ctx();
+        let device_ctx = test_ctx();
         let columns = [vec![1, 2, 3, 4], vec![5, 6], vec![7]]
             .map(|v| v.into_iter().map(F::from_u32).collect_vec());
         let mats = columns
             .into_iter()
-            .map(|c| transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1), &ctx).unwrap())
+            .map(|c| {
+                transport_matrix_h2d_col_major(&ColMajorMatrix::new(c, 1), &device_ctx).unwrap()
+            })
             .collect_vec();
         let mat_refs = mats.iter().collect_vec();
         let l_skip = 3;
-        let (stacked_mat, _layout) = stacked_matrix(l_skip, 0, &mat_refs, &ctx).unwrap();
+        let (stacked_mat, _layout) = stacked_matrix(l_skip, 0, &mat_refs, &device_ctx).unwrap();
         assert_eq!(stacked_mat.height(), 8);
         assert_eq!(stacked_mat.width(), 3);
-        let stacked_h_mat =
-            transport_matrix_d2h_col_major(&stacked_mat.to_evals(l_skip, &ctx).unwrap(), &ctx)
-                .unwrap();
+        let stacked_h_mat = transport_matrix_d2h_col_major(
+            &stacked_mat.to_evals(l_skip, &device_ctx).unwrap(),
+            &device_ctx,
+        )
+        .unwrap();
         assert_eq!(
             stacked_h_mat.values,
             [

--- a/crates/cuda-backend/src/stacked_reduction.rs
+++ b/crates/cuda-backend/src/stacked_reduction.rs
@@ -5,7 +5,7 @@ use openvm_cuda_common::{
     copy::{cuda_memcpy_on, MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
-    stream::DeviceContext,
+    stream::GpuDeviceCtx,
 };
 use openvm_stark_backend::{
     dft::Radix2BowersSerial,
@@ -51,7 +51,7 @@ use crate::{
 pub const STACKED_REDUCTION_S_DEG: usize = 2;
 
 pub struct StackedReductionGpu<D = Digest> {
-    device_ctx: DeviceContext,
+    device_ctx: GpuDeviceCtx,
     sm_count: u32,
 
     l_skip: usize,
@@ -281,7 +281,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         r: &[EF],
         lambda: EF,
         sm_count: u32,
-        device_ctx: DeviceContext,
+        device_ctx: GpuDeviceCtx,
     ) -> Result<Self, StackedReductionError> {
         ensure_device_ntt_twiddles_initialized().map_err(StackedReductionError::InitNttTwiddles)?;
         let mem = MemTracker::start("prover.stacked_reduction_new");

--- a/crates/cuda-backend/src/stacked_reduction.rs
+++ b/crates/cuda-backend/src/stacked_reduction.rs
@@ -2,10 +2,10 @@ use std::{array::from_fn, cmp::max, ffi::c_void, iter::zip, mem, sync::Arc};
 
 use itertools::{zip_eq, Itertools};
 use openvm_cuda_common::{
-    copy::{cuda_memcpy, MemCopyD2H, MemCopyH2D},
+    copy::{cuda_memcpy_on, MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
-    stream::cudaStream_t,
+    stream::DeviceContext,
 };
 use openvm_stark_backend::{
     dft::Radix2BowersSerial,
@@ -51,7 +51,7 @@ use crate::{
 pub const STACKED_REDUCTION_S_DEG: usize = 2;
 
 pub struct StackedReductionGpu<D = Digest> {
-    stream: cudaStream_t,
+    ctx: DeviceContext,
     sm_count: u32,
 
     l_skip: usize,
@@ -203,7 +203,6 @@ where
     HS: GpuHashScheme,
     TS: GpuFiatShamirTranscript<HS::SC>,
 {
-    let stream = device.ctx.stream.as_raw();
     let n_stack = device.config().n_stack;
     // Batching randomness
     let lambda = transcript.sample_ext();
@@ -217,7 +216,7 @@ where
         r,
         lambda,
         device.sm_count(),
-        stream,
+        device.ctx.clone(),
     )?;
 
     // Round 0: univariate sumcheck
@@ -277,12 +276,12 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
     #[instrument("stacked_reduction_new", level = "debug", skip_all)]
     fn new<HS: GpuHashScheme<Digest = D>>(
         mpk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
-        ctx: ProvingContext<GenericGpuBackend<HS>>,
+        proving_ctx: ProvingContext<GenericGpuBackend<HS>>,
         common_main_pcs_data: StackedPcsDataGpu<F, D>,
         r: &[EF],
         lambda: EF,
         sm_count: u32,
-        stream: cudaStream_t,
+        ctx: DeviceContext,
     ) -> Result<Self, StackedReductionError> {
         ensure_device_ntt_twiddles_initialized().map_err(StackedReductionError::InitNttTwiddles)?;
         let mem = MemTracker::start("prover.stacked_reduction_new");
@@ -291,13 +290,13 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
 
         let omega_skip = F::two_adic_generator(l_skip);
         let omega_skip_pows = omega_skip.powers().take(1 << l_skip).collect_vec();
-        let d_omega_skip_pows = omega_skip_pows.to_device()?;
+        let d_omega_skip_pows = omega_skip_pows.to_device_on(&ctx)?;
 
         // NOTE: DeviceMatrix contains an Arc, so clone is lightweight [for now].
         // PERF[jpw]: stack the traces all at once. To save memory, we could either stack and drop
         // traces as we go or even at commit time only store the stacked matrix and drop the traces
         // much earlier.
-        let common_main_traces = ctx
+        let common_main_traces = proving_ctx
             .per_trace
             .iter()
             .map(|(_, air_ctx)| air_ctx.common_main.clone())
@@ -307,7 +306,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
             StackedPcsData2::from_raw(Arc::new(common_main_pcs_data), common_main_traces)
         };
         let mut stacked_per_commit = vec![common_main_stacked];
-        for (air_idx, air_ctx) in ctx.per_trace.iter() {
+        for (air_idx, air_ctx) in proving_ctx.per_trace.iter() {
             for committed in mpk.per_air[*air_idx]
                 .preprocessed_data
                 .iter()
@@ -325,13 +324,13 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
             .iter()
             .all(|d| d.layout().height() == 1 << (l_skip + n_stack)));
 
-        let need_rot_per_trace = ctx
+        let need_rot_per_trace = proving_ctx
             .per_trace
             .iter()
             .map(|(air_idx, _)| mpk.per_air[*air_idx].vk.params.need_rot)
             .collect_vec();
         let mut need_rot_per_commit = vec![need_rot_per_trace];
-        for (air_idx, air_ctx) in ctx.per_trace.iter() {
+        for (air_idx, air_ctx) in proving_ctx.per_trace.iter() {
             let need_rot = mpk.per_air[*air_idx].vk.params.need_rot;
             if mpk.per_air[*air_idx].preprocessed_data.is_some() {
                 need_rot_per_commit.push(vec![need_rot]);
@@ -345,7 +344,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
             .map(|d| d.layout().width() as u32)
             .collect_vec();
         let q_width_max = *q_widths.iter().max().unwrap();
-        let d_q_widths = q_widths.to_device()?;
+        let d_q_widths = q_widths.to_device_on(&ctx)?;
 
         let total_num_cols: usize = stacked_per_commit
             .iter()
@@ -393,9 +392,9 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 lambda_pows[lambda_rot_idx] = lambda_pows_used[lambda_rot_idx];
             }
         }
-        let d_lambda_pows = lambda_pows.to_device()?;
+        let d_lambda_pows = lambda_pows.to_device_on(&ctx)?;
 
-        let d_unstacked_cols = unstacked_cols.to_device()?;
+        let d_unstacked_cols = unstacked_cols.to_device_on(&ctx)?;
         let max_window_len = ht_diff_idxs
             .windows(2)
             .map(|window| window[1] - window[0])
@@ -414,34 +413,34 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 .saturating_sub(l_skip)
         );
         let eq_r_ns =
-            EqEvalSegments::new(&r[1..], stream).map_err(StackedReductionError::EqEvalSegments)?;
+            EqEvalSegments::new(&r[1..], &ctx).map_err(StackedReductionError::EqEvalSegments)?;
 
         let eq_const = eval_eq_uni_at_one(l_skip, r[0] * omega_skip);
         let eq_ub_per_trace = vec![EF::ONE; unstacked_cols.len()];
         let d_q_eval_ptrs = if stacked_per_commit.is_empty() {
             DeviceBuffer::new()
         } else {
-            DeviceBuffer::with_capacity(stacked_per_commit.len())
+            DeviceBuffer::with_capacity_on(stacked_per_commit.len(), &ctx)
         };
         let d_input_ptrs = if stacked_per_commit.is_empty() {
             DeviceBuffer::new()
         } else {
-            DeviceBuffer::with_capacity(stacked_per_commit.len())
+            DeviceBuffer::with_capacity_on(stacked_per_commit.len(), &ctx)
         };
         let d_output_ptrs = if stacked_per_commit.is_empty() {
             DeviceBuffer::new()
         } else {
-            DeviceBuffer::with_capacity(stacked_per_commit.len())
+            DeviceBuffer::with_capacity_on(stacked_per_commit.len(), &ctx)
         };
-        let d_accum = DeviceBuffer::<u64>::with_capacity(STACKED_REDUCTION_S_DEG * D_EF);
+        let d_accum = DeviceBuffer::<u64>::with_capacity_on(STACKED_REDUCTION_S_DEG * D_EF, &ctx);
         let d_eq_ub = if max_window_len > 0 {
-            DeviceBuffer::with_capacity(max_window_len)
+            DeviceBuffer::with_capacity_on(max_window_len, &ctx)
         } else {
             DeviceBuffer::new()
         };
 
         Ok(Self {
-            stream,
+            ctx,
             sm_count,
             l_skip,
             n_stack,
@@ -496,16 +495,17 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
 
         // Accumulation buffers for G0, G1, G2 (on identity coset)
         // d_g_pos: for n >= 0 traces
-        let mut d_g_pos = DeviceBuffer::<EF>::with_capacity(NUM_G * skip_domain);
+        let mut d_g_pos = DeviceBuffer::<EF>::with_capacity_on(NUM_G * skip_domain, &self.ctx);
         d_g_pos
-            .fill_zero()
+            .fill_zero_on(&self.ctx)
             .map_err(StackedReductionError::FillZero)?;
 
         // d_g_neg[k]: for traces with |n| = k+1, where n < 0 and k in 0..l_skip
         let mut d_g_neg: Vec<DeviceBuffer<EF>> = (0..l_skip)
             .map(|_| {
-                let b = DeviceBuffer::with_capacity(NUM_G * skip_domain);
-                b.fill_zero().map_err(StackedReductionError::FillZero)?;
+                let b = DeviceBuffer::with_capacity_on(NUM_G * skip_domain, &self.ctx);
+                b.fill_zero_on(&self.ctx)
+                    .map_err(StackedReductionError::FillZero)?;
                 Ok(b)
             })
             .collect::<Result<Vec<_>, StackedReductionError>>()?;
@@ -532,12 +532,12 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                     trace_height as u32,
                     trace_width as u32,
                     l_skip as u32,
-                    self.stream,
+                    self.ctx.stream.as_raw(),
                 )
             } as usize;
 
             if block_sums_len > self.d_block_sums.len() {
-                self.d_block_sums = DeviceBuffer::<EF>::with_capacity(block_sums_len);
+                self.d_block_sums = DeviceBuffer::<EF>::with_capacity_on(block_sums_len, &self.ctx);
             }
 
             unsafe {
@@ -553,7 +553,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                     trace_height,
                     trace_width,
                     l_skip,
-                    self.stream,
+                    self.ctx.stream.as_raw(),
                 )
                 .map_err(StackedReductionError::SumcheckRound0)?;
             };
@@ -589,7 +589,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         let mut s_0_coeffs = vec![EF::ZERO; large_uni_domain];
 
         // --- Process n >= 0 bucket ---
-        let g_pos = d_g_pos.to_host()?;
+        let g_pos = d_g_pos.to_host_on(&self.ctx)?;
         if !g_pos.iter().all(|&x| x == EF::ZERO) {
             // Build E polynomials for n >= 0
             let e0 = eq_uni_poly::<F, EF>(l_skip, self.r_0);
@@ -613,7 +613,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         // --- Process n < 0 buckets ---
         for (bucket_idx, d_g_neg_bucket) in d_g_neg.into_iter().enumerate() {
             let n_abs = bucket_idx + 1;
-            let g_neg = d_g_neg_bucket.to_host()?;
+            let g_neg = d_g_neg_bucket.to_host_on(&self.ctx)?;
             if g_neg.iter().all(|&x| x == EF::ZERO) {
                 continue;
             }
@@ -709,17 +709,18 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         let skip_domain = 1 << l_skip;
         let inv_lagrange_denoms =
             compute_barycentric_inv_lagrange_denoms(l_skip, &self.omega_skip_pows, u_0);
-        let d_inv_lagrange_denoms = inv_lagrange_denoms.to_device()?;
+        let d_inv_lagrange_denoms = inv_lagrange_denoms.to_device_on(&self.ctx)?;
 
         for stacked in &self.stacked_per_commit {
             let layout = stacked.layout();
             let num_x = 1 << n_stack;
             let stacked_width = layout.width();
             debug_assert_eq!(layout.height(), 1 << (l_skip + n_stack));
-            let folded_evals = DeviceBuffer::<EF>::with_capacity(num_x * stacked_width);
+            let folded_evals =
+                DeviceBuffer::<EF>::with_capacity_on(num_x * stacked_width, &self.ctx);
             // We must fill with zeros because some parts will be left empty due to stacking
             folded_evals
-                .fill_zero()
+                .fill_zero_on(&self.ctx)
                 .map_err(StackedReductionError::FillZero)?;
             let mut dst_offset = 0;
             for trace in &stacked.traces {
@@ -746,7 +747,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         trace.height(),
                         trace.width(),
                         l_skip,
-                        self.stream,
+                        self.ctx.stream.as_raw(),
                     )
                     .map_err(StackedReductionError::FoldPle)?;
                 }
@@ -761,7 +762,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         let eq_uni_u0r0_rot = eval_eq_uni(l_skip, u_0, r_0 * omega_skip);
         let eq_uni_u01 = eval_eq_uni_at_one(l_skip, u_0);
         debug_assert_eq!(self.eq_r_ns.buffer.len(), 2 << n_max);
-        self.k_rot_ns.buffer = DeviceBuffer::with_capacity(2 << n_max);
+        self.k_rot_ns.buffer = DeviceBuffer::with_capacity_on(2 << n_max, &self.ctx);
         [EF::ZERO].copy_to(&mut self.k_rot_ns.buffer)?;
         unsafe {
             // SAFETY:
@@ -772,12 +773,16 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 eq_uni_u0r0_rot,
                 self.eq_const * eq_uni_u01,
                 n_max as u32,
-                self.stream,
+                self.ctx.stream.as_raw(),
             )
             .map_err(StackedReductionError::InitKRot)?;
         }
-        vector_scalar_multiply_ext(&mut self.eq_r_ns.buffer, eq_uni_u0r0, self.stream)
-            .map_err(StackedReductionError::VectorScalarMul)?;
+        vector_scalar_multiply_ext(
+            &mut self.eq_r_ns.buffer,
+            eq_uni_u0r0,
+            self.ctx.stream.as_raw(),
+        )
+        .map_err(StackedReductionError::VectorScalarMul)?;
 
         // Compute the special eq values for n = -l_skip..0
         // First in order -n = 1..=l_skip, then reverse to order n = -l_skip..0 corresponding to
@@ -821,19 +826,21 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
             // SAFETY: size of eq_r_ns, k_rot_ns is currently 2 * 2^{n_max - round + 1}
             unsafe {
                 // D2H copy of single EF element
-                cuda_memcpy::<true, false>(
+                cuda_memcpy_on::<true, false>(
                     tmp.as_mut_ptr() as *mut c_void,
                     self.eq_r_ns.get_ptr(0) as *const c_void,
                     size_of::<EF>(),
+                    &self.ctx,
                 )?;
 
                 self.eq_stable.push(tmp[0]);
 
                 // D2H copy of single EF element
-                cuda_memcpy::<true, false>(
+                cuda_memcpy_on::<true, false>(
                     tmp.as_mut_ptr() as *mut c_void,
                     self.k_rot_ns.get_ptr(0) as *const c_void,
                     size_of::<EF>(),
+                    &self.ctx,
                 )?;
 
                 self.k_rot_stable.push(tmp[0]);
@@ -852,7 +859,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
 
             // Zero-initialize accumulator for atomic adds
             self.d_accum
-                .fill_zero()
+                .fill_zero_on(&self.ctx)
                 .map_err(StackedReductionError::FillZero)?;
 
             if log_height < l_skip + round {
@@ -866,7 +873,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 // this transfer can be minimized.
                 let eq_ub_slice = &self.eq_ub_per_trace[window[0]..window[1]];
                 if eq_ub_slice.len() > self.d_eq_ub.len() {
-                    self.d_eq_ub = DeviceBuffer::with_capacity(eq_ub_slice.len());
+                    self.d_eq_ub = DeviceBuffer::with_capacity_on(eq_ub_slice.len(), &self.ctx);
                 }
                 eq_ub_slice.copy_to(&mut self.d_eq_ub)?;
                 let stacked_height = self.stacked_height(round);
@@ -883,7 +890,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         window_len,
                         l_skip,
                         round,
-                        self.stream,
+                        self.ctx.stream.as_raw(),
                     )
                     .map_err(StackedReductionError::SumcheckMleRoundDegenerate)?;
                 }
@@ -906,14 +913,14 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         window_len,
                         num_y,
                         self.sm_count,
-                        self.stream,
+                        self.ctx.stream.as_raw(),
                     )
                     .map_err(StackedReductionError::SumcheckMleRound)?;
                 };
             }
 
             // D2H copy and reduce modulo P
-            let h_accum = self.d_accum.to_host()?;
+            let h_accum = self.d_accum.to_host_on(&self.ctx)?;
             let evals = reduce_raw_u64_to_ef(&h_accum);
             s_evals_batch.push(evals);
         }
@@ -931,7 +938,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
             .q_evals
             .iter()
             .map(|q| {
-                let folded = DeviceBuffer::with_capacity(q.len() >> 1);
+                let folded = DeviceBuffer::with_capacity_on(q.len() >> 1, &self.ctx);
                 let output_ptr = folded.as_mut_ptr();
                 (folded, q.as_ptr(), output_ptr)
             })
@@ -954,7 +961,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 self.stacked_height(round + 1) as u32,
                 self.q_width_max * output_height,
                 u_round,
-                self.stream,
+                self.ctx.stream.as_raw(),
             )
             .map_err(StackedReductionError::FoldMle)?;
         }
@@ -965,7 +972,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
             let output_max_n = input_max_n.saturating_sub(1);
             let output_len = 1 << input_max_n;
 
-            let mut buffer = DeviceBuffer::<EF>::with_capacity(output_len);
+            let mut buffer = DeviceBuffer::<EF>::with_capacity_on(output_len, &self.ctx);
             [EF::ZERO].copy_to(&mut buffer)?;
             // SAFETY:
             // - eq_r_ns has max_n equal to input_max_n
@@ -978,14 +985,14 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         &self.eq_r_ns,
                         u_round,
                         output_max_n,
-                        self.stream,
+                        self.ctx.stream.as_raw(),
                     )
                     .map_err(StackedReductionError::TriangularFoldMle)?;
                 }
                 self.eq_r_ns = output;
             }
 
-            let mut buffer = DeviceBuffer::<EF>::with_capacity(output_len);
+            let mut buffer = DeviceBuffer::<EF>::with_capacity_on(output_len, &self.ctx);
             [EF::ZERO].copy_to(&mut buffer)?;
             // SAFETY:
             // - k_rot_ns has max_n equal to input_max_n
@@ -998,7 +1005,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         &self.k_rot_ns,
                         u_round,
                         output_max_n,
-                        self.stream,
+                        self.ctx.stream.as_raw(),
                     )
                     .map_err(StackedReductionError::TriangularFoldMle)?;
                 }
@@ -1024,7 +1031,10 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
     fn get_stacked_openings(&self) -> Result<Vec<Vec<EF>>, StackedReductionError> {
         self.q_evals
             .iter()
-            .map(|q| q.to_host().map_err(StackedReductionError::MemCopy))
+            .map(|q| {
+                q.to_host_on(&self.ctx)
+                    .map_err(StackedReductionError::MemCopy)
+            })
             .collect::<Result<Vec<_>, _>>()
     }
 }

--- a/crates/cuda-backend/src/stacked_reduction.rs
+++ b/crates/cuda-backend/src/stacked_reduction.rs
@@ -548,6 +548,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                     trace_height,
                     trace_width,
                     l_skip,
+                    cudaStreamPerThread,
                 )
                 .map_err(StackedReductionError::SumcheckRound0)?;
             };
@@ -740,6 +741,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         trace.height(),
                         trace.width(),
                         l_skip,
+                        cudaStreamPerThread,
                     )
                     .map_err(StackedReductionError::FoldPle)?;
                 }
@@ -765,10 +767,11 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 eq_uni_u0r0_rot,
                 self.eq_const * eq_uni_u01,
                 n_max as u32,
+                cudaStreamPerThread,
             )
             .map_err(StackedReductionError::InitKRot)?;
         }
-        vector_scalar_multiply_ext(&mut self.eq_r_ns.buffer, eq_uni_u0r0)
+        vector_scalar_multiply_ext(&mut self.eq_r_ns.buffer, eq_uni_u0r0, cudaStreamPerThread)
             .map_err(StackedReductionError::VectorScalarMul)?;
 
         // Compute the special eq values for n = -l_skip..0
@@ -875,6 +878,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         window_len,
                         l_skip,
                         round,
+                        cudaStreamPerThread,
                     )
                     .map_err(StackedReductionError::SumcheckMleRoundDegenerate)?;
                 }
@@ -897,6 +901,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         window_len,
                         num_y,
                         self.sm_count,
+                        cudaStreamPerThread,
                     )
                     .map_err(StackedReductionError::SumcheckMleRound)?;
                 };
@@ -944,6 +949,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 self.stacked_height(round + 1) as u32,
                 self.q_width_max * output_height,
                 u_round,
+                cudaStreamPerThread,
             )
             .map_err(StackedReductionError::FoldMle)?;
         }
@@ -962,8 +968,14 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
             unsafe {
                 let mut output = EqEvalSegments::from_raw_parts(buffer, output_max_n);
                 if input_max_n != 0 {
-                    triangular_fold_mle(&mut output, &self.eq_r_ns, u_round, output_max_n)
-                        .map_err(StackedReductionError::TriangularFoldMle)?;
+                    triangular_fold_mle(
+                        &mut output,
+                        &self.eq_r_ns,
+                        u_round,
+                        output_max_n,
+                        cudaStreamPerThread,
+                    )
+                    .map_err(StackedReductionError::TriangularFoldMle)?;
                 }
                 self.eq_r_ns = output;
             }
@@ -976,8 +988,14 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
             unsafe {
                 let mut output = EqEvalSegments::from_raw_parts(buffer, output_max_n);
                 if input_max_n != 0 {
-                    triangular_fold_mle(&mut output, &self.k_rot_ns, u_round, output_max_n)
-                        .map_err(StackedReductionError::TriangularFoldMle)?;
+                    triangular_fold_mle(
+                        &mut output,
+                        &self.k_rot_ns,
+                        u_round,
+                        output_max_n,
+                        cudaStreamPerThread,
+                    )
+                    .map_err(StackedReductionError::TriangularFoldMle)?;
                 }
                 self.k_rot_ns = output;
             }

--- a/crates/cuda-backend/src/stacked_reduction.rs
+++ b/crates/cuda-backend/src/stacked_reduction.rs
@@ -51,7 +51,7 @@ use crate::{
 pub const STACKED_REDUCTION_S_DEG: usize = 2;
 
 pub struct StackedReductionGpu<D = Digest> {
-    ctx: DeviceContext,
+    device_ctx: DeviceContext,
     sm_count: u32,
 
     l_skip: usize,
@@ -216,7 +216,7 @@ where
         r,
         lambda,
         device.sm_count(),
-        device.ctx.clone(),
+        device.device_ctx.clone(),
     )?;
 
     // Round 0: univariate sumcheck
@@ -281,7 +281,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         r: &[EF],
         lambda: EF,
         sm_count: u32,
-        ctx: DeviceContext,
+        device_ctx: DeviceContext,
     ) -> Result<Self, StackedReductionError> {
         ensure_device_ntt_twiddles_initialized().map_err(StackedReductionError::InitNttTwiddles)?;
         let mem = MemTracker::start("prover.stacked_reduction_new");
@@ -290,7 +290,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
 
         let omega_skip = F::two_adic_generator(l_skip);
         let omega_skip_pows = omega_skip.powers().take(1 << l_skip).collect_vec();
-        let d_omega_skip_pows = omega_skip_pows.to_device_on(&ctx)?;
+        let d_omega_skip_pows = omega_skip_pows.to_device_on(&device_ctx)?;
 
         // NOTE: DeviceMatrix contains an Arc, so clone is lightweight [for now].
         // PERF[jpw]: stack the traces all at once. To save memory, we could either stack and drop
@@ -344,7 +344,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
             .map(|d| d.layout().width() as u32)
             .collect_vec();
         let q_width_max = *q_widths.iter().max().unwrap();
-        let d_q_widths = q_widths.to_device_on(&ctx)?;
+        let d_q_widths = q_widths.to_device_on(&device_ctx)?;
 
         let total_num_cols: usize = stacked_per_commit
             .iter()
@@ -392,9 +392,9 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 lambda_pows[lambda_rot_idx] = lambda_pows_used[lambda_rot_idx];
             }
         }
-        let d_lambda_pows = lambda_pows.to_device_on(&ctx)?;
+        let d_lambda_pows = lambda_pows.to_device_on(&device_ctx)?;
 
-        let d_unstacked_cols = unstacked_cols.to_device_on(&ctx)?;
+        let d_unstacked_cols = unstacked_cols.to_device_on(&device_ctx)?;
         let max_window_len = ht_diff_idxs
             .windows(2)
             .map(|window| window[1] - window[0])
@@ -412,35 +412,36 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 .unwrap_or(0)
                 .saturating_sub(l_skip)
         );
-        let eq_r_ns =
-            EqEvalSegments::new(&r[1..], &ctx).map_err(StackedReductionError::EqEvalSegments)?;
+        let eq_r_ns = EqEvalSegments::new(&r[1..], &device_ctx)
+            .map_err(StackedReductionError::EqEvalSegments)?;
 
         let eq_const = eval_eq_uni_at_one(l_skip, r[0] * omega_skip);
         let eq_ub_per_trace = vec![EF::ONE; unstacked_cols.len()];
         let d_q_eval_ptrs = if stacked_per_commit.is_empty() {
             DeviceBuffer::new()
         } else {
-            DeviceBuffer::with_capacity_on(stacked_per_commit.len(), &ctx)
+            DeviceBuffer::with_capacity_on(stacked_per_commit.len(), &device_ctx)
         };
         let d_input_ptrs = if stacked_per_commit.is_empty() {
             DeviceBuffer::new()
         } else {
-            DeviceBuffer::with_capacity_on(stacked_per_commit.len(), &ctx)
+            DeviceBuffer::with_capacity_on(stacked_per_commit.len(), &device_ctx)
         };
         let d_output_ptrs = if stacked_per_commit.is_empty() {
             DeviceBuffer::new()
         } else {
-            DeviceBuffer::with_capacity_on(stacked_per_commit.len(), &ctx)
+            DeviceBuffer::with_capacity_on(stacked_per_commit.len(), &device_ctx)
         };
-        let d_accum = DeviceBuffer::<u64>::with_capacity_on(STACKED_REDUCTION_S_DEG * D_EF, &ctx);
+        let d_accum =
+            DeviceBuffer::<u64>::with_capacity_on(STACKED_REDUCTION_S_DEG * D_EF, &device_ctx);
         let d_eq_ub = if max_window_len > 0 {
-            DeviceBuffer::with_capacity_on(max_window_len, &ctx)
+            DeviceBuffer::with_capacity_on(max_window_len, &device_ctx)
         } else {
             DeviceBuffer::new()
         };
 
         Ok(Self {
-            ctx,
+            device_ctx,
             sm_count,
             l_skip,
             n_stack,
@@ -495,16 +496,17 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
 
         // Accumulation buffers for G0, G1, G2 (on identity coset)
         // d_g_pos: for n >= 0 traces
-        let mut d_g_pos = DeviceBuffer::<EF>::with_capacity_on(NUM_G * skip_domain, &self.ctx);
+        let mut d_g_pos =
+            DeviceBuffer::<EF>::with_capacity_on(NUM_G * skip_domain, &self.device_ctx);
         d_g_pos
-            .fill_zero_on(&self.ctx)
+            .fill_zero_on(&self.device_ctx)
             .map_err(StackedReductionError::FillZero)?;
 
         // d_g_neg[k]: for traces with |n| = k+1, where n < 0 and k in 0..l_skip
         let mut d_g_neg: Vec<DeviceBuffer<EF>> = (0..l_skip)
             .map(|_| {
-                let b = DeviceBuffer::with_capacity_on(NUM_G * skip_domain, &self.ctx);
-                b.fill_zero_on(&self.ctx)
+                let b = DeviceBuffer::with_capacity_on(NUM_G * skip_domain, &self.device_ctx);
+                b.fill_zero_on(&self.device_ctx)
                     .map_err(StackedReductionError::FillZero)?;
                 Ok(b)
             })
@@ -532,12 +534,13 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                     trace_height as u32,
                     trace_width as u32,
                     l_skip as u32,
-                    self.ctx.stream.as_raw(),
+                    self.device_ctx.stream.as_raw(),
                 )
             } as usize;
 
             if block_sums_len > self.d_block_sums.len() {
-                self.d_block_sums = DeviceBuffer::<EF>::with_capacity_on(block_sums_len, &self.ctx);
+                self.d_block_sums =
+                    DeviceBuffer::<EF>::with_capacity_on(block_sums_len, &self.device_ctx);
             }
 
             unsafe {
@@ -553,7 +556,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                     trace_height,
                     trace_width,
                     l_skip,
-                    self.ctx.stream.as_raw(),
+                    self.device_ctx.stream.as_raw(),
                 )
                 .map_err(StackedReductionError::SumcheckRound0)?;
             };
@@ -589,7 +592,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         let mut s_0_coeffs = vec![EF::ZERO; large_uni_domain];
 
         // --- Process n >= 0 bucket ---
-        let g_pos = d_g_pos.to_host_on(&self.ctx)?;
+        let g_pos = d_g_pos.to_host_on(&self.device_ctx)?;
         if !g_pos.iter().all(|&x| x == EF::ZERO) {
             // Build E polynomials for n >= 0
             let e0 = eq_uni_poly::<F, EF>(l_skip, self.r_0);
@@ -613,7 +616,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         // --- Process n < 0 buckets ---
         for (bucket_idx, d_g_neg_bucket) in d_g_neg.into_iter().enumerate() {
             let n_abs = bucket_idx + 1;
-            let g_neg = d_g_neg_bucket.to_host_on(&self.ctx)?;
+            let g_neg = d_g_neg_bucket.to_host_on(&self.device_ctx)?;
             if g_neg.iter().all(|&x| x == EF::ZERO) {
                 continue;
             }
@@ -709,7 +712,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         let skip_domain = 1 << l_skip;
         let inv_lagrange_denoms =
             compute_barycentric_inv_lagrange_denoms(l_skip, &self.omega_skip_pows, u_0);
-        let d_inv_lagrange_denoms = inv_lagrange_denoms.to_device_on(&self.ctx)?;
+        let d_inv_lagrange_denoms = inv_lagrange_denoms.to_device_on(&self.device_ctx)?;
 
         for stacked in &self.stacked_per_commit {
             let layout = stacked.layout();
@@ -717,10 +720,10 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
             let stacked_width = layout.width();
             debug_assert_eq!(layout.height(), 1 << (l_skip + n_stack));
             let folded_evals =
-                DeviceBuffer::<EF>::with_capacity_on(num_x * stacked_width, &self.ctx);
+                DeviceBuffer::<EF>::with_capacity_on(num_x * stacked_width, &self.device_ctx);
             // We must fill with zeros because some parts will be left empty due to stacking
             folded_evals
-                .fill_zero_on(&self.ctx)
+                .fill_zero_on(&self.device_ctx)
                 .map_err(StackedReductionError::FillZero)?;
             let mut dst_offset = 0;
             for trace in &stacked.traces {
@@ -747,7 +750,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         trace.height(),
                         trace.width(),
                         l_skip,
-                        self.ctx.stream.as_raw(),
+                        self.device_ctx.stream.as_raw(),
                     )
                     .map_err(StackedReductionError::FoldPle)?;
                 }
@@ -762,8 +765,8 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         let eq_uni_u0r0_rot = eval_eq_uni(l_skip, u_0, r_0 * omega_skip);
         let eq_uni_u01 = eval_eq_uni_at_one(l_skip, u_0);
         debug_assert_eq!(self.eq_r_ns.buffer.len(), 2 << n_max);
-        self.k_rot_ns.buffer = DeviceBuffer::with_capacity_on(2 << n_max, &self.ctx);
-        [EF::ZERO].copy_to_on(&mut self.k_rot_ns.buffer, &self.ctx)?;
+        self.k_rot_ns.buffer = DeviceBuffer::with_capacity_on(2 << n_max, &self.device_ctx);
+        [EF::ZERO].copy_to_on(&mut self.k_rot_ns.buffer, &self.device_ctx)?;
         unsafe {
             // SAFETY:
             // - We allocated `k_rot_ns` with same capacity as `eq_r_ns` above.
@@ -773,14 +776,14 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 eq_uni_u0r0_rot,
                 self.eq_const * eq_uni_u01,
                 n_max as u32,
-                self.ctx.stream.as_raw(),
+                self.device_ctx.stream.as_raw(),
             )
             .map_err(StackedReductionError::InitKRot)?;
         }
         vector_scalar_multiply_ext(
             &mut self.eq_r_ns.buffer,
             eq_uni_u0r0,
-            self.ctx.stream.as_raw(),
+            self.device_ctx.stream.as_raw(),
         )
         .map_err(StackedReductionError::VectorScalarMul)?;
 
@@ -814,7 +817,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         let l_skip = self.l_skip;
 
         let q_eval_ptrs = self.q_evals.iter().map(|q| q.as_ptr()).collect_vec();
-        q_eval_ptrs.copy_to_on(&mut self.d_q_eval_ptrs, &self.ctx)?;
+        q_eval_ptrs.copy_to_on(&mut self.d_q_eval_ptrs, &self.device_ctx)?;
 
         if self.n_max >= (round - 1) {
             // Move stable eq, k_rot to stable vectors
@@ -830,7 +833,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                     tmp.as_mut_ptr() as *mut c_void,
                     self.eq_r_ns.get_ptr(0) as *const c_void,
                     size_of::<EF>(),
-                    &self.ctx,
+                    &self.device_ctx,
                 )?;
 
                 self.eq_stable.push(tmp[0]);
@@ -840,7 +843,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                     tmp.as_mut_ptr() as *mut c_void,
                     self.k_rot_ns.get_ptr(0) as *const c_void,
                     size_of::<EF>(),
-                    &self.ctx,
+                    &self.device_ctx,
                 )?;
 
                 self.k_rot_stable.push(tmp[0]);
@@ -859,7 +862,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
 
             // Zero-initialize accumulator for atomic adds
             self.d_accum
-                .fill_zero_on(&self.ctx)
+                .fill_zero_on(&self.device_ctx)
                 .map_err(StackedReductionError::FillZero)?;
 
             if log_height < l_skip + round {
@@ -873,9 +876,10 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 // this transfer can be minimized.
                 let eq_ub_slice = &self.eq_ub_per_trace[window[0]..window[1]];
                 if eq_ub_slice.len() > self.d_eq_ub.len() {
-                    self.d_eq_ub = DeviceBuffer::with_capacity_on(eq_ub_slice.len(), &self.ctx);
+                    self.d_eq_ub =
+                        DeviceBuffer::with_capacity_on(eq_ub_slice.len(), &self.device_ctx);
                 }
-                eq_ub_slice.copy_to_on(&mut self.d_eq_ub, &self.ctx)?;
+                eq_ub_slice.copy_to_on(&mut self.d_eq_ub, &self.device_ctx)?;
                 let stacked_height = self.stacked_height(round);
                 unsafe {
                     stacked_reduction_sumcheck_mle_round_degenerate(
@@ -890,7 +894,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         window_len,
                         l_skip,
                         round,
-                        self.ctx.stream.as_raw(),
+                        self.device_ctx.stream.as_raw(),
                     )
                     .map_err(StackedReductionError::SumcheckMleRoundDegenerate)?;
                 }
@@ -913,14 +917,14 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         window_len,
                         num_y,
                         self.sm_count,
-                        self.ctx.stream.as_raw(),
+                        self.device_ctx.stream.as_raw(),
                     )
                     .map_err(StackedReductionError::SumcheckMleRound)?;
                 };
             }
 
             // D2H copy and reduce modulo P
-            let h_accum = self.d_accum.to_host_on(&self.ctx)?;
+            let h_accum = self.d_accum.to_host_on(&self.device_ctx)?;
             let evals = reduce_raw_u64_to_ef(&h_accum);
             s_evals_batch.push(evals);
         }
@@ -938,13 +942,13 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
             .q_evals
             .iter()
             .map(|q| {
-                let folded = DeviceBuffer::with_capacity_on(q.len() >> 1, &self.ctx);
+                let folded = DeviceBuffer::with_capacity_on(q.len() >> 1, &self.device_ctx);
                 let output_ptr = folded.as_mut_ptr();
                 (folded, q.as_ptr(), output_ptr)
             })
             .multiunzip();
-        input_ptrs.copy_to_on(&mut self.d_input_ptrs, &self.ctx)?;
-        output_ptrs.copy_to_on(&mut self.d_output_ptrs, &self.ctx)?;
+        input_ptrs.copy_to_on(&mut self.d_input_ptrs, &self.device_ctx)?;
+        output_ptrs.copy_to_on(&mut self.d_output_ptrs, &self.device_ctx)?;
 
         // SAFETY:
         // - `d_input_ptrs` points to matrices with widths specified by `d_q_widths` and heights
@@ -961,7 +965,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 self.stacked_height(round + 1) as u32,
                 self.q_width_max * output_height,
                 u_round,
-                self.ctx.stream.as_raw(),
+                self.device_ctx.stream.as_raw(),
             )
             .map_err(StackedReductionError::FoldMle)?;
         }
@@ -972,8 +976,8 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
             let output_max_n = input_max_n.saturating_sub(1);
             let output_len = 1 << input_max_n;
 
-            let mut buffer = DeviceBuffer::<EF>::with_capacity_on(output_len, &self.ctx);
-            [EF::ZERO].copy_to_on(&mut buffer, &self.ctx)?;
+            let mut buffer = DeviceBuffer::<EF>::with_capacity_on(output_len, &self.device_ctx);
+            [EF::ZERO].copy_to_on(&mut buffer, &self.device_ctx)?;
             // SAFETY:
             // - eq_r_ns has max_n equal to input_max_n
             // - we allocate output for half the size of eq_r_ns
@@ -985,15 +989,15 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         &self.eq_r_ns,
                         u_round,
                         output_max_n,
-                        self.ctx.stream.as_raw(),
+                        self.device_ctx.stream.as_raw(),
                     )
                     .map_err(StackedReductionError::TriangularFoldMle)?;
                 }
                 self.eq_r_ns = output;
             }
 
-            let mut buffer = DeviceBuffer::<EF>::with_capacity_on(output_len, &self.ctx);
-            [EF::ZERO].copy_to_on(&mut buffer, &self.ctx)?;
+            let mut buffer = DeviceBuffer::<EF>::with_capacity_on(output_len, &self.device_ctx);
+            [EF::ZERO].copy_to_on(&mut buffer, &self.device_ctx)?;
             // SAFETY:
             // - k_rot_ns has max_n equal to input_max_n
             // - we allocate output for half the size of eq_r_ns
@@ -1005,7 +1009,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         &self.k_rot_ns,
                         u_round,
                         output_max_n,
-                        self.ctx.stream.as_raw(),
+                        self.device_ctx.stream.as_raw(),
                     )
                     .map_err(StackedReductionError::TriangularFoldMle)?;
                 }
@@ -1032,7 +1036,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         self.q_evals
             .iter()
             .map(|q| {
-                q.to_host_on(&self.ctx)
+                q.to_host_on(&self.device_ctx)
                     .map_err(StackedReductionError::MemCopy)
             })
             .collect::<Result<Vec<_>, _>>()

--- a/crates/cuda-backend/src/stacked_reduction.rs
+++ b/crates/cuda-backend/src/stacked_reduction.rs
@@ -5,7 +5,7 @@ use openvm_cuda_common::{
     copy::{cuda_memcpy, MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
-    stream::cudaStreamPerThread,
+    stream::cudaStream_t,
 };
 use openvm_stark_backend::{
     dft::Radix2BowersSerial,
@@ -51,6 +51,7 @@ use crate::{
 pub const STACKED_REDUCTION_S_DEG: usize = 2;
 
 pub struct StackedReductionGpu<D = Digest> {
+    stream: cudaStream_t,
     sm_count: u32,
 
     l_skip: usize,
@@ -202,6 +203,7 @@ where
     HS: GpuHashScheme,
     TS: GpuFiatShamirTranscript<HS::SC>,
 {
+    let stream = device.ctx.stream.as_raw();
     let n_stack = device.config().n_stack;
     // Batching randomness
     let lambda = transcript.sample_ext();
@@ -215,6 +217,7 @@ where
         r,
         lambda,
         device.sm_count(),
+        stream,
     )?;
 
     // Round 0: univariate sumcheck
@@ -279,6 +282,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         r: &[EF],
         lambda: EF,
         sm_count: u32,
+        stream: cudaStream_t,
     ) -> Result<Self, StackedReductionError> {
         ensure_device_ntt_twiddles_initialized().map_err(StackedReductionError::InitNttTwiddles)?;
         let mem = MemTracker::start("prover.stacked_reduction_new");
@@ -410,7 +414,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 .saturating_sub(l_skip)
         );
         let eq_r_ns =
-            EqEvalSegments::new(&r[1..]).map_err(StackedReductionError::EqEvalSegments)?;
+            EqEvalSegments::new(&r[1..], stream).map_err(StackedReductionError::EqEvalSegments)?;
 
         let eq_const = eval_eq_uni_at_one(l_skip, r[0] * omega_skip);
         let eq_ub_per_trace = vec![EF::ONE; unstacked_cols.len()];
@@ -437,6 +441,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         };
 
         Ok(Self {
+            stream,
             sm_count,
             l_skip,
             n_stack,
@@ -527,7 +532,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                     trace_height as u32,
                     trace_width as u32,
                     l_skip as u32,
-                    cudaStreamPerThread,
+                    self.stream,
                 )
             } as usize;
 
@@ -548,7 +553,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                     trace_height,
                     trace_width,
                     l_skip,
-                    cudaStreamPerThread,
+                    self.stream,
                 )
                 .map_err(StackedReductionError::SumcheckRound0)?;
             };
@@ -741,7 +746,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         trace.height(),
                         trace.width(),
                         l_skip,
-                        cudaStreamPerThread,
+                        self.stream,
                     )
                     .map_err(StackedReductionError::FoldPle)?;
                 }
@@ -767,11 +772,11 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 eq_uni_u0r0_rot,
                 self.eq_const * eq_uni_u01,
                 n_max as u32,
-                cudaStreamPerThread,
+                self.stream,
             )
             .map_err(StackedReductionError::InitKRot)?;
         }
-        vector_scalar_multiply_ext(&mut self.eq_r_ns.buffer, eq_uni_u0r0, cudaStreamPerThread)
+        vector_scalar_multiply_ext(&mut self.eq_r_ns.buffer, eq_uni_u0r0, self.stream)
             .map_err(StackedReductionError::VectorScalarMul)?;
 
         // Compute the special eq values for n = -l_skip..0
@@ -878,7 +883,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         window_len,
                         l_skip,
                         round,
-                        cudaStreamPerThread,
+                        self.stream,
                     )
                     .map_err(StackedReductionError::SumcheckMleRoundDegenerate)?;
                 }
@@ -901,7 +906,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         window_len,
                         num_y,
                         self.sm_count,
-                        cudaStreamPerThread,
+                        self.stream,
                     )
                     .map_err(StackedReductionError::SumcheckMleRound)?;
                 };
@@ -949,7 +954,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 self.stacked_height(round + 1) as u32,
                 self.q_width_max * output_height,
                 u_round,
-                cudaStreamPerThread,
+                self.stream,
             )
             .map_err(StackedReductionError::FoldMle)?;
         }
@@ -973,7 +978,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         &self.eq_r_ns,
                         u_round,
                         output_max_n,
-                        cudaStreamPerThread,
+                        self.stream,
                     )
                     .map_err(StackedReductionError::TriangularFoldMle)?;
                 }
@@ -993,7 +998,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         &self.k_rot_ns,
                         u_round,
                         output_max_n,
-                        cudaStreamPerThread,
+                        self.stream,
                     )
                     .map_err(StackedReductionError::TriangularFoldMle)?;
                 }

--- a/crates/cuda-backend/src/stacked_reduction.rs
+++ b/crates/cuda-backend/src/stacked_reduction.rs
@@ -203,7 +203,7 @@ where
     HS: GpuHashScheme,
     TS: GpuFiatShamirTranscript<HS::SC>,
 {
-    let n_stack = device.config().n_stack;
+    let n_stack = device.params().n_stack;
     // Batching randomness
     let lambda = transcript.sample_ext();
 

--- a/crates/cuda-backend/src/stacked_reduction.rs
+++ b/crates/cuda-backend/src/stacked_reduction.rs
@@ -5,6 +5,7 @@ use openvm_cuda_common::{
     copy::{cuda_memcpy, MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
+    stream::cudaStreamPerThread,
 };
 use openvm_stark_backend::{
     dft::Radix2BowersSerial,
@@ -526,6 +527,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                     trace_height as u32,
                     trace_width as u32,
                     l_skip as u32,
+                    cudaStreamPerThread,
                 )
             } as usize;
 

--- a/crates/cuda-backend/src/stacked_reduction.rs
+++ b/crates/cuda-backend/src/stacked_reduction.rs
@@ -201,7 +201,7 @@ where
     HS: GpuHashScheme,
     TS: GpuFiatShamirTranscript<HS::SC>,
 {
-    let n_stack = device.config.n_stack;
+    let n_stack = device.config().n_stack;
     // Batching randomness
     let lambda = transcript.sample_ext();
 

--- a/crates/cuda-backend/src/stacked_reduction.rs
+++ b/crates/cuda-backend/src/stacked_reduction.rs
@@ -763,7 +763,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         let eq_uni_u01 = eval_eq_uni_at_one(l_skip, u_0);
         debug_assert_eq!(self.eq_r_ns.buffer.len(), 2 << n_max);
         self.k_rot_ns.buffer = DeviceBuffer::with_capacity_on(2 << n_max, &self.ctx);
-        [EF::ZERO].copy_to(&mut self.k_rot_ns.buffer)?;
+        [EF::ZERO].copy_to_on(&mut self.k_rot_ns.buffer, &self.ctx)?;
         unsafe {
             // SAFETY:
             // - We allocated `k_rot_ns` with same capacity as `eq_r_ns` above.
@@ -814,7 +814,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         let l_skip = self.l_skip;
 
         let q_eval_ptrs = self.q_evals.iter().map(|q| q.as_ptr()).collect_vec();
-        q_eval_ptrs.copy_to(&mut self.d_q_eval_ptrs)?;
+        q_eval_ptrs.copy_to_on(&mut self.d_q_eval_ptrs, &self.ctx)?;
 
         if self.n_max >= (round - 1) {
             // Move stable eq, k_rot to stable vectors
@@ -875,7 +875,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 if eq_ub_slice.len() > self.d_eq_ub.len() {
                     self.d_eq_ub = DeviceBuffer::with_capacity_on(eq_ub_slice.len(), &self.ctx);
                 }
-                eq_ub_slice.copy_to(&mut self.d_eq_ub)?;
+                eq_ub_slice.copy_to_on(&mut self.d_eq_ub, &self.ctx)?;
                 let stacked_height = self.stacked_height(round);
                 unsafe {
                     stacked_reduction_sumcheck_mle_round_degenerate(
@@ -943,8 +943,8 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 (folded, q.as_ptr(), output_ptr)
             })
             .multiunzip();
-        input_ptrs.copy_to(&mut self.d_input_ptrs)?;
-        output_ptrs.copy_to(&mut self.d_output_ptrs)?;
+        input_ptrs.copy_to_on(&mut self.d_input_ptrs, &self.ctx)?;
+        output_ptrs.copy_to_on(&mut self.d_output_ptrs, &self.ctx)?;
 
         // SAFETY:
         // - `d_input_ptrs` points to matrices with widths specified by `d_q_widths` and heights
@@ -973,7 +973,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
             let output_len = 1 << input_max_n;
 
             let mut buffer = DeviceBuffer::<EF>::with_capacity_on(output_len, &self.ctx);
-            [EF::ZERO].copy_to(&mut buffer)?;
+            [EF::ZERO].copy_to_on(&mut buffer, &self.ctx)?;
             // SAFETY:
             // - eq_r_ns has max_n equal to input_max_n
             // - we allocate output for half the size of eq_r_ns
@@ -993,7 +993,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
             }
 
             let mut buffer = DeviceBuffer::<EF>::with_capacity_on(output_len, &self.ctx);
-            [EF::ZERO].copy_to(&mut buffer)?;
+            [EF::ZERO].copy_to_on(&mut buffer, &self.ctx)?;
             // SAFETY:
             // - k_rot_ns has max_n equal to input_max_n
             // - we allocate output for half the size of eq_r_ns

--- a/crates/cuda-backend/src/sumcheck.rs
+++ b/crates/cuda-backend/src/sumcheck.rs
@@ -2,6 +2,7 @@
 use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
+    stream::cudaStreamPerThread,
 };
 use openvm_stark_backend::{
     p3_util::log2_strict_usize,
@@ -96,6 +97,7 @@ where
                 num_matrices as u32,
                 current_height as u32,
                 d as u32,
+                cudaStreamPerThread,
             )
             .map_err(|e| SumcheckError::SumcheckMleRound(e.into()))?;
         }
@@ -126,6 +128,7 @@ where
                 output_height,
                 width as u32 * output_height,
                 r_round,
+                cudaStreamPerThread,
             )
             .map_err(|e| SumcheckError::FoldMle(e.into()))?;
         }
@@ -197,8 +200,14 @@ pub fn sumcheck_prismalinear_gpu(
     // Input: [height=2^(l_skip+n), width=1]
     // Treat as: [height=2^l_skip, width=2^n]
     unsafe {
-        batch_ntt_small(&mut d_coeffs, l_skip, num_x * width, true)
-            .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
+        batch_ntt_small(
+            &mut d_coeffs,
+            l_skip,
+            num_x * width,
+            true,
+            cudaStreamPerThread,
+        )
+        .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
     }
 
     if domain_size == large_domain_size {
@@ -210,6 +219,7 @@ pub fn sumcheck_prismalinear_gpu(
                 num_x as u32,
                 width as u32,
                 large_domain_size as u32,
+                cudaStreamPerThread,
             )
             .map_err(|e| SumcheckError::ReduceOverXAndCols(e.into()))?;
         }
@@ -225,14 +235,21 @@ pub fn sumcheck_prismalinear_gpu(
                 (num_x * width) as u32,
                 large_domain_size as u32,
                 domain_size as u32,
+                cudaStreamPerThread,
             )
             .map_err(|e| SumcheckError::BatchExpandPadWide(e.into()))?;
         }
 
         // Step 3: DFT on large domain
         unsafe {
-            batch_ntt_small(&mut d_coeffs_large, log_large_domain, num_x * width, false)
-                .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
+            batch_ntt_small(
+                &mut d_coeffs_large,
+                log_large_domain,
+                num_x * width,
+                false,
+                cudaStreamPerThread,
+            )
+            .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
         }
 
         // Step 4: Sum over all x and columns
@@ -243,6 +260,7 @@ pub fn sumcheck_prismalinear_gpu(
                 num_x as u32,
                 width as u32,
                 large_domain_size as u32,
+                cudaStreamPerThread,
             )
             .map_err(|e| SumcheckError::ReduceOverXAndCols(e.into()))?;
         }
@@ -250,8 +268,14 @@ pub fn sumcheck_prismalinear_gpu(
 
         // Step 5: iDFT to get coefficients
         unsafe {
-            batch_ntt_small(&mut d_s0_coeffs, log_large_domain, 1, true)
-                .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
+            batch_ntt_small(
+                &mut d_s0_coeffs,
+                log_large_domain,
+                1,
+                true,
+                cudaStreamPerThread,
+            )
+            .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
         }
     }
     // Step 6: Copy to host and convert to extension field
@@ -284,6 +308,7 @@ pub fn sumcheck_prismalinear_gpu(
             width as u32,
             domain_size as u32,
             r_0,
+            cudaStreamPerThread,
         )
         .map_err(|e| SumcheckError::FoldPleFromCoeffs(e.into()))?;
     }
@@ -328,6 +353,7 @@ pub fn sumcheck_prismalinear_gpu(
                 num_matrices as u32,
                 current_height as u32,
                 d as u32,
+                cudaStreamPerThread,
             )
             .map_err(|e| SumcheckError::SumcheckMleRound(e.into()))?;
         }
@@ -353,6 +379,7 @@ pub fn sumcheck_prismalinear_gpu(
                 output_height,
                 width as u32 * output_height,
                 r_round,
+                cudaStreamPerThread,
             )
             .map_err(|e| SumcheckError::FoldMle(e.into()))?;
         }

--- a/crates/cuda-backend/src/sumcheck.rs
+++ b/crates/cuda-backend/src/sumcheck.rs
@@ -36,7 +36,7 @@ use crate::{
 pub fn sumcheck_multilinear_gpu<F: Field>(
     transcript: &mut DuplexSpongeGpu,
     evals: &[F],
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<(SumcheckCubeProof<EF>, Vec<EF>), SumcheckError>
 where
     EF: ExtensionField<F>,
@@ -61,16 +61,16 @@ where
 
     // Allocate ping-pong buffers
     let total_size = width * current_height;
-    let mut d_buffer_a = evals_ext.to_device_on(ctx)?;
-    let mut d_buffer_b = DeviceBuffer::<EF>::with_capacity_on(total_size / 2, ctx);
+    let mut d_buffer_a = evals_ext.to_device_on(device_ctx)?;
+    let mut d_buffer_b = DeviceBuffer::<EF>::with_capacity_on(total_size / 2, device_ctx);
 
     // Set up pointer arrays on device
-    let mut d_input_ptrs = DeviceBuffer::<*const EF>::with_capacity_on(num_matrices, ctx);
-    let mut d_output_ptrs = DeviceBuffer::<*mut EF>::with_capacity_on(num_matrices, ctx);
-    let d_widths = [width as u32].to_device_on(ctx)?;
+    let mut d_input_ptrs = DeviceBuffer::<*const EF>::with_capacity_on(num_matrices, device_ctx);
+    let mut d_output_ptrs = DeviceBuffer::<*mut EF>::with_capacity_on(num_matrices, device_ctx);
+    let d_widths = [width as u32].to_device_on(device_ctx)?;
 
     // Buffer for round output [d * WD]
-    let d_round_output = DeviceBuffer::<EF>::with_capacity_on(d * WD, ctx);
+    let d_round_output = DeviceBuffer::<EF>::with_capacity_on(d * WD, device_ctx);
 
     // Sumcheck rounds
     for round in 0..n {
@@ -85,8 +85,8 @@ where
         let input_ptr = input_buf.as_ptr();
         let output_ptr = output_buf.as_mut_ptr();
 
-        [input_ptr].copy_to_on(&mut d_input_ptrs, ctx)?;
-        [output_ptr].copy_to_on(&mut d_output_ptrs, ctx)?;
+        [input_ptr].copy_to_on(&mut d_input_ptrs, device_ctx)?;
+        [output_ptr].copy_to_on(&mut d_output_ptrs, device_ctx)?;
 
         // Call sumcheck_mle_round kernel (uses output_buf as tmp)
         unsafe {
@@ -98,13 +98,13 @@ where
                 num_matrices as u32,
                 current_height as u32,
                 d as u32,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
             .map_err(|e| SumcheckError::SumcheckMleRound(e.into()))?;
         }
 
         // Copy result back to host
-        let h_round_output = d_round_output.to_host_on(ctx)?;
+        let h_round_output = d_round_output.to_host_on(device_ctx)?;
 
         // Observe in transcript
         let s = h_round_output[0..d].to_vec();
@@ -129,7 +129,7 @@ where
                 output_height,
                 width as u32 * output_height,
                 r_round,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
             .map_err(|e| SumcheckError::FoldMle(e.into()))?;
         }
@@ -139,7 +139,7 @@ where
 
     // After all rounds, get final evaluation claim
     let final_buf = if n % 2 == 1 { &d_buffer_b } else { &d_buffer_a };
-    let eval_claim_vec = final_buf.to_host_on(ctx)?;
+    let eval_claim_vec = final_buf.to_host_on(device_ctx)?;
     let eval_claim = eval_claim_vec[0];
 
     transcript.observe_ext(eval_claim);
@@ -170,7 +170,7 @@ pub fn sumcheck_prismalinear_gpu(
     transcript: &mut DuplexSpongeGpu,
     l_skip: usize,
     evals: &[F],
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<(SumcheckPrismProof<EF>, Vec<EF>), SumcheckError> {
     let prism_dim = p3_util::log2_strict_usize(evals.len());
     assert!(prism_dim >= l_skip);
@@ -195,8 +195,8 @@ pub fn sumcheck_prismalinear_gpu(
     // ========== Round 0: Special PLE round ==========
     let _round0_span = info_span!("sumcheck_prismalinear.round0").entered();
 
-    let mut d_coeffs = evals.to_device_on(ctx)?;
-    let mut d_s0_coeffs = DeviceBuffer::<F>::with_capacity_on(large_domain_size, ctx);
+    let mut d_coeffs = evals.to_device_on(device_ctx)?;
+    let mut d_s0_coeffs = DeviceBuffer::<F>::with_capacity_on(large_domain_size, device_ctx);
 
     // Step 1: iDFT on skip domain (reinterpreting dimensions)
     // Input: [height=2^(l_skip+n), width=1]
@@ -207,7 +207,7 @@ pub fn sumcheck_prismalinear_gpu(
             l_skip,
             num_x * width,
             true,
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )
         .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
     }
@@ -221,13 +221,13 @@ pub fn sumcheck_prismalinear_gpu(
                 num_x as u32,
                 width as u32,
                 large_domain_size as u32,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
             .map_err(|e| SumcheckError::ReduceOverXAndCols(e.into()))?;
         }
     } else {
         let mut d_coeffs_large =
-            DeviceBuffer::<F>::with_capacity_on(num_x * width * large_domain_size, ctx);
+            DeviceBuffer::<F>::with_capacity_on(num_x * width * large_domain_size, device_ctx);
 
         // Step 2: Copy and pad each column to large domain size
         unsafe {
@@ -237,7 +237,7 @@ pub fn sumcheck_prismalinear_gpu(
                 (num_x * width) as u32,
                 large_domain_size as u32,
                 domain_size as u32,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
             .map_err(|e| SumcheckError::BatchExpandPadWide(e.into()))?;
         }
@@ -249,7 +249,7 @@ pub fn sumcheck_prismalinear_gpu(
                 log_large_domain,
                 num_x * width,
                 false,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
             .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
         }
@@ -262,7 +262,7 @@ pub fn sumcheck_prismalinear_gpu(
                 num_x as u32,
                 width as u32,
                 large_domain_size as u32,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
             .map_err(|e| SumcheckError::ReduceOverXAndCols(e.into()))?;
         }
@@ -275,13 +275,13 @@ pub fn sumcheck_prismalinear_gpu(
                 log_large_domain,
                 1,
                 true,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
             .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
         }
     }
     // Step 6: Copy to host and convert to extension field
-    let s0_coeffs_host: Vec<F> = d_s0_coeffs.to_host_on(ctx)?;
+    let s0_coeffs_host: Vec<F> = d_s0_coeffs.to_host_on(device_ctx)?;
     drop(d_s0_coeffs);
     let s0_coeffs_ext: Vec<EF> = s0_coeffs_host[0..=s_deg]
         .iter()
@@ -301,7 +301,7 @@ pub fn sumcheck_prismalinear_gpu(
 
     // ========== Fold PLE: Evaluate at r_0 ==========
 
-    let d_folded = DeviceBuffer::<EF>::with_capacity_on(num_x, ctx);
+    let d_folded = DeviceBuffer::<EF>::with_capacity_on(num_x, device_ctx);
     unsafe {
         fold_ple_from_coeffs(
             d_coeffs.as_ptr(),     // Original input (base field, but modified by iDFT)
@@ -310,7 +310,7 @@ pub fn sumcheck_prismalinear_gpu(
             width as u32,
             domain_size as u32,
             r_0,
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )
         .map_err(|e| SumcheckError::FoldPleFromCoeffs(e.into()))?;
     }
@@ -325,12 +325,12 @@ pub fn sumcheck_prismalinear_gpu(
 
     // Allocate ping-pong buffers for MLE rounds
     let mut d_buffer_a = d_folded; // Reuse folded result
-    let mut d_buffer_b = DeviceBuffer::<EF>::with_capacity_on(current_height / 2, ctx);
+    let mut d_buffer_b = DeviceBuffer::<EF>::with_capacity_on(current_height / 2, device_ctx);
 
-    let mut d_input_ptrs = DeviceBuffer::<*const EF>::with_capacity_on(num_matrices, ctx);
-    let mut d_output_ptrs = DeviceBuffer::<*mut EF>::with_capacity_on(num_matrices, ctx);
-    let d_widths = [width as u32].to_device_on(ctx)?;
-    let d_round_output = DeviceBuffer::<EF>::with_capacity_on(d, ctx);
+    let mut d_input_ptrs = DeviceBuffer::<*const EF>::with_capacity_on(num_matrices, device_ctx);
+    let mut d_output_ptrs = DeviceBuffer::<*mut EF>::with_capacity_on(num_matrices, device_ctx);
+    let d_widths = [width as u32].to_device_on(device_ctx)?;
+    let d_round_output = DeviceBuffer::<EF>::with_capacity_on(d, device_ctx);
 
     for round in 1..=n {
         let (input_buf, output_buf) = if round % 2 == 1 {
@@ -342,8 +342,8 @@ pub fn sumcheck_prismalinear_gpu(
         let input_ptr = input_buf.as_ptr();
         let output_ptr = output_buf.as_mut_ptr();
 
-        [input_ptr].copy_to_on(&mut d_input_ptrs, ctx)?;
-        [output_ptr].copy_to_on(&mut d_output_ptrs, ctx)?;
+        [input_ptr].copy_to_on(&mut d_input_ptrs, device_ctx)?;
+        [output_ptr].copy_to_on(&mut d_output_ptrs, device_ctx)?;
 
         // Sumcheck MLE round
         unsafe {
@@ -355,12 +355,12 @@ pub fn sumcheck_prismalinear_gpu(
                 num_matrices as u32,
                 current_height as u32,
                 d as u32,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
             .map_err(|e| SumcheckError::SumcheckMleRound(e.into()))?;
         }
 
-        let h_round_output = d_round_output.to_host_on(ctx)?;
+        let h_round_output = d_round_output.to_host_on(device_ctx)?;
         let s = h_round_output[0..d].to_vec();
         assert_eq!(s.len(), d);
         transcript.observe_ext(s[0]);
@@ -381,7 +381,7 @@ pub fn sumcheck_prismalinear_gpu(
                 output_height,
                 width as u32 * output_height,
                 r_round,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
             .map_err(|e| SumcheckError::FoldMle(e.into()))?;
         }
@@ -392,7 +392,7 @@ pub fn sumcheck_prismalinear_gpu(
 
     // Get final evaluation claim
     let final_buf = if n % 2 == 1 { &d_buffer_b } else { &d_buffer_a };
-    let eval_claim_vec = final_buf.to_host_on(ctx)?;
+    let eval_claim_vec = final_buf.to_host_on(device_ctx)?;
     let eval_claim = eval_claim_vec[0];
 
     transcript.observe_ext(eval_claim);

--- a/crates/cuda-backend/src/sumcheck.rs
+++ b/crates/cuda-backend/src/sumcheck.rs
@@ -2,7 +2,7 @@
 use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
-    stream::cudaStream_t,
+    stream::DeviceContext,
 };
 use openvm_stark_backend::{
     p3_util::log2_strict_usize,
@@ -36,7 +36,7 @@ use crate::{
 pub fn sumcheck_multilinear_gpu<F: Field>(
     transcript: &mut DuplexSpongeGpu,
     evals: &[F],
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<(SumcheckCubeProof<EF>, Vec<EF>), SumcheckError>
 where
     EF: ExtensionField<F>,
@@ -61,16 +61,16 @@ where
 
     // Allocate ping-pong buffers
     let total_size = width * current_height;
-    let mut d_buffer_a = evals_ext.to_device()?;
-    let mut d_buffer_b = DeviceBuffer::<EF>::with_capacity(total_size / 2);
+    let mut d_buffer_a = evals_ext.to_device_on(ctx)?;
+    let mut d_buffer_b = DeviceBuffer::<EF>::with_capacity_on(total_size / 2, ctx);
 
     // Set up pointer arrays on device
-    let mut d_input_ptrs = DeviceBuffer::<*const EF>::with_capacity(num_matrices);
-    let mut d_output_ptrs = DeviceBuffer::<*mut EF>::with_capacity(num_matrices);
-    let d_widths = [width as u32].to_device()?;
+    let mut d_input_ptrs = DeviceBuffer::<*const EF>::with_capacity_on(num_matrices, ctx);
+    let mut d_output_ptrs = DeviceBuffer::<*mut EF>::with_capacity_on(num_matrices, ctx);
+    let d_widths = [width as u32].to_device_on(ctx)?;
 
     // Buffer for round output [d * WD]
-    let d_round_output = DeviceBuffer::<EF>::with_capacity(d * WD);
+    let d_round_output = DeviceBuffer::<EF>::with_capacity_on(d * WD, ctx);
 
     // Sumcheck rounds
     for round in 0..n {
@@ -85,8 +85,8 @@ where
         let input_ptr = input_buf.as_ptr();
         let output_ptr = output_buf.as_mut_ptr();
 
-        [input_ptr].copy_to(&mut d_input_ptrs)?;
-        [output_ptr].copy_to(&mut d_output_ptrs)?;
+        [input_ptr].copy_to_on(&mut d_input_ptrs, ctx)?;
+        [output_ptr].copy_to_on(&mut d_output_ptrs, ctx)?;
 
         // Call sumcheck_mle_round kernel (uses output_buf as tmp)
         unsafe {
@@ -98,13 +98,13 @@ where
                 num_matrices as u32,
                 current_height as u32,
                 d as u32,
-                stream,
+                ctx.stream.as_raw(),
             )
             .map_err(|e| SumcheckError::SumcheckMleRound(e.into()))?;
         }
 
         // Copy result back to host
-        let h_round_output = d_round_output.to_host()?;
+        let h_round_output = d_round_output.to_host_on(ctx)?;
 
         // Observe in transcript
         let s = h_round_output[0..d].to_vec();
@@ -129,7 +129,7 @@ where
                 output_height,
                 width as u32 * output_height,
                 r_round,
-                stream,
+                ctx.stream.as_raw(),
             )
             .map_err(|e| SumcheckError::FoldMle(e.into()))?;
         }
@@ -139,7 +139,7 @@ where
 
     // After all rounds, get final evaluation claim
     let final_buf = if n % 2 == 1 { &d_buffer_b } else { &d_buffer_a };
-    let eval_claim_vec = final_buf.to_host()?;
+    let eval_claim_vec = final_buf.to_host_on(ctx)?;
     let eval_claim = eval_claim_vec[0];
 
     transcript.observe_ext(eval_claim);
@@ -170,7 +170,7 @@ pub fn sumcheck_prismalinear_gpu(
     transcript: &mut DuplexSpongeGpu,
     l_skip: usize,
     evals: &[F],
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<(SumcheckPrismProof<EF>, Vec<EF>), SumcheckError> {
     let prism_dim = p3_util::log2_strict_usize(evals.len());
     assert!(prism_dim >= l_skip);
@@ -195,15 +195,21 @@ pub fn sumcheck_prismalinear_gpu(
     // ========== Round 0: Special PLE round ==========
     let _round0_span = info_span!("sumcheck_prismalinear.round0").entered();
 
-    let mut d_coeffs = evals.to_device()?;
-    let mut d_s0_coeffs = DeviceBuffer::<F>::with_capacity(large_domain_size);
+    let mut d_coeffs = evals.to_device_on(ctx)?;
+    let mut d_s0_coeffs = DeviceBuffer::<F>::with_capacity_on(large_domain_size, ctx);
 
     // Step 1: iDFT on skip domain (reinterpreting dimensions)
     // Input: [height=2^(l_skip+n), width=1]
     // Treat as: [height=2^l_skip, width=2^n]
     unsafe {
-        batch_ntt_small(&mut d_coeffs, l_skip, num_x * width, true, stream)
-            .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
+        batch_ntt_small(
+            &mut d_coeffs,
+            l_skip,
+            num_x * width,
+            true,
+            ctx.stream.as_raw(),
+        )
+        .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
     }
 
     if domain_size == large_domain_size {
@@ -215,13 +221,13 @@ pub fn sumcheck_prismalinear_gpu(
                 num_x as u32,
                 width as u32,
                 large_domain_size as u32,
-                stream,
+                ctx.stream.as_raw(),
             )
             .map_err(|e| SumcheckError::ReduceOverXAndCols(e.into()))?;
         }
     } else {
         let mut d_coeffs_large =
-            DeviceBuffer::<F>::with_capacity(num_x * width * large_domain_size);
+            DeviceBuffer::<F>::with_capacity_on(num_x * width * large_domain_size, ctx);
 
         // Step 2: Copy and pad each column to large domain size
         unsafe {
@@ -231,7 +237,7 @@ pub fn sumcheck_prismalinear_gpu(
                 (num_x * width) as u32,
                 large_domain_size as u32,
                 domain_size as u32,
-                stream,
+                ctx.stream.as_raw(),
             )
             .map_err(|e| SumcheckError::BatchExpandPadWide(e.into()))?;
         }
@@ -243,7 +249,7 @@ pub fn sumcheck_prismalinear_gpu(
                 log_large_domain,
                 num_x * width,
                 false,
-                stream,
+                ctx.stream.as_raw(),
             )
             .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
         }
@@ -256,7 +262,7 @@ pub fn sumcheck_prismalinear_gpu(
                 num_x as u32,
                 width as u32,
                 large_domain_size as u32,
-                stream,
+                ctx.stream.as_raw(),
             )
             .map_err(|e| SumcheckError::ReduceOverXAndCols(e.into()))?;
         }
@@ -264,12 +270,18 @@ pub fn sumcheck_prismalinear_gpu(
 
         // Step 5: iDFT to get coefficients
         unsafe {
-            batch_ntt_small(&mut d_s0_coeffs, log_large_domain, 1, true, stream)
-                .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
+            batch_ntt_small(
+                &mut d_s0_coeffs,
+                log_large_domain,
+                1,
+                true,
+                ctx.stream.as_raw(),
+            )
+            .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
         }
     }
     // Step 6: Copy to host and convert to extension field
-    let s0_coeffs_host: Vec<F> = d_s0_coeffs.to_host()?;
+    let s0_coeffs_host: Vec<F> = d_s0_coeffs.to_host_on(ctx)?;
     drop(d_s0_coeffs);
     let s0_coeffs_ext: Vec<EF> = s0_coeffs_host[0..=s_deg]
         .iter()
@@ -289,7 +301,7 @@ pub fn sumcheck_prismalinear_gpu(
 
     // ========== Fold PLE: Evaluate at r_0 ==========
 
-    let d_folded = DeviceBuffer::<EF>::with_capacity(num_x);
+    let d_folded = DeviceBuffer::<EF>::with_capacity_on(num_x, ctx);
     unsafe {
         fold_ple_from_coeffs(
             d_coeffs.as_ptr(),     // Original input (base field, but modified by iDFT)
@@ -298,7 +310,7 @@ pub fn sumcheck_prismalinear_gpu(
             width as u32,
             domain_size as u32,
             r_0,
-            stream,
+            ctx.stream.as_raw(),
         )
         .map_err(|e| SumcheckError::FoldPleFromCoeffs(e.into()))?;
     }
@@ -313,12 +325,12 @@ pub fn sumcheck_prismalinear_gpu(
 
     // Allocate ping-pong buffers for MLE rounds
     let mut d_buffer_a = d_folded; // Reuse folded result
-    let mut d_buffer_b = DeviceBuffer::<EF>::with_capacity(current_height / 2);
+    let mut d_buffer_b = DeviceBuffer::<EF>::with_capacity_on(current_height / 2, ctx);
 
-    let mut d_input_ptrs = DeviceBuffer::<*const EF>::with_capacity(num_matrices);
-    let mut d_output_ptrs = DeviceBuffer::<*mut EF>::with_capacity(num_matrices);
-    let d_widths = [width as u32].to_device()?;
-    let d_round_output = DeviceBuffer::<EF>::with_capacity(d);
+    let mut d_input_ptrs = DeviceBuffer::<*const EF>::with_capacity_on(num_matrices, ctx);
+    let mut d_output_ptrs = DeviceBuffer::<*mut EF>::with_capacity_on(num_matrices, ctx);
+    let d_widths = [width as u32].to_device_on(ctx)?;
+    let d_round_output = DeviceBuffer::<EF>::with_capacity_on(d, ctx);
 
     for round in 1..=n {
         let (input_buf, output_buf) = if round % 2 == 1 {
@@ -330,8 +342,8 @@ pub fn sumcheck_prismalinear_gpu(
         let input_ptr = input_buf.as_ptr();
         let output_ptr = output_buf.as_mut_ptr();
 
-        [input_ptr].copy_to(&mut d_input_ptrs)?;
-        [output_ptr].copy_to(&mut d_output_ptrs)?;
+        [input_ptr].copy_to_on(&mut d_input_ptrs, ctx)?;
+        [output_ptr].copy_to_on(&mut d_output_ptrs, ctx)?;
 
         // Sumcheck MLE round
         unsafe {
@@ -343,12 +355,12 @@ pub fn sumcheck_prismalinear_gpu(
                 num_matrices as u32,
                 current_height as u32,
                 d as u32,
-                stream,
+                ctx.stream.as_raw(),
             )
             .map_err(|e| SumcheckError::SumcheckMleRound(e.into()))?;
         }
 
-        let h_round_output = d_round_output.to_host()?;
+        let h_round_output = d_round_output.to_host_on(ctx)?;
         let s = h_round_output[0..d].to_vec();
         assert_eq!(s.len(), d);
         transcript.observe_ext(s[0]);
@@ -369,7 +381,7 @@ pub fn sumcheck_prismalinear_gpu(
                 output_height,
                 width as u32 * output_height,
                 r_round,
-                stream,
+                ctx.stream.as_raw(),
             )
             .map_err(|e| SumcheckError::FoldMle(e.into()))?;
         }
@@ -380,7 +392,7 @@ pub fn sumcheck_prismalinear_gpu(
 
     // Get final evaluation claim
     let final_buf = if n % 2 == 1 { &d_buffer_b } else { &d_buffer_a };
-    let eval_claim_vec = final_buf.to_host()?;
+    let eval_claim_vec = final_buf.to_host_on(ctx)?;
     let eval_claim = eval_claim_vec[0];
 
     transcript.observe_ext(eval_claim);

--- a/crates/cuda-backend/src/sumcheck.rs
+++ b/crates/cuda-backend/src/sumcheck.rs
@@ -2,7 +2,7 @@
 use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
-    stream::DeviceContext,
+    stream::GpuDeviceCtx,
 };
 use openvm_stark_backend::{
     p3_util::log2_strict_usize,
@@ -36,7 +36,7 @@ use crate::{
 pub fn sumcheck_multilinear_gpu<F: Field>(
     transcript: &mut DuplexSpongeGpu,
     evals: &[F],
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(SumcheckCubeProof<EF>, Vec<EF>), SumcheckError>
 where
     EF: ExtensionField<F>,
@@ -170,7 +170,7 @@ pub fn sumcheck_prismalinear_gpu(
     transcript: &mut DuplexSpongeGpu,
     l_skip: usize,
     evals: &[F],
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(SumcheckPrismProof<EF>, Vec<EF>), SumcheckError> {
     let prism_dim = p3_util::log2_strict_usize(evals.len());
     assert!(prism_dim >= l_skip);

--- a/crates/cuda-backend/src/sumcheck.rs
+++ b/crates/cuda-backend/src/sumcheck.rs
@@ -2,7 +2,7 @@
 use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
-    stream::cudaStreamPerThread,
+    stream::cudaStream_t,
 };
 use openvm_stark_backend::{
     p3_util::log2_strict_usize,
@@ -36,6 +36,7 @@ use crate::{
 pub fn sumcheck_multilinear_gpu<F: Field>(
     transcript: &mut DuplexSpongeGpu,
     evals: &[F],
+    stream: cudaStream_t,
 ) -> Result<(SumcheckCubeProof<EF>, Vec<EF>), SumcheckError>
 where
     EF: ExtensionField<F>,
@@ -97,7 +98,7 @@ where
                 num_matrices as u32,
                 current_height as u32,
                 d as u32,
-                cudaStreamPerThread,
+                stream,
             )
             .map_err(|e| SumcheckError::SumcheckMleRound(e.into()))?;
         }
@@ -128,7 +129,7 @@ where
                 output_height,
                 width as u32 * output_height,
                 r_round,
-                cudaStreamPerThread,
+                stream,
             )
             .map_err(|e| SumcheckError::FoldMle(e.into()))?;
         }
@@ -169,6 +170,7 @@ pub fn sumcheck_prismalinear_gpu(
     transcript: &mut DuplexSpongeGpu,
     l_skip: usize,
     evals: &[F],
+    stream: cudaStream_t,
 ) -> Result<(SumcheckPrismProof<EF>, Vec<EF>), SumcheckError> {
     let prism_dim = p3_util::log2_strict_usize(evals.len());
     assert!(prism_dim >= l_skip);
@@ -200,14 +202,8 @@ pub fn sumcheck_prismalinear_gpu(
     // Input: [height=2^(l_skip+n), width=1]
     // Treat as: [height=2^l_skip, width=2^n]
     unsafe {
-        batch_ntt_small(
-            &mut d_coeffs,
-            l_skip,
-            num_x * width,
-            true,
-            cudaStreamPerThread,
-        )
-        .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
+        batch_ntt_small(&mut d_coeffs, l_skip, num_x * width, true, stream)
+            .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
     }
 
     if domain_size == large_domain_size {
@@ -219,7 +215,7 @@ pub fn sumcheck_prismalinear_gpu(
                 num_x as u32,
                 width as u32,
                 large_domain_size as u32,
-                cudaStreamPerThread,
+                stream,
             )
             .map_err(|e| SumcheckError::ReduceOverXAndCols(e.into()))?;
         }
@@ -235,7 +231,7 @@ pub fn sumcheck_prismalinear_gpu(
                 (num_x * width) as u32,
                 large_domain_size as u32,
                 domain_size as u32,
-                cudaStreamPerThread,
+                stream,
             )
             .map_err(|e| SumcheckError::BatchExpandPadWide(e.into()))?;
         }
@@ -247,7 +243,7 @@ pub fn sumcheck_prismalinear_gpu(
                 log_large_domain,
                 num_x * width,
                 false,
-                cudaStreamPerThread,
+                stream,
             )
             .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
         }
@@ -260,7 +256,7 @@ pub fn sumcheck_prismalinear_gpu(
                 num_x as u32,
                 width as u32,
                 large_domain_size as u32,
-                cudaStreamPerThread,
+                stream,
             )
             .map_err(|e| SumcheckError::ReduceOverXAndCols(e.into()))?;
         }
@@ -268,14 +264,8 @@ pub fn sumcheck_prismalinear_gpu(
 
         // Step 5: iDFT to get coefficients
         unsafe {
-            batch_ntt_small(
-                &mut d_s0_coeffs,
-                log_large_domain,
-                1,
-                true,
-                cudaStreamPerThread,
-            )
-            .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
+            batch_ntt_small(&mut d_s0_coeffs, log_large_domain, 1, true, stream)
+                .map_err(|e| SumcheckError::BatchNttSmall(e.into()))?;
         }
     }
     // Step 6: Copy to host and convert to extension field
@@ -308,7 +298,7 @@ pub fn sumcheck_prismalinear_gpu(
             width as u32,
             domain_size as u32,
             r_0,
-            cudaStreamPerThread,
+            stream,
         )
         .map_err(|e| SumcheckError::FoldPleFromCoeffs(e.into()))?;
     }
@@ -353,7 +343,7 @@ pub fn sumcheck_prismalinear_gpu(
                 num_matrices as u32,
                 current_height as u32,
                 d as u32,
-                cudaStreamPerThread,
+                stream,
             )
             .map_err(|e| SumcheckError::SumcheckMleRound(e.into()))?;
         }
@@ -379,7 +369,7 @@ pub fn sumcheck_prismalinear_gpu(
                 output_height,
                 width as u32 * output_height,
                 r_round,
-                cudaStreamPerThread,
+                stream,
             )
             .map_err(|e| SumcheckError::FoldMle(e.into()))?;
         }

--- a/crates/cuda-backend/src/tests.rs
+++ b/crates/cuda-backend/src/tests.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 use openvm_cuda_common::copy::{MemCopyD2H, MemCopyH2D};
+use openvm_cuda_common::stream::cudaStreamPerThread;
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 use openvm_stark_backend::{
     hasher::{Hasher as CpuMerkleHasher, MerkleHasher, MultiFieldHasher},
@@ -533,8 +534,15 @@ fn test_batch_ntt_small_partial_last_block_roundtrip(l_skip: usize) {
     let mut d_values = original.to_device().unwrap();
 
     unsafe {
-        batch_ntt_small(&mut d_values, l_skip, cnt_blocks, false).unwrap();
-        batch_ntt_small(&mut d_values, l_skip, cnt_blocks, true).unwrap();
+        batch_ntt_small(
+            &mut d_values,
+            l_skip,
+            cnt_blocks,
+            false,
+            cudaStreamPerThread,
+        )
+        .unwrap();
+        batch_ntt_small(&mut d_values, l_skip, cnt_blocks, true, cudaStreamPerThread).unwrap();
     }
 
     assert_eq!(d_values.to_host().unwrap(), original);
@@ -579,6 +587,7 @@ fn test_frac_matrix_vertically_repeat_guards_tail_rows() {
             width as u32,
             lifted_height as u32,
             height as u32,
+            cudaStreamPerThread,
         )
         .unwrap();
     }
@@ -768,6 +777,7 @@ fn test_monomial_vs_dag_equivalence() {
             is_first,
             is_last,
             sel_height,
+            cudaStreamPerThread,
         )
         .unwrap();
     }
@@ -849,8 +859,14 @@ fn test_monomial_vs_dag_equivalence() {
             crate::base::DeviceMatrix::<EF>::with_capacity(s_deg * num_y as usize, columns.len());
         let d_columns = columns.to_device().unwrap();
         unsafe {
-            interpolate_columns_gpu(interpolated.buffer(), &d_columns, s_deg, num_y as usize)
-                .expect("failed to interpolate columns");
+            interpolate_columns_gpu(
+                interpolated.buffer(),
+                &d_columns,
+                s_deg,
+                num_y as usize,
+                cudaStreamPerThread,
+            )
+            .expect("failed to interpolate columns");
         }
 
         let interpolated_height = interpolated.height();

--- a/crates/cuda-backend/src/tests.rs
+++ b/crates/cuda-backend/src/tests.rs
@@ -10,7 +10,10 @@ use std::sync::Arc;
 use itertools::Itertools;
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 use openvm_cuda_common::copy::{MemCopyD2H, MemCopyH2D};
-use openvm_cuda_common::stream::cudaStreamPerThread;
+use openvm_cuda_common::{
+    common::get_device,
+    stream::{CudaStream, DeviceContext, StreamGuard},
+};
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 use openvm_stark_backend::{
     hasher::{Hasher as CpuMerkleHasher, MerkleHasher, MultiFieldHasher},
@@ -58,6 +61,13 @@ use crate::{
 
 type RefEngine = BabyBearPoseidon2RefEngine<DuplexSponge>;
 type Engine = RefEngine;
+
+fn test_ctx() -> DeviceContext {
+    DeviceContext {
+        device_id: get_device().unwrap() as u32,
+        stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
+    }
+}
 
 // ===========================================================================
 // Shared test suite (engine-generic + WHIR)
@@ -251,6 +261,7 @@ fn bn254_row_hash_emulated(vals: &[F]) -> Bn254Digest {
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 #[test]
 fn test_bn254_merkle_gpu_matches_host_large_matrix() {
+    let ctx = test_ctx();
     let height = 1 << 16;
     let width = 19;
     let rows_per_query = 1 << 4;
@@ -259,16 +270,19 @@ fn test_bn254_merkle_gpu_matches_host_large_matrix() {
         .collect_vec();
 
     let host_layers = bn254_host_merkle_layers(&host_matrix, height, width, rows_per_query);
-    let device_matrix =
-        DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
+    let device_matrix = DeviceMatrix::new(
+        Arc::new(host_matrix.to_device_on(&ctx).unwrap()),
+        height,
+        width,
+    );
     let gpu_tree = MerkleTreeGpu::<F, Bn254Digest>::new_with_hash::<
         crate::hash_scheme::Bn254Poseidon2MerkleHash,
-    >(device_matrix, rows_per_query, true, cudaStreamPerThread)
+    >(device_matrix, rows_per_query, true, &ctx)
     .unwrap();
     let gpu_layers = gpu_tree
         .digest_layers
         .iter()
-        .map(|layer| layer.to_host().unwrap())
+        .map(|layer| layer.to_host_on(&ctx).unwrap())
         .collect_vec();
 
     for (layer_idx, (gpu_layer, host_layer)) in
@@ -299,6 +313,7 @@ fn test_bn254_merkle_gpu_matches_host_large_matrix() {
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 #[test]
 fn test_bn254_merkle_proof_queries_gpu_match_host() {
+    let ctx = test_ctx();
     let height = 1 << 12;
     let width = 19;
     let rows_per_query = 1;
@@ -315,23 +330,34 @@ fn test_bn254_merkle_proof_queries_gpu_match_host() {
     let tree_a = MerkleTreeGpu::<F, Bn254Digest>::new_with_hash::<
         crate::hash_scheme::Bn254Poseidon2MerkleHash,
     >(
-        DeviceMatrix::new(Arc::new(host_matrix_a.to_device().unwrap()), height, width),
+        DeviceMatrix::new(
+            Arc::new(host_matrix_a.to_device_on(&ctx).unwrap()),
+            height,
+            width,
+        ),
         rows_per_query,
         true,
+        &ctx,
     )
     .unwrap();
     let tree_b = MerkleTreeGpu::<F, Bn254Digest>::new_with_hash::<
         crate::hash_scheme::Bn254Poseidon2MerkleHash,
     >(
-        DeviceMatrix::new(Arc::new(host_matrix_b.to_device().unwrap()), height, width),
+        DeviceMatrix::new(
+            Arc::new(host_matrix_b.to_device_on(&ctx).unwrap()),
+            height,
+            width,
+        ),
         rows_per_query,
         true,
+        &ctx,
     )
     .unwrap();
 
     let gpu_proofs = MerkleTreeGpu::<F, Bn254Digest>::batch_query_merkle_proofs(
         &[&tree_a, &tree_b],
         &query_indices,
+        &ctx,
     )
     .unwrap();
 
@@ -348,6 +374,7 @@ fn test_bn254_merkle_proof_queries_gpu_match_host() {
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 #[test]
 fn test_bn254_row_hash_gpu_matches_host_multi_block_rows() {
+    let ctx = test_ctx();
     let height = 1 << 12;
     let width = 19;
     let rows_per_query = 1;
@@ -356,13 +383,16 @@ fn test_bn254_row_hash_gpu_matches_host_multi_block_rows() {
         .collect_vec();
 
     let host_layers = bn254_host_merkle_layers(&host_matrix, height, width, rows_per_query);
-    let device_matrix =
-        DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
+    let device_matrix = DeviceMatrix::new(
+        Arc::new(host_matrix.to_device_on(&ctx).unwrap()),
+        height,
+        width,
+    );
     let gpu_tree = MerkleTreeGpu::<F, Bn254Digest>::new_with_hash::<
         crate::hash_scheme::Bn254Poseidon2MerkleHash,
-    >(device_matrix, rows_per_query, true, cudaStreamPerThread)
+    >(device_matrix, rows_per_query, true, &ctx)
     .unwrap();
-    let gpu_layer0 = gpu_tree.digest_layers[0].to_host().unwrap();
+    let gpu_layer0 = gpu_tree.digest_layers[0].to_host_on(&ctx).unwrap();
 
     if let Some((digest_idx, (gpu_digest, host_digest))) = gpu_layer0
         .iter()
@@ -377,6 +407,7 @@ fn test_bn254_row_hash_gpu_matches_host_multi_block_rows() {
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 #[test]
 fn test_bn254_row_hash_ext_gpu_matches_host_multi_block_rows() {
+    let ctx = test_ctx();
     let height = 1 << 11;
     let width = 5;
     let rows_per_query = 1;
@@ -393,13 +424,16 @@ fn test_bn254_row_hash_ext_gpu_matches_host_multi_block_rows() {
         .collect_vec();
 
     let host_layers = bn254_host_merkle_layers_ext(&host_matrix, height, width, rows_per_query);
-    let device_matrix =
-        DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
+    let device_matrix = DeviceMatrix::new(
+        Arc::new(host_matrix.to_device_on(&ctx).unwrap()),
+        height,
+        width,
+    );
     let gpu_tree = MerkleTreeGpu::<EF, Bn254Digest>::new_with_hash::<
         crate::hash_scheme::Bn254Poseidon2MerkleHash,
-    >(device_matrix, rows_per_query, true, cudaStreamPerThread)
+    >(device_matrix, rows_per_query, true, &ctx)
     .unwrap();
-    let gpu_layer0 = gpu_tree.digest_layers[0].to_host().unwrap();
+    let gpu_layer0 = gpu_tree.digest_layers[0].to_host_on(&ctx).unwrap();
 
     if let Some((digest_idx, (gpu_digest, host_digest))) = gpu_layer0
         .iter()
@@ -432,6 +466,7 @@ fn test_bn254_row_hash_emulation_matches_host_multi_block_rows() {
 fn test_merkle_gpu_supports_1024_rows_per_query() {
     use openvm_cuda_common::copy::MemCopyH2D;
 
+    let ctx = test_ctx();
     let height = 1 << 10;
     let width = 7;
     let rows_per_query = 1 << 10;
@@ -439,11 +474,14 @@ fn test_merkle_gpu_supports_1024_rows_per_query() {
         .map(|i| F::from_u32((i as u32).wrapping_mul(31).wrapping_add((i >> 2) as u32)))
         .collect_vec();
 
-    let device_matrix =
-        DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
+    let device_matrix = DeviceMatrix::new(
+        Arc::new(host_matrix.to_device_on(&ctx).unwrap()),
+        height,
+        width,
+    );
     let tree = MerkleTreeGpu::<F, crate::prelude::Digest>::new_with_hash::<
         crate::hash_scheme::Poseidon2MerkleHash,
-    >(device_matrix, rows_per_query, true, cudaStreamPerThread)
+    >(device_matrix, rows_per_query, true, &ctx)
     .expect("rows_per_query=1024 should be supported");
 
     assert_eq!(tree.query_stride(), 1);
@@ -454,6 +492,7 @@ fn test_merkle_gpu_supports_1024_rows_per_query() {
 fn test_merkle_batch_query_zero_work_returns_empty() {
     use openvm_cuda_common::copy::MemCopyH2D;
 
+    let ctx = test_ctx();
     let height = 1 << 3;
     let width = 4;
     let rows_per_query = height;
@@ -461,29 +500,26 @@ fn test_merkle_batch_query_zero_work_returns_empty() {
         .map(|i| F::from_u32((i as u32).wrapping_mul(19).wrapping_add(7)))
         .collect_vec();
 
-    let device_matrix =
-        DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
+    let device_matrix = DeviceMatrix::new(
+        Arc::new(host_matrix.to_device_on(&ctx).unwrap()),
+        height,
+        width,
+    );
     let tree = MerkleTreeGpu::<F, crate::prelude::Digest>::new_with_hash::<
         crate::hash_scheme::Poseidon2MerkleHash,
-    >(device_matrix, rows_per_query, true, cudaStreamPerThread)
+    >(device_matrix, rows_per_query, true, &ctx)
     .unwrap();
 
-    let proofs = MerkleTreeGpu::<F, crate::prelude::Digest>::batch_query_merkle_proofs(
-        &[&tree],
-        &[0],
-        cudaStreamPerThread,
-    )
-    .unwrap();
+    let proofs =
+        MerkleTreeGpu::<F, crate::prelude::Digest>::batch_query_merkle_proofs(&[&tree], &[0], &ctx)
+            .unwrap();
     assert_eq!(proofs.len(), 1);
     assert_eq!(proofs[0].len(), 1);
     assert!(proofs[0][0].is_empty());
 
-    let empty_queries = MerkleTreeGpu::<F, crate::prelude::Digest>::batch_query_merkle_proofs(
-        &[&tree],
-        &[],
-        cudaStreamPerThread,
-    )
-    .unwrap();
+    let empty_queries =
+        MerkleTreeGpu::<F, crate::prelude::Digest>::batch_query_merkle_proofs(&[&tree], &[], &ctx)
+            .unwrap();
     assert_eq!(empty_queries.len(), 1);
     assert!(empty_queries[0].is_empty());
 }
@@ -492,20 +528,24 @@ fn test_merkle_batch_query_zero_work_returns_empty() {
 fn test_merkle_batch_open_rows_empty_queries_returns_empty() {
     use openvm_cuda_common::copy::MemCopyH2D;
 
+    let ctx = test_ctx();
     let height = 1 << 3;
     let width = 4;
     let host_matrix = (0..width * height)
         .map(|i| F::from_u32((i as u32).wrapping_mul(23).wrapping_add(11)))
         .collect_vec();
-    let device_matrix =
-        DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
+    let device_matrix = DeviceMatrix::new(
+        Arc::new(host_matrix.to_device_on(&ctx).unwrap()),
+        height,
+        width,
+    );
 
     let opened_rows = MerkleTreeGpu::<F, crate::prelude::Digest>::batch_open_rows(
         &[&device_matrix],
         &[],
         1,
         1,
-        cudaStreamPerThread,
+        &ctx,
     )
     .unwrap();
     assert_eq!(opened_rows.len(), 1);
@@ -536,13 +576,14 @@ fn test_batch_ntt_small_partial_last_block_roundtrip(l_skip: usize) {
     use openvm_cuda_common::copy::{MemCopyD2H, MemCopyH2D};
 
     setup_tracing_with_log_level(Level::DEBUG);
+    let gpu_ctx = test_ctx();
 
     let block_size = 1usize << l_skip;
     let cnt_blocks = (1024usize >> l_skip) + 1;
     let original = (0..(cnt_blocks * block_size))
         .map(|i| F::from_u32((i as u32).wrapping_mul(17).wrapping_add(5)))
         .collect_vec();
-    let mut d_values = original.to_device().unwrap();
+    let mut d_values = original.to_device_on(&gpu_ctx).unwrap();
 
     unsafe {
         batch_ntt_small(
@@ -550,13 +591,20 @@ fn test_batch_ntt_small_partial_last_block_roundtrip(l_skip: usize) {
             l_skip,
             cnt_blocks,
             false,
-            cudaStreamPerThread,
+            gpu_ctx.stream.as_raw(),
         )
         .unwrap();
-        batch_ntt_small(&mut d_values, l_skip, cnt_blocks, true, cudaStreamPerThread).unwrap();
+        batch_ntt_small(
+            &mut d_values,
+            l_skip,
+            cnt_blocks,
+            true,
+            gpu_ctx.stream.as_raw(),
+        )
+        .unwrap();
     }
 
-    assert_eq!(d_values.to_host().unwrap(), original);
+    assert_eq!(d_values.to_host_on(&gpu_ctx).unwrap(), original);
 }
 
 #[test]
@@ -568,6 +616,7 @@ fn test_frac_matrix_vertically_repeat_guards_tail_rows() {
     use openvm_stark_backend::prover::fractional_sumcheck_gkr::Frac;
 
     setup_tracing_with_log_level(Level::DEBUG);
+    let gpu_ctx = test_ctx();
 
     let width = 3usize;
     let height = 769usize;
@@ -587,9 +636,11 @@ fn test_frac_matrix_vertically_repeat_guards_tail_rows() {
         }
     }
 
-    let d_input = input.to_device().unwrap();
-    let mut d_output = DeviceBuffer::<Frac<EF>>::with_capacity(output_len);
-    vec![canary; output_len].copy_to(&mut d_output).unwrap();
+    let d_input = input.to_device_on(&gpu_ctx).unwrap();
+    let mut d_output = DeviceBuffer::<Frac<EF>>::with_capacity_on(output_len, &gpu_ctx);
+    vec![canary; output_len]
+        .copy_to_on(&mut d_output, &gpu_ctx)
+        .unwrap();
 
     unsafe {
         frac_matrix_vertically_repeat(
@@ -598,12 +649,12 @@ fn test_frac_matrix_vertically_repeat_guards_tail_rows() {
             width as u32,
             lifted_height as u32,
             height as u32,
-            cudaStreamPerThread,
+            gpu_ctx.stream.as_raw(),
         )
         .unwrap();
     }
 
-    let output = d_output.to_host().unwrap();
+    let output = d_output.to_host_on(&gpu_ctx).unwrap();
     assert_eq!(output.len(), expected.len());
     for (idx, (got, want)) in output.iter().zip(expected.iter()).enumerate() {
         assert_eq!(got.p, want.p, "numerator mismatch at index {idx}");
@@ -707,6 +758,7 @@ fn test_monomial_vs_dag_equivalence() {
     };
 
     setup_tracing_with_log_level(Level::DEBUG);
+    let gpu_ctx = test_ctx();
 
     let log_trace_degree = 5;
     let threshold = 32u32;
@@ -730,13 +782,14 @@ fn test_monomial_vs_dag_equivalence() {
     let ((_, _), r) =
         prove_up_to_batch_constraints(&gpu_engine, &mut prover_sponge, &pk, ctx_for_challenges);
 
-    let ctx = <_ as DeviceDataTransporter<SC, GpuBackend>>::transport_proving_ctx_to_device(
-        device,
-        &fib.generate_proving_ctx(),
-    )
-    .into_sorted();
+    let proving_ctx =
+        <_ as DeviceDataTransporter<SC, GpuBackend>>::transport_proving_ctx_to_device(
+            device,
+            &fib.generate_proving_ctx(),
+        )
+        .into_sorted();
 
-    let height = ctx.per_trace[0].1.common_main.height();
+    let height = proving_ctx.per_trace[0].1.common_main.height();
     let n_calc = log2_strict_usize(height).saturating_sub(l_skip);
     let xi_len = l_skip + n_calc + 1;
 
@@ -752,22 +805,21 @@ fn test_monomial_vs_dag_equivalence() {
 
     let omega_skip = F::two_adic_generator(l_skip);
     let omega_skip_pows: Vec<F> = omega_skip.powers().take(1 << l_skip).collect();
-    let d_omega_skip_pows = omega_skip_pows.to_device().unwrap();
+    let d_omega_skip_pows = omega_skip_pows.to_device_on(&gpu_ctx).unwrap();
 
-    let (air_idx, air_ctx) = &ctx.per_trace[0];
+    let (air_idx, air_ctx) = &proving_ctx.per_trace[0];
     let height = air_ctx.common_main.height();
     let n = log2_strict_usize(height) as isize - l_skip as isize;
     let n_lift = n.max(0) as usize;
 
-    let eq_xis =
-        EqEvalSegments::new(&xi[l_skip..], cudaStreamPerThread).expect("failed to compute eq_xis");
+    let eq_xis = EqEvalSegments::new(&xi[l_skip..], &gpu_ctx).expect("failed to compute eq_xis");
 
     let sel_height = 1 << n_lift;
     let mut sel_cols = F::zero_vec(3 * sel_height);
     sel_cols[sel_height..2 * sel_height - 1].fill(F::ONE);
     sel_cols[0] = F::ONE;
     sel_cols[2 * sel_height + sel_height - 1] = F::ONE;
-    let d_sels_base = sel_cols.to_device().unwrap();
+    let d_sels_base = sel_cols.to_device_on(&gpu_ctx).unwrap();
 
     let (l, r_fold) = if n.is_negative() {
         (
@@ -780,8 +832,10 @@ fn test_monomial_vs_dag_equivalence() {
     let omega = F::two_adic_generator(l);
     let is_first = eval_eq_uni_at_one(l, r_fold);
     let is_last = eval_eq_uni_at_one(l, r_fold * omega);
-    let d_sels_folded =
-        openvm_cuda_common::d_buffer::DeviceBuffer::<EF>::with_capacity(sel_height * 3);
+    let d_sels_folded = openvm_cuda_common::d_buffer::DeviceBuffer::<EF>::with_capacity_on(
+        sel_height * 3,
+        &gpu_ctx,
+    );
     unsafe {
         fold_selectors_round0(
             d_sels_folded.as_mut_ptr(),
@@ -789,14 +843,14 @@ fn test_monomial_vs_dag_equivalence() {
             is_first,
             is_last,
             sel_height,
-            cudaStreamPerThread,
+            gpu_ctx.stream.as_raw(),
         )
         .unwrap();
     }
 
     let inv_lagrange_denoms_r0 =
         crate::utils::compute_barycentric_inv_lagrange_denoms(l_skip, &omega_skip_pows, r[0]);
-    let d_inv_lagrange_denoms_r0 = inv_lagrange_denoms_r0.to_device().unwrap();
+    let d_inv_lagrange_denoms_r0 = inv_lagrange_denoms_r0.to_device_on(&gpu_ctx).unwrap();
 
     let mat_folded = fold_ple_evals_rotate(
         l_skip,
@@ -804,7 +858,7 @@ fn test_monomial_vs_dag_equivalence() {
         &air_ctx.common_main,
         &d_inv_lagrange_denoms_r0,
         true,
-        cudaStreamPerThread,
+        &gpu_ctx,
     )
     .unwrap();
 
@@ -817,12 +871,12 @@ fn test_monomial_vs_dag_equivalence() {
         .constraint_idx
         .len();
     let h_lambda_pows: Vec<EF> = lambda.powers().take(max_num_constraints).collect();
-    let d_lambda_pows = h_lambda_pows.to_device().unwrap();
+    let d_lambda_pows = h_lambda_pows.to_device_on(&gpu_ctx).unwrap();
 
     let d_public_values = if air_ctx.public_values.is_empty() {
         openvm_cuda_common::d_buffer::DeviceBuffer::new()
     } else {
-        air_ctx.public_values.to_device().unwrap()
+        air_ctx.public_values.to_device_on(&gpu_ctx).unwrap()
     };
 
     let dag = &air_pk.vk.symbolic_constraints;
@@ -868,16 +922,19 @@ fn test_monomial_vs_dag_equivalence() {
             );
         }
 
-        let interpolated =
-            crate::base::DeviceMatrix::<EF>::with_capacity(s_deg * num_y as usize, columns.len());
-        let d_columns = columns.to_device().unwrap();
+        let interpolated = crate::base::DeviceMatrix::<EF>::with_capacity_on(
+            s_deg * num_y as usize,
+            columns.len(),
+            &gpu_ctx,
+        );
+        let d_columns = columns.to_device_on(&gpu_ctx).unwrap();
         unsafe {
             interpolate_columns_gpu(
                 interpolated.buffer(),
                 &d_columns,
                 s_deg,
                 num_y as usize,
-                cudaStreamPerThread,
+                gpu_ctx.stream.as_raw(),
             )
             .expect("failed to interpolate columns");
         }
@@ -896,7 +953,7 @@ fn test_monomial_vs_dag_equivalence() {
                 .wrapping_add(4 * interpolated_height),
             air_width: mat_folded.width() as u32 / 2,
         }];
-        let main_ptrs_dev = main_ptrs.to_device().unwrap();
+        let main_ptrs_dev = main_ptrs.to_device_on(&gpu_ctx).unwrap();
 
         let trace_ctx = TraceCtx {
             trace_idx: 0,
@@ -917,27 +974,24 @@ fn test_monomial_vs_dag_equivalence() {
             eq_3bs_ptr: std::ptr::null(),
         };
 
-        let dag_builder = ZerocheckMleBatchBuilder::new(
-            std::iter::once(&trace_ctx),
-            &pk,
-            s_deg as u32,
-            cudaStreamPerThread,
-        )
-        .unwrap();
+        let dag_builder =
+            ZerocheckMleBatchBuilder::new(std::iter::once(&trace_ctx), &pk, s_deg as u32, &gpu_ctx)
+                .unwrap();
         let dag_output = dag_builder.evaluate(&d_lambda_pows, s_deg as u32).unwrap();
-        let dag_results: Vec<EF> = dag_output.to_host().expect("copy DAG output");
+        let dag_results: Vec<EF> = dag_output.to_host_on(&gpu_ctx).expect("copy DAG output");
 
-        let lambda_comb =
-            compute_lambda_combinations(&pk, 0, &d_lambda_pows, cudaStreamPerThread).unwrap();
+        let lambda_comb = compute_lambda_combinations(&pk, 0, &d_lambda_pows, &gpu_ctx).unwrap();
         let mono_batch = ZerocheckMonomialBatch::new(
             std::iter::once(&trace_ctx),
             &pk,
             &[&lambda_comb],
-            cudaStreamPerThread,
+            &gpu_ctx,
         )
         .unwrap();
         let mono_output = mono_batch.evaluate(s_deg as u32).unwrap();
-        let mono_results: Vec<EF> = mono_output.to_host().expect("copy monomial output");
+        let mono_results: Vec<EF> = mono_output
+            .to_host_on(&gpu_ctx)
+            .expect("copy monomial output");
 
         assert_eq!(
             dag_results.len(),

--- a/crates/cuda-backend/src/tests.rs
+++ b/crates/cuda-backend/src/tests.rs
@@ -263,7 +263,7 @@ fn test_bn254_merkle_gpu_matches_host_large_matrix() {
         DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
     let gpu_tree = MerkleTreeGpu::<F, Bn254Digest>::new_with_hash::<
         crate::hash_scheme::Bn254Poseidon2MerkleHash,
-    >(device_matrix, rows_per_query, true)
+    >(device_matrix, rows_per_query, true, cudaStreamPerThread)
     .unwrap();
     let gpu_layers = gpu_tree
         .digest_layers
@@ -360,7 +360,7 @@ fn test_bn254_row_hash_gpu_matches_host_multi_block_rows() {
         DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
     let gpu_tree = MerkleTreeGpu::<F, Bn254Digest>::new_with_hash::<
         crate::hash_scheme::Bn254Poseidon2MerkleHash,
-    >(device_matrix, rows_per_query, true)
+    >(device_matrix, rows_per_query, true, cudaStreamPerThread)
     .unwrap();
     let gpu_layer0 = gpu_tree.digest_layers[0].to_host().unwrap();
 
@@ -397,7 +397,7 @@ fn test_bn254_row_hash_ext_gpu_matches_host_multi_block_rows() {
         DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
     let gpu_tree = MerkleTreeGpu::<EF, Bn254Digest>::new_with_hash::<
         crate::hash_scheme::Bn254Poseidon2MerkleHash,
-    >(device_matrix, rows_per_query, true)
+    >(device_matrix, rows_per_query, true, cudaStreamPerThread)
     .unwrap();
     let gpu_layer0 = gpu_tree.digest_layers[0].to_host().unwrap();
 
@@ -443,7 +443,7 @@ fn test_merkle_gpu_supports_1024_rows_per_query() {
         DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
     let tree = MerkleTreeGpu::<F, crate::prelude::Digest>::new_with_hash::<
         crate::hash_scheme::Poseidon2MerkleHash,
-    >(device_matrix, rows_per_query, true)
+    >(device_matrix, rows_per_query, true, cudaStreamPerThread)
     .expect("rows_per_query=1024 should be supported");
 
     assert_eq!(tree.query_stride(), 1);
@@ -465,19 +465,25 @@ fn test_merkle_batch_query_zero_work_returns_empty() {
         DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
     let tree = MerkleTreeGpu::<F, crate::prelude::Digest>::new_with_hash::<
         crate::hash_scheme::Poseidon2MerkleHash,
-    >(device_matrix, rows_per_query, true)
+    >(device_matrix, rows_per_query, true, cudaStreamPerThread)
     .unwrap();
 
-    let proofs =
-        MerkleTreeGpu::<F, crate::prelude::Digest>::batch_query_merkle_proofs(&[&tree], &[0])
-            .unwrap();
+    let proofs = MerkleTreeGpu::<F, crate::prelude::Digest>::batch_query_merkle_proofs(
+        &[&tree],
+        &[0],
+        cudaStreamPerThread,
+    )
+    .unwrap();
     assert_eq!(proofs.len(), 1);
     assert_eq!(proofs[0].len(), 1);
     assert!(proofs[0][0].is_empty());
 
-    let empty_queries =
-        MerkleTreeGpu::<F, crate::prelude::Digest>::batch_query_merkle_proofs(&[&tree], &[])
-            .unwrap();
+    let empty_queries = MerkleTreeGpu::<F, crate::prelude::Digest>::batch_query_merkle_proofs(
+        &[&tree],
+        &[],
+        cudaStreamPerThread,
+    )
+    .unwrap();
     assert_eq!(empty_queries.len(), 1);
     assert!(empty_queries[0].is_empty());
 }
@@ -494,9 +500,14 @@ fn test_merkle_batch_open_rows_empty_queries_returns_empty() {
     let device_matrix =
         DeviceMatrix::new(Arc::new(host_matrix.to_device().unwrap()), height, width);
 
-    let opened_rows =
-        MerkleTreeGpu::<F, crate::prelude::Digest>::batch_open_rows(&[&device_matrix], &[], 1, 1)
-            .unwrap();
+    let opened_rows = MerkleTreeGpu::<F, crate::prelude::Digest>::batch_open_rows(
+        &[&device_matrix],
+        &[],
+        1,
+        1,
+        cudaStreamPerThread,
+    )
+    .unwrap();
     assert_eq!(opened_rows.len(), 1);
     assert!(opened_rows[0].is_empty());
 }
@@ -748,7 +759,8 @@ fn test_monomial_vs_dag_equivalence() {
     let n = log2_strict_usize(height) as isize - l_skip as isize;
     let n_lift = n.max(0) as usize;
 
-    let eq_xis = EqEvalSegments::new(&xi[l_skip..]).expect("failed to compute eq_xis");
+    let eq_xis =
+        EqEvalSegments::new(&xi[l_skip..], cudaStreamPerThread).expect("failed to compute eq_xis");
 
     let sel_height = 1 << n_lift;
     let mut sel_cols = F::zero_vec(3 * sel_height);
@@ -792,6 +804,7 @@ fn test_monomial_vs_dag_equivalence() {
         &air_ctx.common_main,
         &d_inv_lagrange_denoms_r0,
         true,
+        cudaStreamPerThread,
     )
     .unwrap();
 
@@ -904,14 +917,25 @@ fn test_monomial_vs_dag_equivalence() {
             eq_3bs_ptr: std::ptr::null(),
         };
 
-        let dag_builder =
-            ZerocheckMleBatchBuilder::new(std::iter::once(&trace_ctx), &pk, s_deg as u32).unwrap();
+        let dag_builder = ZerocheckMleBatchBuilder::new(
+            std::iter::once(&trace_ctx),
+            &pk,
+            s_deg as u32,
+            cudaStreamPerThread,
+        )
+        .unwrap();
         let dag_output = dag_builder.evaluate(&d_lambda_pows, s_deg as u32).unwrap();
         let dag_results: Vec<EF> = dag_output.to_host().expect("copy DAG output");
 
-        let lambda_comb = compute_lambda_combinations(&pk, 0, &d_lambda_pows).unwrap();
-        let mono_batch =
-            ZerocheckMonomialBatch::new(std::iter::once(&trace_ctx), &pk, &[&lambda_comb]).unwrap();
+        let lambda_comb =
+            compute_lambda_combinations(&pk, 0, &d_lambda_pows, cudaStreamPerThread).unwrap();
+        let mono_batch = ZerocheckMonomialBatch::new(
+            std::iter::once(&trace_ctx),
+            &pk,
+            &[&lambda_comb],
+            cudaStreamPerThread,
+        )
+        .unwrap();
         let mono_output = mono_batch.evaluate(s_deg as u32).unwrap();
         let mono_results: Vec<EF> = mono_output.to_host().expect("copy monomial output");
 

--- a/crates/cuda-backend/src/tests.rs
+++ b/crates/cuda-backend/src/tests.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use openvm_cuda_common::copy::{MemCopyD2H, MemCopyH2D};
 use openvm_cuda_common::{
     common::get_device,
-    stream::{CudaStream, DeviceContext, StreamGuard},
+    stream::{CudaStream, GpuDeviceCtx, StreamGuard},
 };
 #[cfg(feature = "baby-bear-bn254-poseidon2")]
 use openvm_stark_backend::{
@@ -62,8 +62,8 @@ use crate::{
 type RefEngine = BabyBearPoseidon2RefEngine<DuplexSponge>;
 type Engine = RefEngine;
 
-fn test_ctx() -> DeviceContext {
-    DeviceContext {
+fn test_ctx() -> GpuDeviceCtx {
+    GpuDeviceCtx {
         device_id: get_device().unwrap() as u32,
         stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
     }

--- a/crates/cuda-backend/src/whir.rs
+++ b/crates/cuda-backend/src/whir.rs
@@ -5,7 +5,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
-    stream::DeviceContext,
+    stream::GpuDeviceCtx,
 };
 use openvm_stark_backend::{
     proof::{MerkleProof, WhirProof},
@@ -65,7 +65,7 @@ pub fn prove_whir_opening_gpu<HS, TS>(
     transcript: &mut TS,
     mut stacked_per_commit: Vec<StackedPcsData2<HS::Digest>>,
     u: &[EF],
-    device_ctx: &DeviceContext,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<WhirProof<HS::SC>, WhirProverError>
 where
     HS: GpuHashScheme,

--- a/crates/cuda-backend/src/whir.rs
+++ b/crates/cuda-backend/src/whir.rs
@@ -5,7 +5,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
-    stream::cudaStreamPerThread,
+    stream::cudaStream_t,
 };
 use openvm_stark_backend::{
     proof::{MerkleProof, WhirProof},
@@ -65,6 +65,7 @@ pub fn prove_whir_opening_gpu<HS, TS>(
     transcript: &mut TS,
     mut stacked_per_commit: Vec<StackedPcsData2<HS::Digest>>,
     u: &[EF],
+    stream: cudaStream_t,
 ) -> Result<WhirProof<HS::SC>, WhirProverError>
 where
     HS: GpuHashScheme,
@@ -90,7 +91,7 @@ where
     // Proof-of-work grinding before μ batching challenge.
     // This amplifies soundness of the initial batching step.
     let mu_pow_witness = transcript
-        .grind_gpu(whir_params.mu_pow_bits)
+        .grind_gpu(whir_params.mu_pow_bits, stream)
         .map_err(WhirProverError::MuGrind)?;
     // Sample randomness for algebraic batching.
     // We batch the codewords for \hat{q}_j together _before_ applying WHIR.
@@ -131,7 +132,7 @@ where
                 &d_packets,
                 &d_mu_powers,
                 1 << l_skip,
-                cudaStreamPerThread,
+                stream,
             )
             .map_err(WhirProverError::AlgebraicBatch)?;
         }
@@ -149,19 +150,13 @@ where
     // coefficients c_z(x) of f(Z, x) for a fixed boolean assignment x in H_{m - l_skip}.
     unsafe {
         let num_poly = f_ple_evals.len() >> l_skip;
-        batch_ntt_small(
-            &mut f_ple_evals,
-            l_skip,
-            num_poly,
-            true,
-            cudaStreamPerThread,
-        )
-        .map_err(WhirProverError::CustomBatchIntt)?;
+        batch_ntt_small(&mut f_ple_evals, l_skip, num_poly, true, stream)
+            .map_err(WhirProverError::CustomBatchIntt)?;
     }
     let mut f_coeffs = DeviceBuffer::<EF>::with_capacity(height);
     // SAFETY: `f_ple_evals` is constructed with length `height * D_EF`.
     unsafe {
-        transpose_fp_to_fpext_vec(&mut f_coeffs, &f_ple_evals, cudaStreamPerThread)
+        transpose_fp_to_fpext_vec(&mut f_coeffs, &f_ple_evals, stream)
             .map_err(WhirProverError::Transpose)?;
     }
     drop(f_ple_evals);
@@ -173,7 +168,7 @@ where
         let step = 1u32 << i;
         // SAFETY: `f_coeffs` has length `2^m` with `m >= l_skip`.
         unsafe {
-            mle_interpolate_stage_ext(&mut f_coeffs, step, false, cudaStreamPerThread)
+            mle_interpolate_stage_ext(&mut f_coeffs, step, false, stream)
                 .map_err(|error| WhirProverError::MleInterpolate { error, step })?;
         }
     }
@@ -187,7 +182,7 @@ where
     // For initial \hat{w} = mobius_eq(u, -), these moments are exactly eq(u, -).
     let mut w_moments = DeviceBuffer::<EF>::with_capacity(1 << m);
     unsafe {
-        evals_eq_hypercube(&mut w_moments, u).map_err(WhirProverError::EvalEq)?;
+        evals_eq_hypercube(&mut w_moments, u, stream).map_err(WhirProverError::EvalEq)?;
     }
 
     let mut whir_sumcheck_polys: Vec<[EF; 2]> = vec![];
@@ -224,10 +219,7 @@ where
             debug_assert!(w_moments.len() >= f_height);
             let output_height = f_height / 2;
             let tmp_buffer_capacity = unsafe {
-                _whir_sumcheck_coeff_moments_required_temp_buffer_size(
-                    f_height as u32,
-                    cudaStreamPerThread,
-                )
+                _whir_sumcheck_coeff_moments_required_temp_buffer_size(f_height as u32, stream)
             };
             if d_sumcheck_tmp.len() < tmp_buffer_capacity as usize {
                 d_sumcheck_tmp = DeviceBuffer::<EF>::with_capacity(tmp_buffer_capacity as usize);
@@ -244,7 +236,7 @@ where
                     &mut d_s_evals,
                     &mut d_sumcheck_tmp,
                     f_height as u32,
-                    cudaStreamPerThread,
+                    stream,
                 )
                 .map_err(|error| WhirProverError::SumcheckMleRound {
                     error,
@@ -260,7 +252,7 @@ where
 
             folding_pow_witnesses.push(
                 transcript
-                    .grind_gpu(whir_params.folding_pow_bits)
+                    .grind_gpu(whir_params.folding_pow_bits, stream)
                     .map_err(WhirProverError::FoldingGrind)?,
             );
             let alpha = transcript.sample_ext();
@@ -277,7 +269,7 @@ where
                     &mut new_w_moments,
                     alpha,
                     f_height as u32,
-                    cudaStreamPerThread,
+                    stream,
                 )
                 .map_err(|error| WhirProverError::FoldMle {
                     error,
@@ -302,7 +294,7 @@ where
                 &f_coeffs,
                 f_height as u64,
                 f_height as u32,
-                cudaStreamPerThread,
+                stream,
             )
             .map_err(|error| WhirProverError::SplitExtPoly { error, whir_round })?;
         }
@@ -322,7 +314,7 @@ where
                     D_EF as u32,
                     codeword_height as u32,
                     f_height as u32,
-                    cudaStreamPerThread,
+                    stream,
                 )
                 .map_err(|error| WhirProverError::BatchExpandPad { error, whir_round })?;
 
@@ -333,6 +325,7 @@ where
                     D_EF as u32,
                     true,
                     false,
+                    stream,
                 );
             }
 
@@ -340,6 +333,7 @@ where
                 DeviceMatrix::new(Arc::new(g_rs), codeword_height, D_EF),
                 1 << k_whir,
                 true,
+                stream,
             )
             .map_err(WhirProverError::MerkleTree)?;
             let g_commit = g_tree.root();
@@ -351,13 +345,8 @@ where
             // - `g_coeffs` is coefficient form of `\hat{g}`, which is degree `2^{m-k_whir}`.
             // - `g_coeffs` is F-column major matrix.
             let g_opened_value = unsafe {
-                eval_poly_ext_at_point_from_base(
-                    &g_coeffs,
-                    1 << (m - k_whir),
-                    z_0,
-                    cudaStreamPerThread,
-                )
-                .map_err(|error| WhirProverError::EvalPolyAtPoint { error, whir_round })?
+                eval_poly_ext_at_point_from_base(&g_coeffs, 1 << (m - k_whir), z_0, stream)
+                    .map_err(|error| WhirProverError::EvalPolyAtPoint { error, whir_round })?
             };
             transcript.observe_ext(g_opened_value);
             ood_values.push(g_opened_value);
@@ -385,7 +374,7 @@ where
         let mut query_indices = Vec::with_capacity(num_queries);
         query_phase_pow_witnesses.push(
             transcript
-                .grind_gpu(whir_params.query_phase_pow_bits)
+                .grind_gpu(whir_params.query_phase_pow_bits, stream)
                 .map_err(WhirProverError::QueryPhaseGrind)?,
         );
         // Sample query indices first
@@ -413,7 +402,7 @@ where
                     let traces = d.traces.iter().collect_vec();
                     debug_assert!(!traces.is_empty());
                     let backing_matrix =
-                        rs_code_matrix(log_blowup, layout, &traces, &d.inner.matrix)
+                        rs_code_matrix(log_blowup, layout, &traces, &d.inner.matrix, stream)
                             .map_err(WhirProverError::RsCodeMatrix)?;
                     d.traces.clear();
                     *backing_mat_owned = Some(backing_matrix);
@@ -426,6 +415,7 @@ where
                 <MerkleTreeGpu<F, HS::Digest>>::batch_query_merkle_proofs(
                     trees.as_slice(),
                     &query_indices,
+                    stream,
                 )
                 .map_err(WhirProverError::MerkleTree)?;
 
@@ -447,6 +437,7 @@ where
                 &query_indices,
                 query_stride,
                 num_rows_per_query,
+                stream,
             )
             .map_err(WhirProverError::MerkleTree)?
             .into_iter()
@@ -470,16 +461,21 @@ where
         } else {
             let tree: &MerkleTreeGpu<F, HS::Digest> = rs_tree.as_ref().unwrap();
             codeword_merkle_proofs[whir_round - 1] =
-                <MerkleTreeGpu<F, HS::Digest>>::batch_query_merkle_proofs(&[tree], &query_indices)
-                    .map_err(WhirProverError::MerkleTree)?
-                    .pop()
-                    .expect("exactly 1 tree");
+                <MerkleTreeGpu<F, HS::Digest>>::batch_query_merkle_proofs(
+                    &[tree],
+                    &query_indices,
+                    stream,
+                )
+                .map_err(WhirProverError::MerkleTree)?
+                .pop()
+                .expect("exactly 1 tree");
             codeword_opened_values[whir_round - 1] =
                 MerkleTreeGpu::<F, HS::Digest>::batch_open_rows(
                     &[tree.backing_matrix.as_ref().unwrap()],
                     &query_indices,
                     tree.query_stride(),
                     tree.rows_per_query,
+                    stream,
                 )
                 .map_err(WhirProverError::MerkleTree)?
                 .pop()
@@ -531,7 +527,7 @@ where
                     gamma,
                     num_queries as u32,
                     log_height,
-                    cudaStreamPerThread,
+                    stream,
                 )
                 .map_err(|error| WhirProverError::WMomentsAccumulate { error, whir_round })?;
             }
@@ -667,12 +663,14 @@ mod tests {
         }
 
         let mut prover_sponge = DuplexSpongeGpu::default();
+        let stream = device.ctx.stream.as_raw();
 
         let proof = prove_whir_opening_gpu::<crate::DefaultHashScheme, _>(
             &params,
             &mut prover_sponge,
             stacked_per_commit,
             &z_cube,
+            stream,
         )
         .unwrap();
 

--- a/crates/cuda-backend/src/whir.rs
+++ b/crates/cuda-backend/src/whir.rs
@@ -5,6 +5,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
+    stream::cudaStreamPerThread,
 };
 use openvm_stark_backend::{
     proof::{MerkleProof, WhirProof},
@@ -211,7 +212,7 @@ where
             debug_assert!(w_moments.len() >= f_height);
             let output_height = f_height / 2;
             let tmp_buffer_capacity =
-                unsafe { _whir_sumcheck_coeff_moments_required_temp_buffer_size(f_height as u32) };
+                unsafe { _whir_sumcheck_coeff_moments_required_temp_buffer_size(f_height as u32, cudaStreamPerThread) };
             if d_sumcheck_tmp.len() < tmp_buffer_capacity as usize {
                 d_sumcheck_tmp = DeviceBuffer::<EF>::with_capacity(tmp_buffer_capacity as usize);
             }

--- a/crates/cuda-backend/src/whir.rs
+++ b/crates/cuda-backend/src/whir.rs
@@ -65,7 +65,7 @@ pub fn prove_whir_opening_gpu<HS, TS>(
     transcript: &mut TS,
     mut stacked_per_commit: Vec<StackedPcsData2<HS::Digest>>,
     u: &[EF],
-    ctx: &DeviceContext,
+    device_ctx: &DeviceContext,
 ) -> Result<WhirProof<HS::SC>, WhirProverError>
 where
     HS: GpuHashScheme,
@@ -91,7 +91,7 @@ where
     // Proof-of-work grinding before μ batching challenge.
     // This amplifies soundness of the initial batching step.
     let mu_pow_witness = transcript
-        .grind_gpu(whir_params.mu_pow_bits, ctx)
+        .grind_gpu(whir_params.mu_pow_bits, device_ctx)
         .map_err(WhirProverError::MuGrind)?;
     // Sample randomness for algebraic batching.
     // We batch the codewords for \hat{q}_j together _before_ applying WHIR.
@@ -99,7 +99,7 @@ where
     let num_commits = stacked_per_commit.len();
 
     // The coefficient table of `\hat{f}` in the current WHIR round (MLE coefficient form).
-    let mut f_ple_evals = DeviceBuffer::<F>::with_capacity_on(height * D_EF, ctx);
+    let mut f_ple_evals = DeviceBuffer::<F>::with_capacity_on(height * D_EF, device_ctx);
     // We algebraically batch all matrices together so we only need to interpolate one column vector
     {
         let mut packets = Vec::new();
@@ -120,8 +120,8 @@ where
             total_stacked_width += layout.width() as u32;
         }
         let mu_powers = mu.powers().take(total_stacked_width as usize).collect_vec();
-        let d_mu_powers = mu_powers.to_device_on(ctx)?;
-        let d_packets = packets.to_device_on(ctx)?;
+        let d_mu_powers = mu_powers.to_device_on(device_ctx)?;
+        let d_packets = packets.to_device_on(device_ctx)?;
         // SAFETY:
         // - `mu_powers` has length `total_width`.
         // - `f_ple_evals` has capacity `height * D_EF` (stacked height in base coordinates).
@@ -132,7 +132,7 @@ where
                 &d_packets,
                 &d_mu_powers,
                 1 << l_skip,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
             .map_err(WhirProverError::AlgebraicBatch)?;
         }
@@ -155,14 +155,14 @@ where
             l_skip,
             num_poly,
             true,
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )
         .map_err(WhirProverError::CustomBatchIntt)?;
     }
-    let mut f_coeffs = DeviceBuffer::<EF>::with_capacity_on(height, ctx);
+    let mut f_coeffs = DeviceBuffer::<EF>::with_capacity_on(height, device_ctx);
     // SAFETY: `f_ple_evals` is constructed with length `height * D_EF`.
     unsafe {
-        transpose_fp_to_fpext_vec(&mut f_coeffs, &f_ple_evals, ctx.stream.as_raw())
+        transpose_fp_to_fpext_vec(&mut f_coeffs, &f_ple_evals, device_ctx.stream.as_raw())
             .map_err(WhirProverError::Transpose)?;
     }
     drop(f_ple_evals);
@@ -174,7 +174,7 @@ where
         let step = 1u32 << i;
         // SAFETY: `f_coeffs` has length `2^m` with `m >= l_skip`.
         unsafe {
-            mle_interpolate_stage_ext(&mut f_coeffs, step, false, ctx.stream.as_raw())
+            mle_interpolate_stage_ext(&mut f_coeffs, step, false, device_ctx.stream.as_raw())
                 .map_err(|error| WhirProverError::MleInterpolate { error, step })?;
         }
     }
@@ -186,9 +186,9 @@ where
     // We maintain moments of \hat{w}:
     // M[T] = sum_{x superset T} \hat{w}(x).
     // For initial \hat{w} = mobius_eq(u, -), these moments are exactly eq(u, -).
-    let mut w_moments = DeviceBuffer::<EF>::with_capacity_on(1 << m, ctx);
+    let mut w_moments = DeviceBuffer::<EF>::with_capacity_on(1 << m, device_ctx);
     unsafe {
-        evals_eq_hypercube(&mut w_moments, u, ctx).map_err(WhirProverError::EvalEq)?;
+        evals_eq_hypercube(&mut w_moments, u, device_ctx).map_err(WhirProverError::EvalEq)?;
     }
 
     let mut whir_sumcheck_polys: Vec<[EF; 2]> = vec![];
@@ -205,7 +205,7 @@ where
     let mut log_rs_domain_size = m + log_blowup;
     let mut final_poly = None;
 
-    let mut d_s_evals = DeviceBuffer::<EF>::with_capacity_on(2, ctx);
+    let mut d_s_evals = DeviceBuffer::<EF>::with_capacity_on(2, device_ctx);
     let mut d_sumcheck_tmp = DeviceBuffer::<EF>::new();
 
     mem.tracing_info("before_whir_rounds");
@@ -227,15 +227,15 @@ where
             let tmp_buffer_capacity = unsafe {
                 _whir_sumcheck_coeff_moments_required_temp_buffer_size(
                     f_height as u32,
-                    ctx.stream.as_raw(),
+                    device_ctx.stream.as_raw(),
                 )
             };
             if d_sumcheck_tmp.len() < tmp_buffer_capacity as usize {
                 d_sumcheck_tmp =
-                    DeviceBuffer::<EF>::with_capacity_on(tmp_buffer_capacity as usize, ctx);
+                    DeviceBuffer::<EF>::with_capacity_on(tmp_buffer_capacity as usize, device_ctx);
             }
-            let mut new_f_coeffs = DeviceBuffer::<EF>::with_capacity_on(output_height, ctx);
-            let mut new_w_moments = DeviceBuffer::<EF>::with_capacity_on(output_height, ctx);
+            let mut new_f_coeffs = DeviceBuffer::<EF>::with_capacity_on(output_height, device_ctx);
+            let mut new_w_moments = DeviceBuffer::<EF>::with_capacity_on(output_height, device_ctx);
             // SAFETY:
             // - `d_s_evals` has length 2
             // - `d_sumcheck_tmp` has at least required scratch length
@@ -246,7 +246,7 @@ where
                     &mut d_s_evals,
                     &mut d_sumcheck_tmp,
                     f_height as u32,
-                    ctx.stream.as_raw(),
+                    device_ctx.stream.as_raw(),
                 )
                 .map_err(|error| WhirProverError::SumcheckMleRound {
                     error,
@@ -254,7 +254,7 @@ where
                     round,
                 })?;
             }
-            let s_evals = d_s_evals.to_host_on(ctx)?;
+            let s_evals = d_s_evals.to_host_on(device_ctx)?;
             for &eval in &s_evals {
                 transcript.observe_ext(eval);
             }
@@ -262,7 +262,7 @@ where
 
             folding_pow_witnesses.push(
                 transcript
-                    .grind_gpu(whir_params.folding_pow_bits, ctx)
+                    .grind_gpu(whir_params.folding_pow_bits, device_ctx)
                     .map_err(WhirProverError::FoldingGrind)?,
             );
             let alpha = transcript.sample_ext();
@@ -279,7 +279,7 @@ where
                     &mut new_w_moments,
                     alpha,
                     f_height as u32,
-                    ctx.stream.as_raw(),
+                    device_ctx.stream.as_raw(),
                 )
                 .map_err(|error| WhirProverError::FoldMle {
                     error,
@@ -295,7 +295,7 @@ where
         let f_height = 1 << (m - k_whir);
         debug_assert!(f_coeffs.len() >= f_height);
         debug_assert_eq!(size_of::<EF>() / size_of::<F>(), D_EF);
-        let mut g_coeffs = DeviceBuffer::<F>::with_capacity_on(f_height * D_EF, ctx);
+        let mut g_coeffs = DeviceBuffer::<F>::with_capacity_on(f_height * D_EF, device_ctx);
         // SAFETY: we allocated `f_coeffs.len() * D_EF` space for `g_coeffs` to do a 1-to-D_EF
         // (1-to-4) split
         unsafe {
@@ -304,14 +304,14 @@ where
                 &f_coeffs,
                 f_height as u64,
                 f_height as u32,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
             .map_err(|error| WhirProverError::SplitExtPoly { error, whir_round })?;
         }
         let (g_tree, z_0) = if !is_last_round {
             let codeword_height = 1 << (log_rs_domain_size - 1);
             // `g: \mathcal{L}^{(2)} \to \mathbb F`
-            let g_rs = DeviceBuffer::<F>::with_capacity_on(D_EF * codeword_height, ctx);
+            let g_rs = DeviceBuffer::<F>::with_capacity_on(D_EF * codeword_height, device_ctx);
             // SAFETY:
             // - g_coeffs is a single EF polynomial, treated as 4 F-polynomials of height
             //   2^{m-k_whir}
@@ -324,7 +324,7 @@ where
                     D_EF as u32,
                     codeword_height as u32,
                     f_height as u32,
-                    ctx.stream.as_raw(),
+                    device_ctx.stream.as_raw(),
                 )
                 .map_err(|error| WhirProverError::BatchExpandPad { error, whir_round })?;
 
@@ -335,7 +335,7 @@ where
                     D_EF as u32,
                     true,
                     false,
-                    ctx,
+                    device_ctx,
                 );
             }
 
@@ -343,7 +343,7 @@ where
                 DeviceMatrix::new(Arc::new(g_rs), codeword_height, D_EF),
                 1 << k_whir,
                 true,
-                ctx,
+                device_ctx,
             )
             .map_err(WhirProverError::MerkleTree)?;
             let g_commit = g_tree.root();
@@ -355,7 +355,7 @@ where
             // - `g_coeffs` is coefficient form of `\hat{g}`, which is degree `2^{m-k_whir}`.
             // - `g_coeffs` is F-column major matrix.
             let g_opened_value = unsafe {
-                eval_poly_ext_at_point_from_base(&g_coeffs, 1 << (m - k_whir), z_0, ctx)
+                eval_poly_ext_at_point_from_base(&g_coeffs, 1 << (m - k_whir), z_0, device_ctx)
                     .map_err(|error| WhirProverError::EvalPolyAtPoint { error, whir_round })?
             };
             transcript.observe_ext(g_opened_value);
@@ -366,7 +366,7 @@ where
             // Observe the final poly
             debug_assert_eq!(log_final_poly_len, m - k_whir);
             let final_poly_len = 1 << log_final_poly_len;
-            let base_coeffs = g_coeffs.to_host_on(ctx)?;
+            let base_coeffs = g_coeffs.to_host_on(device_ctx)?;
             debug_assert_eq!(base_coeffs.len(), D_EF * final_poly_len);
             let mut coeffs = Vec::with_capacity(final_poly_len);
             for i in 0..final_poly_len {
@@ -384,7 +384,7 @@ where
         let mut query_indices = Vec::with_capacity(num_queries);
         query_phase_pow_witnesses.push(
             transcript
-                .grind_gpu(whir_params.query_phase_pow_bits, ctx)
+                .grind_gpu(whir_params.query_phase_pow_bits, device_ctx)
                 .map_err(WhirProverError::QueryPhaseGrind)?,
         );
         // Sample query indices first
@@ -412,7 +412,7 @@ where
                     let traces = d.traces.iter().collect_vec();
                     debug_assert!(!traces.is_empty());
                     let backing_matrix =
-                        rs_code_matrix(log_blowup, layout, &traces, &d.inner.matrix, ctx)
+                        rs_code_matrix(log_blowup, layout, &traces, &d.inner.matrix, device_ctx)
                             .map_err(WhirProverError::RsCodeMatrix)?;
                     d.traces.clear();
                     *backing_mat_owned = Some(backing_matrix);
@@ -425,7 +425,7 @@ where
                 <MerkleTreeGpu<F, HS::Digest>>::batch_query_merkle_proofs(
                     trees.as_slice(),
                     &query_indices,
-                    ctx,
+                    device_ctx,
                 )
                 .map_err(WhirProverError::MerkleTree)?;
 
@@ -447,7 +447,7 @@ where
                 &query_indices,
                 query_stride,
                 num_rows_per_query,
-                ctx,
+                device_ctx,
             )
             .map_err(WhirProverError::MerkleTree)?
             .into_iter()
@@ -474,7 +474,7 @@ where
                 <MerkleTreeGpu<F, HS::Digest>>::batch_query_merkle_proofs(
                     &[tree],
                     &query_indices,
-                    ctx,
+                    device_ctx,
                 )
                 .map_err(WhirProverError::MerkleTree)?
                 .pop()
@@ -485,7 +485,7 @@ where
                     &query_indices,
                     tree.query_stride(),
                     tree.rows_per_query,
-                    ctx,
+                    device_ctx,
                 )
                 .map_err(WhirProverError::MerkleTree)?
                 .pop()
@@ -527,8 +527,8 @@ where
                 }
             }
 
-            let d_z0_pows2 = z0_pows2.to_device_on(ctx)?;
-            let d_z_pows2 = z_pows2.to_device_on(ctx)?;
+            let d_z0_pows2 = z0_pows2.to_device_on(device_ctx)?;
+            let d_z_pows2 = z_pows2.to_device_on(device_ctx)?;
             unsafe {
                 w_moments_accumulate(
                     &mut w_moments,
@@ -537,7 +537,7 @@ where
                     gamma,
                     num_queries as u32,
                     log_height,
-                    ctx.stream.as_raw(),
+                    device_ctx.stream.as_raw(),
                 )
                 .map_err(|error| WhirProverError::WMomentsAccumulate { error, whir_round })?;
             }
@@ -679,7 +679,7 @@ mod tests {
             &mut prover_sponge,
             stacked_per_commit,
             &z_cube,
-            &device.ctx,
+            &device.device_ctx,
         )
         .unwrap();
 

--- a/crates/cuda-backend/src/whir.rs
+++ b/crates/cuda-backend/src/whir.rs
@@ -5,7 +5,7 @@ use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
-    stream::cudaStream_t,
+    stream::DeviceContext,
 };
 use openvm_stark_backend::{
     proof::{MerkleProof, WhirProof},
@@ -65,7 +65,7 @@ pub fn prove_whir_opening_gpu<HS, TS>(
     transcript: &mut TS,
     mut stacked_per_commit: Vec<StackedPcsData2<HS::Digest>>,
     u: &[EF],
-    stream: cudaStream_t,
+    ctx: &DeviceContext,
 ) -> Result<WhirProof<HS::SC>, WhirProverError>
 where
     HS: GpuHashScheme,
@@ -91,7 +91,7 @@ where
     // Proof-of-work grinding before μ batching challenge.
     // This amplifies soundness of the initial batching step.
     let mu_pow_witness = transcript
-        .grind_gpu(whir_params.mu_pow_bits, stream)
+        .grind_gpu(whir_params.mu_pow_bits, ctx)
         .map_err(WhirProverError::MuGrind)?;
     // Sample randomness for algebraic batching.
     // We batch the codewords for \hat{q}_j together _before_ applying WHIR.
@@ -99,7 +99,7 @@ where
     let num_commits = stacked_per_commit.len();
 
     // The coefficient table of `\hat{f}` in the current WHIR round (MLE coefficient form).
-    let mut f_ple_evals = DeviceBuffer::<F>::with_capacity(height * D_EF);
+    let mut f_ple_evals = DeviceBuffer::<F>::with_capacity_on(height * D_EF, ctx);
     // We algebraically batch all matrices together so we only need to interpolate one column vector
     {
         let mut packets = Vec::new();
@@ -120,8 +120,8 @@ where
             total_stacked_width += layout.width() as u32;
         }
         let mu_powers = mu.powers().take(total_stacked_width as usize).collect_vec();
-        let d_mu_powers = mu_powers.to_device()?;
-        let d_packets = packets.to_device()?;
+        let d_mu_powers = mu_powers.to_device_on(ctx)?;
+        let d_packets = packets.to_device_on(ctx)?;
         // SAFETY:
         // - `mu_powers` has length `total_width`.
         // - `f_ple_evals` has capacity `height * D_EF` (stacked height in base coordinates).
@@ -132,7 +132,7 @@ where
                 &d_packets,
                 &d_mu_powers,
                 1 << l_skip,
-                stream,
+                ctx.stream.as_raw(),
             )
             .map_err(WhirProverError::AlgebraicBatch)?;
         }
@@ -150,13 +150,19 @@ where
     // coefficients c_z(x) of f(Z, x) for a fixed boolean assignment x in H_{m - l_skip}.
     unsafe {
         let num_poly = f_ple_evals.len() >> l_skip;
-        batch_ntt_small(&mut f_ple_evals, l_skip, num_poly, true, stream)
-            .map_err(WhirProverError::CustomBatchIntt)?;
+        batch_ntt_small(
+            &mut f_ple_evals,
+            l_skip,
+            num_poly,
+            true,
+            ctx.stream.as_raw(),
+        )
+        .map_err(WhirProverError::CustomBatchIntt)?;
     }
-    let mut f_coeffs = DeviceBuffer::<EF>::with_capacity(height);
+    let mut f_coeffs = DeviceBuffer::<EF>::with_capacity_on(height, ctx);
     // SAFETY: `f_ple_evals` is constructed with length `height * D_EF`.
     unsafe {
-        transpose_fp_to_fpext_vec(&mut f_coeffs, &f_ple_evals, stream)
+        transpose_fp_to_fpext_vec(&mut f_coeffs, &f_ple_evals, ctx.stream.as_raw())
             .map_err(WhirProverError::Transpose)?;
     }
     drop(f_ple_evals);
@@ -168,7 +174,7 @@ where
         let step = 1u32 << i;
         // SAFETY: `f_coeffs` has length `2^m` with `m >= l_skip`.
         unsafe {
-            mle_interpolate_stage_ext(&mut f_coeffs, step, false, stream)
+            mle_interpolate_stage_ext(&mut f_coeffs, step, false, ctx.stream.as_raw())
                 .map_err(|error| WhirProverError::MleInterpolate { error, step })?;
         }
     }
@@ -180,9 +186,9 @@ where
     // We maintain moments of \hat{w}:
     // M[T] = sum_{x superset T} \hat{w}(x).
     // For initial \hat{w} = mobius_eq(u, -), these moments are exactly eq(u, -).
-    let mut w_moments = DeviceBuffer::<EF>::with_capacity(1 << m);
+    let mut w_moments = DeviceBuffer::<EF>::with_capacity_on(1 << m, ctx);
     unsafe {
-        evals_eq_hypercube(&mut w_moments, u, stream).map_err(WhirProverError::EvalEq)?;
+        evals_eq_hypercube(&mut w_moments, u, ctx).map_err(WhirProverError::EvalEq)?;
     }
 
     let mut whir_sumcheck_polys: Vec<[EF; 2]> = vec![];
@@ -199,7 +205,7 @@ where
     let mut log_rs_domain_size = m + log_blowup;
     let mut final_poly = None;
 
-    let mut d_s_evals = DeviceBuffer::<EF>::with_capacity(2);
+    let mut d_s_evals = DeviceBuffer::<EF>::with_capacity_on(2, ctx);
     let mut d_sumcheck_tmp = DeviceBuffer::<EF>::new();
 
     mem.tracing_info("before_whir_rounds");
@@ -219,13 +225,17 @@ where
             debug_assert!(w_moments.len() >= f_height);
             let output_height = f_height / 2;
             let tmp_buffer_capacity = unsafe {
-                _whir_sumcheck_coeff_moments_required_temp_buffer_size(f_height as u32, stream)
+                _whir_sumcheck_coeff_moments_required_temp_buffer_size(
+                    f_height as u32,
+                    ctx.stream.as_raw(),
+                )
             };
             if d_sumcheck_tmp.len() < tmp_buffer_capacity as usize {
-                d_sumcheck_tmp = DeviceBuffer::<EF>::with_capacity(tmp_buffer_capacity as usize);
+                d_sumcheck_tmp =
+                    DeviceBuffer::<EF>::with_capacity_on(tmp_buffer_capacity as usize, ctx);
             }
-            let mut new_f_coeffs = DeviceBuffer::<EF>::with_capacity(output_height);
-            let mut new_w_moments = DeviceBuffer::<EF>::with_capacity(output_height);
+            let mut new_f_coeffs = DeviceBuffer::<EF>::with_capacity_on(output_height, ctx);
+            let mut new_w_moments = DeviceBuffer::<EF>::with_capacity_on(output_height, ctx);
             // SAFETY:
             // - `d_s_evals` has length 2
             // - `d_sumcheck_tmp` has at least required scratch length
@@ -236,7 +246,7 @@ where
                     &mut d_s_evals,
                     &mut d_sumcheck_tmp,
                     f_height as u32,
-                    stream,
+                    ctx.stream.as_raw(),
                 )
                 .map_err(|error| WhirProverError::SumcheckMleRound {
                     error,
@@ -244,7 +254,7 @@ where
                     round,
                 })?;
             }
-            let s_evals = d_s_evals.to_host()?;
+            let s_evals = d_s_evals.to_host_on(ctx)?;
             for &eval in &s_evals {
                 transcript.observe_ext(eval);
             }
@@ -252,7 +262,7 @@ where
 
             folding_pow_witnesses.push(
                 transcript
-                    .grind_gpu(whir_params.folding_pow_bits, stream)
+                    .grind_gpu(whir_params.folding_pow_bits, ctx)
                     .map_err(WhirProverError::FoldingGrind)?,
             );
             let alpha = transcript.sample_ext();
@@ -269,7 +279,7 @@ where
                     &mut new_w_moments,
                     alpha,
                     f_height as u32,
-                    stream,
+                    ctx.stream.as_raw(),
                 )
                 .map_err(|error| WhirProverError::FoldMle {
                     error,
@@ -285,7 +295,7 @@ where
         let f_height = 1 << (m - k_whir);
         debug_assert!(f_coeffs.len() >= f_height);
         debug_assert_eq!(size_of::<EF>() / size_of::<F>(), D_EF);
-        let mut g_coeffs = DeviceBuffer::<F>::with_capacity(f_height * D_EF);
+        let mut g_coeffs = DeviceBuffer::<F>::with_capacity_on(f_height * D_EF, ctx);
         // SAFETY: we allocated `f_coeffs.len() * D_EF` space for `g_coeffs` to do a 1-to-D_EF
         // (1-to-4) split
         unsafe {
@@ -294,14 +304,14 @@ where
                 &f_coeffs,
                 f_height as u64,
                 f_height as u32,
-                stream,
+                ctx.stream.as_raw(),
             )
             .map_err(|error| WhirProverError::SplitExtPoly { error, whir_round })?;
         }
         let (g_tree, z_0) = if !is_last_round {
             let codeword_height = 1 << (log_rs_domain_size - 1);
             // `g: \mathcal{L}^{(2)} \to \mathbb F`
-            let g_rs = DeviceBuffer::<F>::with_capacity(D_EF * codeword_height);
+            let g_rs = DeviceBuffer::<F>::with_capacity_on(D_EF * codeword_height, ctx);
             // SAFETY:
             // - g_coeffs is a single EF polynomial, treated as 4 F-polynomials of height
             //   2^{m-k_whir}
@@ -314,7 +324,7 @@ where
                     D_EF as u32,
                     codeword_height as u32,
                     f_height as u32,
-                    stream,
+                    ctx.stream.as_raw(),
                 )
                 .map_err(|error| WhirProverError::BatchExpandPad { error, whir_round })?;
 
@@ -325,7 +335,7 @@ where
                     D_EF as u32,
                     true,
                     false,
-                    stream,
+                    ctx,
                 );
             }
 
@@ -333,7 +343,7 @@ where
                 DeviceMatrix::new(Arc::new(g_rs), codeword_height, D_EF),
                 1 << k_whir,
                 true,
-                stream,
+                ctx,
             )
             .map_err(WhirProverError::MerkleTree)?;
             let g_commit = g_tree.root();
@@ -345,7 +355,7 @@ where
             // - `g_coeffs` is coefficient form of `\hat{g}`, which is degree `2^{m-k_whir}`.
             // - `g_coeffs` is F-column major matrix.
             let g_opened_value = unsafe {
-                eval_poly_ext_at_point_from_base(&g_coeffs, 1 << (m - k_whir), z_0, stream)
+                eval_poly_ext_at_point_from_base(&g_coeffs, 1 << (m - k_whir), z_0, ctx)
                     .map_err(|error| WhirProverError::EvalPolyAtPoint { error, whir_round })?
             };
             transcript.observe_ext(g_opened_value);
@@ -356,7 +366,7 @@ where
             // Observe the final poly
             debug_assert_eq!(log_final_poly_len, m - k_whir);
             let final_poly_len = 1 << log_final_poly_len;
-            let base_coeffs = g_coeffs.to_host()?;
+            let base_coeffs = g_coeffs.to_host_on(ctx)?;
             debug_assert_eq!(base_coeffs.len(), D_EF * final_poly_len);
             let mut coeffs = Vec::with_capacity(final_poly_len);
             for i in 0..final_poly_len {
@@ -374,7 +384,7 @@ where
         let mut query_indices = Vec::with_capacity(num_queries);
         query_phase_pow_witnesses.push(
             transcript
-                .grind_gpu(whir_params.query_phase_pow_bits, stream)
+                .grind_gpu(whir_params.query_phase_pow_bits, ctx)
                 .map_err(WhirProverError::QueryPhaseGrind)?,
         );
         // Sample query indices first
@@ -402,7 +412,7 @@ where
                     let traces = d.traces.iter().collect_vec();
                     debug_assert!(!traces.is_empty());
                     let backing_matrix =
-                        rs_code_matrix(log_blowup, layout, &traces, &d.inner.matrix, stream)
+                        rs_code_matrix(log_blowup, layout, &traces, &d.inner.matrix, ctx)
                             .map_err(WhirProverError::RsCodeMatrix)?;
                     d.traces.clear();
                     *backing_mat_owned = Some(backing_matrix);
@@ -415,7 +425,7 @@ where
                 <MerkleTreeGpu<F, HS::Digest>>::batch_query_merkle_proofs(
                     trees.as_slice(),
                     &query_indices,
-                    stream,
+                    ctx,
                 )
                 .map_err(WhirProverError::MerkleTree)?;
 
@@ -437,7 +447,7 @@ where
                 &query_indices,
                 query_stride,
                 num_rows_per_query,
-                stream,
+                ctx,
             )
             .map_err(WhirProverError::MerkleTree)?
             .into_iter()
@@ -464,7 +474,7 @@ where
                 <MerkleTreeGpu<F, HS::Digest>>::batch_query_merkle_proofs(
                     &[tree],
                     &query_indices,
-                    stream,
+                    ctx,
                 )
                 .map_err(WhirProverError::MerkleTree)?
                 .pop()
@@ -475,7 +485,7 @@ where
                     &query_indices,
                     tree.query_stride(),
                     tree.rows_per_query,
-                    stream,
+                    ctx,
                 )
                 .map_err(WhirProverError::MerkleTree)?
                 .pop()
@@ -517,8 +527,8 @@ where
                 }
             }
 
-            let d_z0_pows2 = z0_pows2.to_device()?;
-            let d_z_pows2 = z_pows2.to_device()?;
+            let d_z0_pows2 = z0_pows2.to_device_on(ctx)?;
+            let d_z_pows2 = z_pows2.to_device_on(ctx)?;
             unsafe {
                 w_moments_accumulate(
                     &mut w_moments,
@@ -527,7 +537,7 @@ where
                     gamma,
                     num_queries as u32,
                     log_height,
-                    stream,
+                    ctx.stream.as_raw(),
                 )
                 .map_err(|error| WhirProverError::WMomentsAccumulate { error, whir_round })?;
             }
@@ -663,14 +673,13 @@ mod tests {
         }
 
         let mut prover_sponge = DuplexSpongeGpu::default();
-        let stream = device.ctx.stream.as_raw();
 
         let proof = prove_whir_opening_gpu::<crate::DefaultHashScheme, _>(
             &params,
             &mut prover_sponge,
             stacked_per_commit,
             &z_cube,
-            stream,
+            &device.ctx,
         )
         .unwrap();
 

--- a/crates/cuda-backend/src/whir.rs
+++ b/crates/cuda-backend/src/whir.rs
@@ -126,8 +126,14 @@ where
         // - `f_ple_evals` has capacity `height * D_EF` (stacked height in base coordinates).
         // - `d_packets` contain valid pointers and stacked row indices by construction.
         unsafe {
-            whir_algebraic_batch_traces(&mut f_ple_evals, &d_packets, &d_mu_powers, 1 << l_skip)
-                .map_err(WhirProverError::AlgebraicBatch)?;
+            whir_algebraic_batch_traces(
+                &mut f_ple_evals,
+                &d_packets,
+                &d_mu_powers,
+                1 << l_skip,
+                cudaStreamPerThread,
+            )
+            .map_err(WhirProverError::AlgebraicBatch)?;
         }
         for stacked in &mut stacked_per_commit {
             // drop traces to free device memory if RS codewords matrix exists
@@ -143,13 +149,19 @@ where
     // coefficients c_z(x) of f(Z, x) for a fixed boolean assignment x in H_{m - l_skip}.
     unsafe {
         let num_poly = f_ple_evals.len() >> l_skip;
-        batch_ntt_small(&mut f_ple_evals, l_skip, num_poly, true)
-            .map_err(WhirProverError::CustomBatchIntt)?;
+        batch_ntt_small(
+            &mut f_ple_evals,
+            l_skip,
+            num_poly,
+            true,
+            cudaStreamPerThread,
+        )
+        .map_err(WhirProverError::CustomBatchIntt)?;
     }
     let mut f_coeffs = DeviceBuffer::<EF>::with_capacity(height);
     // SAFETY: `f_ple_evals` is constructed with length `height * D_EF`.
     unsafe {
-        transpose_fp_to_fpext_vec(&mut f_coeffs, &f_ple_evals)
+        transpose_fp_to_fpext_vec(&mut f_coeffs, &f_ple_evals, cudaStreamPerThread)
             .map_err(WhirProverError::Transpose)?;
     }
     drop(f_ple_evals);
@@ -161,7 +173,7 @@ where
         let step = 1u32 << i;
         // SAFETY: `f_coeffs` has length `2^m` with `m >= l_skip`.
         unsafe {
-            mle_interpolate_stage_ext(&mut f_coeffs, step, false)
+            mle_interpolate_stage_ext(&mut f_coeffs, step, false, cudaStreamPerThread)
                 .map_err(|error| WhirProverError::MleInterpolate { error, step })?;
         }
     }
@@ -211,8 +223,12 @@ where
             );
             debug_assert!(w_moments.len() >= f_height);
             let output_height = f_height / 2;
-            let tmp_buffer_capacity =
-                unsafe { _whir_sumcheck_coeff_moments_required_temp_buffer_size(f_height as u32, cudaStreamPerThread) };
+            let tmp_buffer_capacity = unsafe {
+                _whir_sumcheck_coeff_moments_required_temp_buffer_size(
+                    f_height as u32,
+                    cudaStreamPerThread,
+                )
+            };
             if d_sumcheck_tmp.len() < tmp_buffer_capacity as usize {
                 d_sumcheck_tmp = DeviceBuffer::<EF>::with_capacity(tmp_buffer_capacity as usize);
             }
@@ -228,6 +244,7 @@ where
                     &mut d_s_evals,
                     &mut d_sumcheck_tmp,
                     f_height as u32,
+                    cudaStreamPerThread,
                 )
                 .map_err(|error| WhirProverError::SumcheckMleRound {
                     error,
@@ -260,6 +277,7 @@ where
                     &mut new_w_moments,
                     alpha,
                     f_height as u32,
+                    cudaStreamPerThread,
                 )
                 .map_err(|error| WhirProverError::FoldMle {
                     error,
@@ -284,6 +302,7 @@ where
                 &f_coeffs,
                 f_height as u64,
                 f_height as u32,
+                cudaStreamPerThread,
             )
             .map_err(|error| WhirProverError::SplitExtPoly { error, whir_round })?;
         }
@@ -303,6 +322,7 @@ where
                     D_EF as u32,
                     codeword_height as u32,
                     f_height as u32,
+                    cudaStreamPerThread,
                 )
                 .map_err(|error| WhirProverError::BatchExpandPad { error, whir_round })?;
 
@@ -331,8 +351,13 @@ where
             // - `g_coeffs` is coefficient form of `\hat{g}`, which is degree `2^{m-k_whir}`.
             // - `g_coeffs` is F-column major matrix.
             let g_opened_value = unsafe {
-                eval_poly_ext_at_point_from_base(&g_coeffs, 1 << (m - k_whir), z_0)
-                    .map_err(|error| WhirProverError::EvalPolyAtPoint { error, whir_round })?
+                eval_poly_ext_at_point_from_base(
+                    &g_coeffs,
+                    1 << (m - k_whir),
+                    z_0,
+                    cudaStreamPerThread,
+                )
+                .map_err(|error| WhirProverError::EvalPolyAtPoint { error, whir_round })?
             };
             transcript.observe_ext(g_opened_value);
             ood_values.push(g_opened_value);
@@ -506,6 +531,7 @@ where
                     gamma,
                     num_queries as u32,
                     log_height,
+                    cudaStreamPerThread,
                 )
                 .map_err(|error| WhirProverError::WMomentsAccumulate { error, whir_round })?;
             }

--- a/crates/cuda-backend/tests/ntt_roundtrip.rs
+++ b/crates/cuda-backend/tests/ntt_roundtrip.rs
@@ -2,6 +2,7 @@ use openvm_cuda_backend::{ntt::batch_ntt, prelude::F};
 use openvm_cuda_common::{
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
+    stream::cudaStreamPerThread,
 };
 use p3_field::PrimeCharacteristicRing;
 
@@ -19,8 +20,8 @@ fn ntt_roundtrip_max_log_domain_size() {
     let mut device = DeviceBuffer::<F>::with_capacity(n);
     host.copy_to(&mut device).expect("host->device copy failed");
 
-    batch_ntt(&device, LOG_N, 0, 1, true, false);
-    batch_ntt(&device, LOG_N, 0, 1, true, true);
+    batch_ntt(&device, LOG_N, 0, 1, true, false, cudaStreamPerThread);
+    batch_ntt(&device, LOG_N, 0, 1, true, true, cudaStreamPerThread);
 
     let output = device.to_host().expect("device->host copy failed");
     for (i, got) in output.iter().enumerate() {

--- a/crates/cuda-backend/tests/ntt_roundtrip.rs
+++ b/crates/cuda-backend/tests/ntt_roundtrip.rs
@@ -3,7 +3,7 @@ use openvm_cuda_common::{
     common::get_device,
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
-    stream::{CudaStream, DeviceContext, StreamGuard},
+    stream::{CudaStream, GpuDeviceCtx, StreamGuard},
 };
 use p3_field::PrimeCharacteristicRing;
 
@@ -11,7 +11,7 @@ use p3_field::PrimeCharacteristicRing;
 #[ignore] // Run explicitly: requires large GPU memory and significant runtime.
 fn ntt_roundtrip_max_log_domain_size() {
     const LOG_N: u32 = 27;
-    let ctx = DeviceContext {
+    let ctx = GpuDeviceCtx {
         device_id: get_device().unwrap() as u32,
         stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
     };

--- a/crates/cuda-backend/tests/ntt_roundtrip.rs
+++ b/crates/cuda-backend/tests/ntt_roundtrip.rs
@@ -1,8 +1,9 @@
 use openvm_cuda_backend::{ntt::batch_ntt, prelude::F};
 use openvm_cuda_common::{
+    common::get_device,
     copy::{MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
-    stream::cudaStreamPerThread,
+    stream::{CudaStream, DeviceContext, StreamGuard},
 };
 use p3_field::PrimeCharacteristicRing;
 
@@ -10,6 +11,10 @@ use p3_field::PrimeCharacteristicRing;
 #[ignore] // Run explicitly: requires large GPU memory and significant runtime.
 fn ntt_roundtrip_max_log_domain_size() {
     const LOG_N: u32 = 27;
+    let ctx = DeviceContext {
+        device_id: get_device().unwrap() as u32,
+        stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
+    };
     let n = 1usize << LOG_N;
     let mut host = Vec::<F>::with_capacity(n);
 
@@ -17,13 +22,14 @@ fn ntt_roundtrip_max_log_domain_size() {
         host.push(F::from_usize(i));
     }
 
-    let mut device = DeviceBuffer::<F>::with_capacity(n);
-    host.copy_to(&mut device).expect("host->device copy failed");
+    let mut device = DeviceBuffer::<F>::with_capacity_on(n, &ctx);
+    host.copy_to_on(&mut device, &ctx)
+        .expect("host->device copy failed");
 
-    batch_ntt(&device, LOG_N, 0, 1, true, false, cudaStreamPerThread);
-    batch_ntt(&device, LOG_N, 0, 1, true, true, cudaStreamPerThread);
+    batch_ntt(&device, LOG_N, 0, 1, true, false, &ctx);
+    batch_ntt(&device, LOG_N, 0, 1, true, true, &ctx);
 
-    let output = device.to_host().expect("device->host copy failed");
+    let output = device.to_host_on(&ctx).expect("device->host copy failed");
     for (i, got) in output.iter().enumerate() {
         assert_eq!(*got, host[i], "mismatch at index {}", i);
     }

--- a/crates/cuda-backend/tests/ntt_roundtrip.rs
+++ b/crates/cuda-backend/tests/ntt_roundtrip.rs
@@ -11,7 +11,7 @@ use p3_field::PrimeCharacteristicRing;
 #[ignore] // Run explicitly: requires large GPU memory and significant runtime.
 fn ntt_roundtrip_max_log_domain_size() {
     const LOG_N: u32 = 27;
-    let ctx = GpuDeviceCtx {
+    let device_ctx = GpuDeviceCtx {
         device_id: get_device().unwrap() as u32,
         stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
     };
@@ -22,14 +22,16 @@ fn ntt_roundtrip_max_log_domain_size() {
         host.push(F::from_usize(i));
     }
 
-    let mut device = DeviceBuffer::<F>::with_capacity_on(n, &ctx);
-    host.copy_to_on(&mut device, &ctx)
+    let mut device = DeviceBuffer::<F>::with_capacity_on(n, &device_ctx);
+    host.copy_to_on(&mut device, &device_ctx)
         .expect("host->device copy failed");
 
-    batch_ntt(&device, LOG_N, 0, 1, true, false, &ctx);
-    batch_ntt(&device, LOG_N, 0, 1, true, true, &ctx);
+    batch_ntt(&device, LOG_N, 0, 1, true, false, &device_ctx);
+    batch_ntt(&device, LOG_N, 0, 1, true, true, &device_ctx);
 
-    let output = device.to_host_on(&ctx).expect("device->host copy failed");
+    let output = device
+        .to_host_on(&device_ctx)
+        .expect("device->host copy failed");
     for (i, got) in output.iter().enumerate() {
         assert_eq!(*got, host[i], "mismatch at index {}", i);
     }

--- a/crates/cuda-builder/src/lib.rs
+++ b/crates/cuda-builder/src/lib.rs
@@ -38,7 +38,6 @@ impl Default for CudaBuilder {
                 "--std=c++17".to_string(),
                 "--expt-relaxed-constexpr".to_string(),
                 "-Xfatbin=-compress-all".to_string(),
-                "--default-stream=per-thread".to_string(),
             ],
             link_libraries: vec!["cudart".to_string(), "cuda".to_string()],
             link_search_paths,

--- a/crates/cuda-common/Cargo.toml
+++ b/crates/cuda-common/Cargo.toml
@@ -22,3 +22,4 @@ tokio = { workspace = true, features = ["full"] }
 
 [features]
 touchemall = []
+debug-cuda-stream = []

--- a/crates/cuda-common/Cargo.toml
+++ b/crates/cuda-common/Cargo.toml
@@ -22,4 +22,7 @@ tokio = { workspace = true, features = ["full"] }
 
 [features]
 touchemall = []
+# Tracks the allocating stream per DeviceBuffer and debug-asserts that
+# operations (fill_zero, etc.) use the same stream. Useful for catching
+# accidental cross-stream misuse during development.
 debug-cuda-stream = []

--- a/crates/cuda-common/include/launcher.cuh
+++ b/crates/cuda-common/include/launcher.cuh
@@ -38,12 +38,23 @@ inline std::pair<dim3, dim3> kernel_launch_2d_params(size_t x, size_t y) {
     inline int cuda_check_kernel(const char* kernel_name) {
         cudaError_t err = cudaDeviceSynchronize();
         if (err != cudaSuccess) {
-            fprintf(stderr, "[ERROR] Kernel '%s' failed: %s\n", 
+            fprintf(stderr, "[ERROR] Kernel '%s' failed: %s\n",
                     kernel_name, cudaGetErrorString(err));
         }
         return err;
     }
 #   define CHECK_KERNEL() cuda_check_kernel(__func__)
+
+    inline int cuda_check_kernel_on(cudaStream_t stream, const char* kernel_name) {
+        cudaError_t err = cudaStreamSynchronize(stream);
+        if (err != cudaSuccess) {
+            fprintf(stderr, "[ERROR] Kernel '%s' failed: %s\n",
+                    kernel_name, cudaGetErrorString(err));
+        }
+        return err;
+    }
+#   define CHECK_KERNEL_ON(stream) cuda_check_kernel_on(stream, __func__)
 #else
 #   define CHECK_KERNEL() cudaGetLastError()
+#   define CHECK_KERNEL_ON(stream) cudaGetLastError()
 #endif

--- a/crates/cuda-common/include/launcher.cuh
+++ b/crates/cuda-common/include/launcher.cuh
@@ -44,17 +44,6 @@ inline std::pair<dim3, dim3> kernel_launch_2d_params(size_t x, size_t y) {
         return err;
     }
 #   define CHECK_KERNEL() cuda_check_kernel(__func__)
-
-    inline int cuda_check_kernel_on(cudaStream_t stream, const char* kernel_name) {
-        cudaError_t err = cudaStreamSynchronize(stream);
-        if (err != cudaSuccess) {
-            fprintf(stderr, "[ERROR] Kernel '%s' failed: %s\n",
-                    kernel_name, cudaGetErrorString(err));
-        }
-        return err;
-    }
-#   define CHECK_KERNEL_ON(stream) cuda_check_kernel_on(stream, __func__)
 #else
 #   define CHECK_KERNEL() cudaGetLastError()
-#   define CHECK_KERNEL_ON(stream) cudaGetLastError()
 #endif

--- a/crates/cuda-common/include/launcher.cuh
+++ b/crates/cuda-common/include/launcher.cuh
@@ -15,12 +15,18 @@ inline std::pair<dim3, dim3> kernel_launch_params(
     size_t count,
     size_t threads_per_block = MAX_THREADS
 ) {
+    if (count == 0) {
+        return std::make_pair(dim3(0, 1, 1), dim3(1, 1, 1));
+    }
     size_t block = std::min(count, threads_per_block);
     size_t grid = div_ceil(count, block);
     return std::make_pair(dim3(grid, 1, 1), dim3(block, 1, 1));
 }
 
 inline std::pair<dim3, dim3> kernel_launch_2d_params(size_t x, size_t y) {
+    if (x == 0 || y == 0) {
+        return std::make_pair(dim3(0, 1, 1), dim3(1, 1, 1));
+    }
     dim3 block = dim3(std::min(x, WARP_SIZE), std::min(y, WARP_SIZE));
     dim3 grid = dim3(div_ceil(x, block.x), div_ceil(y, block.y));
     return std::make_pair(grid, block);

--- a/crates/cuda-common/src/common.rs
+++ b/crates/cuda-common/src/common.rs
@@ -28,15 +28,19 @@ pub fn device_reset_epoch() -> u64 {
     DEVICE_RESET_EPOCH.load(Ordering::Acquire)
 }
 
-pub fn set_device() -> Result<i32, CudaError> {
-    let mut device = 0;
+pub fn set_device_by_id(device: i32) -> Result<(), CudaError> {
+    assert!(device >= 0);
     unsafe {
-        // 1. Create a context
-        check(cudaFree(std::ptr::null_mut()))?;
-        // 2. Set the device
-        check(cudaGetDevice(&mut device))?;
         check(cudaSetDevice(device))?;
+        // Force primary-context initialization on the selected device.
+        check(cudaFree(std::ptr::null_mut()))?;
     }
+    Ok(())
+}
+
+pub fn set_device() -> Result<i32, CudaError> {
+    let device = get_device()?;
+    set_device_by_id(device)?;
     Ok(device)
 }
 

--- a/crates/cuda-common/src/copy.rs
+++ b/crates/cuda-common/src/copy.rs
@@ -3,7 +3,7 @@ use std::ffi::c_void;
 use crate::{
     d_buffer::DeviceBuffer,
     error::{check, MemCopyError},
-    stream::{cudaStream_t, DeviceContext},
+    stream::{cudaStream_t, GpuDeviceCtx},
 };
 
 #[repr(i32)]
@@ -37,7 +37,7 @@ pub unsafe fn cuda_memcpy_on<const SRC_DEVICE: bool, const DST_DEVICE: bool>(
     dst: *mut c_void,
     src: *const c_void,
     size_bytes: usize,
-    ctx: &DeviceContext,
+    ctx: &GpuDeviceCtx,
 ) -> Result<(), MemCopyError> {
     check(unsafe {
         cudaMemcpyAsync(
@@ -56,19 +56,16 @@ pub unsafe fn cuda_memcpy_on<const SRC_DEVICE: bool, const DST_DEVICE: bool>(
 // ---- Host -> Device ----
 
 pub trait MemCopyH2D<T> {
-    fn copy_to_on(
-        &self,
-        dst: &mut DeviceBuffer<T>,
-        ctx: &DeviceContext,
-    ) -> Result<(), MemCopyError>;
-    fn to_device_on(&self, ctx: &DeviceContext) -> Result<DeviceBuffer<T>, MemCopyError>;
+    fn copy_to_on(&self, dst: &mut DeviceBuffer<T>, ctx: &GpuDeviceCtx)
+        -> Result<(), MemCopyError>;
+    fn to_device_on(&self, ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError>;
 }
 
 impl<T> MemCopyH2D<T> for [T] {
     fn copy_to_on(
         &self,
         dst: &mut DeviceBuffer<T>,
-        ctx: &DeviceContext,
+        ctx: &GpuDeviceCtx,
     ) -> Result<(), MemCopyError> {
         if self.len() > dst.len() {
             return Err(MemCopyError::SizeMismatch {
@@ -90,7 +87,7 @@ impl<T> MemCopyH2D<T> for [T] {
         .map_err(MemCopyError::from)
     }
 
-    fn to_device_on(&self, ctx: &DeviceContext) -> Result<DeviceBuffer<T>, MemCopyError> {
+    fn to_device_on(&self, ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError> {
         let mut dst = DeviceBuffer::with_capacity_on(self.len(), ctx);
         self.copy_to_on(&mut dst, ctx)?;
         Ok(dst)
@@ -100,11 +97,11 @@ impl<T> MemCopyH2D<T> for [T] {
 // ---- Device -> Host ----
 
 pub trait MemCopyD2H<T> {
-    fn to_host_on(&self, ctx: &DeviceContext) -> Result<Vec<T>, MemCopyError>;
+    fn to_host_on(&self, ctx: &GpuDeviceCtx) -> Result<Vec<T>, MemCopyError>;
 }
 
 impl<T> MemCopyD2H<T> for DeviceBuffer<T> {
-    fn to_host_on(&self, ctx: &DeviceContext) -> Result<Vec<T>, MemCopyError> {
+    fn to_host_on(&self, ctx: &GpuDeviceCtx) -> Result<Vec<T>, MemCopyError> {
         let mut host_vec = Vec::with_capacity(self.len());
         let size_bytes = std::mem::size_of::<T>() * self.len();
 
@@ -129,16 +126,16 @@ impl<T> MemCopyD2H<T> for DeviceBuffer<T> {
 // ---- Device -> Device ----
 
 pub trait MemCopyD2D<T> {
-    fn device_copy_on(&self, ctx: &DeviceContext) -> Result<DeviceBuffer<T>, MemCopyError>;
+    fn device_copy_on(&self, ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError>;
     fn device_copy_to_on(
         &self,
         dst: &mut DeviceBuffer<T>,
-        ctx: &DeviceContext,
+        ctx: &GpuDeviceCtx,
     ) -> Result<(), MemCopyError>;
 }
 
 impl<T> MemCopyD2D<T> for DeviceBuffer<T> {
-    fn device_copy_on(&self, ctx: &DeviceContext) -> Result<DeviceBuffer<T>, MemCopyError> {
+    fn device_copy_on(&self, ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError> {
         let mut dst = DeviceBuffer::<T>::with_capacity_on(self.len(), ctx);
         self.device_copy_to_on(&mut dst, ctx)?;
         Ok(dst)
@@ -147,7 +144,7 @@ impl<T> MemCopyD2D<T> for DeviceBuffer<T> {
     fn device_copy_to_on(
         &self,
         dst: &mut DeviceBuffer<T>,
-        ctx: &DeviceContext,
+        ctx: &GpuDeviceCtx,
     ) -> Result<(), MemCopyError> {
         if self.len() > dst.len() {
             return Err(MemCopyError::SizeMismatch {
@@ -176,8 +173,8 @@ mod tests {
     use super::*;
     use crate::d_buffer::DeviceBuffer;
 
-    fn test_ctx() -> DeviceContext {
-        DeviceContext::for_current_device().unwrap()
+    fn test_ctx() -> GpuDeviceCtx {
+        GpuDeviceCtx::for_current_device().unwrap()
     }
 
     #[test]

--- a/crates/cuda-common/src/copy.rs
+++ b/crates/cuda-common/src/copy.rs
@@ -37,7 +37,7 @@ pub unsafe fn cuda_memcpy_on<const SRC_DEVICE: bool, const DST_DEVICE: bool>(
     dst: *mut c_void,
     src: *const c_void,
     size_bytes: usize,
-    ctx: &GpuDeviceCtx,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(), MemCopyError> {
     check(unsafe {
         cudaMemcpyAsync(
@@ -47,7 +47,7 @@ pub unsafe fn cuda_memcpy_on<const SRC_DEVICE: bool, const DST_DEVICE: bool>(
             std::mem::transmute::<i32, cudaMemcpyKind>(
                 if DST_DEVICE { 1 } else { 0 } + if SRC_DEVICE { 2 } else { 0 },
             ),
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )
     })
     .map_err(MemCopyError::from)
@@ -56,16 +56,19 @@ pub unsafe fn cuda_memcpy_on<const SRC_DEVICE: bool, const DST_DEVICE: bool>(
 // ---- Host -> Device ----
 
 pub trait MemCopyH2D<T> {
-    fn copy_to_on(&self, dst: &mut DeviceBuffer<T>, ctx: &GpuDeviceCtx)
-        -> Result<(), MemCopyError>;
-    fn to_device_on(&self, ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError>;
+    fn copy_to_on(
+        &self,
+        dst: &mut DeviceBuffer<T>,
+        device_ctx: &GpuDeviceCtx,
+    ) -> Result<(), MemCopyError>;
+    fn to_device_on(&self, device_ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError>;
 }
 
 impl<T> MemCopyH2D<T> for [T] {
     fn copy_to_on(
         &self,
         dst: &mut DeviceBuffer<T>,
-        ctx: &GpuDeviceCtx,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<(), MemCopyError> {
         if self.len() > dst.len() {
             return Err(MemCopyError::SizeMismatch {
@@ -81,15 +84,15 @@ impl<T> MemCopyH2D<T> for [T] {
                 self.as_ptr() as *const c_void,
                 size_bytes,
                 cudaMemcpyKind::cudaMemcpyHostToDevice,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
         })
         .map_err(MemCopyError::from)
     }
 
-    fn to_device_on(&self, ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError> {
-        let mut dst = DeviceBuffer::with_capacity_on(self.len(), ctx);
-        self.copy_to_on(&mut dst, ctx)?;
+    fn to_device_on(&self, device_ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError> {
+        let mut dst = DeviceBuffer::with_capacity_on(self.len(), device_ctx);
+        self.copy_to_on(&mut dst, device_ctx)?;
         Ok(dst)
     }
 }
@@ -97,11 +100,11 @@ impl<T> MemCopyH2D<T> for [T] {
 // ---- Device -> Host ----
 
 pub trait MemCopyD2H<T> {
-    fn to_host_on(&self, ctx: &GpuDeviceCtx) -> Result<Vec<T>, MemCopyError>;
+    fn to_host_on(&self, device_ctx: &GpuDeviceCtx) -> Result<Vec<T>, MemCopyError>;
 }
 
 impl<T> MemCopyD2H<T> for DeviceBuffer<T> {
-    fn to_host_on(&self, ctx: &GpuDeviceCtx) -> Result<Vec<T>, MemCopyError> {
+    fn to_host_on(&self, device_ctx: &GpuDeviceCtx) -> Result<Vec<T>, MemCopyError> {
         let mut host_vec = Vec::with_capacity(self.len());
         let size_bytes = std::mem::size_of::<T>() * self.len();
 
@@ -111,10 +114,10 @@ impl<T> MemCopyD2H<T> for DeviceBuffer<T> {
                 self.as_raw_ptr(),
                 size_bytes,
                 cudaMemcpyKind::cudaMemcpyDeviceToHost,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
         })?;
-        ctx.stream.to_host_sync()?;
+        device_ctx.stream.to_host_sync()?;
         unsafe {
             host_vec.set_len(self.len());
         }
@@ -126,25 +129,25 @@ impl<T> MemCopyD2H<T> for DeviceBuffer<T> {
 // ---- Device -> Device ----
 
 pub trait MemCopyD2D<T> {
-    fn device_copy_on(&self, ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError>;
+    fn device_copy_on(&self, device_ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError>;
     fn device_copy_to_on(
         &self,
         dst: &mut DeviceBuffer<T>,
-        ctx: &GpuDeviceCtx,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<(), MemCopyError>;
 }
 
 impl<T> MemCopyD2D<T> for DeviceBuffer<T> {
-    fn device_copy_on(&self, ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError> {
-        let mut dst = DeviceBuffer::<T>::with_capacity_on(self.len(), ctx);
-        self.device_copy_to_on(&mut dst, ctx)?;
+    fn device_copy_on(&self, device_ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError> {
+        let mut dst = DeviceBuffer::<T>::with_capacity_on(self.len(), device_ctx);
+        self.device_copy_to_on(&mut dst, device_ctx)?;
         Ok(dst)
     }
 
     fn device_copy_to_on(
         &self,
         dst: &mut DeviceBuffer<T>,
-        ctx: &GpuDeviceCtx,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<(), MemCopyError> {
         if self.len() > dst.len() {
             return Err(MemCopyError::SizeMismatch {
@@ -161,7 +164,7 @@ impl<T> MemCopyD2D<T> for DeviceBuffer<T> {
                 self.as_raw_ptr(),
                 size_bytes,
                 cudaMemcpyKind::cudaMemcpyDeviceToDevice,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
         })
         .map_err(MemCopyError::from)
@@ -179,15 +182,15 @@ mod tests {
 
     #[test]
     fn test_mem_copy() {
-        let ctx = test_ctx();
+        let device_ctx = test_ctx();
         let h = vec![1, 2, 3, 4, 5];
 
-        let d1 = h.to_device_on(&ctx).unwrap();
-        let mut d2 = DeviceBuffer::<i32>::with_capacity_on(h.len(), &ctx);
-        h.copy_to_on(&mut d2, &ctx).unwrap();
+        let d1 = h.to_device_on(&device_ctx).unwrap();
+        let mut d2 = DeviceBuffer::<i32>::with_capacity_on(h.len(), &device_ctx);
+        h.copy_to_on(&mut d2, &device_ctx).unwrap();
 
-        let h1 = d1.to_host_on(&ctx).unwrap();
-        let h2 = d2.to_host_on(&ctx).unwrap();
+        let h1 = d1.to_host_on(&device_ctx).unwrap();
+        let h2 = d2.to_host_on(&device_ctx).unwrap();
 
         assert_eq!(h, h1, "First device buffer mismatch");
         assert_eq!(h, h2, "Second device buffer mismatch");

--- a/crates/cuda-common/src/copy.rs
+++ b/crates/cuda-common/src/copy.rs
@@ -5,7 +5,7 @@ use lazy_static::lazy_static;
 use crate::{
     d_buffer::DeviceBuffer,
     error::{check, MemCopyError},
-    stream::{cudaStreamPerThread, cudaStream_t, CudaEvent},
+    stream::{cudaStreamPerThread, cudaStream_t, CudaEvent, DeviceContext},
 };
 
 lazy_static! {
@@ -58,10 +58,45 @@ pub unsafe fn cuda_memcpy<const SRC_DEVICE: bool, const DST_DEVICE: bool>(
     .map_err(MemCopyError::from)
 }
 
-// Host -> Device
+/// FFI binding for `cudaMemcpyAsync` on an explicit stream.
+///
+/// # Safety
+/// Must follow the rules of the `cudaMemcpyAsync` function from the CUDA runtime API.
+pub unsafe fn cuda_memcpy_on<const SRC_DEVICE: bool, const DST_DEVICE: bool>(
+    dst: *mut c_void,
+    src: *const c_void,
+    size_bytes: usize,
+    ctx: &DeviceContext,
+) -> Result<(), MemCopyError> {
+    check(unsafe {
+        cudaMemcpyAsync(
+            dst,
+            src,
+            size_bytes,
+            std::mem::transmute::<i32, cudaMemcpyKind>(
+                if DST_DEVICE { 1 } else { 0 } + if SRC_DEVICE { 2 } else { 0 },
+            ),
+            ctx.stream.as_raw(),
+        )
+    })
+    .map_err(MemCopyError::from)
+}
+
+// ---- Host -> Device ----
+
 pub trait MemCopyH2D<T> {
     fn copy_to(&self, dst: &mut DeviceBuffer<T>) -> Result<(), MemCopyError>;
     fn to_device(&self) -> Result<DeviceBuffer<T>, MemCopyError>;
+    fn copy_to_on(
+        &self,
+        _dst: &mut DeviceBuffer<T>,
+        _ctx: &DeviceContext,
+    ) -> Result<(), MemCopyError> {
+        unimplemented!("copy_to_on not implemented for this type")
+    }
+    fn to_device_on(&self, _ctx: &DeviceContext) -> Result<DeviceBuffer<T>, MemCopyError> {
+        unimplemented!("to_device_on not implemented for this type")
+    }
 }
 
 impl<T> MemCopyH2D<T> for [T] {
@@ -91,11 +126,46 @@ impl<T> MemCopyH2D<T> for [T] {
         self.copy_to(&mut dst)?;
         Ok(dst)
     }
+
+    fn copy_to_on(
+        &self,
+        dst: &mut DeviceBuffer<T>,
+        ctx: &DeviceContext,
+    ) -> Result<(), MemCopyError> {
+        if self.len() > dst.len() {
+            return Err(MemCopyError::SizeMismatch {
+                operation: "copy_to_device_on",
+                src_len: self.len(),
+                dst_len: dst.len(),
+            });
+        }
+        let size_bytes = std::mem::size_of_val(self);
+        check(unsafe {
+            cudaMemcpyAsync(
+                dst.as_mut_raw_ptr(),
+                self.as_ptr() as *const c_void,
+                size_bytes,
+                cudaMemcpyKind::cudaMemcpyHostToDevice,
+                ctx.stream.as_raw(),
+            )
+        })
+        .map_err(MemCopyError::from)
+    }
+
+    fn to_device_on(&self, ctx: &DeviceContext) -> Result<DeviceBuffer<T>, MemCopyError> {
+        let mut dst = DeviceBuffer::with_capacity_on(self.len(), ctx);
+        self.copy_to_on(&mut dst, ctx)?;
+        Ok(dst)
+    }
 }
 
-// Device -> Host
+// ---- Device -> Host ----
+
 pub trait MemCopyD2H<T> {
     fn to_host(&self) -> Result<Vec<T>, MemCopyError>;
+    fn to_host_on(&self, _ctx: &DeviceContext) -> Result<Vec<T>, MemCopyError> {
+        unimplemented!("to_host_on not implemented for this type")
+    }
 }
 
 impl<T> MemCopyD2H<T> for DeviceBuffer<T> {
@@ -123,11 +193,44 @@ impl<T> MemCopyD2H<T> for DeviceBuffer<T> {
 
         Ok(host_vec)
     }
+
+    fn to_host_on(&self, ctx: &DeviceContext) -> Result<Vec<T>, MemCopyError> {
+        let mut host_vec = Vec::with_capacity(self.len());
+        let size_bytes = std::mem::size_of::<T>() * self.len();
+
+        check(unsafe {
+            cudaMemcpyAsync(
+                host_vec.as_mut_ptr() as *mut c_void,
+                self.as_raw_ptr(),
+                size_bytes,
+                cudaMemcpyKind::cudaMemcpyDeviceToHost,
+                ctx.stream.as_raw(),
+            )
+        })?;
+        ctx.stream.to_host_sync()?;
+        unsafe {
+            host_vec.set_len(self.len());
+        }
+
+        Ok(host_vec)
+    }
 }
+
+// ---- Device -> Device ----
 
 pub trait MemCopyD2D<T> {
     fn device_copy(&self) -> Result<DeviceBuffer<T>, MemCopyError>;
     fn device_copy_to(&self, dst: &mut DeviceBuffer<T>) -> Result<(), MemCopyError>;
+    fn device_copy_on(&self, _ctx: &DeviceContext) -> Result<DeviceBuffer<T>, MemCopyError> {
+        unimplemented!("device_copy_on not implemented for this type")
+    }
+    fn device_copy_to_on(
+        &self,
+        _dst: &mut DeviceBuffer<T>,
+        _ctx: &DeviceContext,
+    ) -> Result<(), MemCopyError> {
+        unimplemented!("device_copy_to_on not implemented for this type")
+    }
 }
 
 impl<T> MemCopyD2D<T> for DeviceBuffer<T> {
@@ -154,6 +257,38 @@ impl<T> MemCopyD2D<T> for DeviceBuffer<T> {
                 size_bytes,
                 cudaMemcpyKind::cudaMemcpyDeviceToDevice,
                 cudaStreamPerThread,
+            )
+        })
+        .map_err(MemCopyError::from)
+    }
+
+    fn device_copy_on(&self, ctx: &DeviceContext) -> Result<DeviceBuffer<T>, MemCopyError> {
+        let mut dst = DeviceBuffer::<T>::with_capacity_on(self.len(), ctx);
+        self.device_copy_to_on(&mut dst, ctx)?;
+        Ok(dst)
+    }
+
+    fn device_copy_to_on(
+        &self,
+        dst: &mut DeviceBuffer<T>,
+        ctx: &DeviceContext,
+    ) -> Result<(), MemCopyError> {
+        if self.len() > dst.len() {
+            return Err(MemCopyError::SizeMismatch {
+                operation: "device_copy_to_on",
+                src_len: self.len(),
+                dst_len: dst.len(),
+            });
+        }
+        let size_bytes = std::mem::size_of::<T>() * self.len();
+
+        check(unsafe {
+            cudaMemcpyAsync(
+                dst.as_mut_raw_ptr(),
+                self.as_raw_ptr(),
+                size_bytes,
+                cudaMemcpyKind::cudaMemcpyDeviceToDevice,
+                ctx.stream.as_raw(),
             )
         })
         .map_err(MemCopyError::from)

--- a/crates/cuda-common/src/copy.rs
+++ b/crates/cuda-common/src/copy.rs
@@ -1,16 +1,10 @@
-use std::{ffi::c_void, sync::Mutex};
-
-use lazy_static::lazy_static;
+use std::ffi::c_void;
 
 use crate::{
     d_buffer::DeviceBuffer,
     error::{check, MemCopyError},
-    stream::{cudaStreamPerThread, cudaStream_t, CudaEvent, DeviceContext},
+    stream::{cudaStream_t, DeviceContext},
 };
-
-lazy_static! {
-    static ref COPY_EVENT: Mutex<CudaEvent> = Mutex::new(CudaEvent::new().unwrap());
-}
 
 #[repr(i32)]
 #[non_exhaustive]
@@ -33,29 +27,6 @@ extern "C" {
         kind: cudaMemcpyKind,
         stream: cudaStream_t,
     ) -> i32;
-}
-
-/// FFI binding for the `cudaMemcpyAsync` function on the default cuda stream.
-///
-/// # Safety
-/// Must follow the rules of the `cudaMemcpyAsync` function from the CUDA runtime API.
-pub unsafe fn cuda_memcpy<const SRC_DEVICE: bool, const DST_DEVICE: bool>(
-    dst: *mut c_void,
-    src: *const c_void,
-    size_bytes: usize,
-) -> Result<(), MemCopyError> {
-    check(unsafe {
-        cudaMemcpyAsync(
-            dst,
-            src,
-            size_bytes,
-            std::mem::transmute::<i32, cudaMemcpyKind>(
-                if DST_DEVICE { 1 } else { 0 } + if SRC_DEVICE { 2 } else { 0 },
-            ),
-            cudaStreamPerThread,
-        )
-    })
-    .map_err(MemCopyError::from)
 }
 
 /// FFI binding for `cudaMemcpyAsync` on an explicit stream.
@@ -85,48 +56,15 @@ pub unsafe fn cuda_memcpy_on<const SRC_DEVICE: bool, const DST_DEVICE: bool>(
 // ---- Host -> Device ----
 
 pub trait MemCopyH2D<T> {
-    fn copy_to(&self, dst: &mut DeviceBuffer<T>) -> Result<(), MemCopyError>;
-    fn to_device(&self) -> Result<DeviceBuffer<T>, MemCopyError>;
     fn copy_to_on(
         &self,
-        _dst: &mut DeviceBuffer<T>,
-        _ctx: &DeviceContext,
-    ) -> Result<(), MemCopyError> {
-        unimplemented!("copy_to_on not implemented for this type")
-    }
-    fn to_device_on(&self, _ctx: &DeviceContext) -> Result<DeviceBuffer<T>, MemCopyError> {
-        unimplemented!("to_device_on not implemented for this type")
-    }
+        dst: &mut DeviceBuffer<T>,
+        ctx: &DeviceContext,
+    ) -> Result<(), MemCopyError>;
+    fn to_device_on(&self, ctx: &DeviceContext) -> Result<DeviceBuffer<T>, MemCopyError>;
 }
 
 impl<T> MemCopyH2D<T> for [T] {
-    fn copy_to(&self, dst: &mut DeviceBuffer<T>) -> Result<(), MemCopyError> {
-        if self.len() > dst.len() {
-            return Err(MemCopyError::SizeMismatch {
-                operation: "copy_to_device",
-                src_len: self.len(),
-                dst_len: dst.len(),
-            });
-        }
-        let size_bytes = std::mem::size_of_val(self);
-        check(unsafe {
-            cudaMemcpyAsync(
-                dst.as_mut_raw_ptr(),
-                self.as_ptr() as *const c_void,
-                size_bytes,
-                cudaMemcpyKind::cudaMemcpyHostToDevice,
-                cudaStreamPerThread,
-            )
-        })
-        .map_err(MemCopyError::from)
-    }
-
-    fn to_device(&self) -> Result<DeviceBuffer<T>, MemCopyError> {
-        let mut dst = DeviceBuffer::with_capacity(self.len());
-        self.copy_to(&mut dst)?;
-        Ok(dst)
-    }
-
     fn copy_to_on(
         &self,
         dst: &mut DeviceBuffer<T>,
@@ -162,38 +100,10 @@ impl<T> MemCopyH2D<T> for [T] {
 // ---- Device -> Host ----
 
 pub trait MemCopyD2H<T> {
-    fn to_host(&self) -> Result<Vec<T>, MemCopyError>;
-    fn to_host_on(&self, _ctx: &DeviceContext) -> Result<Vec<T>, MemCopyError> {
-        unimplemented!("to_host_on not implemented for this type")
-    }
+    fn to_host_on(&self, ctx: &DeviceContext) -> Result<Vec<T>, MemCopyError>;
 }
 
 impl<T> MemCopyD2H<T> for DeviceBuffer<T> {
-    fn to_host(&self) -> Result<Vec<T>, MemCopyError> {
-        let mut host_vec = Vec::with_capacity(self.len());
-        let size_bytes = std::mem::size_of::<T>() * self.len();
-
-        check(unsafe {
-            cudaMemcpyAsync(
-                host_vec.as_mut_ptr() as *mut c_void,
-                self.as_raw_ptr(),
-                size_bytes,
-                cudaMemcpyKind::cudaMemcpyDeviceToHost,
-                cudaStreamPerThread,
-            )
-        })?;
-        unsafe {
-            COPY_EVENT
-                .lock()
-                .unwrap()
-                .record_and_wait(cudaStreamPerThread)?;
-
-            host_vec.set_len(self.len());
-        }
-
-        Ok(host_vec)
-    }
-
     fn to_host_on(&self, ctx: &DeviceContext) -> Result<Vec<T>, MemCopyError> {
         let mut host_vec = Vec::with_capacity(self.len());
         let size_bytes = std::mem::size_of::<T>() * self.len();
@@ -219,49 +129,15 @@ impl<T> MemCopyD2H<T> for DeviceBuffer<T> {
 // ---- Device -> Device ----
 
 pub trait MemCopyD2D<T> {
-    fn device_copy(&self) -> Result<DeviceBuffer<T>, MemCopyError>;
-    fn device_copy_to(&self, dst: &mut DeviceBuffer<T>) -> Result<(), MemCopyError>;
-    fn device_copy_on(&self, _ctx: &DeviceContext) -> Result<DeviceBuffer<T>, MemCopyError> {
-        unimplemented!("device_copy_on not implemented for this type")
-    }
+    fn device_copy_on(&self, ctx: &DeviceContext) -> Result<DeviceBuffer<T>, MemCopyError>;
     fn device_copy_to_on(
         &self,
-        _dst: &mut DeviceBuffer<T>,
-        _ctx: &DeviceContext,
-    ) -> Result<(), MemCopyError> {
-        unimplemented!("device_copy_to_on not implemented for this type")
-    }
+        dst: &mut DeviceBuffer<T>,
+        ctx: &DeviceContext,
+    ) -> Result<(), MemCopyError>;
 }
 
 impl<T> MemCopyD2D<T> for DeviceBuffer<T> {
-    fn device_copy(&self) -> Result<DeviceBuffer<T>, MemCopyError> {
-        let mut dst = DeviceBuffer::<T>::with_capacity(self.len());
-        self.device_copy_to(&mut dst)?;
-        Ok(dst)
-    }
-
-    fn device_copy_to(&self, dst: &mut DeviceBuffer<T>) -> Result<(), MemCopyError> {
-        if self.len() > dst.len() {
-            return Err(MemCopyError::SizeMismatch {
-                operation: "device_copy_to",
-                src_len: self.len(),
-                dst_len: dst.len(),
-            });
-        }
-        let size_bytes = std::mem::size_of::<T>() * self.len();
-
-        check(unsafe {
-            cudaMemcpyAsync(
-                dst.as_mut_raw_ptr(),
-                self.as_raw_ptr(),
-                size_bytes,
-                cudaMemcpyKind::cudaMemcpyDeviceToDevice,
-                cudaStreamPerThread,
-            )
-        })
-        .map_err(MemCopyError::from)
-    }
-
     fn device_copy_on(&self, ctx: &DeviceContext) -> Result<DeviceBuffer<T>, MemCopyError> {
         let mut dst = DeviceBuffer::<T>::with_capacity_on(self.len(), ctx);
         self.device_copy_to_on(&mut dst, ctx)?;
@@ -300,23 +176,21 @@ mod tests {
     use super::*;
     use crate::d_buffer::DeviceBuffer;
 
+    fn test_ctx() -> DeviceContext {
+        DeviceContext::for_current_device().unwrap()
+    }
+
     #[test]
     fn test_mem_copy() {
-        // Our source data on the host
+        let ctx = test_ctx();
         let h = vec![1, 2, 3, 4, 5];
 
-        // 1) Copy to a newly allocated device buffer
-        let d1 = h.to_device().unwrap();
+        let d1 = h.to_device_on(&ctx).unwrap();
+        let mut d2 = DeviceBuffer::<i32>::with_capacity_on(h.len(), &ctx);
+        h.copy_to_on(&mut d2, &ctx).unwrap();
 
-        // 2) Create another device buffer of the same size
-        let mut d2 = DeviceBuffer::<i32>::with_capacity(h.len());
-
-        // 3) Copy into that existing buffer
-        h.copy_to(&mut d2).unwrap();
-
-        // 4) Copy both buffers back to host
-        let h1 = d1.to_host().unwrap();
-        let h2 = d2.to_host().unwrap();
+        let h1 = d1.to_host_on(&ctx).unwrap();
+        let h2 = d2.to_host_on(&ctx).unwrap();
 
         assert_eq!(h, h1, "First device buffer mismatch");
         assert_eq!(h, h2, "Second device buffer mismatch");

--- a/crates/cuda-common/src/copy.rs
+++ b/crates/cuda-common/src/copy.rs
@@ -72,7 +72,7 @@ impl<T> MemCopyH2D<T> for [T] {
     ) -> Result<(), MemCopyError> {
         if self.len() > dst.len() {
             return Err(MemCopyError::SizeMismatch {
-                operation: "copy_to_device_on",
+                operation: "copy_to_on",
                 src_len: self.len(),
                 dst_len: dst.len(),
             });

--- a/crates/cuda-common/src/d_buffer.rs
+++ b/crates/cuda-common/src/d_buffer.rs
@@ -1,10 +1,9 @@
 use std::{ffi::c_void, fmt::Debug, ptr};
 
 use crate::{
-    copy::MemCopyD2H,
     error::{check, CudaError},
-    memory_manager::{d_free, d_malloc, d_malloc_on},
-    stream::{cudaStreamPerThread, cudaStream_t, DeviceContext},
+    memory_manager::{d_free, d_malloc_on},
+    stream::{cudaStream_t, DeviceContext},
 };
 
 #[link(name = "cudart")]
@@ -65,33 +64,6 @@ impl<T> DeviceBuffer<T> {
         }
     }
 
-    /// Allocate device memory for `len` elements of type `T` (PTDS path).
-    pub fn with_capacity(len: usize) -> Self {
-        tracing::debug!(
-            "Creating device buffer of size {} (sizeof type = {})",
-            len,
-            size_of::<T>()
-        );
-        assert_ne!(len, 0, "Zero capacity request is wrong");
-        let size_bytes = std::mem::size_of::<T>() * len;
-        let raw_ptr = d_malloc(size_bytes).expect("GPU allocation failed");
-        #[cfg(feature = "touchemall")]
-        {
-            // 0xffffffff is `Fp::invalid()` and shouldn't occur in a trace
-            unsafe {
-                cudaMemsetAsync(raw_ptr, 0xff, size_bytes, cudaStreamPerThread);
-            }
-        }
-        let typed_ptr = raw_ptr as *mut T;
-
-        DeviceBuffer {
-            ptr: typed_ptr,
-            len,
-            #[cfg(feature = "debug-cuda-stream")]
-            alloc_stream: cudaStreamPerThread,
-        }
-    }
-
     /// Allocate device memory for `len` elements of type `T` on an explicit stream.
     pub fn with_capacity_on(len: usize, ctx: &DeviceContext) -> Self {
         tracing::debug!(
@@ -118,13 +90,6 @@ impl<T> DeviceBuffer<T> {
         }
     }
 
-    /// Fills the buffer with zeros (PTDS path).
-    pub fn fill_zero(&self) -> Result<(), CudaError> {
-        assert_ne!(self.len, 0, "Empty buffer");
-        let size_bytes = std::mem::size_of::<T>() * self.len;
-        check(unsafe { cudaMemsetAsync(self.as_mut_raw_ptr(), 0, size_bytes, cudaStreamPerThread) })
-    }
-
     /// Fills the buffer with zeros on an explicit stream.
     pub fn fill_zero_on(&self, ctx: &DeviceContext) -> Result<(), CudaError> {
         assert_ne!(self.len, 0, "Empty buffer");
@@ -136,24 +101,6 @@ impl<T> DeviceBuffer<T> {
         );
         let size_bytes = std::mem::size_of::<T>() * self.len;
         check(unsafe { cudaMemsetAsync(self.as_mut_raw_ptr(), 0, size_bytes, ctx.stream.as_raw()) })
-    }
-
-    /// Fills a suffix of the buffer with zeros (PTDS path).
-    /// The `start_idx` is the index in the buffer, in `T` elements.
-    pub fn fill_zero_suffix(&self, start_idx: usize) -> Result<(), CudaError> {
-        assert!(
-            start_idx < self.len,
-            "start index has to be smaller than length"
-        );
-        let size_bytes = std::mem::size_of::<T>() * (self.len - start_idx);
-        check(unsafe {
-            cudaMemsetAsync(
-                self.as_mut_ptr().add(start_idx) as *mut c_void,
-                0,
-                size_bytes,
-                cudaStreamPerThread,
-            )
-        })
     }
 
     /// Fills a suffix of the buffer with zeros on an explicit stream.
@@ -264,20 +211,29 @@ impl<T> Drop for DeviceBuffer<T> {
 
 impl<T: Debug> Debug for DeviceBuffer<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let host_vec = self.to_host().unwrap();
-        write!(f, "DeviceBuffer (len = {}): {:?}", self.len(), host_vec)
+        write!(
+            f,
+            "DeviceBuffer(len = {}, ptr = {:?})",
+            self.len(),
+            self.ptr
+        )
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::copy::MemCopyH2D;
+    use crate::copy::{MemCopyD2H, MemCopyH2D};
+
+    fn test_ctx() -> DeviceContext {
+        DeviceContext::for_current_device().unwrap()
+    }
 
     #[test]
     fn test_device_buffer_float() {
+        let ctx = test_ctx();
         // Create a DeviceBuffer of 10 floats
-        let db = DeviceBuffer::<f32>::with_capacity(10);
+        let db = DeviceBuffer::<f32>::with_capacity_on(10, &ctx);
 
         assert_eq!(db.len(), 10);
         assert!(!db.as_ptr().is_null());
@@ -288,9 +244,10 @@ mod tests {
 
     #[test]
     fn test_device_buffer_fill_zero() {
+        let ctx = test_ctx();
         let v: Vec<u64> = (0..10).collect();
-        let d_array = v.to_device().unwrap();
-        d_array.fill_zero().unwrap();
-        assert_eq!(d_array.to_host().unwrap(), vec![0; v.len()]);
+        let d_array = v.to_device_on(&ctx).unwrap();
+        d_array.fill_zero_on(&ctx).unwrap();
+        assert_eq!(d_array.to_host_on(&ctx).unwrap(), vec![0; v.len()]);
     }
 }

--- a/crates/cuda-common/src/d_buffer.rs
+++ b/crates/cuda-common/src/d_buffer.rs
@@ -3,7 +3,7 @@ use std::{ffi::c_void, fmt::Debug, ptr};
 use crate::{
     error::{check, CudaError},
     memory_manager::{d_free, d_malloc_on},
-    stream::{cudaStream_t, DeviceContext},
+    stream::{cudaStream_t, GpuDeviceCtx},
 };
 
 #[link(name = "cudart")]
@@ -65,7 +65,7 @@ impl<T> DeviceBuffer<T> {
     }
 
     /// Allocate device memory for `len` elements of type `T` on an explicit stream.
-    pub fn with_capacity_on(len: usize, ctx: &DeviceContext) -> Self {
+    pub fn with_capacity_on(len: usize, ctx: &GpuDeviceCtx) -> Self {
         tracing::debug!(
             "Creating device buffer of size {} (sizeof type = {}) on stream {:?}",
             len,
@@ -95,7 +95,7 @@ impl<T> DeviceBuffer<T> {
     ///
     /// The caller should use the same stream that allocated this buffer.
     /// `fill_zero` is async; same-stream guarantees ordering without explicit sync.
-    pub fn fill_zero_on(&self, ctx: &DeviceContext) -> Result<(), CudaError> {
+    pub fn fill_zero_on(&self, ctx: &GpuDeviceCtx) -> Result<(), CudaError> {
         assert_ne!(self.len, 0, "Empty buffer");
         #[cfg(feature = "debug-cuda-stream")]
         debug_assert_eq!(
@@ -111,7 +111,7 @@ impl<T> DeviceBuffer<T> {
     pub fn fill_zero_suffix_on(
         &self,
         start_idx: usize,
-        ctx: &DeviceContext,
+        ctx: &GpuDeviceCtx,
     ) -> Result<(), CudaError> {
         assert!(
             start_idx < self.len,
@@ -233,8 +233,8 @@ mod tests {
     use super::*;
     use crate::copy::{MemCopyD2H, MemCopyH2D};
 
-    fn test_ctx() -> DeviceContext {
-        DeviceContext::for_current_device().unwrap()
+    fn test_ctx() -> GpuDeviceCtx {
+        GpuDeviceCtx::for_current_device().unwrap()
     }
 
     #[test]

--- a/crates/cuda-common/src/d_buffer.rs
+++ b/crates/cuda-common/src/d_buffer.rs
@@ -3,8 +3,8 @@ use std::{ffi::c_void, fmt::Debug, ptr};
 use crate::{
     copy::MemCopyD2H,
     error::{check, CudaError},
-    memory_manager::{d_free, d_malloc},
-    stream::{cudaStreamPerThread, cudaStream_t},
+    memory_manager::{d_free, d_malloc, d_malloc_on},
+    stream::{cudaStreamPerThread, cudaStream_t, DeviceContext},
 };
 
 #[link(name = "cudart")]
@@ -19,6 +19,8 @@ extern "C" {
 pub struct DeviceBuffer<T> {
     ptr: *mut T,
     len: usize,
+    #[cfg(feature = "debug-cuda-stream")]
+    alloc_stream: cudaStream_t,
 }
 
 /// A struct that packs a pointer with a size in bytes to pass on CUDA.
@@ -43,6 +45,8 @@ impl<T> DeviceBuffer<T> {
         DeviceBuffer {
             ptr: ptr::null_mut(),
             len: 0,
+            #[cfg(feature = "debug-cuda-stream")]
+            alloc_stream: std::ptr::null_mut(),
         }
     }
 
@@ -53,10 +57,15 @@ impl<T> DeviceBuffer<T> {
     ///   either have been allocated by the internal memory manager (VPMM) or the caller must use
     ///   `ManuallyDrop` to prevent double-free.
     pub unsafe fn from_raw_parts(ptr: *mut T, len: usize) -> Self {
-        DeviceBuffer { ptr, len }
+        DeviceBuffer {
+            ptr,
+            len,
+            #[cfg(feature = "debug-cuda-stream")]
+            alloc_stream: std::ptr::null_mut(),
+        }
     }
 
-    /// Allocate device memory for `len` elements of type `T`.
+    /// Allocate device memory for `len` elements of type `T` (PTDS path).
     pub fn with_capacity(len: usize) -> Self {
         tracing::debug!(
             "Creating device buffer of size {} (sizeof type = {})",
@@ -78,17 +87,58 @@ impl<T> DeviceBuffer<T> {
         DeviceBuffer {
             ptr: typed_ptr,
             len,
+            #[cfg(feature = "debug-cuda-stream")]
+            alloc_stream: cudaStreamPerThread,
         }
     }
 
-    /// Fills the buffer with zeros.
+    /// Allocate device memory for `len` elements of type `T` on an explicit stream.
+    pub fn with_capacity_on(len: usize, ctx: &DeviceContext) -> Self {
+        tracing::debug!(
+            "Creating device buffer of size {} (sizeof type = {}) on stream",
+            len,
+            size_of::<T>()
+        );
+        assert_ne!(len, 0, "Zero capacity request is wrong");
+        let size_bytes = std::mem::size_of::<T>() * len;
+        let raw_ptr = d_malloc_on(size_bytes, &ctx.stream).expect("GPU allocation failed");
+        #[cfg(feature = "touchemall")]
+        {
+            unsafe {
+                cudaMemsetAsync(raw_ptr, 0xff, size_bytes, ctx.stream.as_raw());
+            }
+        }
+        let typed_ptr = raw_ptr as *mut T;
+
+        DeviceBuffer {
+            ptr: typed_ptr,
+            len,
+            #[cfg(feature = "debug-cuda-stream")]
+            alloc_stream: ctx.stream.as_raw(),
+        }
+    }
+
+    /// Fills the buffer with zeros (PTDS path).
     pub fn fill_zero(&self) -> Result<(), CudaError> {
         assert_ne!(self.len, 0, "Empty buffer");
         let size_bytes = std::mem::size_of::<T>() * self.len;
         check(unsafe { cudaMemsetAsync(self.as_mut_raw_ptr(), 0, size_bytes, cudaStreamPerThread) })
     }
 
-    /// Fills a suffix of the buffer with zeros.
+    /// Fills the buffer with zeros on an explicit stream.
+    pub fn fill_zero_on(&self, ctx: &DeviceContext) -> Result<(), CudaError> {
+        assert_ne!(self.len, 0, "Empty buffer");
+        #[cfg(feature = "debug-cuda-stream")]
+        debug_assert_eq!(
+            ctx.stream.as_raw(),
+            self.alloc_stream,
+            "fill_zero_on: stream mismatch"
+        );
+        let size_bytes = std::mem::size_of::<T>() * self.len;
+        check(unsafe { cudaMemsetAsync(self.as_mut_raw_ptr(), 0, size_bytes, ctx.stream.as_raw()) })
+    }
+
+    /// Fills a suffix of the buffer with zeros (PTDS path).
     /// The `start_idx` is the index in the buffer, in `T` elements.
     pub fn fill_zero_suffix(&self, start_idx: usize) -> Result<(), CudaError> {
         assert!(
@@ -102,6 +152,33 @@ impl<T> DeviceBuffer<T> {
                 0,
                 size_bytes,
                 cudaStreamPerThread,
+            )
+        })
+    }
+
+    /// Fills a suffix of the buffer with zeros on an explicit stream.
+    pub fn fill_zero_suffix_on(
+        &self,
+        start_idx: usize,
+        ctx: &DeviceContext,
+    ) -> Result<(), CudaError> {
+        assert!(
+            start_idx < self.len,
+            "start index has to be smaller than length"
+        );
+        #[cfg(feature = "debug-cuda-stream")]
+        debug_assert_eq!(
+            ctx.stream.as_raw(),
+            self.alloc_stream,
+            "fill_zero_suffix_on: stream mismatch"
+        );
+        let size_bytes = std::mem::size_of::<T>() * (self.len - start_idx);
+        check(unsafe {
+            cudaMemsetAsync(
+                self.as_mut_ptr().add(start_idx) as *mut c_void,
+                0,
+                size_bytes,
+                ctx.stream.as_raw(),
             )
         })
     }
@@ -152,6 +229,8 @@ impl<T> DeviceBuffer<T> {
         let res = DeviceBuffer {
             ptr: self.ptr as *mut U,
             len: self.len * (size_of::<T>() / size_of::<U>()),
+            #[cfg(feature = "debug-cuda-stream")]
+            alloc_stream: self.alloc_stream,
         };
         self.ptr = ptr::null_mut(); // for safe drop
         self.len = 0;

--- a/crates/cuda-common/src/d_buffer.rs
+++ b/crates/cuda-common/src/d_buffer.rs
@@ -67,9 +67,10 @@ impl<T> DeviceBuffer<T> {
     /// Allocate device memory for `len` elements of type `T` on an explicit stream.
     pub fn with_capacity_on(len: usize, ctx: &DeviceContext) -> Self {
         tracing::debug!(
-            "Creating device buffer of size {} (sizeof type = {}) on stream",
+            "Creating device buffer of size {} (sizeof type = {}) on stream {:?}",
             len,
-            size_of::<T>()
+            size_of::<T>(),
+            ctx.stream
         );
         assert_ne!(len, 0, "Zero capacity request is wrong");
         let size_bytes = std::mem::size_of::<T>() * len;
@@ -91,6 +92,9 @@ impl<T> DeviceBuffer<T> {
     }
 
     /// Fills the buffer with zeros on an explicit stream.
+    ///
+    /// The caller should use the same stream that allocated this buffer.
+    /// `fill_zero` is async; same-stream guarantees ordering without explicit sync.
     pub fn fill_zero_on(&self, ctx: &DeviceContext) -> Result<(), CudaError> {
         assert_ne!(self.len, 0, "Empty buffer");
         #[cfg(feature = "debug-cuda-stream")]

--- a/crates/cuda-common/src/d_buffer.rs
+++ b/crates/cuda-common/src/d_buffer.rs
@@ -65,20 +65,20 @@ impl<T> DeviceBuffer<T> {
     }
 
     /// Allocate device memory for `len` elements of type `T` on an explicit stream.
-    pub fn with_capacity_on(len: usize, ctx: &GpuDeviceCtx) -> Self {
+    pub fn with_capacity_on(len: usize, device_ctx: &GpuDeviceCtx) -> Self {
         tracing::debug!(
             "Creating device buffer of size {} (sizeof type = {}) on stream {:?}",
             len,
             size_of::<T>(),
-            ctx.stream
+            device_ctx.stream
         );
         assert_ne!(len, 0, "Zero capacity request is wrong");
         let size_bytes = std::mem::size_of::<T>() * len;
-        let raw_ptr = d_malloc_on(size_bytes, &ctx.stream).expect("GPU allocation failed");
+        let raw_ptr = d_malloc_on(size_bytes, &device_ctx.stream).expect("GPU allocation failed");
         #[cfg(feature = "touchemall")]
         {
             unsafe {
-                cudaMemsetAsync(raw_ptr, 0xff, size_bytes, ctx.stream.as_raw());
+                cudaMemsetAsync(raw_ptr, 0xff, size_bytes, device_ctx.stream.as_raw());
             }
         }
         let typed_ptr = raw_ptr as *mut T;
@@ -87,7 +87,7 @@ impl<T> DeviceBuffer<T> {
             ptr: typed_ptr,
             len,
             #[cfg(feature = "debug-cuda-stream")]
-            alloc_stream: ctx.stream.as_raw(),
+            alloc_stream: device_ctx.stream.as_raw(),
         }
     }
 
@@ -95,31 +95,43 @@ impl<T> DeviceBuffer<T> {
     ///
     /// The caller should use the same stream that allocated this buffer.
     /// `fill_zero` is async; same-stream guarantees ordering without explicit sync.
-    pub fn fill_zero_on(&self, ctx: &GpuDeviceCtx) -> Result<(), CudaError> {
-        assert_ne!(self.len, 0, "Empty buffer");
+    pub fn fill_zero_on(&self, device_ctx: &GpuDeviceCtx) -> Result<(), CudaError> {
+        if self.len == 0 {
+            return Ok(());
+        }
         #[cfg(feature = "debug-cuda-stream")]
         debug_assert_eq!(
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
             self.alloc_stream,
             "fill_zero_on: stream mismatch"
         );
         let size_bytes = std::mem::size_of::<T>() * self.len;
-        check(unsafe { cudaMemsetAsync(self.as_mut_raw_ptr(), 0, size_bytes, ctx.stream.as_raw()) })
+        check(unsafe {
+            cudaMemsetAsync(
+                self.as_mut_raw_ptr(),
+                0,
+                size_bytes,
+                device_ctx.stream.as_raw(),
+            )
+        })
     }
 
     /// Fills a suffix of the buffer with zeros on an explicit stream.
     pub fn fill_zero_suffix_on(
         &self,
         start_idx: usize,
-        ctx: &GpuDeviceCtx,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<(), CudaError> {
         assert!(
-            start_idx < self.len,
-            "start index has to be smaller than length"
+            start_idx <= self.len,
+            "start index has to be smaller than or equal to length"
         );
+        if start_idx == self.len {
+            return Ok(());
+        }
         #[cfg(feature = "debug-cuda-stream")]
         debug_assert_eq!(
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
             self.alloc_stream,
             "fill_zero_suffix_on: stream mismatch"
         );
@@ -129,7 +141,7 @@ impl<T> DeviceBuffer<T> {
                 self.as_mut_ptr().add(start_idx) as *mut c_void,
                 0,
                 size_bytes,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
         })
     }
@@ -239,9 +251,9 @@ mod tests {
 
     #[test]
     fn test_device_buffer_float() {
-        let ctx = test_ctx();
+        let device_ctx = test_ctx();
         // Create a DeviceBuffer of 10 floats
-        let db = DeviceBuffer::<f32>::with_capacity_on(10, &ctx);
+        let db = DeviceBuffer::<f32>::with_capacity_on(10, &device_ctx);
 
         assert_eq!(db.len(), 10);
         assert!(!db.as_ptr().is_null());
@@ -252,10 +264,10 @@ mod tests {
 
     #[test]
     fn test_device_buffer_fill_zero() {
-        let ctx = test_ctx();
+        let device_ctx = test_ctx();
         let v: Vec<u64> = (0..10).collect();
-        let d_array = v.to_device_on(&ctx).unwrap();
-        d_array.fill_zero_on(&ctx).unwrap();
-        assert_eq!(d_array.to_host_on(&ctx).unwrap(), vec![0; v.len()]);
+        let d_array = v.to_device_on(&device_ctx).unwrap();
+        d_array.fill_zero_on(&device_ctx).unwrap();
+        assert_eq!(d_array.to_host_on(&device_ctx).unwrap(), vec![0; v.len()]);
     }
 }

--- a/crates/cuda-common/src/d_buffer.rs
+++ b/crates/cuda-common/src/d_buffer.rs
@@ -204,6 +204,10 @@ impl<T> Drop for DeviceBuffer<T> {
                 self.len,
                 size_of::<T>()
             );
+            // d_free enqueues cudaFreeAsync on the stream that originally
+            // allocated this buffer (stored in the memory manager's record).
+            // This is correct even when Drop runs on a different thread —
+            // CUDA handles cross-thread stream operations safely.
             unsafe {
                 d_free(self.ptr as *mut c_void).expect("GPU free failed");
             }

--- a/crates/cuda-common/src/error.rs
+++ b/crates/cuda-common/src/error.rs
@@ -52,7 +52,6 @@ impl CudaError {
 
     /// Returns `Ok(())` if `code == 0` (cudaSuccess), or `Err(CudaError)` if non-zero.
     pub fn from_result(code: i32) -> Result<(), Self> {
-        crate::stream::mark_cuda_thread_used();
         if code == 0 {
             Ok(())
         } else {

--- a/crates/cuda-common/src/memory_manager/mod.rs
+++ b/crates/cuda-common/src/memory_manager/mod.rs
@@ -112,8 +112,9 @@ impl MemoryManager {
     /// `StreamGuard` that must be dropped AFTER the lock is released.
     ///
     /// # Safety
-    /// The pointer `ptr` must be a valid, previously allocated device pointer.
-    /// The caller must ensure that `ptr` is not used after this function is called.
+    /// - The pointer `ptr` must be a valid, previously allocated device pointer.
+    /// - The caller must ensure that `ptr` is not used after this function is called.
+    /// - The caller must hold the `MEMORY_MANAGER` lock before calling this method.
     unsafe fn d_free_under_lock(&mut self, ptr: *mut c_void) -> Result<StreamGuard, MemoryError> {
         let nn = NonNull::new(ptr).ok_or(MemoryError::NullPointer)?;
 

--- a/crates/cuda-common/src/memory_manager/mod.rs
+++ b/crates/cuda-common/src/memory_manager/mod.rs
@@ -10,7 +10,9 @@ use bytesize::ByteSize;
 
 use crate::{
     error::{check, MemoryError},
-    stream::{cudaStreamPerThread, cudaStream_t, current_stream_id, device_synchronize},
+    stream::{
+        cudaStreamPerThread, cudaStream_t, current_stream_id, device_synchronize, StreamGuard,
+    },
 };
 
 mod cuda;
@@ -42,9 +44,26 @@ fn init() {
     tracing::info!("Memory manager initialized at program start");
 }
 
+/// Allocation record for the small-allocation path (`cudaMallocAsync`).
+enum AllocRecord {
+    /// Legacy PTDS allocation (during transition).
+    Legacy { size: usize },
+    /// Tracked allocation on an explicit stream.
+    Tracked { size: usize, stream: StreamGuard },
+}
+
+impl AllocRecord {
+    fn size(&self) -> usize {
+        match self {
+            AllocRecord::Legacy { size } => *size,
+            AllocRecord::Tracked { size, .. } => *size,
+        }
+    }
+}
+
 pub struct MemoryManager {
     pool: VirtualMemoryPool,
-    allocated_ptrs: HashMap<NonNull<c_void>, usize>,
+    allocated_ptrs: HashMap<NonNull<c_void>, AllocRecord>,
     current_size: usize,
     max_used_size: usize,
 }
@@ -68,6 +87,7 @@ impl MemoryManager {
         }
     }
 
+    /// Legacy PTDS allocation path.
     fn d_malloc(&mut self, size: usize) -> Result<*mut c_void, MemoryError> {
         assert!(size != 0, "Requested size must be non-zero");
 
@@ -82,7 +102,7 @@ impl MemoryManager {
             )?;
             self.allocated_ptrs.insert(
                 NonNull::new(ptr).expect("BUG: cudaMallocAsync returned null"),
-                size,
+                AllocRecord::Legacy { size },
             );
             ptr
         } else {
@@ -98,25 +118,79 @@ impl MemoryManager {
         Ok(ptr)
     }
 
+    /// Explicit-stream allocation path.
+    fn d_malloc_on(
+        &mut self,
+        size: usize,
+        stream: &StreamGuard,
+    ) -> Result<*mut c_void, MemoryError> {
+        assert!(size != 0, "Requested size must be non-zero");
+
+        let mut tracked_size = size;
+        let ptr = if size < self.pool.page_size {
+            let mut ptr: *mut c_void = std::ptr::null_mut();
+            check(unsafe { cudaMallocAsync(&mut ptr, size, stream.as_raw()) }).map_err(|e| {
+                tracing::error!("cudaMallocAsync failed: size={}: {:?}", size, e);
+                MemoryError::from(e)
+            })?;
+            self.allocated_ptrs.insert(
+                NonNull::new(ptr).expect("BUG: cudaMallocAsync returned null"),
+                AllocRecord::Tracked {
+                    size,
+                    stream: stream.clone(),
+                },
+            );
+            ptr
+        } else {
+            tracked_size = size.next_multiple_of(self.pool.page_size);
+            self.pool.malloc_internal_on(tracked_size, stream)?
+        };
+
+        self.current_size += tracked_size;
+        if self.current_size > self.max_used_size {
+            self.max_used_size = self.current_size;
+        }
+        Ok(ptr)
+    }
+
+    /// Two-stage free: first resolves the record under the lock, returning an optional
+    /// `StreamGuard` that must be dropped AFTER the lock is released.
+    ///
     /// # Safety
     /// The pointer `ptr` must be a valid, previously allocated device pointer.
     /// The caller must ensure that `ptr` is not used after this function is called.
-    unsafe fn d_free(&mut self, ptr: *mut c_void) -> Result<(), MemoryError> {
+    unsafe fn d_free_under_lock(
+        &mut self,
+        ptr: *mut c_void,
+    ) -> Result<Option<StreamGuard>, MemoryError> {
         let nn = NonNull::new(ptr).ok_or(MemoryError::NullPointer)?;
 
-        if let Some(size) = self.allocated_ptrs.remove(&nn) {
+        if let Some(record) = self.allocated_ptrs.remove(&nn) {
+            let size = record.size();
             self.current_size -= size;
-            check(unsafe { cudaFreeAsync(ptr, cudaStreamPerThread) }).map_err(|e| {
-                tracing::error!("cudaFreeAsync failed: ptr={:p}: {:?}", ptr, e);
-                MemoryError::from(e)
-            })?;
+            match record {
+                AllocRecord::Legacy { .. } => {
+                    check(unsafe { cudaFreeAsync(ptr, cudaStreamPerThread) }).map_err(|e| {
+                        tracing::error!("cudaFreeAsync failed: ptr={:p}: {:?}", ptr, e);
+                        MemoryError::from(e)
+                    })?;
+                    Ok(None)
+                }
+                AllocRecord::Tracked { stream, .. } => {
+                    check(unsafe { cudaFreeAsync(ptr, stream.as_raw()) }).map_err(|e| {
+                        tracing::error!("cudaFreeAsync failed: ptr={:p}: {:?}", ptr, e);
+                        MemoryError::from(e)
+                    })?;
+                    // Return the guard so it's dropped after the lock is released
+                    Ok(Some(stream))
+                }
+            }
         } else {
             let stream_id = current_stream_id()?;
-            let freed_size = self.pool.free_internal(ptr, stream_id)?;
+            let (freed_size, guard) = self.pool.free_internal(ptr, stream_id)?;
             self.current_size -= freed_size;
+            Ok(guard)
         }
-
-        Ok(())
     }
 }
 
@@ -125,7 +199,7 @@ impl Drop for MemoryManager {
         device_synchronize().unwrap();
         let ptrs: Vec<*mut c_void> = self.allocated_ptrs.keys().map(|nn| nn.as_ptr()).collect();
         for &ptr in &ptrs {
-            if let Err(e) = unsafe { self.d_free(ptr) } {
+            if let Err(e) = unsafe { self.d_free_under_lock(ptr) } {
                 tracing::error!("MemoryManager drop: failed to free {:p}: {:?}", ptr, e);
             }
         }
@@ -138,10 +212,18 @@ impl Default for MemoryManager {
     }
 }
 
+/// Legacy PTDS allocation.
 pub fn d_malloc(size: usize) -> Result<*mut c_void, MemoryError> {
     let manager = MEMORY_MANAGER.get().unwrap();
     let mut manager = manager.lock().map_err(|_| MemoryError::LockError)?;
     manager.d_malloc(size)
+}
+
+/// Explicit-stream allocation.
+pub fn d_malloc_on(size: usize, stream: &StreamGuard) -> Result<*mut c_void, MemoryError> {
+    let manager = MEMORY_MANAGER.get().unwrap();
+    let mut manager = manager.lock().map_err(|_| MemoryError::LockError)?;
+    manager.d_malloc_on(size, stream)
 }
 
 /// # Safety
@@ -150,7 +232,11 @@ pub fn d_malloc(size: usize) -> Result<*mut c_void, MemoryError> {
 pub unsafe fn d_free(ptr: *mut c_void) -> Result<(), MemoryError> {
     let manager = MEMORY_MANAGER.get().unwrap();
     let mut manager = manager.lock().map_err(|_| MemoryError::LockError)?;
-    manager.d_free(ptr)
+    let guard = manager.d_free_under_lock(ptr)?;
+    // Drop the lock before dropping the StreamGuard
+    drop(manager);
+    drop(guard);
+    Ok(())
 }
 
 #[derive(Debug, Clone)]

--- a/crates/cuda-common/src/memory_manager/mod.rs
+++ b/crates/cuda-common/src/memory_manager/mod.rs
@@ -10,9 +10,7 @@ use bytesize::ByteSize;
 
 use crate::{
     error::{check, MemoryError},
-    stream::{
-        cudaStreamPerThread, cudaStream_t, current_stream_id, device_synchronize, StreamGuard,
-    },
+    stream::{cudaStream_t, device_synchronize, StreamGuard},
 };
 
 mod cuda;
@@ -45,20 +43,9 @@ fn init() {
 }
 
 /// Allocation record for the small-allocation path (`cudaMallocAsync`).
-enum AllocRecord {
-    /// Legacy PTDS allocation (during transition).
-    Legacy { size: usize },
-    /// Tracked allocation on an explicit stream.
-    Tracked { size: usize, stream: StreamGuard },
-}
-
-impl AllocRecord {
-    fn size(&self) -> usize {
-        match self {
-            AllocRecord::Legacy { size } => *size,
-            AllocRecord::Tracked { size, .. } => *size,
-        }
-    }
+struct AllocRecord {
+    size: usize,
+    stream: StreamGuard,
 }
 
 pub struct MemoryManager {
@@ -87,38 +74,6 @@ impl MemoryManager {
         }
     }
 
-    /// Legacy PTDS allocation path.
-    fn d_malloc(&mut self, size: usize) -> Result<*mut c_void, MemoryError> {
-        assert!(size != 0, "Requested size must be non-zero");
-
-        let mut tracked_size = size;
-        let ptr = if size < self.pool.page_size {
-            let mut ptr: *mut c_void = std::ptr::null_mut();
-            check(unsafe { cudaMallocAsync(&mut ptr, size, cudaStreamPerThread) }).map_err(
-                |e| {
-                    tracing::error!("cudaMallocAsync failed: size={}: {:?}", size, e);
-                    MemoryError::from(e)
-                },
-            )?;
-            self.allocated_ptrs.insert(
-                NonNull::new(ptr).expect("BUG: cudaMallocAsync returned null"),
-                AllocRecord::Legacy { size },
-            );
-            ptr
-        } else {
-            tracked_size = size.next_multiple_of(self.pool.page_size);
-            let stream_id = current_stream_id()?;
-            self.pool.malloc_internal(tracked_size, stream_id)?
-        };
-
-        self.current_size += tracked_size;
-        if self.current_size > self.max_used_size {
-            self.max_used_size = self.current_size;
-        }
-        Ok(ptr)
-    }
-
-    /// Explicit-stream allocation path.
     fn d_malloc_on(
         &mut self,
         size: usize,
@@ -135,7 +90,7 @@ impl MemoryManager {
             })?;
             self.allocated_ptrs.insert(
                 NonNull::new(ptr).expect("BUG: cudaMallocAsync returned null"),
-                AllocRecord::Tracked {
+                AllocRecord {
                     size,
                     stream: stream.clone(),
                 },
@@ -143,7 +98,7 @@ impl MemoryManager {
             ptr
         } else {
             tracked_size = size.next_multiple_of(self.pool.page_size);
-            self.pool.malloc_internal_on(tracked_size, stream)?
+            self.pool.malloc_internal(tracked_size, stream)?
         };
 
         self.current_size += tracked_size;
@@ -153,41 +108,25 @@ impl MemoryManager {
         Ok(ptr)
     }
 
-    /// Two-stage free: first resolves the record under the lock, returning an optional
+    /// Two-stage free: first resolves the record under the lock, returning the
     /// `StreamGuard` that must be dropped AFTER the lock is released.
     ///
     /// # Safety
     /// The pointer `ptr` must be a valid, previously allocated device pointer.
     /// The caller must ensure that `ptr` is not used after this function is called.
-    unsafe fn d_free_under_lock(
-        &mut self,
-        ptr: *mut c_void,
-    ) -> Result<Option<StreamGuard>, MemoryError> {
+    unsafe fn d_free_under_lock(&mut self, ptr: *mut c_void) -> Result<StreamGuard, MemoryError> {
         let nn = NonNull::new(ptr).ok_or(MemoryError::NullPointer)?;
 
         if let Some(record) = self.allocated_ptrs.remove(&nn) {
-            let size = record.size();
+            let size = record.size;
             self.current_size -= size;
-            match record {
-                AllocRecord::Legacy { .. } => {
-                    check(unsafe { cudaFreeAsync(ptr, cudaStreamPerThread) }).map_err(|e| {
-                        tracing::error!("cudaFreeAsync failed: ptr={:p}: {:?}", ptr, e);
-                        MemoryError::from(e)
-                    })?;
-                    Ok(None)
-                }
-                AllocRecord::Tracked { stream, .. } => {
-                    check(unsafe { cudaFreeAsync(ptr, stream.as_raw()) }).map_err(|e| {
-                        tracing::error!("cudaFreeAsync failed: ptr={:p}: {:?}", ptr, e);
-                        MemoryError::from(e)
-                    })?;
-                    // Return the guard so it's dropped after the lock is released
-                    Ok(Some(stream))
-                }
-            }
+            check(unsafe { cudaFreeAsync(ptr, record.stream.as_raw()) }).map_err(|e| {
+                tracing::error!("cudaFreeAsync failed: ptr={:p}: {:?}", ptr, e);
+                MemoryError::from(e)
+            })?;
+            Ok(record.stream)
         } else {
-            let stream_id = current_stream_id()?;
-            let (freed_size, guard) = self.pool.free_internal(ptr, stream_id)?;
+            let (freed_size, guard) = self.pool.free_internal(ptr)?;
             self.current_size -= freed_size;
             Ok(guard)
         }
@@ -199,8 +138,9 @@ impl Drop for MemoryManager {
         device_synchronize().unwrap();
         let ptrs: Vec<*mut c_void> = self.allocated_ptrs.keys().map(|nn| nn.as_ptr()).collect();
         for &ptr in &ptrs {
-            if let Err(e) = unsafe { self.d_free_under_lock(ptr) } {
-                tracing::error!("MemoryManager drop: failed to free {:p}: {:?}", ptr, e);
+            match unsafe { self.d_free_under_lock(ptr) } {
+                Ok(guard) => drop(guard),
+                Err(e) => tracing::error!("MemoryManager drop: failed to free {:p}: {:?}", ptr, e),
             }
         }
     }
@@ -212,14 +152,6 @@ impl Default for MemoryManager {
     }
 }
 
-/// Legacy PTDS allocation.
-pub fn d_malloc(size: usize) -> Result<*mut c_void, MemoryError> {
-    let manager = MEMORY_MANAGER.get().unwrap();
-    let mut manager = manager.lock().map_err(|_| MemoryError::LockError)?;
-    manager.d_malloc(size)
-}
-
-/// Explicit-stream allocation.
 pub fn d_malloc_on(size: usize, stream: &StreamGuard) -> Result<*mut c_void, MemoryError> {
     let manager = MEMORY_MANAGER.get().unwrap();
     let mut manager = manager.lock().map_err(|_| MemoryError::LockError)?;
@@ -233,7 +165,6 @@ pub unsafe fn d_free(ptr: *mut c_void) -> Result<(), MemoryError> {
     let manager = MEMORY_MANAGER.get().unwrap();
     let mut manager = manager.lock().map_err(|_| MemoryError::LockError)?;
     let guard = manager.d_free_under_lock(ptr)?;
-    // Drop the lock before dropping the StreamGuard
     drop(manager);
     drop(guard);
     Ok(())

--- a/crates/cuda-common/src/memory_manager/tests.rs
+++ b/crates/cuda-common/src/memory_manager/tests.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::{
     d_buffer::DeviceBuffer,
     error::MemoryError,
-    stream::{DeviceContext, StreamGuard},
+    stream::{GpuDeviceCtx, StreamGuard},
 };
 
 #[link(name = "cudart")]
@@ -23,8 +23,8 @@ fn get_gpu_free_memory() -> usize {
     free
 }
 
-fn test_ctx() -> DeviceContext {
-    DeviceContext::for_current_device().unwrap()
+fn test_ctx() -> GpuDeviceCtx {
+    GpuDeviceCtx::for_current_device().unwrap()
 }
 
 fn test_stream() -> StreamGuard {

--- a/crates/cuda-common/src/memory_manager/tests.rs
+++ b/crates/cuda-common/src/memory_manager/tests.rs
@@ -1,9 +1,13 @@
 //! Tests for memory_manager - focused on edge cases and dangerous scenarios
 
-use super::vm_pool::{VirtualMemoryPool, VpmmConfig};
+use super::{
+    d_free, d_malloc_on,
+    vm_pool::{VirtualMemoryPool, VpmmConfig},
+};
 use crate::{
     d_buffer::DeviceBuffer,
-    stream::{current_stream_id, current_stream_sync},
+    error::MemoryError,
+    stream::{DeviceContext, StreamGuard},
 };
 
 #[link(name = "cudart")]
@@ -19,15 +23,24 @@ fn get_gpu_free_memory() -> usize {
     free
 }
 
+fn test_ctx() -> DeviceContext {
+    DeviceContext::for_current_device().unwrap()
+}
+
+fn test_stream() -> StreamGuard {
+    test_ctx().stream
+}
+
 // ============================================================================
 // Coalescing: free B first, then A, then C - should coalesce into one region
 // ============================================================================
 #[test]
 fn test_coalescing_via_combined_alloc() {
+    let ctx = test_ctx();
     let len = 2 << 30; // 2 GB per allocation
-    let buf_a = DeviceBuffer::<u8>::with_capacity(len);
-    let buf_b = DeviceBuffer::<u8>::with_capacity(len);
-    let buf_c = DeviceBuffer::<u8>::with_capacity(len);
+    let buf_a = DeviceBuffer::<u8>::with_capacity_on(len, &ctx);
+    let buf_b = DeviceBuffer::<u8>::with_capacity_on(len, &ctx);
+    let buf_c = DeviceBuffer::<u8>::with_capacity_on(len, &ctx);
 
     let addr_a = buf_a.as_raw_ptr();
 
@@ -38,7 +51,7 @@ fn test_coalescing_via_combined_alloc() {
 
     // Request combined size - if coalescing worked, this should reuse from A's start
     let combined_len = 3 * len;
-    let buf_combined = DeviceBuffer::<u8>::with_capacity(combined_len);
+    let buf_combined = DeviceBuffer::<u8>::with_capacity_on(combined_len, &ctx);
     assert_eq!(
         addr_a,
         buf_combined.as_raw_ptr(),
@@ -65,7 +78,7 @@ fn test_va_exhaustion_reserves_more() {
     }
 
     let page_size = pool.page_size;
-    let stream_id = current_stream_id().unwrap();
+    let stream = test_stream();
 
     // Initial state: 1 VA root
     assert_eq!(pool.roots.len(), 1);
@@ -75,7 +88,7 @@ fn test_va_exhaustion_reserves_more() {
     let mut ptrs = Vec::new();
     for _ in 0..4 {
         // Allocate 4 pages total → needs 2 VA chunks
-        match pool.malloc_internal(page_size, stream_id) {
+        match pool.malloc_internal(page_size, &stream) {
             Ok(ptr) => ptrs.push(ptr),
             Err(e) => panic!("Allocation failed: {:?}", e),
         }
@@ -89,7 +102,7 @@ fn test_va_exhaustion_reserves_more() {
 
     // Cleanup
     for ptr in ptrs {
-        pool.free_internal(ptr, stream_id).unwrap();
+        pool.free_internal(ptr).unwrap();
     }
 }
 
@@ -126,27 +139,27 @@ fn run_doc_scenario(
     }
 
     let page_size = pool.page_size;
-    let stream_id = current_stream_id().unwrap();
+    let stream = test_stream();
 
     // Step 1: +10 pages
-    let ptr_10 = pool.malloc_internal(10 * page_size, stream_id).unwrap();
+    let ptr_10 = pool.malloc_internal(10 * page_size, &stream).unwrap();
     assert!(!ptr_10.is_null());
 
     // Step 2: +1 page
-    let ptr_1 = pool.malloc_internal(page_size, stream_id).unwrap();
+    let ptr_1 = pool.malloc_internal(page_size, &stream).unwrap();
     assert!(!ptr_1.is_null());
     // Should be right after the 10-page allocation
     assert_eq!(ptr_1 as usize, ptr_10 as usize + 10 * page_size);
 
     // Step 3: -10 pages
-    pool.free_internal(ptr_10, stream_id).unwrap();
+    pool.free_internal(ptr_10).unwrap();
 
     // Step 4: +4 pages
-    let ptr_4 = pool.malloc_internal(4 * page_size, stream_id).unwrap();
+    let ptr_4 = pool.malloc_internal(4 * page_size, &stream).unwrap();
     assert!(!ptr_4.is_null());
 
     // Step 5: +11 pages
-    let ptr_11 = pool.malloc_internal(11 * page_size, stream_id).unwrap();
+    let ptr_11 = pool.malloc_internal(11 * page_size, &stream).unwrap();
     assert!(!ptr_11.is_null());
 
     (pool, page_size, ptr_1, ptr_4, ptr_11)
@@ -161,7 +174,6 @@ fn test_defrag_case_a_enough_free_pages() {
     let initial_pages = 22; // X = 22 - 11 = 11
 
     let (pool, page_size, ptr_1, ptr_4, ptr_11) = run_doc_scenario(initial_pages);
-    let stream_id = current_stream_id().unwrap();
 
     // Memory usage should be exactly 22 pages (no new allocation needed)
     assert_eq!(
@@ -181,9 +193,9 @@ fn test_defrag_case_a_enough_free_pages() {
 
     // Cleanup
     let mut pool = pool;
-    pool.free_internal(ptr_1, stream_id).unwrap();
-    pool.free_internal(ptr_4, stream_id).unwrap();
-    pool.free_internal(ptr_11, stream_id).unwrap();
+    pool.free_internal(ptr_1).unwrap();
+    pool.free_internal(ptr_4).unwrap();
+    pool.free_internal(ptr_11).unwrap();
 }
 
 #[test]
@@ -195,7 +207,6 @@ fn test_defrag_case_b_defrag_no_new_pages() {
     let initial_pages = 18; // X = 18 - 11 = 7
 
     let (pool, page_size, ptr_1, ptr_4, ptr_11) = run_doc_scenario(initial_pages);
-    let stream_id = current_stream_id().unwrap();
 
     // Memory usage should still be 18 pages (defrag reuses existing)
     assert_eq!(
@@ -213,9 +224,9 @@ fn test_defrag_case_b_defrag_no_new_pages() {
 
     // Cleanup
     let mut pool = pool;
-    pool.free_internal(ptr_1, stream_id).unwrap();
-    pool.free_internal(ptr_4, stream_id).unwrap();
-    pool.free_internal(ptr_11, stream_id).unwrap();
+    pool.free_internal(ptr_1).unwrap();
+    pool.free_internal(ptr_4).unwrap();
+    pool.free_internal(ptr_11).unwrap();
 }
 
 #[test]
@@ -227,7 +238,6 @@ fn test_defrag_case_c_defrag_plus_new_page() {
     let initial_pages = 15; // X = 15 - 11 = 4
 
     let (pool, page_size, ptr_1, ptr_4, ptr_11) = run_doc_scenario(initial_pages);
-    let stream_id = current_stream_id().unwrap();
 
     // Memory usage: 15 original + 1 new = 16 pages
     assert_eq!(
@@ -245,9 +255,9 @@ fn test_defrag_case_c_defrag_plus_new_page() {
 
     // Cleanup
     let mut pool = pool;
-    pool.free_internal(ptr_1, stream_id).unwrap();
-    pool.free_internal(ptr_4, stream_id).unwrap();
-    pool.free_internal(ptr_11, stream_id).unwrap();
+    pool.free_internal(ptr_1).unwrap();
+    pool.free_internal(ptr_4).unwrap();
+    pool.free_internal(ptr_11).unwrap();
 }
 
 #[test]
@@ -259,7 +269,6 @@ fn test_defrag_case_d_not_enough_for_4() {
     let initial_pages = 12; // X = 12 - 11 = 1
 
     let (pool, page_size, ptr_1, ptr_4, ptr_11) = run_doc_scenario(initial_pages);
-    let stream_id = current_stream_id().unwrap();
 
     // Memory usage: need 11 more pages but only have 6+1=7 free
     // So allocate 11-7=4 new pages → 12 + 4 = 16 total
@@ -277,9 +286,9 @@ fn test_defrag_case_d_not_enough_for_4() {
 
     // Cleanup
     let mut pool = pool;
-    pool.free_internal(ptr_1, stream_id).unwrap();
-    pool.free_internal(ptr_4, stream_id).unwrap();
-    pool.free_internal(ptr_11, stream_id).unwrap();
+    pool.free_internal(ptr_1).unwrap();
+    pool.free_internal(ptr_4).unwrap();
+    pool.free_internal(ptr_11).unwrap();
 }
 
 // ============================================================================
@@ -299,6 +308,7 @@ fn test_mixed_allocations() {
 
         for thread_idx in 0..4 {
             let handle = tokio::task::spawn_blocking(move || {
+                let ctx = test_ctx();
                 let mut buffers: Vec<DeviceBuffer<u8>> = Vec::new();
 
                 for op in 0..15 {
@@ -310,7 +320,7 @@ fn test_mixed_allocations() {
                         ((thread_idx + 1) * (op + 1) % 4 + 1) * (100 << 20)
                     };
 
-                    let buf = DeviceBuffer::<u8>::with_capacity(len);
+                    let buf = DeviceBuffer::<u8>::with_capacity_on(len, &ctx);
                     buffers.push(buf);
 
                     if op % 2 == 0 && !buffers.is_empty() {
@@ -327,8 +337,9 @@ fn test_mixed_allocations() {
     });
 
     // Verify pool is functional after mixed operations
-    current_stream_sync().expect("stream sync failed");
-    let large = DeviceBuffer::<u8>::with_capacity(1 << 30);
+    let ctx = test_ctx();
+    ctx.stream.synchronize().expect("stream sync failed");
+    let large = DeviceBuffer::<u8>::with_capacity_on(1 << 30, &ctx);
     assert!(
         !large.as_ptr().is_null(),
         "Large allocation should work after mixed operations"
@@ -341,8 +352,7 @@ fn test_mixed_allocations() {
 #[test]
 #[ignore] // Heavy: intentionally exhausts GPU memory
 fn test_oom_recovery_after_error() {
-    use super::d_malloc;
-    use crate::error::MemoryError;
+    let ctx = test_ctx();
 
     // Allocate large chunks to drive the device near OOM. Keep them alive to
     // simulate a server that retains existing allocations.
@@ -351,7 +361,7 @@ fn test_oom_recovery_after_error() {
 
     // Fill GPU memory until we hit OOM on a 2 GB request
     loop {
-        match d_malloc(chunk_size) {
+        match d_malloc_on(chunk_size, &ctx.stream) {
             Ok(ptr) => buffers.push(ptr),
             Err(MemoryError::OutOfMemory { .. }) => break,
             Err(e) => panic!("Expected OOM, got {:?}", e),
@@ -360,7 +370,7 @@ fn test_oom_recovery_after_error() {
 
     // After OOM, allocator should still succeed for smaller requests without
     // freeing the large buffers we already hold.
-    let small = d_malloc(1 << 20).expect("Small allocation after OOM failed"); // 1 MB (cudaMallocAsync path)
+    let small = d_malloc_on(1 << 20, &ctx.stream).expect("Small allocation after OOM failed");
 
     // Request just under the currently free memory to exercise the pool path.
     let free_after_oom = get_gpu_free_memory();
@@ -370,15 +380,15 @@ fn test_oom_recovery_after_error() {
         "Not enough free memory to attempt medium alloc after OOM"
     );
     let medium_req = free_after_oom - safety;
-    let medium = d_malloc(medium_req).expect("Pool allocation after OOM failed");
+    let medium = d_malloc_on(medium_req, &ctx.stream).expect("Pool allocation after OOM failed");
 
     // Cleanup
-    unsafe { super::d_free(small).unwrap() };
-    unsafe { super::d_free(medium).unwrap() };
+    unsafe { d_free(small).unwrap() };
+    unsafe { d_free(medium).unwrap() };
     for ptr in buffers {
-        unsafe { super::d_free(ptr).unwrap() };
+        unsafe { d_free(ptr).unwrap() };
     }
-    current_stream_sync().expect("stream sync after cleanup");
+    ctx.stream.synchronize().expect("stream sync after cleanup");
 }
 
 // ============================================================================
@@ -406,26 +416,26 @@ fn create_test_pool(initial_pages: usize) -> VirtualMemoryPool {
 fn test_multiple_defrag_cycles() {
     let mut pool = create_test_pool(8);
     let page_size = pool.page_size;
-    let stream_id = current_stream_id().unwrap();
+    let stream = test_stream();
 
     for cycle in 0..3 {
         // Create fragmentation
         let ptrs: Vec<_> = (0..4)
-            .map(|_| pool.malloc_internal(2 * page_size, stream_id).unwrap())
+            .map(|_| pool.malloc_internal(2 * page_size, &stream).unwrap())
             .collect();
 
         // Free alternating
-        pool.free_internal(ptrs[0], stream_id).unwrap();
-        pool.free_internal(ptrs[2], stream_id).unwrap();
+        pool.free_internal(ptrs[0]).unwrap();
+        pool.free_internal(ptrs[2]).unwrap();
 
         // Request contiguous that requires defrag
-        let ptr_big = pool.malloc_internal(4 * page_size, stream_id).unwrap();
+        let ptr_big = pool.malloc_internal(4 * page_size, &stream).unwrap();
         assert!(!ptr_big.is_null(), "Cycle {} failed to allocate", cycle);
 
         // Cleanup for next cycle
-        pool.free_internal(ptrs[1], stream_id).unwrap();
-        pool.free_internal(ptrs[3], stream_id).unwrap();
-        pool.free_internal(ptr_big, stream_id).unwrap();
+        pool.free_internal(ptrs[1]).unwrap();
+        pool.free_internal(ptrs[3]).unwrap();
+        pool.free_internal(ptr_big).unwrap();
     }
 }
 
@@ -441,58 +451,58 @@ fn test_multiple_defrag_cycles() {
 fn test_coalesce_all_neighbor_cases() {
     let mut pool = create_test_pool(6);
     let page_size = pool.page_size;
-    let stream_id = current_stream_id().unwrap();
+    let stream = test_stream();
 
     // --- Case 1: Coalesce with PREV neighbor ---
     // Allocate: [A(2)][B(2)][C(2)]
-    let ptr_a = pool.malloc_internal(2 * page_size, stream_id).unwrap();
-    let ptr_b = pool.malloc_internal(2 * page_size, stream_id).unwrap();
-    let ptr_c = pool.malloc_internal(2 * page_size, stream_id).unwrap();
+    let ptr_a = pool.malloc_internal(2 * page_size, &stream).unwrap();
+    let ptr_b = pool.malloc_internal(2 * page_size, &stream).unwrap();
+    let ptr_c = pool.malloc_internal(2 * page_size, &stream).unwrap();
 
     // Free B, then A -> A merges with B (prev neighbor)
-    pool.free_internal(ptr_b, stream_id).unwrap();
-    pool.free_internal(ptr_a, stream_id).unwrap();
+    pool.free_internal(ptr_b).unwrap();
+    pool.free_internal(ptr_a).unwrap();
 
     // Verify 4 pages available from coalesced A+B
-    let ptr_4 = pool.malloc_internal(4 * page_size, stream_id).unwrap();
+    let ptr_4 = pool.malloc_internal(4 * page_size, &stream).unwrap();
     assert_eq!(ptr_4 as usize, ptr_a as usize, "Prev: should start at A");
     assert_eq!(pool.memory_usage(), 6 * page_size, "Prev: no new alloc");
 
     // Reset for next case
-    pool.free_internal(ptr_c, stream_id).unwrap();
-    pool.free_internal(ptr_4, stream_id).unwrap();
+    pool.free_internal(ptr_c).unwrap();
+    pool.free_internal(ptr_4).unwrap();
 
     // --- Case 2: Coalesce with NEXT neighbor ---
-    let ptr_a = pool.malloc_internal(2 * page_size, stream_id).unwrap();
-    let ptr_b = pool.malloc_internal(2 * page_size, stream_id).unwrap();
-    let ptr_c = pool.malloc_internal(2 * page_size, stream_id).unwrap();
+    let ptr_a = pool.malloc_internal(2 * page_size, &stream).unwrap();
+    let ptr_b = pool.malloc_internal(2 * page_size, &stream).unwrap();
+    let ptr_c = pool.malloc_internal(2 * page_size, &stream).unwrap();
 
     // Free A, then B -> B merges with A (next neighbor from A's POV)
-    pool.free_internal(ptr_a, stream_id).unwrap();
-    pool.free_internal(ptr_b, stream_id).unwrap();
+    pool.free_internal(ptr_a).unwrap();
+    pool.free_internal(ptr_b).unwrap();
 
-    let ptr_4 = pool.malloc_internal(4 * page_size, stream_id).unwrap();
+    let ptr_4 = pool.malloc_internal(4 * page_size, &stream).unwrap();
     assert_eq!(ptr_4 as usize, ptr_a as usize, "Next: should start at A");
 
     // Reset for next case
-    pool.free_internal(ptr_c, stream_id).unwrap();
-    pool.free_internal(ptr_4, stream_id).unwrap();
+    pool.free_internal(ptr_c).unwrap();
+    pool.free_internal(ptr_4).unwrap();
 
     // --- Case 3: Coalesce with BOTH neighbors ---
-    let ptr_a = pool.malloc_internal(2 * page_size, stream_id).unwrap();
-    let ptr_b = pool.malloc_internal(2 * page_size, stream_id).unwrap();
-    let ptr_c = pool.malloc_internal(2 * page_size, stream_id).unwrap();
+    let ptr_a = pool.malloc_internal(2 * page_size, &stream).unwrap();
+    let ptr_b = pool.malloc_internal(2 * page_size, &stream).unwrap();
+    let ptr_c = pool.malloc_internal(2 * page_size, &stream).unwrap();
 
     // Free A, C, then B (middle) -> B merges with both
-    pool.free_internal(ptr_a, stream_id).unwrap();
-    pool.free_internal(ptr_c, stream_id).unwrap();
-    pool.free_internal(ptr_b, stream_id).unwrap();
+    pool.free_internal(ptr_a).unwrap();
+    pool.free_internal(ptr_c).unwrap();
+    pool.free_internal(ptr_b).unwrap();
 
-    let ptr_6 = pool.malloc_internal(6 * page_size, stream_id).unwrap();
+    let ptr_6 = pool.malloc_internal(6 * page_size, &stream).unwrap();
     assert_eq!(ptr_6 as usize, ptr_a as usize, "Both: should start at A");
     assert_eq!(pool.memory_usage(), 6 * page_size, "Both: no new alloc");
 
-    pool.free_internal(ptr_6, stream_id).unwrap();
+    pool.free_internal(ptr_6).unwrap();
 }
 
 // ============================================================================
@@ -502,27 +512,26 @@ fn test_coalesce_all_neighbor_cases() {
 fn test_no_coalesce_across_streams() {
     let mut pool = create_test_pool(6);
     let page_size = pool.page_size;
-    let stream_id_1 = current_stream_id().unwrap();
-    let stream_id_2 = stream_id_1 + 1000; // Simulate different stream
+    let stream_1 = test_stream();
+    let stream_2 = test_stream();
 
     // Allocate: [A(2)][B(2)][C(2)]
-    let ptr_a = pool.malloc_internal(2 * page_size, stream_id_1).unwrap();
-    let ptr_b = pool.malloc_internal(2 * page_size, stream_id_1).unwrap();
-    let ptr_c = pool.malloc_internal(2 * page_size, stream_id_1).unwrap();
+    let ptr_a = pool.malloc_internal(2 * page_size, &stream_1).unwrap();
+    let ptr_b = pool.malloc_internal(2 * page_size, &stream_1).unwrap();
+    let ptr_c = pool.malloc_internal(2 * page_size, &stream_1).unwrap();
 
-    // Free A on stream_1, B on stream_2, C on stream_1
-    // B should NOT coalesce with A or C (different stream)
-    pool.free_internal(ptr_a, stream_id_1).unwrap();
-    pool.free_internal(ptr_b, stream_id_2).unwrap();
-    pool.free_internal(ptr_c, stream_id_1).unwrap();
+    // B keeps its own recorded stream, so it should NOT coalesce with A or C.
+    pool.free_internal(ptr_a).unwrap();
+    pool.free_internal(ptr_b).unwrap();
+    pool.free_internal(ptr_c).unwrap();
 
     // Requesting 4 pages needs defrag to combine A + C (skipping B)
     let memory_before = pool.memory_usage();
-    let ptr_4 = pool.malloc_internal(4 * page_size, stream_id_1).unwrap();
+    let ptr_4 = pool.malloc_internal(4 * page_size, &stream_2).unwrap();
     assert!(!ptr_4.is_null());
     assert_eq!(pool.memory_usage(), memory_before, "Defrag reused existing");
 
-    pool.free_internal(ptr_4, stream_id_1).unwrap();
+    pool.free_internal(ptr_4).unwrap();
 }
 
 // ============================================================================
@@ -533,30 +542,30 @@ fn test_no_coalesce_across_streams() {
 fn test_defrag_tail_regions_returned() {
     let mut pool = create_test_pool(10);
     let page_size = pool.page_size;
-    let stream_id = current_stream_id().unwrap();
+    let stream = test_stream();
 
     // Allocate 5 x 2-page regions
     let ptrs: Vec<_> = (0..5)
-        .map(|_| pool.malloc_internal(2 * page_size, stream_id).unwrap())
+        .map(|_| pool.malloc_internal(2 * page_size, &stream).unwrap())
         .collect();
 
     // Free alternating to create fragmentation with 6 free pages in 3 regions
     // Layout: [2 free][2 alloc][2 free][2 alloc][2 free]
-    pool.free_internal(ptrs[0], stream_id).unwrap();
-    pool.free_internal(ptrs[2], stream_id).unwrap();
-    pool.free_internal(ptrs[4], stream_id).unwrap();
+    pool.free_internal(ptrs[0]).unwrap();
+    pool.free_internal(ptrs[2]).unwrap();
+    pool.free_internal(ptrs[4]).unwrap();
 
     // Request 5 pages -> defrag takes 2+2+1, leaving 1 page as tail
     let memory_before = pool.memory_usage();
-    let ptr_5 = pool.malloc_internal(5 * page_size, stream_id).unwrap();
+    let ptr_5 = pool.malloc_internal(5 * page_size, &stream).unwrap();
     assert_eq!(pool.memory_usage(), memory_before, "No new pages needed");
 
     // Verify tail exists: can allocate 1 more without new allocation
-    let ptr_1 = pool.malloc_internal(page_size, stream_id).unwrap();
+    let ptr_1 = pool.malloc_internal(page_size, &stream).unwrap();
     assert_eq!(pool.memory_usage(), memory_before, "Tail page reused");
 
     // Now requesting more requires new allocation
-    let ptr_extra = pool.malloc_internal(page_size, stream_id).unwrap();
+    let ptr_extra = pool.malloc_internal(page_size, &stream).unwrap();
     assert_eq!(
         pool.memory_usage(),
         memory_before + page_size,
@@ -564,11 +573,11 @@ fn test_defrag_tail_regions_returned() {
     );
 
     // Cleanup
-    pool.free_internal(ptrs[1], stream_id).unwrap();
-    pool.free_internal(ptrs[3], stream_id).unwrap();
-    pool.free_internal(ptr_5, stream_id).unwrap();
-    pool.free_internal(ptr_1, stream_id).unwrap();
-    pool.free_internal(ptr_extra, stream_id).unwrap();
+    pool.free_internal(ptrs[1]).unwrap();
+    pool.free_internal(ptrs[3]).unwrap();
+    pool.free_internal(ptr_5).unwrap();
+    pool.free_internal(ptr_1).unwrap();
+    pool.free_internal(ptr_extra).unwrap();
 }
 
 // ============================================================================
@@ -578,32 +587,32 @@ fn test_defrag_tail_regions_returned() {
 fn test_unmapped_region_coalescing_comprehensive() {
     let mut pool = create_test_pool(6);
     let page_size = pool.page_size;
-    let stream_id = current_stream_id().unwrap();
+    let stream = test_stream();
 
     // Allocate: [A(2)][B(2)][C(2)]
-    let ptr_a = pool.malloc_internal(2 * page_size, stream_id).unwrap();
-    let ptr_b = pool.malloc_internal(2 * page_size, stream_id).unwrap();
-    let ptr_c = pool.malloc_internal(2 * page_size, stream_id).unwrap();
+    let ptr_a = pool.malloc_internal(2 * page_size, &stream).unwrap();
+    let ptr_b = pool.malloc_internal(2 * page_size, &stream).unwrap();
+    let ptr_c = pool.malloc_internal(2 * page_size, &stream).unwrap();
 
     // Free A and B -> should coalesce to 4 free pages
-    pool.free_internal(ptr_a, stream_id).unwrap();
-    pool.free_internal(ptr_b, stream_id).unwrap();
+    pool.free_internal(ptr_a).unwrap();
+    pool.free_internal(ptr_b).unwrap();
 
     // Request 4 pages from coalesced region
-    let ptr_4 = pool.malloc_internal(4 * page_size, stream_id).unwrap();
+    let ptr_4 = pool.malloc_internal(4 * page_size, &stream).unwrap();
     assert_eq!(ptr_4 as usize, ptr_a as usize);
 
     // Free everything
-    pool.free_internal(ptr_4, stream_id).unwrap();
-    pool.free_internal(ptr_c, stream_id).unwrap();
+    pool.free_internal(ptr_4).unwrap();
+    pool.free_internal(ptr_c).unwrap();
 
     // Request 7 pages -> needs remap + 1 new page
     // Unmapped regions from remap should coalesce properly
     let memory_before = pool.memory_usage();
-    let ptr_7 = pool.malloc_internal(7 * page_size, stream_id).unwrap();
+    let ptr_7 = pool.malloc_internal(7 * page_size, &stream).unwrap();
     assert_eq!(pool.memory_usage(), memory_before + page_size);
 
-    pool.free_internal(ptr_7, stream_id).unwrap();
+    pool.free_internal(ptr_7).unwrap();
 }
 
 // ============================================================================
@@ -624,32 +633,32 @@ fn test_defrag_new_pages_merge_with_existing() {
     }
 
     let page_size = pool.page_size;
-    let stream_id = current_stream_id().unwrap();
+    let stream = test_stream();
 
     // Allocate 2 pages, then free them
-    let ptr_2 = pool.malloc_internal(2 * page_size, stream_id).unwrap();
+    let ptr_2 = pool.malloc_internal(2 * page_size, &stream).unwrap();
     assert_eq!(pool.memory_usage(), 2 * page_size);
-    pool.free_internal(ptr_2, stream_id).unwrap();
+    pool.free_internal(ptr_2).unwrap();
 
     // Request 4 pages -> allocates 2 new + uses 2 free (merge)
-    let ptr_4 = pool.malloc_internal(4 * page_size, stream_id).unwrap();
+    let ptr_4 = pool.malloc_internal(4 * page_size, &stream).unwrap();
     assert_eq!(pool.memory_usage(), 4 * page_size);
     assert!(!ptr_4.is_null());
 
     // Test with preallocated pool: alloc merges with prev free
-    pool.free_internal(ptr_4, stream_id).unwrap();
+    pool.free_internal(ptr_4).unwrap();
 
-    let ptr_a = pool.malloc_internal(2 * page_size, stream_id).unwrap();
-    let ptr_b = pool.malloc_internal(2 * page_size, stream_id).unwrap();
-    pool.free_internal(ptr_a, stream_id).unwrap();
+    let ptr_a = pool.malloc_internal(2 * page_size, &stream).unwrap();
+    let ptr_b = pool.malloc_internal(2 * page_size, &stream).unwrap();
+    pool.free_internal(ptr_a).unwrap();
 
     // Request 4 pages with 2 free -> need 2 more
-    let ptr_req = pool.malloc_internal(4 * page_size, stream_id).unwrap();
+    let ptr_req = pool.malloc_internal(4 * page_size, &stream).unwrap();
     assert!(!ptr_req.is_null());
     assert_eq!(pool.memory_usage(), 6 * page_size);
 
-    pool.free_internal(ptr_b, stream_id).unwrap();
-    pool.free_internal(ptr_req, stream_id).unwrap();
+    pool.free_internal(ptr_b).unwrap();
+    pool.free_internal(ptr_req).unwrap();
 }
 
 // ============================================================================
@@ -660,42 +669,42 @@ fn test_defrag_new_pages_merge_with_existing() {
 fn test_defrag_various_scenarios() {
     let mut pool = create_test_pool(10);
     let page_size = pool.page_size;
-    let stream_id = current_stream_id().unwrap();
+    let stream = test_stream();
 
     // --- Scenario 1: Exact fit, no tail ---
     let ptrs: Vec<_> = (0..5)
-        .map(|_| pool.malloc_internal(2 * page_size, stream_id).unwrap())
+        .map(|_| pool.malloc_internal(2 * page_size, &stream).unwrap())
         .collect();
 
     // Free all in scattered order -> should coalesce completely
-    pool.free_internal(ptrs[1], stream_id).unwrap();
-    pool.free_internal(ptrs[3], stream_id).unwrap();
-    pool.free_internal(ptrs[0], stream_id).unwrap();
-    pool.free_internal(ptrs[4], stream_id).unwrap();
-    pool.free_internal(ptrs[2], stream_id).unwrap();
+    pool.free_internal(ptrs[1]).unwrap();
+    pool.free_internal(ptrs[3]).unwrap();
+    pool.free_internal(ptrs[0]).unwrap();
+    pool.free_internal(ptrs[4]).unwrap();
+    pool.free_internal(ptrs[2]).unwrap();
 
     // Request all 10 pages (exact fit)
-    let ptr_10 = pool.malloc_internal(10 * page_size, stream_id).unwrap();
+    let ptr_10 = pool.malloc_internal(10 * page_size, &stream).unwrap();
     assert!(!ptr_10.is_null());
     assert_eq!(pool.memory_usage(), 10 * page_size);
 
     // --- Scenario 2: Remap with new page allocation (reuse same pool state) ---
     // Layout now: [10 malloc]
     // Free the 10-page region, then create fragmentation
-    pool.free_internal(ptr_10, stream_id).unwrap();
+    pool.free_internal(ptr_10).unwrap();
 
     // Allocate 6 + 4 pages
-    let ptr_a = pool.malloc_internal(6 * page_size, stream_id).unwrap();
-    let ptr_b = pool.malloc_internal(4 * page_size, stream_id).unwrap();
+    let ptr_a = pool.malloc_internal(6 * page_size, &stream).unwrap();
+    let ptr_b = pool.malloc_internal(4 * page_size, &stream).unwrap();
 
     // Free A, keep B -> [6 free][4 malloc]
-    pool.free_internal(ptr_a, stream_id).unwrap();
+    pool.free_internal(ptr_a).unwrap();
 
     // Request 7 pages: 6 free + need 1 more
     let memory_before = pool.memory_usage();
-    let ptr_7 = pool.malloc_internal(7 * page_size, stream_id).unwrap();
+    let ptr_7 = pool.malloc_internal(7 * page_size, &stream).unwrap();
     assert_eq!(pool.memory_usage(), memory_before + page_size);
 
-    pool.free_internal(ptr_b, stream_id).unwrap();
-    pool.free_internal(ptr_7, stream_id).unwrap();
+    pool.free_internal(ptr_b).unwrap();
+    pool.free_internal(ptr_7).unwrap();
 }

--- a/crates/cuda-common/src/memory_manager/vm_pool.rs
+++ b/crates/cuda-common/src/memory_manager/vm_pool.rs
@@ -12,10 +12,7 @@ use super::cuda::*;
 use crate::{
     common::set_device,
     error::MemoryError,
-    stream::{
-        current_stream_id, current_stream_sync, default_stream_wait, CudaEvent, CudaStreamId,
-        StreamGuard,
-    },
+    stream::{device_synchronize, CudaEvent, CudaStream, StreamGuard},
 };
 
 #[link(name = "cudart")]
@@ -92,19 +89,14 @@ impl VpmmConfig {
 // ============================================================================
 
 /// Allocation record for the VPMM path.
-pub(super) enum VpmmRecord {
-    /// Legacy PTDS allocation (during transition).
-    Legacy { size: usize },
-    /// Tracked allocation on an explicit stream.
-    Tracked { size: usize, stream: StreamGuard },
+pub(super) struct VpmmRecord {
+    size: usize,
+    stream: StreamGuard,
 }
 
 impl VpmmRecord {
     pub(super) fn size(&self) -> usize {
-        match self {
-            VpmmRecord::Legacy { size } => *size,
-            VpmmRecord::Tracked { size, .. } => *size,
-        }
+        self.size
     }
 }
 
@@ -117,9 +109,7 @@ impl VpmmRecord {
 struct FreeRegionMeta {
     size: usize,
     event: Arc<CudaEvent>,
-    stream_id: CudaStreamId,
-    /// `Some` for tracked (explicit-stream) regions, `None` for legacy PTDS regions.
-    stream: Option<StreamGuard>,
+    stream: StreamGuard,
     id: usize,
 }
 
@@ -237,9 +227,8 @@ impl VirtualMemoryPool {
         // Preallocate pages if requested (skip if VPMM not supported)
         if config.initial_pages > 0 && page_size != usize::MAX {
             let alloc_size = config.initial_pages * page_size;
-            if let Err(e) =
-                pool.defragment_or_create_new_pages(alloc_size, current_stream_id().unwrap())
-            {
+            let init_stream = StreamGuard::new(CudaStream::new_non_blocking().unwrap());
+            if let Err(e) = pool.defragment_or_create_new_pages(alloc_size, &init_stream) {
                 let mut free_mem = 0usize;
                 let mut total_mem = 0usize;
                 unsafe {
@@ -262,64 +251,11 @@ impl VirtualMemoryPool {
     }
 
     // ========================================================================
-    // Legacy PTDS path
-    // ========================================================================
-
-    /// Allocates memory from the pool's free regions (legacy PTDS path).
-    pub(super) fn malloc_internal(
-        &mut self,
-        requested: usize,
-        stream_id: CudaStreamId,
-    ) -> Result<*mut c_void, MemoryError> {
-        debug_assert!(
-            requested != 0 && requested.is_multiple_of(self.page_size),
-            "Requested size must be a multiple of the page size"
-        );
-
-        // Phase 0: Cleanup zombie regions
-        self.cleanup_zombie_regions();
-
-        // Phase 1: Zero-cost attempts
-        let mut best_region = self.find_best_fit(requested, stream_id);
-
-        if best_region.is_none() {
-            // Phase 2: Defragmentation
-            best_region = self.defragment_or_create_new_pages(requested, stream_id)?;
-        }
-
-        if let Some(ptr) = best_region {
-            let region = self
-                .free_regions
-                .remove(&ptr)
-                .expect("BUG: free region address not found after find_best_fit");
-            debug_assert_eq!(region.stream_id, stream_id);
-
-            // If region is larger, return the untouched tail with its original guard metadata.
-            if region.size > requested {
-                self.reinsert_split_free_region(
-                    ptr + requested as u64,
-                    region.size - requested,
-                    region,
-                );
-            }
-
-            self.malloc_regions
-                .insert(ptr, VpmmRecord::Legacy { size: requested });
-            return Ok(ptr as *mut c_void);
-        }
-
-        Err(MemoryError::OutOfMemory {
-            requested,
-            available: self.free_regions.values().map(|r| r.size).sum(),
-        })
-    }
-
-    // ========================================================================
     // Tracked (explicit-stream) path
     // ========================================================================
 
-    /// Allocates memory from the pool's free regions (explicit-stream path).
-    pub(super) fn malloc_internal_on(
+    /// Allocates memory from the pool's free regions.
+    pub(super) fn malloc_internal(
         &mut self,
         requested: usize,
         stream: &StreamGuard,
@@ -331,17 +267,17 @@ impl VirtualMemoryPool {
 
         self.cleanup_zombie_regions();
 
-        let mut best_region = self.find_best_fit_on(requested, stream);
+        let mut best_region = self.find_best_fit(requested, stream);
 
         if best_region.is_none() {
-            best_region = self.defragment_or_create_new_pages_on(requested, stream)?;
+            best_region = self.defragment_or_create_new_pages(requested, stream)?;
         }
 
         if let Some(ptr) = best_region {
             let region = self
                 .free_regions
                 .remove(&ptr)
-                .expect("BUG: free region address not found after find_best_fit_on");
+                .expect("BUG: free region address not found after find_best_fit");
 
             if region.size > requested {
                 self.reinsert_split_free_region(
@@ -353,7 +289,7 @@ impl VirtualMemoryPool {
 
             self.malloc_regions.insert(
                 ptr,
-                VpmmRecord::Tracked {
+                VpmmRecord {
                     size: requested,
                     stream: stream.clone(),
                 },
@@ -367,8 +303,8 @@ impl VirtualMemoryPool {
         })
     }
 
-    /// Phase 1 best-fit for the tracked path: prefers same-stream via `Arc::ptr_eq`.
-    fn find_best_fit_on(&mut self, requested: usize, stream: &StreamGuard) -> Option<CUdeviceptr> {
+    /// Phase 1 best-fit: prefer same-stream regions via `Arc::ptr_eq`.
+    fn find_best_fit(&mut self, requested: usize, stream: &StreamGuard) -> Option<CUdeviceptr> {
         let mut candidates: Vec<(CUdeviceptr, &mut FreeRegionMeta)> = self
             .free_regions
             .iter_mut()
@@ -383,12 +319,7 @@ impl VirtualMemoryPool {
         // 1a. Prefer same stream (smallest fit) — could be not completed
         if let Some((addr, _)) = candidates
             .iter()
-            .filter(|(_, region)| {
-                region
-                    .stream
-                    .as_ref()
-                    .is_some_and(|s| s.is_same_stream(stream))
-            })
+            .filter(|(_, region)| region.stream.is_same_stream(stream))
             .min_by_key(|(_, region)| region.size)
         {
             return Some(*addr);
@@ -400,18 +331,17 @@ impl VirtualMemoryPool {
             .filter(|(_, region)| region.event.completed())
             .min_by_key(|(_, region)| region.size)
             .map(|(addr, region)| {
-                region.stream = Some(stream.clone());
+                region.stream = stream.clone();
                 *addr
             })
     }
 
-    /// Frees a pointer and returns `(size, Option<StreamGuard>)`.
+    /// Frees a pointer and returns `(size, StreamGuard)`.
     /// The `StreamGuard` must be dropped by the caller AFTER releasing the memory manager lock.
     pub(super) fn free_internal(
         &mut self,
         ptr: *mut c_void,
-        stream_id: CudaStreamId,
-    ) -> Result<(usize, Option<StreamGuard>), MemoryError> {
+    ) -> Result<(usize, StreamGuard), MemoryError> {
         let ptr = ptr as CUdeviceptr;
         let record = self
             .malloc_regions
@@ -419,18 +349,9 @@ impl VirtualMemoryPool {
             .ok_or(MemoryError::InvalidPointer)?;
 
         let size = record.size();
-        let guard = match record {
-            VpmmRecord::Legacy { .. } => {
-                self.free_region_insert(ptr, size, stream_id);
-                None
-            }
-            VpmmRecord::Tracked { stream, .. } => {
-                self.free_region_insert_on(ptr, size, &stream);
-                Some(stream)
-            }
-        };
+        self.free_region_insert(ptr, size, &record.stream);
 
-        Ok((size, guard))
+        Ok((size, record.stream))
     }
 
     // ========================================================================
@@ -458,83 +379,8 @@ impl VirtualMemoryPool {
         }
     }
 
-    /// Phase 1: Try to find a suitable free region without defragmentation (legacy path)
-    fn find_best_fit(&mut self, requested: usize, stream_id: CudaStreamId) -> Option<CUdeviceptr> {
-        let mut candidates: Vec<(CUdeviceptr, &mut FreeRegionMeta)> = self
-            .free_regions
-            .iter_mut()
-            .filter(|(_, region)| region.size >= requested)
-            .map(|(addr, region)| (*addr, region))
-            .collect();
-
-        if candidates.is_empty() {
-            return None;
-        }
-
-        // 1a. Prefer current stream (smallest fit) - could be not completed
-        if let Some((addr, _)) = candidates
-            .iter()
-            .filter(|(_, region)| region.stream_id == stream_id)
-            .min_by_key(|(_, region)| region.size)
-        {
-            return Some(*addr);
-        }
-
-        // 1b. Other streams (smallest fit) - ONLY if already completed (no sync)
-        candidates
-            .iter_mut()
-            .filter(|(_, region)| region.event.completed())
-            .min_by_key(|(_, region)| region.size)
-            .map(|(addr, region)| {
-                region.stream_id = stream_id;
-                *addr
-            })
-    }
-
-    /// Legacy PTDS path: inserts a new free region, possibly merging with adjacent regions.
+    /// Inserts a new free region, possibly merging with adjacent same-stream regions.
     fn free_region_insert(
-        &mut self,
-        mut ptr: CUdeviceptr,
-        mut size: usize,
-        stream_id: CudaStreamId,
-    ) -> (CUdeviceptr, usize) {
-        // Potential merge with next neighbor
-        if let Some((&next_ptr, next_region)) = self.free_regions.range(ptr + 1..).next() {
-            if next_region.stream_id == stream_id && ptr + size as u64 == next_ptr {
-                let next_region = self.free_regions.remove(&next_ptr).unwrap();
-                size += next_region.size;
-            }
-        }
-        // Potential merge with previous neighbor
-        if let Some((&prev_ptr, prev_region)) = self.free_regions.range(..ptr).next_back() {
-            if prev_region.stream_id == stream_id && prev_ptr + prev_region.size as u64 == ptr {
-                let prev_region = self.free_regions.remove(&prev_ptr).unwrap();
-                ptr = prev_ptr;
-                size += prev_region.size;
-            }
-        }
-        // Record a new event to capture the current point in the stream
-        let event = Arc::new(CudaEvent::new().unwrap());
-        event.record_on_this().unwrap();
-        // Assign an id to the free region
-        let id = self.free_num;
-        self.free_num += 1;
-
-        self.free_regions.insert(
-            ptr,
-            FreeRegionMeta {
-                size,
-                event,
-                stream_id,
-                stream: None,
-                id,
-            },
-        );
-        (ptr, size)
-    }
-
-    /// Tracked path: inserts a new free region, merging with adjacent same-stream regions.
-    fn free_region_insert_on(
         &mut self,
         mut ptr: CUdeviceptr,
         mut size: usize,
@@ -542,22 +388,16 @@ impl VirtualMemoryPool {
     ) -> (CUdeviceptr, usize) {
         // Potential merge with next neighbor
         if let Some((&next_ptr, next_region)) = self.free_regions.range(ptr + 1..).next() {
-            let same_stream = next_region
-                .stream
-                .as_ref()
-                .is_some_and(|s| s.is_same_stream(stream));
-            if same_stream && ptr + size as u64 == next_ptr {
+            if next_region.stream.is_same_stream(stream) && ptr + size as u64 == next_ptr {
                 let next_region = self.free_regions.remove(&next_ptr).unwrap();
                 size += next_region.size;
             }
         }
         // Potential merge with previous neighbor
         if let Some((&prev_ptr, prev_region)) = self.free_regions.range(..ptr).next_back() {
-            let same_stream = prev_region
-                .stream
-                .as_ref()
-                .is_some_and(|s| s.is_same_stream(stream));
-            if same_stream && prev_ptr + prev_region.size as u64 == ptr {
+            if prev_region.stream.is_same_stream(stream)
+                && prev_ptr + prev_region.size as u64 == ptr
+            {
                 let prev_region = self.free_regions.remove(&prev_ptr).unwrap();
                 ptr = prev_ptr;
                 size += prev_region.size;
@@ -573,8 +413,7 @@ impl VirtualMemoryPool {
             FreeRegionMeta {
                 size,
                 event,
-                stream_id: 0, // not used in tracked path
-                stream: Some(stream.clone()),
+                stream: stream.clone(),
                 id,
             },
         );
@@ -685,165 +524,6 @@ impl VirtualMemoryPool {
     fn defragment_or_create_new_pages(
         &mut self,
         requested: usize,
-        stream_id: CudaStreamId,
-    ) -> Result<Option<CUdeviceptr>, MemoryError> {
-        debug_assert_eq!(requested % self.page_size, 0);
-        if requested == 0 {
-            return Ok(None);
-        }
-
-        let total_free_size = self.free_regions.values().map(|r| r.size).sum::<usize>();
-        tracing::debug!(
-            "VPMM: Defragging or creating new pages: requested={}, free={} stream_id={}",
-            ByteSize::b(requested as u64),
-            ByteSize::b(total_free_size as u64),
-            stream_id
-        );
-
-        // Find a best fit unmapped region
-        let dst = self.take_unmapped_region(requested)?;
-        // Sentinel value until we have a valid free region pointer from allocation
-        let mut allocated_ptr = CUdeviceptr::MAX;
-
-        // Allocate new pages if we don't have enough free regions
-        let mut allocated_dst = dst;
-        let mut allocate_size = requested.saturating_sub(total_free_size);
-        debug_assert_eq!(allocate_size % self.page_size, 0);
-        let mut allocated_pages: Vec<(CUdeviceptr, CUmemGenericAllocationHandle)> = Vec::new();
-        while allocated_dst < dst + allocate_size as u64 {
-            let handle = unsafe {
-                match vpmm_create_physical(self.device_id, self.page_size) {
-                    Ok(handle) => handle,
-                    Err(e) => {
-                        tracing::error!(
-                            "vpmm_create_physical failed: device={}, page_size={}: {:?}",
-                            self.device_id,
-                            self.page_size,
-                            e
-                        );
-                        if e.is_out_of_memory() {
-                            self.rollback_new_pages(dst, requested, &allocated_pages);
-                            return Err(MemoryError::OutOfMemory {
-                                requested: allocate_size,
-                                available: (allocated_dst - dst) as usize,
-                            });
-                        } else {
-                            return Err(MemoryError::from(e));
-                        }
-                    }
-                }
-            };
-            unsafe {
-                vpmm_map(allocated_dst, self.page_size, handle).map_err(|e| {
-                    tracing::error!(
-                        "vpmm_map failed: addr={:#x}, page_size={}, handle={}: {:?}",
-                        allocated_dst,
-                        self.page_size,
-                        handle,
-                        e
-                    );
-                    MemoryError::from(e)
-                })?;
-            }
-            self.active_pages.insert(allocated_dst, handle);
-            allocated_pages.push((allocated_dst, handle));
-            allocated_dst += self.page_size as u64;
-        }
-        debug_assert_eq!(allocated_dst, dst + allocate_size as u64);
-        if allocate_size > 0 {
-            tracing::debug!(
-                "VPMM: Allocated {} bytes on stream {}. Total allocated: {}",
-                ByteSize::b(allocate_size as u64),
-                stream_id,
-                ByteSize::b(self.memory_usage() as u64)
-            );
-            unsafe {
-                vpmm_set_access(dst, allocate_size, self.device_id).map_err(|e| {
-                    tracing::error!(
-                        "vpmm_set_access failed: addr={:#x}, size={}, device={}: {:?}",
-                        dst,
-                        allocate_size,
-                        self.device_id,
-                        e
-                    );
-                    MemoryError::from(e)
-                })?;
-            }
-            let (merged_ptr, merged_size) = self.free_region_insert(dst, allocate_size, stream_id);
-            debug_assert!(merged_size >= allocate_size);
-            allocated_ptr = merged_ptr;
-            allocate_size = merged_size;
-        }
-
-        let mut remaining = requested.saturating_sub(allocate_size);
-        if remaining == 0 {
-            debug_assert_ne!(
-                allocated_ptr,
-                CUdeviceptr::MAX,
-                "Allocation returned no valid free region"
-            );
-            return Ok(Some(allocated_ptr));
-        }
-        debug_assert!(allocate_size == 0 || allocated_ptr <= dst);
-
-        // Pull free regions (current stream first, the other stream oldest first)
-        let mut to_defrag: Vec<(CUdeviceptr, usize)> = Vec::new();
-        let mut ordered_free_regions: Vec<_> = self
-            .free_regions
-            .iter()
-            .filter(|(&addr, _)| allocate_size == 0 || addr != allocated_ptr)
-            .map(|(&addr, region)| (region.stream_id != stream_id, region.id, addr))
-            .collect();
-        ordered_free_regions.sort_by_key(|(is_other, id, _)| (*is_other, *id));
-        for (other_stream, _, addr) in ordered_free_regions {
-            if remaining == 0 {
-                break;
-            }
-
-            let region = self
-                .free_regions
-                .remove(&addr)
-                .expect("BUG: free region disappeared");
-
-            if other_stream && !region.event.completed() {
-                default_stream_wait(&region.event)?;
-            }
-
-            let take = remaining.min(region.size);
-
-            self.zombie_regions.push(ZombieRegion {
-                ptr: addr,
-                size: take,
-                event: region.event.clone(),
-            });
-
-            to_defrag.push((addr, take));
-            remaining -= take;
-
-            if region.size > take {
-                let leftover_addr = addr + take as u64;
-                let leftover_size = region.size - take;
-                self.reinsert_split_free_region(leftover_addr, leftover_size, region);
-            }
-        }
-        let remapped_ptr = self.remap_regions(to_defrag, allocated_dst, stream_id)?;
-        let result = std::cmp::min(allocated_ptr, remapped_ptr);
-        debug_assert!(allocate_size == 0 || allocated_ptr == remapped_ptr);
-        debug_assert_ne!(
-            result,
-            CUdeviceptr::MAX,
-            "Both allocation and remapping returned no valid free region"
-        );
-        Ok(Some(result))
-    }
-
-    // ========================================================================
-    // Defragmentation — tracked (explicit-stream) path
-    // ========================================================================
-
-    fn defragment_or_create_new_pages_on(
-        &mut self,
-        requested: usize,
         stream: &StreamGuard,
     ) -> Result<Option<CUdeviceptr>, MemoryError> {
         debug_assert_eq!(requested % self.page_size, 0);
@@ -853,7 +533,7 @@ impl VirtualMemoryPool {
 
         let total_free_size = self.free_regions.values().map(|r| r.size).sum::<usize>();
         tracing::debug!(
-            "VPMM: Defragging or creating new pages (tracked): requested={}, free={}",
+            "VPMM: Defragging or creating new pages: requested={}, free={}",
             ByteSize::b(requested as u64),
             ByteSize::b(total_free_size as u64),
         );
@@ -907,7 +587,7 @@ impl VirtualMemoryPool {
         debug_assert_eq!(allocated_dst, dst + allocate_size as u64);
         if allocate_size > 0 {
             tracing::debug!(
-                "VPMM: Allocated {} bytes (tracked). Total allocated: {}",
+                "VPMM: Allocated {} bytes. Total allocated: {}",
                 ByteSize::b(allocate_size as u64),
                 ByteSize::b(self.memory_usage() as u64)
             );
@@ -923,7 +603,7 @@ impl VirtualMemoryPool {
                     MemoryError::from(e)
                 })?;
             }
-            let (merged_ptr, merged_size) = self.free_region_insert_on(dst, allocate_size, stream);
+            let (merged_ptr, merged_size) = self.free_region_insert(dst, allocate_size, stream);
             debug_assert!(merged_size >= allocate_size);
             allocated_ptr = merged_ptr;
             allocate_size = merged_size;
@@ -946,13 +626,7 @@ impl VirtualMemoryPool {
             .free_regions
             .iter()
             .filter(|(&addr, _)| allocate_size == 0 || addr != allocated_ptr)
-            .map(|(&addr, region)| {
-                let is_other = !region
-                    .stream
-                    .as_ref()
-                    .is_some_and(|s| s.is_same_stream(stream));
-                (is_other, region.id, addr)
-            })
+            .map(|(&addr, region)| (!region.stream.is_same_stream(stream), region.id, addr))
             .collect();
         ordered_free_regions.sort_by_key(|(is_other, id, _)| (*is_other, *id));
         for (other_stream, _, addr) in ordered_free_regions {
@@ -987,7 +661,7 @@ impl VirtualMemoryPool {
                 self.reinsert_split_free_region(leftover_addr, leftover_size, region);
             }
         }
-        let remapped_ptr = self.remap_regions_on(to_defrag, allocated_dst, stream)?;
+        let remapped_ptr = self.remap_regions(to_defrag, allocated_dst, stream)?;
         let result = std::cmp::min(allocated_ptr, remapped_ptr);
         debug_assert!(allocate_size == 0 || allocated_ptr == remapped_ptr);
         debug_assert_ne!(
@@ -998,15 +672,11 @@ impl VirtualMemoryPool {
         Ok(Some(result))
     }
 
-    // ========================================================================
-    // Remap regions — legacy
-    // ========================================================================
-
     fn remap_regions(
         &mut self,
         regions: Vec<(CUdeviceptr, usize)>,
         dst: CUdeviceptr,
-        stream_id: CudaStreamId,
+        stream: &StreamGuard,
     ) -> Result<CUdeviceptr, MemoryError> {
         if regions.is_empty() {
             return Ok(CUdeviceptr::MAX);
@@ -1059,72 +729,7 @@ impl VirtualMemoryPool {
                 MemoryError::from(e)
             })?;
         }
-        let (remapped_ptr, _) = self.free_region_insert(dst, bytes_to_remap, stream_id);
-        Ok(remapped_ptr)
-    }
-
-    // ========================================================================
-    // Remap regions — tracked
-    // ========================================================================
-
-    fn remap_regions_on(
-        &mut self,
-        regions: Vec<(CUdeviceptr, usize)>,
-        dst: CUdeviceptr,
-        stream: &StreamGuard,
-    ) -> Result<CUdeviceptr, MemoryError> {
-        if regions.is_empty() {
-            return Ok(CUdeviceptr::MAX);
-        }
-
-        let bytes_to_remap = regions.iter().map(|(_, size)| *size).sum::<usize>();
-        tracing::debug!(
-            "VPMM: Remapping {} regions (tracked). Total size = {}",
-            regions.len(),
-            ByteSize::b(bytes_to_remap as u64)
-        );
-
-        let mut curr_dst = dst;
-        for (region_addr, region_size) in regions {
-            let num_pages = region_size / self.page_size;
-            for i in 0..num_pages {
-                let page = region_addr + (i * self.page_size) as u64;
-                let handle = self
-                    .active_pages
-                    .remove(&page)
-                    .expect("BUG: active page not found during remapping");
-                unsafe {
-                    vpmm_map(curr_dst, self.page_size, handle).map_err(|e| {
-                        tracing::error!(
-                            "vpmm_map (remap) failed: dst={:#x}, page_size={}, handle={}: {:?}",
-                            curr_dst,
-                            self.page_size,
-                            handle,
-                            e
-                        );
-                        MemoryError::from(e)
-                    })?;
-                }
-                self.active_pages.insert(curr_dst, handle);
-                curr_dst += self.page_size as u64;
-            }
-        }
-
-        debug_assert_eq!(curr_dst - dst, bytes_to_remap as u64);
-
-        unsafe {
-            vpmm_set_access(dst, bytes_to_remap, self.device_id).map_err(|e| {
-                tracing::error!(
-                    "vpmm_set_access (remap) failed: addr={:#x}, size={}, device={}: {:?}",
-                    dst,
-                    bytes_to_remap,
-                    self.device_id,
-                    e
-                );
-                MemoryError::from(e)
-            })?;
-        }
-        let (remapped_ptr, _) = self.free_region_insert_on(dst, bytes_to_remap, stream);
+        let (remapped_ptr, _) = self.free_region_insert(dst, bytes_to_remap, stream);
         Ok(remapped_ptr)
     }
 
@@ -1136,7 +741,7 @@ impl VirtualMemoryPool {
 
 impl Drop for VirtualMemoryPool {
     fn drop(&mut self) {
-        current_stream_sync().unwrap();
+        device_synchronize().unwrap();
 
         // Unmap zombie regions first
         for zombie in self.zombie_regions.drain(..) {
@@ -1196,7 +801,11 @@ impl std::fmt::Debug for VirtualMemoryPool {
 
         let mut regions: Vec<(CUdeviceptr, usize, String)> = Vec::new();
         for (addr, region) in &self.free_regions {
-            regions.push((*addr, region.size, format!("free (s {})", region.stream_id)));
+            regions.push((
+                *addr,
+                region.size,
+                format!("free ({:?})", region.stream.as_raw()),
+            ));
         }
         for (addr, record) in &self.malloc_regions {
             regions.push((*addr, record.size(), "malloc".to_string()));
@@ -1219,7 +828,11 @@ mod tests {
     use std::sync::Arc;
 
     use super::{FreeRegionMeta, VirtualMemoryPool, VpmmConfig};
-    use crate::stream::{current_stream_id, CudaEvent, CudaStream};
+    use crate::stream::{CudaEvent, CudaStream, StreamGuard};
+
+    fn test_stream() -> StreamGuard {
+        StreamGuard::new(CudaStream::new_non_blocking().unwrap())
+    }
 
     #[test]
     fn test_defrag_leftover_preserves_original_metadata() {
@@ -1236,35 +849,30 @@ mod tests {
         }
 
         let page_size = pool.page_size;
-        let stream_id = current_stream_id().unwrap();
-        let other_stream_id = stream_id + 1000;
-        #[allow(deprecated)]
-        let foreign_stream = CudaStream::new().unwrap();
+        let stream = test_stream();
+        let foreign_stream = test_stream();
 
-        let ptr = pool.malloc_internal(2 * page_size, stream_id).unwrap();
-        pool.free_internal(ptr, stream_id).unwrap();
+        let ptr = pool.malloc_internal(2 * page_size, &stream).unwrap();
+        pool.free_internal(ptr).unwrap();
 
         let (&free_addr, region) = pool.free_regions.iter_mut().next().unwrap();
         let original_event = Arc::new(CudaEvent::new().unwrap());
-        unsafe {
-            original_event.record(foreign_stream.as_raw()).unwrap();
-        }
+        original_event.record_on(&foreign_stream).unwrap();
         *region = FreeRegionMeta {
             size: region.size,
             event: original_event.clone(),
-            stream_id: other_stream_id,
-            stream: None,
+            stream: foreign_stream.clone(),
             id: 42,
         };
 
         let leftover_addr = free_addr + page_size as u64;
-        pool.defragment_or_create_new_pages(page_size, stream_id)
+        pool.defragment_or_create_new_pages(page_size, &stream)
             .unwrap()
             .unwrap();
 
         let leftover = pool.free_regions.get(&leftover_addr).unwrap();
         assert_eq!(leftover.size, page_size);
-        assert_eq!(leftover.stream_id, other_stream_id);
+        assert!(leftover.stream.is_same_stream(&foreign_stream));
         assert_eq!(leftover.id, 42);
         assert!(Arc::ptr_eq(&leftover.event, &original_event));
     }

--- a/crates/cuda-common/src/memory_manager/vm_pool.rs
+++ b/crates/cuda-common/src/memory_manager/vm_pool.rs
@@ -14,6 +14,7 @@ use crate::{
     error::MemoryError,
     stream::{
         current_stream_id, current_stream_sync, default_stream_wait, CudaEvent, CudaStreamId,
+        StreamGuard,
     },
 };
 
@@ -87,6 +88,27 @@ impl VpmmConfig {
 }
 
 // ============================================================================
+// VPMM allocation records
+// ============================================================================
+
+/// Allocation record for the VPMM path.
+pub(super) enum VpmmRecord {
+    /// Legacy PTDS allocation (during transition).
+    Legacy { size: usize },
+    /// Tracked allocation on an explicit stream.
+    Tracked { size: usize, stream: StreamGuard },
+}
+
+impl VpmmRecord {
+    pub(super) fn size(&self) -> usize {
+        match self {
+            VpmmRecord::Legacy { size } => *size,
+            VpmmRecord::Tracked { size, .. } => *size,
+        }
+    }
+}
+
+// ============================================================================
 // Pool Implementation
 // ============================================================================
 
@@ -96,6 +118,8 @@ struct FreeRegionMeta {
     size: usize,
     event: Arc<CudaEvent>,
     stream_id: CudaStreamId,
+    /// `Some` for tracked (explicit-stream) regions, `None` for legacy PTDS regions.
+    stream: Option<StreamGuard>,
     id: usize,
 }
 
@@ -118,8 +142,8 @@ pub(super) struct VirtualMemoryPool {
     // Free regions in virtual space (sorted by address)
     free_regions: BTreeMap<CUdeviceptr, FreeRegionMeta>,
 
-    // Active allocations: (ptr, size)
-    malloc_regions: HashMap<CUdeviceptr, usize>,
+    // Active allocations: (ptr, record)
+    malloc_regions: HashMap<CUdeviceptr, VpmmRecord>,
 
     // Unmapped regions: (ptr, size)
     unmapped_regions: BTreeMap<CUdeviceptr, usize>,
@@ -237,9 +261,11 @@ impl VirtualMemoryPool {
         pool
     }
 
-    /// Allocates memory from the pool's free regions.
-    /// Attempts defragmentation if no suitable free region exists.
-    /// Returns an error if there's insufficient memory even after defragmentation.
+    // ========================================================================
+    // Legacy PTDS path
+    // ========================================================================
+
+    /// Allocates memory from the pool's free regions (legacy PTDS path).
     pub(super) fn malloc_internal(
         &mut self,
         requested: usize,
@@ -277,7 +303,8 @@ impl VirtualMemoryPool {
                 );
             }
 
-            self.malloc_regions.insert(ptr, requested);
+            self.malloc_regions
+                .insert(ptr, VpmmRecord::Legacy { size: requested });
             return Ok(ptr as *mut c_void);
         }
 
@@ -287,11 +314,130 @@ impl VirtualMemoryPool {
         })
     }
 
+    // ========================================================================
+    // Tracked (explicit-stream) path
+    // ========================================================================
+
+    /// Allocates memory from the pool's free regions (explicit-stream path).
+    pub(super) fn malloc_internal_on(
+        &mut self,
+        requested: usize,
+        stream: &StreamGuard,
+    ) -> Result<*mut c_void, MemoryError> {
+        debug_assert!(
+            requested != 0 && requested.is_multiple_of(self.page_size),
+            "Requested size must be a multiple of the page size"
+        );
+
+        self.cleanup_zombie_regions();
+
+        let mut best_region = self.find_best_fit_on(requested, stream);
+
+        if best_region.is_none() {
+            best_region = self.defragment_or_create_new_pages_on(requested, stream)?;
+        }
+
+        if let Some(ptr) = best_region {
+            let region = self
+                .free_regions
+                .remove(&ptr)
+                .expect("BUG: free region address not found after find_best_fit_on");
+
+            if region.size > requested {
+                self.reinsert_split_free_region(
+                    ptr + requested as u64,
+                    region.size - requested,
+                    region,
+                );
+            }
+
+            self.malloc_regions.insert(
+                ptr,
+                VpmmRecord::Tracked {
+                    size: requested,
+                    stream: stream.clone(),
+                },
+            );
+            return Ok(ptr as *mut c_void);
+        }
+
+        Err(MemoryError::OutOfMemory {
+            requested,
+            available: self.free_regions.values().map(|r| r.size).sum(),
+        })
+    }
+
+    /// Phase 1 best-fit for the tracked path: prefers same-stream via `Arc::ptr_eq`.
+    fn find_best_fit_on(&mut self, requested: usize, stream: &StreamGuard) -> Option<CUdeviceptr> {
+        let mut candidates: Vec<(CUdeviceptr, &mut FreeRegionMeta)> = self
+            .free_regions
+            .iter_mut()
+            .filter(|(_, region)| region.size >= requested)
+            .map(|(addr, region)| (*addr, region))
+            .collect();
+
+        if candidates.is_empty() {
+            return None;
+        }
+
+        // 1a. Prefer same stream (smallest fit) — could be not completed
+        if let Some((addr, _)) = candidates
+            .iter()
+            .filter(|(_, region)| {
+                region
+                    .stream
+                    .as_ref()
+                    .is_some_and(|s| s.is_same_stream(stream))
+            })
+            .min_by_key(|(_, region)| region.size)
+        {
+            return Some(*addr);
+        }
+
+        // 1b. Other streams (smallest fit) — ONLY if already completed (no sync)
+        candidates
+            .iter_mut()
+            .filter(|(_, region)| region.event.completed())
+            .min_by_key(|(_, region)| region.size)
+            .map(|(addr, region)| {
+                region.stream = Some(stream.clone());
+                *addr
+            })
+    }
+
+    /// Frees a pointer and returns `(size, Option<StreamGuard>)`.
+    /// The `StreamGuard` must be dropped by the caller AFTER releasing the memory manager lock.
+    pub(super) fn free_internal(
+        &mut self,
+        ptr: *mut c_void,
+        stream_id: CudaStreamId,
+    ) -> Result<(usize, Option<StreamGuard>), MemoryError> {
+        let ptr = ptr as CUdeviceptr;
+        let record = self
+            .malloc_regions
+            .remove(&ptr)
+            .ok_or(MemoryError::InvalidPointer)?;
+
+        let size = record.size();
+        let guard = match record {
+            VpmmRecord::Legacy { .. } => {
+                self.free_region_insert(ptr, size, stream_id);
+                None
+            }
+            VpmmRecord::Tracked { stream, .. } => {
+                self.free_region_insert_on(ptr, size, &stream);
+                Some(stream)
+            }
+        };
+
+        Ok((size, guard))
+    }
+
+    // ========================================================================
+    // Shared helpers
+    // ========================================================================
+
     /// Reclaims zombie regions whose events have completed.
-    ///
-    /// Zombies are old regions that have been double-mapped to new locations during defrag.
-    /// Once the associated event completes (meaning no GPU work is using the old VA),
-    /// we can safely unmap the old VA and return it to `unmapped_regions` for reuse.
     fn cleanup_zombie_regions(&mut self) {
         let mut i = 0;
         while i < self.zombie_regions.len() {
@@ -312,8 +458,7 @@ impl VirtualMemoryPool {
         }
     }
 
-    /// Phase 1: Try to find a suitable free region without defragmentation
-    /// Returns address if found, None otherwise
+    /// Phase 1: Try to find a suitable free region without defragmentation (legacy path)
     fn find_best_fit(&mut self, requested: usize, stream_id: CudaStreamId) -> Option<CUdeviceptr> {
         let mut candidates: Vec<(CUdeviceptr, &mut FreeRegionMeta)> = self
             .free_regions
@@ -346,35 +491,7 @@ impl VirtualMemoryPool {
             })
     }
 
-    /// Frees a pointer and returns the size of the freed memory.
-    /// Coalesces adjacent free regions.
-    ///
-    /// # Assumptions
-    /// No CUDA streams will use the malloc region starting at `ptr` after the newly recorded event
-    /// on `stream_id` at this point in time.
-    pub(super) fn free_internal(
-        &mut self,
-        ptr: *mut c_void,
-        stream_id: CudaStreamId,
-    ) -> Result<usize, MemoryError> {
-        let ptr = ptr as CUdeviceptr;
-        let size = self
-            .malloc_regions
-            .remove(&ptr)
-            .ok_or(MemoryError::InvalidPointer)?;
-
-        let _ = self.free_region_insert(ptr, size, stream_id);
-
-        Ok(size)
-    }
-
-    /// Inserts a new free region for `(ptr, size)` into the free regions map, **possibly** merging
-    /// with existing adjacent regions. Merges only occur if the regions are both adjacent in memory
-    /// and on the same stream as `stream_id`. The new free region always records a new event on the
-    /// stream.
-    ///
-    /// Returns the starting pointer and size of the (possibly merged) free region containing `(ptr,
-    /// size)`.
+    /// Legacy PTDS path: inserts a new free region, possibly merging with adjacent regions.
     fn free_region_insert(
         &mut self,
         mut ptr: CUdeviceptr,
@@ -409,6 +526,55 @@ impl VirtualMemoryPool {
                 size,
                 event,
                 stream_id,
+                stream: None,
+                id,
+            },
+        );
+        (ptr, size)
+    }
+
+    /// Tracked path: inserts a new free region, merging with adjacent same-stream regions.
+    fn free_region_insert_on(
+        &mut self,
+        mut ptr: CUdeviceptr,
+        mut size: usize,
+        stream: &StreamGuard,
+    ) -> (CUdeviceptr, usize) {
+        // Potential merge with next neighbor
+        if let Some((&next_ptr, next_region)) = self.free_regions.range(ptr + 1..).next() {
+            let same_stream = next_region
+                .stream
+                .as_ref()
+                .is_some_and(|s| s.is_same_stream(stream));
+            if same_stream && ptr + size as u64 == next_ptr {
+                let next_region = self.free_regions.remove(&next_ptr).unwrap();
+                size += next_region.size;
+            }
+        }
+        // Potential merge with previous neighbor
+        if let Some((&prev_ptr, prev_region)) = self.free_regions.range(..ptr).next_back() {
+            let same_stream = prev_region
+                .stream
+                .as_ref()
+                .is_some_and(|s| s.is_same_stream(stream));
+            if same_stream && prev_ptr + prev_region.size as u64 == ptr {
+                let prev_region = self.free_regions.remove(&prev_ptr).unwrap();
+                ptr = prev_ptr;
+                size += prev_region.size;
+            }
+        }
+        let event = Arc::new(CudaEvent::new().unwrap());
+        event.record_on(stream).unwrap();
+        let id = self.free_num;
+        self.free_num += 1;
+
+        self.free_regions.insert(
+            ptr,
+            FreeRegionMeta {
+                size,
+                event,
+                stream_id: 0, // not used in tracked path
+                stream: Some(stream.clone()),
                 id,
             },
         );
@@ -416,9 +582,6 @@ impl VirtualMemoryPool {
     }
 
     /// Reinsert the untouched tail of a split free region without recording a new event.
-    ///
-    /// No new synchronization point was created for these pages, so they must keep the original
-    /// event, stream affinity, and age ordering.
     fn reinsert_split_free_region(
         &mut self,
         ptr: CUdeviceptr,
@@ -431,9 +594,6 @@ impl VirtualMemoryPool {
     }
 
     /// Return the base address of a virtual hole large enough for `requested` bytes.
-    ///
-    /// The returned region is not inside `free_region` or `unmapped_region` map and must be
-    /// properly handled.
     fn take_unmapped_region(&mut self, requested: usize) -> Result<CUdeviceptr, MemoryError> {
         debug_assert!(requested != 0);
         debug_assert_eq!(requested % self.page_size, 0);
@@ -495,7 +655,6 @@ impl VirtualMemoryPool {
     }
 
     /// Roll back partially allocated pages when allocation fails.
-    /// Unmaps and releases any mapped pages and restores the reserved VA span.
     fn rollback_new_pages(
         &mut self,
         reserved_ptr: CUdeviceptr,
@@ -519,12 +678,10 @@ impl VirtualMemoryPool {
         self.insert_unmapped_region(reserved_ptr, reserved_size);
     }
 
-    /// Defragments the pool by reusing existing holes and, if needed, reserving more VA space.
-    /// Moves just enough pages to satisfy `requested`, keeping the remainder in place.
-    ///
-    /// The returned `pointer`, if not `None`, is guaranteed to exist as a key in the `free_regions`
-    /// map. The corresponding free region will have size `>= requested`. Note the size _may_ be
-    /// larger than requested.
+    // ========================================================================
+    // Defragmentation — legacy PTDS path
+    // ========================================================================
+
     fn defragment_or_create_new_pages(
         &mut self,
         requested: usize,
@@ -617,15 +774,7 @@ impl VirtualMemoryPool {
             allocated_ptr = merged_ptr;
             allocate_size = merged_size;
         }
-        // At this point, allocated_ptr is either
-        // - CUdeviceptr::MAX if no allocations occurred
-        // - or some pointer `<= dst` for the start of a free region (with VA-mapping) of at least
-        //   `requested` bytes. The case `allocated_ptr < dst` happens if `free_region_insert`
-        //   merged the allocated region with a previous free region. This only happens if the
-        //   previous free region is on the same `stream_id`. In this case, we have
-        //   [allocated_ptr..dst][dst..allocated_dst] which is all free and safe to use on the
-        //   stream `stream_id` _without_ synchronization, because all events will be sequenced
-        //   afterwards on the stream.
+
         let mut remaining = requested.saturating_sub(allocate_size);
         if remaining == 0 {
             debug_assert_ne!(
@@ -637,8 +786,7 @@ impl VirtualMemoryPool {
         }
         debug_assert!(allocate_size == 0 || allocated_ptr <= dst);
 
-        // Pull free regions (current stream first, the other stream oldest first) until we've
-        // gathered enough pages.
+        // Pull free regions (current stream first, the other stream oldest first)
         let mut to_defrag: Vec<(CUdeviceptr, usize)> = Vec::new();
         let mut ordered_free_regions: Vec<_> = self
             .free_regions
@@ -658,7 +806,6 @@ impl VirtualMemoryPool {
                 .expect("BUG: free region disappeared");
 
             if other_stream && !region.event.completed() {
-                // default_stream_wait always uses current stream (= stream_id)
                 default_stream_wait(&region.event)?;
             }
 
@@ -674,14 +821,12 @@ impl VirtualMemoryPool {
             remaining -= take;
 
             if region.size > take {
-                // Return the untouched tail with its original guard metadata.
                 let leftover_addr = addr + take as u64;
                 let leftover_size = region.size - take;
                 self.reinsert_split_free_region(leftover_addr, leftover_size, region);
             }
         }
         let remapped_ptr = self.remap_regions(to_defrag, allocated_dst, stream_id)?;
-        // Take the minimum in case allocated_ptr is CUdeviceptr::MAX when allocate_size = 0
         let result = std::cmp::min(allocated_ptr, remapped_ptr);
         debug_assert!(allocate_size == 0 || allocated_ptr == remapped_ptr);
         debug_assert_ne!(
@@ -692,16 +837,171 @@ impl VirtualMemoryPool {
         Ok(Some(result))
     }
 
-    /// Remap a list of regions to a new base address via double-mapping.
-    ///
-    /// The regions are mapped consecutively starting at `dst`. The old regions remain mapped
-    /// (double-mapped) and are added to `zombie_regions` by the caller for async unmap.
-    ///
-    /// Returns the starting pointer of the new remapped free region or `CUdeviceptr::MAX` if no
-    /// remapping is needed.
-    ///
-    /// # Assumptions
-    /// The regions are already removed from the free regions map.
+    // ========================================================================
+    // Defragmentation — tracked (explicit-stream) path
+    // ========================================================================
+
+    fn defragment_or_create_new_pages_on(
+        &mut self,
+        requested: usize,
+        stream: &StreamGuard,
+    ) -> Result<Option<CUdeviceptr>, MemoryError> {
+        debug_assert_eq!(requested % self.page_size, 0);
+        if requested == 0 {
+            return Ok(None);
+        }
+
+        let total_free_size = self.free_regions.values().map(|r| r.size).sum::<usize>();
+        tracing::debug!(
+            "VPMM: Defragging or creating new pages (tracked): requested={}, free={}",
+            ByteSize::b(requested as u64),
+            ByteSize::b(total_free_size as u64),
+        );
+
+        let dst = self.take_unmapped_region(requested)?;
+        let mut allocated_ptr = CUdeviceptr::MAX;
+
+        let mut allocated_dst = dst;
+        let mut allocate_size = requested.saturating_sub(total_free_size);
+        debug_assert_eq!(allocate_size % self.page_size, 0);
+        let mut allocated_pages: Vec<(CUdeviceptr, CUmemGenericAllocationHandle)> = Vec::new();
+        while allocated_dst < dst + allocate_size as u64 {
+            let handle = unsafe {
+                match vpmm_create_physical(self.device_id, self.page_size) {
+                    Ok(handle) => handle,
+                    Err(e) => {
+                        tracing::error!(
+                            "vpmm_create_physical failed: device={}, page_size={}: {:?}",
+                            self.device_id,
+                            self.page_size,
+                            e
+                        );
+                        if e.is_out_of_memory() {
+                            self.rollback_new_pages(dst, requested, &allocated_pages);
+                            return Err(MemoryError::OutOfMemory {
+                                requested: allocate_size,
+                                available: (allocated_dst - dst) as usize,
+                            });
+                        } else {
+                            return Err(MemoryError::from(e));
+                        }
+                    }
+                }
+            };
+            unsafe {
+                vpmm_map(allocated_dst, self.page_size, handle).map_err(|e| {
+                    tracing::error!(
+                        "vpmm_map failed: addr={:#x}, page_size={}, handle={}: {:?}",
+                        allocated_dst,
+                        self.page_size,
+                        handle,
+                        e
+                    );
+                    MemoryError::from(e)
+                })?;
+            }
+            self.active_pages.insert(allocated_dst, handle);
+            allocated_pages.push((allocated_dst, handle));
+            allocated_dst += self.page_size as u64;
+        }
+        debug_assert_eq!(allocated_dst, dst + allocate_size as u64);
+        if allocate_size > 0 {
+            tracing::debug!(
+                "VPMM: Allocated {} bytes (tracked). Total allocated: {}",
+                ByteSize::b(allocate_size as u64),
+                ByteSize::b(self.memory_usage() as u64)
+            );
+            unsafe {
+                vpmm_set_access(dst, allocate_size, self.device_id).map_err(|e| {
+                    tracing::error!(
+                        "vpmm_set_access failed: addr={:#x}, size={}, device={}: {:?}",
+                        dst,
+                        allocate_size,
+                        self.device_id,
+                        e
+                    );
+                    MemoryError::from(e)
+                })?;
+            }
+            let (merged_ptr, merged_size) = self.free_region_insert_on(dst, allocate_size, stream);
+            debug_assert!(merged_size >= allocate_size);
+            allocated_ptr = merged_ptr;
+            allocate_size = merged_size;
+        }
+
+        let mut remaining = requested.saturating_sub(allocate_size);
+        if remaining == 0 {
+            debug_assert_ne!(
+                allocated_ptr,
+                CUdeviceptr::MAX,
+                "Allocation returned no valid free region"
+            );
+            return Ok(Some(allocated_ptr));
+        }
+        debug_assert!(allocate_size == 0 || allocated_ptr <= dst);
+
+        // Pull free regions; prefer same stream, then oldest-first for other streams
+        let mut to_defrag: Vec<(CUdeviceptr, usize)> = Vec::new();
+        let mut ordered_free_regions: Vec<_> = self
+            .free_regions
+            .iter()
+            .filter(|(&addr, _)| allocate_size == 0 || addr != allocated_ptr)
+            .map(|(&addr, region)| {
+                let is_other = !region
+                    .stream
+                    .as_ref()
+                    .is_some_and(|s| s.is_same_stream(stream));
+                (is_other, region.id, addr)
+            })
+            .collect();
+        ordered_free_regions.sort_by_key(|(is_other, id, _)| (*is_other, *id));
+        for (other_stream, _, addr) in ordered_free_regions {
+            if remaining == 0 {
+                break;
+            }
+
+            let region = self
+                .free_regions
+                .remove(&addr)
+                .expect("BUG: free region disappeared");
+
+            if other_stream && !region.event.completed() {
+                // Make the caller's stream wait on the cross-stream event
+                stream.wait(&region.event)?;
+            }
+
+            let take = remaining.min(region.size);
+
+            self.zombie_regions.push(ZombieRegion {
+                ptr: addr,
+                size: take,
+                event: region.event.clone(),
+            });
+
+            to_defrag.push((addr, take));
+            remaining -= take;
+
+            if region.size > take {
+                let leftover_addr = addr + take as u64;
+                let leftover_size = region.size - take;
+                self.reinsert_split_free_region(leftover_addr, leftover_size, region);
+            }
+        }
+        let remapped_ptr = self.remap_regions_on(to_defrag, allocated_dst, stream)?;
+        let result = std::cmp::min(allocated_ptr, remapped_ptr);
+        debug_assert!(allocate_size == 0 || allocated_ptr == remapped_ptr);
+        debug_assert_ne!(
+            result,
+            CUdeviceptr::MAX,
+            "Both allocation and remapping returned no valid free region"
+        );
+        Ok(Some(result))
+    }
+
+    // ========================================================================
+    // Remap regions — legacy
+    // ========================================================================
+
     fn remap_regions(
         &mut self,
         regions: Vec<(CUdeviceptr, usize)>,
@@ -709,7 +1009,6 @@ impl VirtualMemoryPool {
         stream_id: CudaStreamId,
     ) -> Result<CUdeviceptr, MemoryError> {
         if regions.is_empty() {
-            // Nothing to remap; return sentinel so caller's min() picks the other operand
             return Ok(CUdeviceptr::MAX);
         }
 
@@ -722,7 +1021,6 @@ impl VirtualMemoryPool {
 
         let mut curr_dst = dst;
         for (region_addr, region_size) in regions {
-            // Double-map: map pages to new VA (old VA remains mapped, will be cleaned up as zombie)
             let num_pages = region_size / self.page_size;
             for i in 0..num_pages {
                 let page = region_addr + (i * self.page_size) as u64;
@@ -749,7 +1047,6 @@ impl VirtualMemoryPool {
 
         debug_assert_eq!(curr_dst - dst, bytes_to_remap as u64);
 
-        // Set access permissions for the remapped region
         unsafe {
             vpmm_set_access(dst, bytes_to_remap, self.device_id).map_err(|e| {
                 tracing::error!(
@@ -763,6 +1060,71 @@ impl VirtualMemoryPool {
             })?;
         }
         let (remapped_ptr, _) = self.free_region_insert(dst, bytes_to_remap, stream_id);
+        Ok(remapped_ptr)
+    }
+
+    // ========================================================================
+    // Remap regions — tracked
+    // ========================================================================
+
+    fn remap_regions_on(
+        &mut self,
+        regions: Vec<(CUdeviceptr, usize)>,
+        dst: CUdeviceptr,
+        stream: &StreamGuard,
+    ) -> Result<CUdeviceptr, MemoryError> {
+        if regions.is_empty() {
+            return Ok(CUdeviceptr::MAX);
+        }
+
+        let bytes_to_remap = regions.iter().map(|(_, size)| *size).sum::<usize>();
+        tracing::debug!(
+            "VPMM: Remapping {} regions (tracked). Total size = {}",
+            regions.len(),
+            ByteSize::b(bytes_to_remap as u64)
+        );
+
+        let mut curr_dst = dst;
+        for (region_addr, region_size) in regions {
+            let num_pages = region_size / self.page_size;
+            for i in 0..num_pages {
+                let page = region_addr + (i * self.page_size) as u64;
+                let handle = self
+                    .active_pages
+                    .remove(&page)
+                    .expect("BUG: active page not found during remapping");
+                unsafe {
+                    vpmm_map(curr_dst, self.page_size, handle).map_err(|e| {
+                        tracing::error!(
+                            "vpmm_map (remap) failed: dst={:#x}, page_size={}, handle={}: {:?}",
+                            curr_dst,
+                            self.page_size,
+                            handle,
+                            e
+                        );
+                        MemoryError::from(e)
+                    })?;
+                }
+                self.active_pages.insert(curr_dst, handle);
+                curr_dst += self.page_size as u64;
+            }
+        }
+
+        debug_assert_eq!(curr_dst - dst, bytes_to_remap as u64);
+
+        unsafe {
+            vpmm_set_access(dst, bytes_to_remap, self.device_id).map_err(|e| {
+                tracing::error!(
+                    "vpmm_set_access (remap) failed: addr={:#x}, size={}, device={}: {:?}",
+                    dst,
+                    bytes_to_remap,
+                    self.device_id,
+                    e
+                );
+                MemoryError::from(e)
+            })?;
+        }
+        let (remapped_ptr, _) = self.free_region_insert_on(dst, bytes_to_remap, stream);
         Ok(remapped_ptr)
     }
 
@@ -817,7 +1179,7 @@ impl std::fmt::Debug for VirtualMemoryPool {
         let reserved = self.roots.len() * self.va_size;
         let allocated = self.memory_usage();
         let free_bytes: usize = self.free_regions.values().map(|r| r.size).sum();
-        let malloc_bytes: usize = self.malloc_regions.values().sum();
+        let malloc_bytes: usize = self.malloc_regions.values().map(|r| r.size()).sum();
         let unmapped_bytes: usize = self.unmapped_regions.values().sum();
         let zombies_bytes: usize = self.zombie_regions.iter().map(|r| r.size).sum();
 
@@ -836,8 +1198,8 @@ impl std::fmt::Debug for VirtualMemoryPool {
         for (addr, region) in &self.free_regions {
             regions.push((*addr, region.size, format!("free (s {})", region.stream_id)));
         }
-        for (addr, size) in &self.malloc_regions {
-            regions.push((*addr, *size, "malloc".to_string()));
+        for (addr, record) in &self.malloc_regions {
+            regions.push((*addr, record.size(), "malloc".to_string()));
         }
         for (addr, size) in &self.unmapped_regions {
             regions.push((*addr, *size, "unmapped".to_string()));
@@ -876,6 +1238,7 @@ mod tests {
         let page_size = pool.page_size;
         let stream_id = current_stream_id().unwrap();
         let other_stream_id = stream_id + 1000;
+        #[allow(deprecated)]
         let foreign_stream = CudaStream::new().unwrap();
 
         let ptr = pool.malloc_internal(2 * page_size, stream_id).unwrap();
@@ -890,6 +1253,7 @@ mod tests {
             size: region.size,
             event: original_event.clone(),
             stream_id: other_stream_id,
+            stream: None,
             id: 42,
         };
 

--- a/crates/cuda-common/src/memory_manager/vm_pool.rs
+++ b/crates/cuda-common/src/memory_manager/vm_pool.rs
@@ -518,7 +518,7 @@ impl VirtualMemoryPool {
     }
 
     // ========================================================================
-    // Defragmentation — legacy PTDS path
+    // Defragmentation
     // ========================================================================
 
     fn defragment_or_create_new_pages(

--- a/crates/cuda-common/src/memory_manager/vm_pool.rs
+++ b/crates/cuda-common/src/memory_manager/vm_pool.rs
@@ -261,6 +261,8 @@ impl VirtualMemoryPool {
     // ========================================================================
 
     /// Allocates memory from the pool's free regions.
+    /// Attempts defragmentation if no suitable free region exists.
+    /// Returns an error if there's insufficient memory even after defragmentation.
     pub(super) fn malloc_internal(
         &mut self,
         requested: usize,
@@ -271,11 +273,14 @@ impl VirtualMemoryPool {
             "Requested size must be a multiple of the page size"
         );
 
+        // Phase 0: Cleanup zombie regions
         self.cleanup_zombie_regions();
 
+        // Phase 1: Zero-cost attempts
         let mut best_region = self.find_best_fit(requested, stream);
 
         if best_region.is_none() {
+            // Phase 2: Defragmentation
             best_region = self.defragment_or_create_new_pages(requested, stream)?;
         }
 
@@ -285,6 +290,7 @@ impl VirtualMemoryPool {
                 .remove(&ptr)
                 .expect("BUG: free region address not found after find_best_fit");
 
+            // If region is larger, return the untouched tail with its original guard metadata.
             if region.size > requested {
                 self.reinsert_split_free_region(
                     ptr + requested as u64,
@@ -325,7 +331,7 @@ impl VirtualMemoryPool {
         // 1a. Prefer same stream (smallest fit) — could be not completed
         if let Some((addr, _)) = candidates
             .iter()
-            .filter(|(_, region)| region.stream.is_same_stream(stream))
+            .filter(|(_, region)| region.stream == *stream)
             .min_by_key(|(_, region)| region.size)
         {
             return Some(*addr);
@@ -343,6 +349,9 @@ impl VirtualMemoryPool {
     }
 
     /// Frees a pointer and returns `(size, StreamGuard)`.
+    /// Frees a pointer and returns the size of the freed memory.
+    /// Coalesces adjacent free regions.
+    ///
     /// The `StreamGuard` must be dropped by the caller AFTER releasing the memory manager lock.
     pub(super) fn free_internal(
         &mut self,
@@ -365,6 +374,10 @@ impl VirtualMemoryPool {
     // ========================================================================
 
     /// Reclaims zombie regions whose events have completed.
+    ///
+    /// Zombies are old regions that have been double-mapped to new locations during defrag.
+    /// Once the associated event completes (meaning no GPU work is using the old VA),
+    /// we can safely unmap the old VA and return it to `unmapped_regions` for reuse.
     fn cleanup_zombie_regions(&mut self) {
         let mut i = 0;
         while i < self.zombie_regions.len() {
@@ -385,7 +398,10 @@ impl VirtualMemoryPool {
         }
     }
 
-    /// Inserts a new free region, possibly merging with adjacent same-stream regions.
+    /// Inserts a new free region for `(ptr, size)` into the free regions map, possibly merging
+    /// with adjacent same-stream regions. Records a new event on the stream.
+    ///
+    /// Returns the starting pointer and size of the (possibly merged) free region.
     fn free_region_insert(
         &mut self,
         mut ptr: CUdeviceptr,
@@ -394,16 +410,14 @@ impl VirtualMemoryPool {
     ) -> (CUdeviceptr, usize) {
         // Potential merge with next neighbor
         if let Some((&next_ptr, next_region)) = self.free_regions.range(ptr + 1..).next() {
-            if next_region.stream.is_same_stream(stream) && ptr + size as u64 == next_ptr {
+            if next_region.stream == *stream && ptr + size as u64 == next_ptr {
                 let next_region = self.free_regions.remove(&next_ptr).unwrap();
                 size += next_region.size;
             }
         }
         // Potential merge with previous neighbor
         if let Some((&prev_ptr, prev_region)) = self.free_regions.range(..ptr).next_back() {
-            if prev_region.stream.is_same_stream(stream)
-                && prev_ptr + prev_region.size as u64 == ptr
-            {
+            if prev_region.stream == *stream && prev_ptr + prev_region.size as u64 == ptr {
                 let prev_region = self.free_regions.remove(&prev_ptr).unwrap();
                 ptr = prev_ptr;
                 size += prev_region.size;
@@ -427,6 +441,9 @@ impl VirtualMemoryPool {
     }
 
     /// Reinsert the untouched tail of a split free region without recording a new event.
+    ///
+    /// No new synchronization point was created for these pages, so they keep the original
+    /// event, stream affinity, and age ordering.
     fn reinsert_split_free_region(
         &mut self,
         ptr: CUdeviceptr,
@@ -527,6 +544,10 @@ impl VirtualMemoryPool {
     // Defragmentation
     // ========================================================================
 
+    /// Defragments the pool by reusing existing holes and, if needed, reserving more VA space.
+    /// Moves just enough pages to satisfy `requested`, keeping the remainder in place.
+    ///
+    /// The returned pointer, if not `None`, is guaranteed to exist as a key in `free_regions`.
     fn defragment_or_create_new_pages(
         &mut self,
         requested: usize,
@@ -544,7 +565,9 @@ impl VirtualMemoryPool {
             ByteSize::b(total_free_size as u64),
         );
 
+        // Find a best fit unmapped region
         let dst = self.take_unmapped_region(requested)?;
+        // Sentinel value until we have a valid free region pointer from allocation
         let mut allocated_ptr = CUdeviceptr::MAX;
 
         let mut allocated_dst = dst;
@@ -632,7 +655,7 @@ impl VirtualMemoryPool {
             .free_regions
             .iter()
             .filter(|(&addr, _)| allocate_size == 0 || addr != allocated_ptr)
-            .map(|(&addr, region)| (!region.stream.is_same_stream(stream), region.id, addr))
+            .map(|(&addr, region)| (region.stream != *stream, region.id, addr))
             .collect();
         ordered_free_regions.sort_by_key(|(is_other, id, _)| (*is_other, *id));
         for (other_stream, _, addr) in ordered_free_regions {
@@ -878,7 +901,7 @@ mod tests {
 
         let leftover = pool.free_regions.get(&leftover_addr).unwrap();
         assert_eq!(leftover.size, page_size);
-        assert!(leftover.stream.is_same_stream(&foreign_stream));
+        assert_eq!(leftover.stream, foreign_stream);
         assert_eq!(leftover.id, 42);
         assert!(Arc::ptr_eq(&leftover.event, &original_event));
     }

--- a/crates/cuda-common/src/memory_manager/vm_pool.rs
+++ b/crates/cuda-common/src/memory_manager/vm_pool.rs
@@ -245,6 +245,12 @@ impl VirtualMemoryPool {
                     ByteSize::b(total_mem as u64)
                 );
             }
+            // Ensure the event recorded during pre-allocation is completed before
+            // any caller uses the pool. Without this, find_best_fit's Phase 1b
+            // may see the event as not-yet-completed (race with GPU processing)
+            // and fall through to defragment_or_create_new_pages, remapping the
+            // pre-allocated pages to a different VA location.
+            init_stream.synchronize().expect("init_stream sync failed");
         }
 
         pool

--- a/crates/cuda-common/src/memory_manager/vm_pool.rs
+++ b/crates/cuda-common/src/memory_manager/vm_pool.rs
@@ -348,7 +348,6 @@ impl VirtualMemoryPool {
             })
     }
 
-    /// Frees a pointer and returns `(size, StreamGuard)`.
     /// Frees a pointer and returns the size of the freed memory.
     /// Coalesces adjacent free regions.
     ///

--- a/crates/cuda-common/src/stream.rs
+++ b/crates/cuda-common/src/stream.rs
@@ -1,6 +1,5 @@
 use std::{
     borrow::Cow,
-    cell::Cell,
     ffi::c_void,
     ops::Deref,
     sync::{Arc, Mutex},
@@ -11,8 +10,6 @@ use crate::error::{check, CudaError};
 #[link(name = "cudart")]
 extern "C" {
     fn cudaDeviceSynchronize() -> i32;
-    fn cudaStreamGetId(stream: cudaStream_t, id: *mut CudaStreamId) -> i32;
-    fn cudaStreamCreate(stream: *mut cudaStream_t) -> i32;
     fn cudaStreamCreateWithFlags(stream: *mut cudaStream_t, flags: u32) -> i32;
     fn cudaStreamDestroy(stream: cudaStream_t) -> i32;
     fn cudaStreamSynchronize(stream: cudaStream_t) -> i32;
@@ -35,9 +32,6 @@ pub type cudaStream_t = *mut c_void;
 pub struct CudaStream {
     stream: cudaStream_t,
     host_event: Mutex<CudaEvent>,
-    /// If `false`, this is a borrowed handle (e.g. PTDS) — `Drop` must not
-    /// call `cudaStreamDestroy`.
-    owned: bool,
 }
 
 impl std::fmt::Debug for CudaStream {
@@ -52,19 +46,6 @@ unsafe impl Send for CudaStream {}
 unsafe impl Sync for CudaStream {}
 
 impl CudaStream {
-    /// Creates a new CUDA stream using `cudaStreamCreate` (blocking stream).
-    #[deprecated(note = "Use CudaStream::new_non_blocking() instead")]
-    pub fn new() -> Result<Self, CudaError> {
-        let mut stream: cudaStream_t = std::ptr::null_mut();
-        check(unsafe { cudaStreamCreate(&mut stream) })?;
-        let host_event = Mutex::new(CudaEvent::new()?);
-        Ok(Self {
-            stream,
-            host_event,
-            owned: true,
-        })
-    }
-
     /// Creates a new non-blocking CUDA stream using `cudaStreamCreateWithFlags`
     /// with `cudaStreamNonBlocking`. Non-blocking streams have no implicit
     /// synchronization with the legacy default stream (stream 0).
@@ -73,24 +54,7 @@ impl CudaStream {
         // 0x1 = cudaStreamNonBlocking
         check(unsafe { cudaStreamCreateWithFlags(&mut stream, 0x1) })?;
         let host_event = Mutex::new(CudaEvent::new()?);
-        Ok(Self {
-            stream,
-            host_event,
-            owned: true,
-        })
-    }
-
-    /// Returns a non-owning handle to the per-thread default stream (PTDS).
-    ///
-    /// During the transition (while allocation paths still use PTDS),
-    /// `GpuDevice` uses this so kernel launches and allocations share the
-    /// same stream. Phase 8 replaces this with `new_non_blocking()`.
-    pub fn ptds() -> Self {
-        Self {
-            stream: cudaStreamPerThread,
-            host_event: Mutex::new(CudaEvent::new().expect("failed to create PTDS host event")),
-            owned: false,
-        }
+        Ok(Self { stream, host_event })
     }
 
     /// Get the raw CUDA stream handle.
@@ -119,7 +83,7 @@ impl CudaStream {
 
 impl Drop for CudaStream {
     fn drop(&mut self) {
-        if self.owned && !self.stream.is_null() {
+        if !self.stream.is_null() {
             // Non-blocking: CUDA defers destruction until the stream is idle
             unsafe { cudaStreamDestroy(self.stream) };
             self.stream = std::ptr::null_mut();
@@ -164,23 +128,14 @@ pub struct DeviceContext {
     pub stream: StreamGuard,
 }
 
-// ---------------------------------------------------------------------------
-// Legacy PTDS helpers (deprecated, removed in Phase 8)
-// ---------------------------------------------------------------------------
-
-#[allow(non_upper_case_globals)]
-pub const cudaStreamPerThread: cudaStream_t = 0x02 as cudaStream_t;
-
-pub type CudaStreamId = u64;
-
-pub fn current_stream_id() -> Result<CudaStreamId, CudaError> {
-    let mut id = 0;
-    check(unsafe { cudaStreamGetId(cudaStreamPerThread, &mut id) })?;
-    Ok(id)
-}
-
-pub fn current_stream_sync() -> Result<(), CudaError> {
-    check(unsafe { cudaStreamSynchronize(cudaStreamPerThread) })
+impl DeviceContext {
+    pub fn for_current_device() -> Result<Self, CudaError> {
+        let device_id = crate::common::get_device()? as u32;
+        Ok(Self {
+            device_id,
+            stream: StreamGuard::new(CudaStream::new_non_blocking()?),
+        })
+    }
 }
 
 /// Synchronize the given explicit CUDA stream, blocking until all previously
@@ -190,40 +145,6 @@ pub fn current_stream_sync() -> Result<(), CudaError> {
 /// The caller must ensure that `stream` is a valid CUDA stream handle.
 pub unsafe fn sync_stream(stream: cudaStream_t) -> Result<(), CudaError> {
     check(cudaStreamSynchronize(stream))
-}
-
-struct CudaThreadCleanup {
-    touched_cuda: Cell<bool>,
-}
-
-impl CudaThreadCleanup {
-    const fn new() -> Self {
-        Self {
-            touched_cuda: Cell::new(false),
-        }
-    }
-
-    fn mark_used(&self) {
-        self.touched_cuda.set(true);
-    }
-}
-
-impl Drop for CudaThreadCleanup {
-    fn drop(&mut self) {
-        if self.touched_cuda.get() {
-            // Best-effort drain of this thread's default stream before CUDA TLS teardown.
-            // Avoid calling `check` here to prevent re-entering TLS tracking during drop.
-            let _ = unsafe { cudaStreamSynchronize(cudaStreamPerThread) };
-        }
-    }
-}
-
-thread_local! {
-    static CUDA_THREAD_CLEANUP: CudaThreadCleanup = const { CudaThreadCleanup::new() };
-}
-
-pub(crate) fn mark_cuda_thread_used() {
-    CUDA_THREAD_CLEANUP.with(|cleanup| cleanup.mark_used());
 }
 
 // ---------------------------------------------------------------------------
@@ -279,10 +200,6 @@ pub struct CudaEvent {
     event: cudaEvent_t,
 }
 
-pub fn default_stream_wait(event: &CudaEvent) -> Result<(), CudaError> {
-    check(unsafe { cudaStreamWaitEvent(cudaStreamPerThread, event.event, 0) })
-}
-
 unsafe impl Send for CudaEvent {}
 unsafe impl Sync for CudaEvent {}
 
@@ -302,10 +219,6 @@ impl CudaEvent {
     /// Record this event on the given `CudaStream` (safe wrapper).
     pub fn record_on(&self, stream: &CudaStream) -> Result<(), CudaError> {
         check(unsafe { cudaEventRecord(self.event, stream.as_raw()) })
-    }
-
-    pub fn record_on_this(&self) -> Result<(), CudaError> {
-        check(unsafe { cudaEventRecord(self.event, cudaStreamPerThread) })
     }
 
     pub fn synchronize(&self) -> Result<(), CudaError> {
@@ -342,32 +255,6 @@ impl Drop for CudaEvent {
 // ---------------------------------------------------------------------------
 // GPU metrics spans
 // ---------------------------------------------------------------------------
-
-/// A GPU-aware span that collects a gauge metric using CUDA events (PTDS path).
-pub fn gpu_metrics_span<R, F: FnOnce() -> R>(
-    name: impl Into<Cow<'static, str>>,
-    f: F,
-) -> Result<R, CudaError> {
-    let start = CudaEvent::new()?;
-    let stop = CudaEvent::new()?;
-    unsafe {
-        check(cudaEventRecord(start.event, cudaStreamPerThread))?;
-    }
-    let res = f();
-    unsafe { stop.record_and_wait(cudaStreamPerThread)? };
-
-    let mut elapsed_ms = 0f32;
-    unsafe {
-        check(cudaEventElapsedTime(
-            &mut elapsed_ms,
-            start.event,
-            stop.event,
-        ))?
-    };
-
-    metrics::gauge!(name.into()).set(elapsed_ms as f64);
-    Ok(res)
-}
 
 /// A GPU-aware span that collects a gauge metric using CUDA events on an explicit stream.
 pub fn gpu_metrics_span_on<R, F: FnOnce() -> R>(

--- a/crates/cuda-common/src/stream.rs
+++ b/crates/cuda-common/src/stream.rs
@@ -139,6 +139,10 @@ pub struct DeviceContext {
 }
 
 impl DeviceContext {
+    /// Creates a new `DeviceContext` for the given device.
+    ///
+    /// NOTE: This calls `set_device_by_id` as a side effect, changing the
+    /// current CUDA device for the calling thread.
     pub fn for_device(device_id: u32) -> Result<Self, CudaError> {
         crate::common::set_device_by_id(device_id as i32)?;
         Ok(Self {

--- a/crates/cuda-common/src/stream.rs
+++ b/crates/cuda-common/src/stream.rs
@@ -35,6 +35,9 @@ pub type cudaStream_t = *mut c_void;
 pub struct CudaStream {
     stream: cudaStream_t,
     host_event: Mutex<CudaEvent>,
+    /// If `false`, this is a borrowed handle (e.g. PTDS) — `Drop` must not
+    /// call `cudaStreamDestroy`.
+    owned: bool,
 }
 
 impl std::fmt::Debug for CudaStream {
@@ -55,7 +58,11 @@ impl CudaStream {
         let mut stream: cudaStream_t = std::ptr::null_mut();
         check(unsafe { cudaStreamCreate(&mut stream) })?;
         let host_event = Mutex::new(CudaEvent::new()?);
-        Ok(Self { stream, host_event })
+        Ok(Self {
+            stream,
+            host_event,
+            owned: true,
+        })
     }
 
     /// Creates a new non-blocking CUDA stream using `cudaStreamCreateWithFlags`
@@ -66,7 +73,24 @@ impl CudaStream {
         // 0x1 = cudaStreamNonBlocking
         check(unsafe { cudaStreamCreateWithFlags(&mut stream, 0x1) })?;
         let host_event = Mutex::new(CudaEvent::new()?);
-        Ok(Self { stream, host_event })
+        Ok(Self {
+            stream,
+            host_event,
+            owned: true,
+        })
+    }
+
+    /// Returns a non-owning handle to the per-thread default stream (PTDS).
+    ///
+    /// During the transition (while allocation paths still use PTDS),
+    /// `GpuDevice` uses this so kernel launches and allocations share the
+    /// same stream. Phase 8 replaces this with `new_non_blocking()`.
+    pub fn ptds() -> Self {
+        Self {
+            stream: cudaStreamPerThread,
+            host_event: Mutex::new(CudaEvent::new().expect("failed to create PTDS host event")),
+            owned: false,
+        }
     }
 
     /// Get the raw CUDA stream handle.
@@ -95,7 +119,7 @@ impl CudaStream {
 
 impl Drop for CudaStream {
     fn drop(&mut self) {
-        if !self.stream.is_null() {
+        if self.owned && !self.stream.is_null() {
             // Non-blocking: CUDA defers destruction until the stream is idle
             unsafe { cudaStreamDestroy(self.stream) };
             self.stream = std::ptr::null_mut();

--- a/crates/cuda-common/src/stream.rs
+++ b/crates/cuda-common/src/stream.rs
@@ -159,6 +159,15 @@ pub fn current_stream_sync() -> Result<(), CudaError> {
     check(unsafe { cudaStreamSynchronize(cudaStreamPerThread) })
 }
 
+/// Synchronize the given explicit CUDA stream, blocking until all previously
+/// enqueued work on `stream` has completed.
+///
+/// # Safety
+/// The caller must ensure that `stream` is a valid CUDA stream handle.
+pub unsafe fn sync_stream(stream: cudaStream_t) -> Result<(), CudaError> {
+    check(cudaStreamSynchronize(stream))
+}
+
 struct CudaThreadCleanup {
     touched_cuda: Cell<bool>,
 }

--- a/crates/cuda-common/src/stream.rs
+++ b/crates/cuda-common/src/stream.rs
@@ -128,18 +128,18 @@ impl Deref for StreamGuard {
 }
 
 // ---------------------------------------------------------------------------
-// DeviceContext — bundles device ID with a stream
+// GpuDeviceCtx — bundles device ID with a stream
 // ---------------------------------------------------------------------------
 
 /// Thin context for all GPU operations in the explicit-stream path.
 #[derive(Clone)]
-pub struct DeviceContext {
+pub struct GpuDeviceCtx {
     pub device_id: u32,
     pub stream: StreamGuard,
 }
 
-impl DeviceContext {
-    /// Creates a new `DeviceContext` for the given device.
+impl GpuDeviceCtx {
+    /// Creates a new `GpuDeviceCtx` for the given device.
     ///
     /// NOTE: This calls `set_device_by_id` as a side effect, changing the
     /// current CUDA device for the calling thread.

--- a/crates/cuda-common/src/stream.rs
+++ b/crates/cuda-common/src/stream.rs
@@ -132,7 +132,7 @@ impl Deref for StreamGuard {
 // ---------------------------------------------------------------------------
 
 /// Thin context for all GPU operations in the explicit-stream path.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct GpuDeviceCtx {
     pub device_id: u32,
     pub stream: StreamGuard,

--- a/crates/cuda-common/src/stream.rs
+++ b/crates/cuda-common/src/stream.rs
@@ -1,4 +1,10 @@
-use std::{borrow::Cow, cell::Cell, ffi::c_void};
+use std::{
+    borrow::Cow,
+    cell::Cell,
+    ffi::c_void,
+    ops::Deref,
+    sync::{Arc, Mutex},
+};
 
 use crate::error::{check, CudaError};
 
@@ -7,6 +13,7 @@ extern "C" {
     fn cudaDeviceSynchronize() -> i32;
     fn cudaStreamGetId(stream: cudaStream_t, id: *mut CudaStreamId) -> i32;
     fn cudaStreamCreate(stream: *mut cudaStream_t) -> i32;
+    fn cudaStreamCreateWithFlags(stream: *mut cudaStream_t, flags: u32) -> i32;
     fn cudaStreamDestroy(stream: cudaStream_t) -> i32;
     fn cudaStreamSynchronize(stream: cudaStream_t) -> i32;
     fn cudaStreamWaitEvent(stream: cudaStream_t, event: cudaEvent_t, flags: u32) -> i32;
@@ -27,17 +34,39 @@ pub type cudaStream_t = *mut c_void;
 
 pub struct CudaStream {
     stream: cudaStream_t,
+    host_event: Mutex<CudaEvent>,
+}
+
+impl std::fmt::Debug for CudaStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CudaStream")
+            .field("stream", &self.stream)
+            .finish()
+    }
 }
 
 unsafe impl Send for CudaStream {}
 unsafe impl Sync for CudaStream {}
 
 impl CudaStream {
-    /// Creates a new non-blocking CUDA stream.
+    /// Creates a new CUDA stream using `cudaStreamCreate` (blocking stream).
+    #[deprecated(note = "Use CudaStream::new_non_blocking() instead")]
     pub fn new() -> Result<Self, CudaError> {
         let mut stream: cudaStream_t = std::ptr::null_mut();
         check(unsafe { cudaStreamCreate(&mut stream) })?;
-        Ok(Self { stream })
+        let host_event = Mutex::new(CudaEvent::new()?);
+        Ok(Self { stream, host_event })
+    }
+
+    /// Creates a new non-blocking CUDA stream using `cudaStreamCreateWithFlags`
+    /// with `cudaStreamNonBlocking`. Non-blocking streams have no implicit
+    /// synchronization with the legacy default stream (stream 0).
+    pub fn new_non_blocking() -> Result<Self, CudaError> {
+        let mut stream: cudaStream_t = std::ptr::null_mut();
+        // 0x1 = cudaStreamNonBlocking
+        check(unsafe { cudaStreamCreateWithFlags(&mut stream, 0x1) })?;
+        let host_event = Mutex::new(CudaEvent::new()?);
+        Ok(Self { stream, host_event })
     }
 
     /// Get the raw CUDA stream handle.
@@ -55,17 +84,65 @@ impl CudaStream {
     pub fn wait(&self, event: &CudaEvent) -> Result<(), CudaError> {
         check(unsafe { cudaStreamWaitEvent(self.stream, event.event, 0) })
     }
+
+    /// Record a per-stream event and synchronize to complete all pending D2H copies.
+    pub fn to_host_sync(&self) -> Result<(), CudaError> {
+        let event = self.host_event.lock().unwrap();
+        unsafe { event.record(self.stream) }?;
+        event.synchronize()
+    }
 }
 
 impl Drop for CudaStream {
     fn drop(&mut self) {
         if !self.stream.is_null() {
-            self.synchronize().unwrap();
-            let _ = unsafe { cudaStreamDestroy(self.stream) };
+            // Non-blocking: CUDA defers destruction until the stream is idle
+            unsafe { cudaStreamDestroy(self.stream) };
             self.stream = std::ptr::null_mut();
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// StreamGuard — keeps a CudaStream alive for allocation records
+// ---------------------------------------------------------------------------
+
+/// Keeps a `CudaStream` alive for the lifetime of an allocation record.
+#[derive(Clone, Debug)]
+pub struct StreamGuard(Arc<CudaStream>);
+
+impl StreamGuard {
+    pub fn new(stream: CudaStream) -> Self {
+        Self(Arc::new(stream))
+    }
+
+    /// Returns `true` if both guards refer to the same underlying `CudaStream`.
+    pub fn is_same_stream(&self, other: &StreamGuard) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Deref for StreamGuard {
+    type Target = CudaStream;
+    fn deref(&self) -> &CudaStream {
+        &self.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DeviceContext — bundles device ID with a stream
+// ---------------------------------------------------------------------------
+
+/// Thin context for all GPU operations in the explicit-stream path.
+#[derive(Clone)]
+pub struct DeviceContext {
+    pub device_id: u32,
+    pub stream: StreamGuard,
+}
+
+// ---------------------------------------------------------------------------
+// Legacy PTDS helpers (deprecated, removed in Phase 8)
+// ---------------------------------------------------------------------------
 
 #[allow(non_upper_case_globals)]
 pub const cudaStreamPerThread: cudaStream_t = 0x02 as cudaStream_t;
@@ -115,6 +192,10 @@ thread_local! {
 pub(crate) fn mark_cuda_thread_used() {
     CUDA_THREAD_CLEANUP.with(|cleanup| cleanup.mark_used());
 }
+
+// ---------------------------------------------------------------------------
+// CudaEvent
+// ---------------------------------------------------------------------------
 
 #[allow(non_camel_case_types)]
 pub type cudaEvent_t = *mut c_void;
@@ -185,6 +266,11 @@ impl CudaEvent {
         check(cudaEventRecord(self.event, stream))
     }
 
+    /// Record this event on the given `CudaStream` (safe wrapper).
+    pub fn record_on(&self, stream: &CudaStream) -> Result<(), CudaError> {
+        check(unsafe { cudaEventRecord(self.event, stream.as_raw()) })
+    }
+
     pub fn record_on_this(&self) -> Result<(), CudaError> {
         check(unsafe { cudaEventRecord(self.event, cudaStreamPerThread) })
     }
@@ -220,7 +306,11 @@ impl Drop for CudaEvent {
     }
 }
 
-/// A GPU-aware span that collects a gauge metric using CUDA events.
+// ---------------------------------------------------------------------------
+// GPU metrics spans
+// ---------------------------------------------------------------------------
+
+/// A GPU-aware span that collects a gauge metric using CUDA events (PTDS path).
 pub fn gpu_metrics_span<R, F: FnOnce() -> R>(
     name: impl Into<Cow<'static, str>>,
     f: F,
@@ -232,6 +322,32 @@ pub fn gpu_metrics_span<R, F: FnOnce() -> R>(
     }
     let res = f();
     unsafe { stop.record_and_wait(cudaStreamPerThread)? };
+
+    let mut elapsed_ms = 0f32;
+    unsafe {
+        check(cudaEventElapsedTime(
+            &mut elapsed_ms,
+            start.event,
+            stop.event,
+        ))?
+    };
+
+    metrics::gauge!(name.into()).set(elapsed_ms as f64);
+    Ok(res)
+}
+
+/// A GPU-aware span that collects a gauge metric using CUDA events on an explicit stream.
+pub fn gpu_metrics_span_on<R, F: FnOnce() -> R>(
+    name: impl Into<Cow<'static, str>>,
+    stream: &CudaStream,
+    f: F,
+) -> Result<R, CudaError> {
+    let start = CudaEvent::new()?;
+    let stop = CudaEvent::new()?;
+    start.record_on(stream)?;
+    let res = f();
+    stop.record_on(stream)?;
+    stop.synchronize()?;
 
     let mut elapsed_ms = 0f32;
     unsafe {

--- a/crates/cuda-common/src/stream.rs
+++ b/crates/cuda-common/src/stream.rs
@@ -129,12 +129,17 @@ pub struct DeviceContext {
 }
 
 impl DeviceContext {
-    pub fn for_current_device() -> Result<Self, CudaError> {
-        let device_id = crate::common::get_device()? as u32;
+    pub fn for_device(device_id: u32) -> Result<Self, CudaError> {
+        crate::common::set_device_by_id(device_id as i32)?;
         Ok(Self {
             device_id,
             stream: StreamGuard::new(CudaStream::new_non_blocking()?),
         })
+    }
+
+    pub fn for_current_device() -> Result<Self, CudaError> {
+        let device_id = crate::common::get_device()? as u32;
+        Self::for_device(device_id)
     }
 }
 

--- a/crates/cuda-common/src/stream.rs
+++ b/crates/cuda-common/src/stream.rs
@@ -110,12 +110,15 @@ impl StreamGuard {
     pub fn new(stream: CudaStream) -> Self {
         Self(Arc::new(stream))
     }
+}
 
-    /// Returns `true` if both guards refer to the same underlying `CudaStream`.
-    pub fn is_same_stream(&self, other: &StreamGuard) -> bool {
+impl PartialEq for StreamGuard {
+    fn eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.0, &other.0)
     }
 }
+
+impl Eq for StreamGuard {}
 
 impl Deref for StreamGuard {
     type Target = CudaStream;

--- a/crates/cuda-common/src/stream.rs
+++ b/crates/cuda-common/src/stream.rs
@@ -45,14 +45,17 @@ impl std::fmt::Debug for CudaStream {
 unsafe impl Send for CudaStream {}
 unsafe impl Sync for CudaStream {}
 
+/// `cudaStreamNonBlocking` flag: no implicit synchronization with the legacy
+/// default stream (stream 0).
+const CUDA_STREAM_NON_BLOCKING: u32 = 0x1;
+
 impl CudaStream {
     /// Creates a new non-blocking CUDA stream using `cudaStreamCreateWithFlags`
     /// with `cudaStreamNonBlocking`. Non-blocking streams have no implicit
     /// synchronization with the legacy default stream (stream 0).
     pub fn new_non_blocking() -> Result<Self, CudaError> {
         let mut stream: cudaStream_t = std::ptr::null_mut();
-        // 0x1 = cudaStreamNonBlocking
-        check(unsafe { cudaStreamCreateWithFlags(&mut stream, 0x1) })?;
+        check(unsafe { cudaStreamCreateWithFlags(&mut stream, CUDA_STREAM_NON_BLOCKING) })?;
         let host_event = Mutex::new(CudaEvent::new()?);
         Ok(Self { stream, host_event })
     }
@@ -74,6 +77,9 @@ impl CudaStream {
     }
 
     /// Record a per-stream event and synchronize to complete all pending D2H copies.
+    /// Uses event-based sync rather than cudaStreamSynchronize because this waits
+    /// only for work up to the event point, allowing future selective sync patterns
+    /// (e.g., wait for a specific copy without draining the entire stream).
     pub fn to_host_sync(&self) -> Result<(), CudaError> {
         let event = self.host_event.lock().unwrap();
         unsafe { event.record(self.stream) }?;
@@ -85,7 +91,8 @@ impl Drop for CudaStream {
     fn drop(&mut self) {
         if !self.stream.is_null() {
             // Non-blocking: CUDA defers destruction until the stream is idle
-            unsafe { cudaStreamDestroy(self.stream) };
+            let err = unsafe { cudaStreamDestroy(self.stream) };
+            debug_assert_eq!(err, 0, "cudaStreamDestroy failed with error code: {err}");
             self.stream = std::ptr::null_mut();
         }
     }
@@ -253,7 +260,8 @@ impl CudaEvent {
 
 impl Drop for CudaEvent {
     fn drop(&mut self) {
-        unsafe { cudaEventDestroy(self.event) };
+        let err = unsafe { cudaEventDestroy(self.event) };
+        debug_assert_eq!(err, 0, "cudaEventDestroy failed with error code: {err}");
     }
 }
 

--- a/crates/stark-backend/src/engine.rs
+++ b/crates/stark-backend/src/engine.rs
@@ -28,6 +28,12 @@ pub struct VerificationData<SC: StarkProtocolConfig> {
 pub type ProverError<E> =
     <<E as StarkEngine>::PD as ProverDevice<<E as StarkEngine>::PB, <E as StarkEngine>::TS>>::Error;
 
+/// Convenience alias for the device context type of a `StarkEngine`.
+pub type EngineDeviceCtx<E> = <<E as StarkEngine>::PD as ProverDevice<
+    <E as StarkEngine>::PB,
+    <E as StarkEngine>::TS,
+>>::DeviceCtx;
+
 /// A helper trait to collect the different steps in multi-trace STARK
 /// keygen and proving.
 pub trait StarkEngine

--- a/crates/stark-backend/src/prover/cpu_backend.rs
+++ b/crates/stark-backend/src/prover/cpu_backend.rs
@@ -69,6 +69,11 @@ where
     TS: FiatShamirTranscript<SC>,
 {
     type Error = RefProverError;
+    type DeviceCtx = ();
+
+    fn device_ctx(&self) -> &() {
+        &()
+    }
 }
 
 impl<SC: StarkProtocolConfig> TraceCommitter<CpuColMajorBackend<SC>> for ReferenceDevice<SC>

--- a/crates/stark-backend/src/prover/hal.rs
+++ b/crates/stark-backend/src/prover/hal.rs
@@ -60,6 +60,11 @@ pub trait ProverDevice<PB: ProverBackend, TS>:
         + From<<Self as TraceCommitter<PB>>::Error>
         + From<<Self as MultiRapProver<PB, TS>>::Error>
         + From<<Self as OpeningProver<PB, TS>>::Error>;
+
+    /// Device-specific context (e.g., CUDA stream). Unit `()` for CPU devices.
+    type DeviceCtx: Clone + Send + Sync;
+
+    fn device_ctx(&self) -> &Self::DeviceCtx;
 }
 
 /// Provides functionality for committing to a batch of trace matrices, possibly of different

--- a/scripts/gen_stub.py
+++ b/scripts/gen_stub.py
@@ -138,6 +138,9 @@ out.append('#define DIGEST_SIZE 8')
 out.append('using Digest = F[DIGEST_SIZE];')
 out.append('#endif')
 
+# -- CUDA runtime type placeholder ------------------------------------------
+out.append('using cudaStream_t = void*;')
+
 # -- Fallback array dimension constants ------------------------------------
 for dim in undefined_array_dims:
     out.append(f'#ifndef {dim}')


### PR DESCRIPTION
Closes INT-6464

## CUDA Explicit Stream Migration

Replace implicit per-thread default stream (PTDS) with explicit `cudaStream_t` management across the entire CUDA stack. Removes the `--default-stream=per-thread` compiler flag, introduces `CudaStream`, `StreamGuard`, and `DeviceContext` abstractions, and threads an explicit stream through every kernel launch, memory operation, and copy path.

**87 files changed, +3750 / -1758**

See [cuda-stream-migration-design.md](https://github.com/openvm-org/v2-proof-system/blob/test/stream-migration/cuda-stream-migration-design.md) for full design rationale.

---

## `openvm-stark-backend` (3 files)

### `ProverDevice` trait — `DeviceCtx` associated type

`ProverDevice` gains an associated type and accessor. GPU devices return `DeviceContext` (CUDA stream + device ID), CPU/Reference devices return `()`:

```rust
pub trait ProverDevice<PB, TS>: ... {
    type DeviceCtx: Clone + Send + Sync;
    fn device_ctx(&self) -> &Self::DeviceCtx;
}
```

A convenience alias `EngineDeviceCtx<E>` is added to `engine.rs` to avoid spelling out the full associated type path.

---

## `openvm-cuda-common` (10 files)

### `stream.rs` — New types

- **`CudaStream`** — RAII wrapper around `cudaStream_t`, created with `cudaStreamNonBlocking`. Non-blocking `Drop` (calls `cudaStreamDestroy` only, no sync). Per-stream `Mutex<CudaEvent>` for D2H sync via `to_host_sync()`.
- **`StreamGuard`** — newtype around `Arc<CudaStream>` for ref-counted stream ownership. `is_same_stream()` via `Arc::ptr_eq`. `Deref<Target=CudaStream>`.
- **`DeviceContext`** — thin `(device_id, StreamGuard)` bundle. Created via `DeviceContext::for_device(id)` which binds the CUDA device before stream creation.

### `memory_manager/` — Stream-aware allocation records

- `AllocRecord { size, stream: StreamGuard }` — tracks which stream each small allocation belongs to
- `VpmmRecord { size, stream: StreamGuard }` — same for VPMM large allocations
- Two-stage `d_free`: bookkeeping + `cudaFreeAsync` under lock, `StreamGuard` dropped outside lock
- VPMM same-stream matching via `Arc::ptr_eq`; cross-stream reuse gated by event completion

### `copy.rs` / `d_buffer.rs` — `_on(&DeviceContext)` API

All legacy streamless APIs removed. Only `_on(&DeviceContext)` variants remain: `to_device_on`, `to_host_on`, `fill_zero_on`, `with_capacity_on`, `d_malloc_on`, `cuda_memcpy_on`. `DeviceBuffer` gains `#[cfg(feature = "debug-cuda-stream")] alloc_stream` field for wrong-stream detection.

### Removed

`cudaStreamPerThread`, `CudaStreamId`, `current_stream_id()`, `current_stream_sync()`, `default_stream_wait()`, `record_on_this()`, `CudaThreadCleanup`, `gpu_metrics_span()` (PTDS variant), `CudaStream::new()` (blocking), global `COPY_EVENT` mutex, `--default-stream=per-thread` flag.

---

## `openvm-cuda-backend` (50+ files)

### Device model (`device.rs`, `engine.rs`)

- `GpuDevice` renamed to `GpuDeviceConfig` (pure config)
- New `GpuDevice { config: GpuDeviceConfig, device_ctx: DeviceContext }` — stream-owning device handle
- `GpuEngine::new()` calls `GpuDevice::new().expect(...)` to preserve infallible `StarkEngine::new()`
- `ProverDevice::DeviceCtx = DeviceContext`, `device_ctx()` returns `&self.device_ctx`

### CUDA launchers (25 `.cu` files)

Every `extern "C"` launcher gains `cudaStream_t stream` as final parameter. All kernel launches use `<<<grid, block, 0, stream>>>`. `CHECK_KERNEL()` unchanged. `cudaDeviceSynchronize()` → `cudaStreamSynchronize(stream)` in `sponge.cu`, `bn254_poseidon2.cu`.

### Rust FFI wrappers (~14 files in `src/cuda/`)

Every `extern "C"` declaration and safe wrapper gains `stream: cudaStream_t`.

### Proving pipeline

Intermediate structs (`StackedReductionGpu`, `NttImpl`, `LogupZerocheckGpu`, etc.) store `device_ctx: DeviceContext`. All allocation/copy calls use `_on` variants. Init paths (`ntt.rs`, `batch_ntt_small.rs`) create temporary `DeviceContext` with private streams.

---

## `benchmarks/fields` (5 files)

`.cu` launchers gain `stream` parameter. `lib.rs` FFI wrappers updated. Tests use `DeviceContext`.

## `scripts/gen_stub.py`

Added `using cudaStream_t = void*;` typedef for the `gpu_signature_match` CI ABI checker.