### PR TITLE
chore(cuda): audit2

### DIFF
--- a/crates/cuda-backend/cuda/src/batch_ntt_small.cu
+++ b/crates/cuda-backend/cuda/src/batch_ntt_small.cu
@@ -82,7 +82,7 @@ __global__ void batch_ntt_kernel(
 ) {
     uint32_t const block_idx = blockIdx.x * blockDim.y + threadIdx.y;
     bool const active_thread = (block_idx < cnt_blocks);
-    buffer += block_idx << l_skip;
+    buffer += static_cast<size_t>(block_idx) << l_skip;
 
 #ifdef CUDA_DEBUG
     assert(blockDim.x <= (1 << l_skip));

--- a/crates/cuda-backend/cuda/src/bn254_poseidon2.cu
+++ b/crates/cuda-backend/cuda/src/bn254_poseidon2.cu
@@ -137,7 +137,7 @@ static const int BN254_NUM_F_ELMS    = 8;
 
 /// Row hash for a base-field (Fp / BabyBear) matrix row.
 static __device__ __forceinline__
-Bn254Fr bn254_row_hash(const Fp* matrix, int width, int height, int row) {
+Bn254Fr bn254_row_hash(const Fp* matrix, size_t width, size_t height, size_t row) {
     Bn254Fr state[3];
     state[0] = bn254_zero_init();
     state[1] = bn254_zero_init();
@@ -146,7 +146,7 @@ Bn254Fr bn254_row_hash(const Fp* matrix, int width, int height, int row) {
     uint32_t buf[BN254_BABY_BEAR_RATE];
     int cnt = 0;
 
-    for (int col = 0; col < width; col++) {
+    for (size_t col = 0; col < width; col++) {
         buf[cnt++] = matrix[col * height + row].asUInt32();
         if (cnt == BN254_BABY_BEAR_RATE) {
             state[0] = bn254_pack_base_2_31(buf, BN254_NUM_F_ELMS);
@@ -167,7 +167,7 @@ Bn254Fr bn254_row_hash(const Fp* matrix, int width, int height, int row) {
 
 /// Row hash for an extension-field (FpExt / BinomialExtensionField<BabyBear,4>) matrix row.
 static __device__ __forceinline__
-Bn254Fr bn254_row_hash_ext(const FpExt* matrix, int width, int height, int row) {
+Bn254Fr bn254_row_hash_ext(const FpExt* matrix, size_t width, size_t height, size_t row) {
     Bn254Fr state[3];
     state[0] = bn254_zero_init();
     state[1] = bn254_zero_init();
@@ -176,7 +176,7 @@ Bn254Fr bn254_row_hash_ext(const FpExt* matrix, int width, int height, int row) 
     uint32_t buf[BN254_BABY_BEAR_RATE];
     int cnt = 0;
 
-    for (int col = 0; col < width; col++) {
+    for (size_t col = 0; col < width; col++) {
         FpExt elem = matrix[col * height + row];
         for (int d = 0; d < 4; d++) {
             buf[cnt++] = elem.elems[d].asUInt32();
@@ -225,12 +225,12 @@ __global__ void bn254_compressing_row_hashes_kernel(
 
     const uint32_t stride_idx = blockDim.x * blockIdx.x + threadIdx.x;
     uint32_t       leaf_idx   = threadIdx.y;
-    const uint32_t row        = leaf_idx * query_stride + stride_idx;
+    const size_t   row        = leaf_idx * query_stride + stride_idx;
 
     Bn254Fr digest = bn254_zero_init();
 
     if (stride_idx < query_stride) {
-        digest = bn254_row_hash(matrix, (int)width, (int)height, (int)row);
+        digest = bn254_row_hash(matrix, width, height, row);
     }
 
     // Tree reduction (same structure as the BabyBear kernel)
@@ -271,12 +271,12 @@ __global__ void bn254_compressing_row_hashes_ext_kernel(
 
     const uint32_t stride_idx = blockDim.x * blockIdx.x + threadIdx.x;
     uint32_t       leaf_idx   = threadIdx.y;
-    const uint32_t row        = leaf_idx * query_stride + stride_idx;
+    const size_t   row        = leaf_idx * query_stride + stride_idx;
 
     Bn254Fr digest = bn254_zero_init();
 
     if (stride_idx < query_stride) {
-        digest = bn254_row_hash_ext(matrix, (int)width, (int)height, (int)row);
+        digest = bn254_row_hash_ext(matrix, width, height, row);
     }
 
     for (int layer = 0; layer < (int)log_rows_per_query; ++layer) {

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/eval_config.cuh
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/eval_config.cuh
@@ -68,7 +68,7 @@ inline std::pair<dim3, dim3> eval_constraints_launch_params(
 }
 
 template <bool COSET_PARALLEL>
-inline uint32_t temp_sums_buffer_size(
+inline size_t temp_sums_buffer_size(
     uint32_t buffer_size,
     uint32_t skip_domain,
     uint32_t num_x,
@@ -87,11 +87,11 @@ inline uint32_t temp_sums_buffer_size(
         threads_per_block
     );
     // Output layout: [num_blocks][num_cosets * skip_domain]
-    return grid.x * num_cosets * skip_domain;
+    return static_cast<size_t>(grid.x) * num_cosets * skip_domain;
 }
 
 template <bool COSET_PARALLEL>
-inline uint32_t intermediates_buffer_size(
+inline size_t intermediates_buffer_size(
     uint32_t buffer_size,
     uint32_t skip_domain,
     uint32_t num_x,
@@ -113,7 +113,7 @@ inline uint32_t intermediates_buffer_size(
         threads_per_block
     );
     // Layout: [buffer_size][num_threads][num_cosets]
-    return grid.x * block.x * buffer_size * num_cosets;
+    return static_cast<size_t>(grid.x) * block.x * buffer_size * num_cosets;
 }
 
 } // namespace round0_config_impl

--- a/crates/cuda-backend/cuda/src/matrix.cu
+++ b/crates/cuda-backend/cuda/src/matrix.cu
@@ -90,8 +90,8 @@ __global__ void split_ext_to_base_col_major_matrix_kernel(
         return;
     }
 
-    uint32_t col_num = (poly_len / matrix_height); // SPLIT_FACTOR = 2
-    for (uint32_t col_idx = 0; col_idx < col_num; col_idx++) {
+    uint64_t col_num = (poly_len / matrix_height); // SPLIT_FACTOR = 2
+    for (uint64_t col_idx = 0; col_idx < col_num; col_idx++) {
         FpExt ext_val = d_poly[col_idx * matrix_height + row_idx];
         d_matrix[(col_idx * 4 + 0) * matrix_height + row_idx] = ext_val.elems[0];
         d_matrix[(col_idx * 4 + 1) * matrix_height + row_idx] = ext_val.elems[1];
@@ -129,9 +129,10 @@ __global__ void batch_rotate_pad_kernel(
                 pidx_rot -= num_x;
             }
         }
-        out[padded_size * pidx + tidx] = in[domain_size * pidx_rot + tidx_rot];
+        out[static_cast<size_t>(padded_size) * pidx + tidx] =
+            in[static_cast<size_t>(domain_size) * pidx_rot + tidx_rot];
     } else if (tidx < padded_size) {
-        out[padded_size * pidx + tidx] = Fp(0);
+        out[static_cast<size_t>(padded_size) * pidx + tidx] = Fp(0);
     }
 }
 
@@ -151,7 +152,8 @@ __global__ void lift_padded_matrix_evals_kernel(
         return;
     }
     // lhs = rhs when tidx < height
-    matrix[col * padded_height + tidx] = matrix[col * padded_height + (tidx % height)];
+    matrix[static_cast<size_t>(col) * padded_height + tidx] =
+        matrix[static_cast<size_t>(col) * padded_height + (tidx % height)];
 }
 
 // Required: lifted_height = height * stride
@@ -169,7 +171,8 @@ __global__ void collapse_strided_matrix_kernel(
         return;
     }
 
-    out[col * height + row] = in[col * lifted_height + row * stride];
+    out[static_cast<size_t>(col) * height + row] =
+        in[static_cast<size_t>(col) * lifted_height + static_cast<size_t>(row) * stride];
 }
 
 // memory layout of in: column-major
@@ -190,9 +193,9 @@ __global__ void batch_expand_pad_kernel(
         for (uint32_t i = 0; i < polyCount; i++) {
             Fp res = Fp(0);
             if (idx < inSize) {
-                res = in[i * inSize + idx];
+                res = in[static_cast<size_t>(i) * inSize + idx];
             }
-            out[i * outSize + idx] = res;
+            out[static_cast<size_t>(i) * outSize + idx] = res;
         }
     }
 }
@@ -214,9 +217,10 @@ __global__ void batch_expand_pad_wide_kernel(
         return;
     }
     if (row < height) {
-        out[col * padded_height + row] = in[col * height + row];
+        out[static_cast<size_t>(col) * padded_height + row] =
+            in[static_cast<size_t>(col) * height + row];
     } else if (row < padded_height) {
-        out[col * padded_height + row] = Fp(0);
+        out[static_cast<size_t>(col) * padded_height + row] = Fp(0);
     }
 }
 

--- a/crates/cuda-backend/cuda/src/matrix.cu
+++ b/crates/cuda-backend/cuda/src/matrix.cu
@@ -114,6 +114,8 @@ __global__ void batch_rotate_pad_kernel(
 ) {
     auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
     auto pidx = blockIdx.y + blockIdx.z * gridDim.y;
+    const size_t padded_stride = padded_size;
+    const size_t domain_stride = domain_size;
 
     if (pidx >= width * num_x) {
         return;
@@ -129,10 +131,9 @@ __global__ void batch_rotate_pad_kernel(
                 pidx_rot -= num_x;
             }
         }
-        out[static_cast<size_t>(padded_size) * pidx + tidx] =
-            in[static_cast<size_t>(domain_size) * pidx_rot + tidx_rot];
+        out[padded_stride * pidx + tidx] = in[domain_stride * pidx_rot + tidx_rot];
     } else if (tidx < padded_size) {
-        out[static_cast<size_t>(padded_size) * pidx + tidx] = Fp(0);
+        out[padded_stride * pidx + tidx] = Fp(0);
     }
 }
 
@@ -148,12 +149,12 @@ __global__ void lift_padded_matrix_evals_kernel(
 ) {
     auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
     auto col = threadIdx.y + blockIdx.y * blockDim.y;
+    const size_t col_stride = padded_height;
     if (tidx >= lifted_height || col >= width) {
         return;
     }
     // lhs = rhs when tidx < height
-    matrix[static_cast<size_t>(col) * padded_height + tidx] =
-        matrix[static_cast<size_t>(col) * padded_height + (tidx % height)];
+    matrix[col * col_stride + tidx] = matrix[col * col_stride + (tidx % height)];
 }
 
 // Required: lifted_height = height * stride
@@ -167,12 +168,14 @@ __global__ void collapse_strided_matrix_kernel(
 ) {
     auto row = threadIdx.x + blockIdx.x * blockDim.x;
     auto col = threadIdx.y + blockIdx.y * blockDim.y;
+    const size_t out_col_stride = height;
+    const size_t in_col_stride = lifted_height;
+    const size_t row_stride = stride;
     if (row >= height || col >= width) {
         return;
     }
 
-    out[static_cast<size_t>(col) * height + row] =
-        in[static_cast<size_t>(col) * lifted_height + static_cast<size_t>(row) * stride];
+    out[col * out_col_stride + row] = in[col * in_col_stride + row * row_stride];
 }
 
 // memory layout of in: column-major
@@ -189,13 +192,15 @@ __global__ void batch_expand_pad_kernel(
     const uint32_t inSize
 ) {
     uint idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const size_t in_stride = inSize;
+    const size_t out_stride = outSize;
     if (idx < outSize) {
         for (uint32_t i = 0; i < polyCount; i++) {
             Fp res = Fp(0);
             if (idx < inSize) {
-                res = in[static_cast<size_t>(i) * inSize + idx];
+                res = in[i * in_stride + idx];
             }
-            out[static_cast<size_t>(i) * outSize + idx] = res;
+            out[i * out_stride + idx] = res;
         }
     }
 }
@@ -213,14 +218,15 @@ __global__ void batch_expand_pad_wide_kernel(
 ) {
     uint32_t row = blockIdx.x * blockDim.x + threadIdx.x;
     uint32_t col = blockIdx.y + blockIdx.z * gridDim.y;
+    const size_t padded_stride = padded_height;
+    const size_t in_stride = height;
     if (col >= width) {
         return;
     }
     if (row < height) {
-        out[static_cast<size_t>(col) * padded_height + row] =
-            in[static_cast<size_t>(col) * height + row];
+        out[col * padded_stride + row] = in[col * in_stride + row];
     } else if (row < padded_height) {
-        out[static_cast<size_t>(col) * padded_height + row] = Fp(0);
+        out[col * padded_stride + row] = Fp(0);
     }
 }
 

--- a/crates/cuda-backend/src/cuda/poly.rs
+++ b/crates/cuda-backend/src/cuda/poly.rs
@@ -201,7 +201,7 @@ pub unsafe fn batch_eq_hypercube_stage(
 ) -> Result<(), CudaError> {
     let width = x.len() as u32;
     debug_assert!(step < height);
-    debug_assert!(out.len() <= (width * height) as usize);
+    debug_assert!(out.len() >= (width * height) as usize);
     check(_batch_eq_hypercube_stage(
         out.as_mut_ptr(),
         x.as_ptr(),

--- a/crates/cuda-backend/tests/ntt_roundtrip.rs
+++ b/crates/cuda-backend/tests/ntt_roundtrip.rs
@@ -11,7 +11,7 @@ use p3_field::PrimeCharacteristicRing;
 #[ignore] // Run explicitly: requires large GPU memory and significant runtime.
 fn ntt_roundtrip_max_log_domain_size() {
     const LOG_N: u32 = 27;
-    let ctx = GpuDeviceCtx {
+    let device_ctx = GpuDeviceCtx {
         device_id: get_device().unwrap() as u32,
         stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
     };
@@ -22,14 +22,16 @@ fn ntt_roundtrip_max_log_domain_size() {
         host.push(F::from_usize(i));
     }
 
-    let mut device = DeviceBuffer::<F>::with_capacity_on(n, &ctx);
-    host.copy_to_on(&mut device, &ctx)
+    let mut device = DeviceBuffer::<F>::with_capacity_on(n, &device_ctx);
+    host.copy_to_on(&mut device, &device_ctx)
         .expect("host->device copy failed");
 
-    batch_ntt(&device, LOG_N, 0, 1, true, false, &ctx);
-    batch_ntt(&device, LOG_N, 0, 1, true, true, &ctx);
+    batch_ntt(&device, LOG_N, 0, 1, true, false, &device_ctx);
+    batch_ntt(&device, LOG_N, 0, 1, true, true, &device_ctx);
 
-    let output = device.to_host_on(&ctx).expect("device->host copy failed");
+    let output = device
+        .to_host_on(&device_ctx)
+        .expect("device->host copy failed");
     for (i, got) in output.iter().enumerate() {
         assert_eq!(*got, host[i], "mismatch at index {}", i);
     }

--- a/crates/cuda-common/include/launcher.cuh
+++ b/crates/cuda-common/include/launcher.cuh
@@ -25,7 +25,7 @@ inline std::pair<dim3, dim3> kernel_launch_params(
 
 inline std::pair<dim3, dim3> kernel_launch_2d_params(size_t x, size_t y) {
     if (x == 0 || y == 0) {
-        return std::make_pair(dim3(0, 0), dim3(1, 1));
+        return std::make_pair(dim3(0, 1, 1), dim3(1, 1, 1));
     }
     dim3 block = dim3(std::min(x, WARP_SIZE), std::min(y, WARP_SIZE));
     dim3 grid = dim3(div_ceil(x, block.x), div_ceil(y, block.y));

--- a/crates/cuda-common/include/launcher.cuh
+++ b/crates/cuda-common/include/launcher.cuh
@@ -15,12 +15,18 @@ inline std::pair<dim3, dim3> kernel_launch_params(
     size_t count,
     size_t threads_per_block = MAX_THREADS
 ) {
+    if (count == 0) {
+        return std::make_pair(dim3(0, 1, 1), dim3(1, 1, 1));
+    }
     size_t block = std::min(count, threads_per_block);
     size_t grid = div_ceil(count, block);
     return std::make_pair(dim3(grid, 1, 1), dim3(block, 1, 1));
 }
 
 inline std::pair<dim3, dim3> kernel_launch_2d_params(size_t x, size_t y) {
+    if (x == 0 || y == 0) {
+        return std::make_pair(dim3(0, 0), dim3(1, 1));
+    }
     dim3 block = dim3(std::min(x, WARP_SIZE), std::min(y, WARP_SIZE));
     dim3 grid = dim3(div_ceil(x, block.x), div_ceil(y, block.y));
     return std::make_pair(grid, block);

--- a/crates/cuda-common/src/copy.rs
+++ b/crates/cuda-common/src/copy.rs
@@ -37,7 +37,7 @@ pub unsafe fn cuda_memcpy_on<const SRC_DEVICE: bool, const DST_DEVICE: bool>(
     dst: *mut c_void,
     src: *const c_void,
     size_bytes: usize,
-    ctx: &GpuDeviceCtx,
+    device_ctx: &GpuDeviceCtx,
 ) -> Result<(), MemCopyError> {
     check(unsafe {
         cudaMemcpyAsync(
@@ -47,7 +47,7 @@ pub unsafe fn cuda_memcpy_on<const SRC_DEVICE: bool, const DST_DEVICE: bool>(
             std::mem::transmute::<i32, cudaMemcpyKind>(
                 if DST_DEVICE { 1 } else { 0 } + if SRC_DEVICE { 2 } else { 0 },
             ),
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
         )
     })
     .map_err(MemCopyError::from)
@@ -56,16 +56,19 @@ pub unsafe fn cuda_memcpy_on<const SRC_DEVICE: bool, const DST_DEVICE: bool>(
 // ---- Host -> Device ----
 
 pub trait MemCopyH2D<T> {
-    fn copy_to_on(&self, dst: &mut DeviceBuffer<T>, ctx: &GpuDeviceCtx)
-        -> Result<(), MemCopyError>;
-    fn to_device_on(&self, ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError>;
+    fn copy_to_on(
+        &self,
+        dst: &mut DeviceBuffer<T>,
+        device_ctx: &GpuDeviceCtx,
+    ) -> Result<(), MemCopyError>;
+    fn to_device_on(&self, device_ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError>;
 }
 
 impl<T> MemCopyH2D<T> for [T] {
     fn copy_to_on(
         &self,
         dst: &mut DeviceBuffer<T>,
-        ctx: &GpuDeviceCtx,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<(), MemCopyError> {
         if self.len() > dst.len() {
             return Err(MemCopyError::SizeMismatch {
@@ -81,15 +84,15 @@ impl<T> MemCopyH2D<T> for [T] {
                 self.as_ptr() as *const c_void,
                 size_bytes,
                 cudaMemcpyKind::cudaMemcpyHostToDevice,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
         })
         .map_err(MemCopyError::from)
     }
 
-    fn to_device_on(&self, ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError> {
-        let mut dst = DeviceBuffer::with_capacity_on(self.len(), ctx);
-        self.copy_to_on(&mut dst, ctx)?;
+    fn to_device_on(&self, device_ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError> {
+        let mut dst = DeviceBuffer::with_capacity_on(self.len(), device_ctx);
+        self.copy_to_on(&mut dst, device_ctx)?;
         Ok(dst)
     }
 }
@@ -97,11 +100,11 @@ impl<T> MemCopyH2D<T> for [T] {
 // ---- Device -> Host ----
 
 pub trait MemCopyD2H<T> {
-    fn to_host_on(&self, ctx: &GpuDeviceCtx) -> Result<Vec<T>, MemCopyError>;
+    fn to_host_on(&self, device_ctx: &GpuDeviceCtx) -> Result<Vec<T>, MemCopyError>;
 }
 
 impl<T> MemCopyD2H<T> for DeviceBuffer<T> {
-    fn to_host_on(&self, ctx: &GpuDeviceCtx) -> Result<Vec<T>, MemCopyError> {
+    fn to_host_on(&self, device_ctx: &GpuDeviceCtx) -> Result<Vec<T>, MemCopyError> {
         let mut host_vec = Vec::with_capacity(self.len());
         let size_bytes = std::mem::size_of::<T>() * self.len();
 
@@ -111,10 +114,10 @@ impl<T> MemCopyD2H<T> for DeviceBuffer<T> {
                 self.as_raw_ptr(),
                 size_bytes,
                 cudaMemcpyKind::cudaMemcpyDeviceToHost,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
         })?;
-        ctx.stream.to_host_sync()?;
+        device_ctx.stream.to_host_sync()?;
         unsafe {
             host_vec.set_len(self.len());
         }
@@ -126,25 +129,25 @@ impl<T> MemCopyD2H<T> for DeviceBuffer<T> {
 // ---- Device -> Device ----
 
 pub trait MemCopyD2D<T> {
-    fn device_copy_on(&self, ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError>;
+    fn device_copy_on(&self, device_ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError>;
     fn device_copy_to_on(
         &self,
         dst: &mut DeviceBuffer<T>,
-        ctx: &GpuDeviceCtx,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<(), MemCopyError>;
 }
 
 impl<T> MemCopyD2D<T> for DeviceBuffer<T> {
-    fn device_copy_on(&self, ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError> {
-        let mut dst = DeviceBuffer::<T>::with_capacity_on(self.len(), ctx);
-        self.device_copy_to_on(&mut dst, ctx)?;
+    fn device_copy_on(&self, device_ctx: &GpuDeviceCtx) -> Result<DeviceBuffer<T>, MemCopyError> {
+        let mut dst = DeviceBuffer::<T>::with_capacity_on(self.len(), device_ctx);
+        self.device_copy_to_on(&mut dst, device_ctx)?;
         Ok(dst)
     }
 
     fn device_copy_to_on(
         &self,
         dst: &mut DeviceBuffer<T>,
-        ctx: &GpuDeviceCtx,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<(), MemCopyError> {
         if self.len() > dst.len() {
             return Err(MemCopyError::SizeMismatch {
@@ -161,7 +164,7 @@ impl<T> MemCopyD2D<T> for DeviceBuffer<T> {
                 self.as_raw_ptr(),
                 size_bytes,
                 cudaMemcpyKind::cudaMemcpyDeviceToDevice,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
         })
         .map_err(MemCopyError::from)
@@ -179,15 +182,15 @@ mod tests {
 
     #[test]
     fn test_mem_copy() {
-        let ctx = test_ctx();
+        let device_ctx = test_ctx();
         let h = vec![1, 2, 3, 4, 5];
 
-        let d1 = h.to_device_on(&ctx).unwrap();
-        let mut d2 = DeviceBuffer::<i32>::with_capacity_on(h.len(), &ctx);
-        h.copy_to_on(&mut d2, &ctx).unwrap();
+        let d1 = h.to_device_on(&device_ctx).unwrap();
+        let mut d2 = DeviceBuffer::<i32>::with_capacity_on(h.len(), &device_ctx);
+        h.copy_to_on(&mut d2, &device_ctx).unwrap();
 
-        let h1 = d1.to_host_on(&ctx).unwrap();
-        let h2 = d2.to_host_on(&ctx).unwrap();
+        let h1 = d1.to_host_on(&device_ctx).unwrap();
+        let h2 = d2.to_host_on(&device_ctx).unwrap();
 
         assert_eq!(h, h1, "First device buffer mismatch");
         assert_eq!(h, h2, "Second device buffer mismatch");

--- a/crates/cuda-common/src/d_buffer.rs
+++ b/crates/cuda-common/src/d_buffer.rs
@@ -270,21 +270,4 @@ mod tests {
         d_array.fill_zero_on(&device_ctx).unwrap();
         assert_eq!(d_array.to_host_on(&device_ctx).unwrap(), vec![0; v.len()]);
     }
-
-    #[test]
-    fn test_device_buffer_fill_zero_empty_is_noop() {
-        let ctx = test_ctx();
-        let d_array = DeviceBuffer::<u64>::new();
-        d_array.fill_zero_on(&ctx).unwrap();
-        assert!(d_array.is_empty());
-    }
-
-    #[test]
-    fn test_device_buffer_fill_zero_suffix_at_len_is_noop() {
-        let ctx = test_ctx();
-        let v: Vec<u64> = (0..10).collect();
-        let d_array = v.to_device_on(&ctx).unwrap();
-        d_array.fill_zero_suffix_on(v.len(), &ctx).unwrap();
-        assert_eq!(d_array.to_host_on(&ctx).unwrap(), v);
-    }
 }

--- a/crates/cuda-common/src/d_buffer.rs
+++ b/crates/cuda-common/src/d_buffer.rs
@@ -96,7 +96,9 @@ impl<T> DeviceBuffer<T> {
     /// The caller should use the same stream that allocated this buffer.
     /// `fill_zero` is async; same-stream guarantees ordering without explicit sync.
     pub fn fill_zero_on(&self, device_ctx: &GpuDeviceCtx) -> Result<(), CudaError> {
-        assert_ne!(self.len, 0, "Empty buffer");
+        if self.len == 0 {
+            return Ok(());
+        }
         #[cfg(feature = "debug-cuda-stream")]
         debug_assert_eq!(
             device_ctx.stream.as_raw(),
@@ -264,5 +266,13 @@ mod tests {
         let d_array = v.to_device_on(&device_ctx).unwrap();
         d_array.fill_zero_on(&device_ctx).unwrap();
         assert_eq!(d_array.to_host_on(&device_ctx).unwrap(), vec![0; v.len()]);
+    }
+
+    #[test]
+    fn test_device_buffer_fill_zero_empty_is_noop() {
+        let ctx = test_ctx();
+        let d_array = DeviceBuffer::<u64>::new();
+        d_array.fill_zero_on(&ctx).unwrap();
+        assert!(d_array.is_empty());
     }
 }

--- a/crates/cuda-common/src/d_buffer.rs
+++ b/crates/cuda-common/src/d_buffer.rs
@@ -123,9 +123,12 @@ impl<T> DeviceBuffer<T> {
         device_ctx: &GpuDeviceCtx,
     ) -> Result<(), CudaError> {
         assert!(
-            start_idx < self.len,
-            "start index has to be smaller than length"
+            start_idx <= self.len,
+            "start index has to be smaller than or equal to length"
         );
+        if start_idx == self.len {
+            return Ok(());
+        }
         #[cfg(feature = "debug-cuda-stream")]
         debug_assert_eq!(
             device_ctx.stream.as_raw(),
@@ -274,5 +277,14 @@ mod tests {
         let d_array = DeviceBuffer::<u64>::new();
         d_array.fill_zero_on(&ctx).unwrap();
         assert!(d_array.is_empty());
+    }
+
+    #[test]
+    fn test_device_buffer_fill_zero_suffix_at_len_is_noop() {
+        let ctx = test_ctx();
+        let v: Vec<u64> = (0..10).collect();
+        let d_array = v.to_device_on(&ctx).unwrap();
+        d_array.fill_zero_suffix_on(v.len(), &ctx).unwrap();
+        assert_eq!(d_array.to_host_on(&ctx).unwrap(), v);
     }
 }

--- a/crates/cuda-common/src/d_buffer.rs
+++ b/crates/cuda-common/src/d_buffer.rs
@@ -65,20 +65,20 @@ impl<T> DeviceBuffer<T> {
     }
 
     /// Allocate device memory for `len` elements of type `T` on an explicit stream.
-    pub fn with_capacity_on(len: usize, ctx: &GpuDeviceCtx) -> Self {
+    pub fn with_capacity_on(len: usize, device_ctx: &GpuDeviceCtx) -> Self {
         tracing::debug!(
             "Creating device buffer of size {} (sizeof type = {}) on stream {:?}",
             len,
             size_of::<T>(),
-            ctx.stream
+            device_ctx.stream
         );
         assert_ne!(len, 0, "Zero capacity request is wrong");
         let size_bytes = std::mem::size_of::<T>() * len;
-        let raw_ptr = d_malloc_on(size_bytes, &ctx.stream).expect("GPU allocation failed");
+        let raw_ptr = d_malloc_on(size_bytes, &device_ctx.stream).expect("GPU allocation failed");
         #[cfg(feature = "touchemall")]
         {
             unsafe {
-                cudaMemsetAsync(raw_ptr, 0xff, size_bytes, ctx.stream.as_raw());
+                cudaMemsetAsync(raw_ptr, 0xff, size_bytes, device_ctx.stream.as_raw());
             }
         }
         let typed_ptr = raw_ptr as *mut T;
@@ -87,7 +87,7 @@ impl<T> DeviceBuffer<T> {
             ptr: typed_ptr,
             len,
             #[cfg(feature = "debug-cuda-stream")]
-            alloc_stream: ctx.stream.as_raw(),
+            alloc_stream: device_ctx.stream.as_raw(),
         }
     }
 
@@ -95,23 +95,30 @@ impl<T> DeviceBuffer<T> {
     ///
     /// The caller should use the same stream that allocated this buffer.
     /// `fill_zero` is async; same-stream guarantees ordering without explicit sync.
-    pub fn fill_zero_on(&self, ctx: &GpuDeviceCtx) -> Result<(), CudaError> {
+    pub fn fill_zero_on(&self, device_ctx: &GpuDeviceCtx) -> Result<(), CudaError> {
         assert_ne!(self.len, 0, "Empty buffer");
         #[cfg(feature = "debug-cuda-stream")]
         debug_assert_eq!(
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
             self.alloc_stream,
             "fill_zero_on: stream mismatch"
         );
         let size_bytes = std::mem::size_of::<T>() * self.len;
-        check(unsafe { cudaMemsetAsync(self.as_mut_raw_ptr(), 0, size_bytes, ctx.stream.as_raw()) })
+        check(unsafe {
+            cudaMemsetAsync(
+                self.as_mut_raw_ptr(),
+                0,
+                size_bytes,
+                device_ctx.stream.as_raw(),
+            )
+        })
     }
 
     /// Fills a suffix of the buffer with zeros on an explicit stream.
     pub fn fill_zero_suffix_on(
         &self,
         start_idx: usize,
-        ctx: &GpuDeviceCtx,
+        device_ctx: &GpuDeviceCtx,
     ) -> Result<(), CudaError> {
         assert!(
             start_idx < self.len,
@@ -119,7 +126,7 @@ impl<T> DeviceBuffer<T> {
         );
         #[cfg(feature = "debug-cuda-stream")]
         debug_assert_eq!(
-            ctx.stream.as_raw(),
+            device_ctx.stream.as_raw(),
             self.alloc_stream,
             "fill_zero_suffix_on: stream mismatch"
         );
@@ -129,7 +136,7 @@ impl<T> DeviceBuffer<T> {
                 self.as_mut_ptr().add(start_idx) as *mut c_void,
                 0,
                 size_bytes,
-                ctx.stream.as_raw(),
+                device_ctx.stream.as_raw(),
             )
         })
     }
@@ -239,9 +246,9 @@ mod tests {
 
     #[test]
     fn test_device_buffer_float() {
-        let ctx = test_ctx();
+        let device_ctx = test_ctx();
         // Create a DeviceBuffer of 10 floats
-        let db = DeviceBuffer::<f32>::with_capacity_on(10, &ctx);
+        let db = DeviceBuffer::<f32>::with_capacity_on(10, &device_ctx);
 
         assert_eq!(db.len(), 10);
         assert!(!db.as_ptr().is_null());
@@ -252,10 +259,10 @@ mod tests {
 
     #[test]
     fn test_device_buffer_fill_zero() {
-        let ctx = test_ctx();
+        let device_ctx = test_ctx();
         let v: Vec<u64> = (0..10).collect();
-        let d_array = v.to_device_on(&ctx).unwrap();
-        d_array.fill_zero_on(&ctx).unwrap();
-        assert_eq!(d_array.to_host_on(&ctx).unwrap(), vec![0; v.len()]);
+        let d_array = v.to_device_on(&device_ctx).unwrap();
+        d_array.fill_zero_on(&device_ctx).unwrap();
+        assert_eq!(d_array.to_host_on(&device_ctx).unwrap(), vec![0; v.len()]);
     }
 }

--- a/crates/cuda-common/src/stream.rs
+++ b/crates/cuda-common/src/stream.rs
@@ -132,7 +132,7 @@ impl Deref for StreamGuard {
 // ---------------------------------------------------------------------------
 
 /// Thin context for all GPU operations in the explicit-stream path.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct GpuDeviceCtx {
     pub device_id: u32,
     pub stream: StreamGuard,


### PR DESCRIPTION
Closes INT-7349

# Fix CUDA audit2 findings (INT-7349)

Addresses 8 findings from the automated CUDA audit that ran on `develop-v2.0.0-rc.1`, validated against the `chore/stream-migration` branch. The remaining 7 of the original 15 findings were triaged as already fixed or false positives and canceled in Linear.

All changes are mechanical hardening — no functional behavior changes for valid inputs.

---

## `openvm-cuda-common` (2 files)

### `d_buffer.rs` — Zero-work edge cases in `fill_zero` / `fill_zero_suffix`

**INT-7364:** `fill_zero_on` panicked via `assert_ne!(self.len, 0)` on empty buffers. Replaced with early-return `Ok(())`.

**INT-7362:** `fill_zero_suffix_on` panicked when `start_idx == self.len` (valid no-op). Changed assert from `<` to `<=` and added early-return.

### `launcher.cuh` — Division by zero in launch param helpers

**INT-7355:** `kernel_launch_params(0)` computed `div_ceil(0, 0)`. Added zero-count guard returning `dim3(0,1,1)` (CUDA no-op grid). Same for `kernel_launch_2d_params`.

---

## `openvm-cuda-backend` — CUDA kernels (4 files)

### `eval_config.cuh` — 32-bit buffer size truncation

**INT-7357:** `round0_config_impl::temp_sums_buffer_size` and `intermediates_buffer_size` returned `uint32_t` with 32-bit multiplication that could overflow. Changed return types to `size_t` and added `static_cast<size_t>` at the multiplication root. (Other namespaces in the same file already used `size_t`.)

### `batch_ntt_small.cu` — 32-bit offset overflow in NTT kernel

**INT-7358:** `buffer += block_idx << l_skip` computed the shift in 32-bit before adding to a 64-bit pointer. Added `static_cast<size_t>(block_idx)` before the shift.

### `matrix.cu` — 32-bit index overflow in 6 matrix kernels

**INT-7354:** Multiple kernels (`batch_rotate_pad`, `lift_padded_matrix_evals`, `collapse_strided_matrix`, `batch_expand_pad`, `batch_expand_pad_wide`, `split_ext_to_base_col_major_matrix`) computed memory offsets in 32-bit `uint32_t` arithmetic. Fixed by introducing local `size_t` stride variables at the top of each kernel (e.g. `const size_t padded_stride = padded_size;`), so all index expressions naturally promote to 64-bit. `split_ext_to_base_col_major_matrix_kernel` uses `uint64_t` loop variables instead since the loop counter itself participates in the index math.

### `bn254_poseidon2.cu` — Signed 32-bit overflow in row hashing

**INT-7353:** `bn254_row_hash` and `bn254_row_hash_ext` used `int` parameters for width/height/row, with `(int)` casts at call sites. Changed signatures to `size_t`, removed truncating casts at callers, and promoted `row` computation in both Merkle kernels to `size_t`.

---

## `openvm-cuda-backend` — Rust (1 file)

### `poly.rs` — Reversed debug assert

**INT-7360:** `batch_eq_hypercube_stage` had `debug_assert!(out.len() <= (width * height))` — backwards. The buffer must be *at least* `width * height`. Flipped to `>=`.
