### PR TITLE
fix: soundness calculator list size terms

### DIFF
--- a/crates/stark-backend/src/config.rs
+++ b/crates/stark-backend/src/config.rs
@@ -247,16 +247,18 @@ impl ProximityRegime {
     /// This treats the per-query error as an upper bound on the maximum agreement.
     ///
     /// - `UniqueDecoding`: max agreement is `(1 + ρ) / 2`.
-    /// - `ListDecoding { m }`: finite-multiplicity Guruswami-Sudan threshold, `sqrt(ρ(1 + 1/m)) +
-    ///   ε` for a tiny `ε`, to keep the proximity threshold strict.
+    /// - `ListDecoding { m }`: finite-multiplicity Guruswami-Sudan threshold, `sqrt(ρ) (1 +
+    ///   1/(2m)).
     pub fn whir_query_security_bits(&self, num_queries: usize, log_inv_rate: usize) -> f64 {
         let rho = 2.0_f64.powf(-(log_inv_rate as f64));
         let max_agreement = match *self {
             ProximityRegime::UniqueDecoding => (1.0 + rho) / 2.0,
             ProximityRegime::ListDecoding { m } => {
                 let m = m.max(1) as f64;
-                // Johnson bound with a tiny epsilon to ensure strict proximity.
-                (rho * (1.0 + 1.0 / m)).sqrt() + 1e-6
+                // The stronger bound of sqrt(ρ(1 + 1/m)) could be used for the Guruswami-Sudan
+                // threshold, but to match the explicit statement in the WHIR paper, we use the
+                // weaker Taylor series expansion to sqrt(ρ) * (1 + 1/(2m))
+                rho.sqrt() * (1.0 + 1.0 / (2.0 * m))
             }
         };
 

--- a/crates/stark-backend/src/soundness.rs
+++ b/crates/stark-backend/src/soundness.rs
@@ -361,7 +361,7 @@ impl SoundnessCalculator {
             // sub-round
             let mut log2_list_size: Option<f64> = None;
 
-            for sub_round in 0..k_whir {
+            for _ in 0..k_whir {
                 current_log_degree -= 1;
 
                 let prox_gaps = Self::whir_proximity_gap_security(
@@ -381,7 +381,6 @@ impl SoundnessCalculator {
 
                 let sumcheck_bits = Self::whir_sumcheck_security(
                     challenge_field_bits,
-                    sub_round,
                     whir.folding_pow_bits,
                     log2_list_size.unwrap(),
                 );
@@ -678,15 +677,15 @@ impl SoundnessCalculator {
 
     /// Computes WHIR sumcheck security bits for a sub-round.
     ///
-    /// Sumcheck error is 2/|F| for sub_round 0 and 3/|F| for sub_round > 0.
-    /// Security bits = |F_ext| - log₂(degree) + folding_pow_bits
+    /// Sumcheck error is d * ℓ / |F|, d^*:= 1 + deg_Z(w0) + max_i deg_{X_i}(w0) and d :=
+    /// max{d^*,3}. Security bits = |F_ext| - log₂(degree) + folding_pow_bits
     fn whir_sumcheck_security(
         challenge_field_bits: f64,
-        sub_round: usize,
         folding_pow_bits: usize,
         log2_list_size: f64,
     ) -> f64 {
-        let sumcheck_degree: f64 = if sub_round == 0 { 2.0 } else { 3.0 };
+        // For our use case, w0 has degree 1 in each variable, so d = 3.
+        let sumcheck_degree: f64 = 3.0;
         challenge_field_bits - sumcheck_degree.log2() - log2_list_size + folding_pow_bits as f64
     }
 

--- a/crates/stark-backend/src/soundness.rs
+++ b/crates/stark-backend/src/soundness.rs
@@ -690,7 +690,7 @@ impl SoundnessCalculator {
     /// Sumcheck error is d * ℓ_{i,s-1} / |F|, d^*:= 1 + deg_Z(w0) + max_i deg_{X_i}(w0) and d :=
     /// max{d^*,3}.
     ///
-    /// Security bits = |F_ext| - log₂(3) - log2(ℓ) + folding_pow_bits
+    /// Security bits = |F_ext| - log₂(d) - log2(ℓ_{i,s-1}) + folding_pow_bits
     fn whir_sumcheck_security(
         challenge_field_bits: f64,
         folding_pow_bits: usize,
@@ -706,7 +706,7 @@ impl SoundnessCalculator {
     /// OOD error is 2^{m_i - 1} ℓ_{i,0}^2 / |F| where m_i is the log_degree at the start of WHIR
     /// round `i`.
     ///
-    /// Security bits = |F_ext| - log_degree + 1 - 2 * log2(ℓ_{i,0})
+    /// Security bits = |F_ext| - m_i + 1 - 2 * log2(ℓ_{i,0})
     fn whir_ood_security(
         log2_list_size: f64,
         challenge_field_bits: f64,

--- a/crates/stark-backend/src/soundness.rs
+++ b/crates/stark-backend/src/soundness.rs
@@ -401,7 +401,7 @@ impl SoundnessCalculator {
             // ε_shift and ε_out reference m_i, ℓ_{i,0} where `i = round + 1` refers to the *next*
             // round.
             let next_log2_list_size = Self::whir_proximity_gap_security(
-                proximity_regime,
+                proximity.in_round(round + 1),
                 challenge_field_bits,
                 current_log_degree,
                 next_rate,

--- a/crates/stark-backend/src/soundness.rs
+++ b/crates/stark-backend/src/soundness.rs
@@ -386,7 +386,7 @@ impl SoundnessCalculator {
                 );
                 min_sumcheck_bits = min_sumcheck_bits.min(sumcheck_bits);
 
-                // Theorem 5.2: ε_fold = d * ℓ / |F| + err*.
+                // Theorem 5.2: ε_fold = d * ℓ_{i,s-1} / |F| + err*.
                 let fold_rbr_bits = Self::combine_security_bits(sumcheck_bits, prox_gaps_bits);
                 min_fold_rbr_bits = min_fold_rbr_bits.min(fold_rbr_bits);
                 min_rbr_bits = min_rbr_bits.min(fold_rbr_bits);
@@ -398,6 +398,16 @@ impl SoundnessCalculator {
                 + whir.query_phase_pow_bits as f64;
             min_query_bits = min_query_bits.min(query_bits);
 
+            // ε_shift and ε_out reference m_i, ℓ_{i,0} where `i = round + 1` refers to the *next*
+            // round.
+            let next_log2_list_size = Self::whir_proximity_gap_security(
+                proximity_regime,
+                challenge_field_bits,
+                current_log_degree,
+                next_rate,
+                2,
+            )
+            .log2_list_size;
             // In-domain γ batching (not protected by PoW; Merkle proofs are observed before γ).
             // NOTE[jpw] For now we use the original paper where this is fixed to 1. <https://github.com/WizardOfMenlo/whir/blob/cf1599b56ff50e09142ebe6d2e2fbd86875c9986/src/whir/parameters.rs#L373> now varies this to increase security in LDR.
             const NUM_OOD_SAMPLES: usize = 1;
@@ -406,13 +416,13 @@ impl SoundnessCalculator {
             let gamma_batching_bits = Self::whir_gamma_batching_security(
                 challenge_field_bits,
                 batch_size,
-                log2_list_size.unwrap(),
+                next_log2_list_size,
             );
             min_gamma_batching_bits = min_gamma_batching_bits.min(gamma_batching_bits);
 
-            // Theorem 5.2 / Claim 5.4: ε_shift = (1 - δ)^t + ℓ * (t + 1) / |F|. The implementation
-            // keeps the same additive structure, with the final round batching only the query
-            // claims.
+            // Theorem 5.2 / Claim 5.4: ε_shift = (1 - δ)^t + ℓ_{i,0} * (t + 1) / |F|. The
+            // implementation keeps the same additive structure, with the final round
+            // batching only the query claims.
             let shift_rbr_bits = Self::combine_security_bits(query_bits, gamma_batching_bits);
             min_shift_rbr_bits = min_shift_rbr_bits.min(shift_rbr_bits);
             min_rbr_bits = min_rbr_bits.min(shift_rbr_bits);
@@ -422,7 +432,7 @@ impl SoundnessCalculator {
                 // This is OOD sample on f_i for the *next* round `i = round + 1` after folding. So
                 // `m_i = current_log_degree` (with the present round `round`'s foldings)
                 let ood_bits = Self::whir_ood_security(
-                    log2_list_size.unwrap(),
+                    next_log2_list_size,
                     challenge_field_bits,
                     current_log_degree,
                 );
@@ -677,7 +687,7 @@ impl SoundnessCalculator {
 
     /// Computes WHIR sumcheck security bits for a sub-round.
     ///
-    /// Sumcheck error is d * ℓ / |F|, d^*:= 1 + deg_Z(w0) + max_i deg_{X_i}(w0) and d :=
+    /// Sumcheck error is d * ℓ_{i,s-1} / |F|, d^*:= 1 + deg_Z(w0) + max_i deg_{X_i}(w0) and d :=
     /// max{d^*,3}.
     ///
     /// Security bits = |F_ext| - log₂(3) - log2(ℓ) + folding_pow_bits
@@ -693,10 +703,10 @@ impl SoundnessCalculator {
 
     /// Computes WHIR out-of-domain (OOD) security bits.
     ///
-    /// OOD error is 2^{m_i - 1} ℓ^2 / |F| where m_i is the log_degree at the start of WHIR round
-    /// `i`.
+    /// OOD error is 2^{m_i - 1} ℓ_{i,0}^2 / |F| where m_i is the log_degree at the start of WHIR
+    /// round `i`.
     ///
-    /// Security bits = |F_ext| - log_degree + 1 - 2 * log2(ℓ)
+    /// Security bits = |F_ext| - log_degree + 1 - 2 * log2(ℓ_{i,0})
     fn whir_ood_security(
         log2_list_size: f64,
         challenge_field_bits: f64,

--- a/crates/stark-backend/src/soundness.rs
+++ b/crates/stark-backend/src/soundness.rs
@@ -678,7 +678,9 @@ impl SoundnessCalculator {
     /// Computes WHIR sumcheck security bits for a sub-round.
     ///
     /// Sumcheck error is d * ℓ / |F|, d^*:= 1 + deg_Z(w0) + max_i deg_{X_i}(w0) and d :=
-    /// max{d^*,3}. Security bits = |F_ext| - log₂(degree) + folding_pow_bits
+    /// max{d^*,3}.
+    ///
+    /// Security bits = |F_ext| - log₂(3) - log2(ℓ) + folding_pow_bits
     fn whir_sumcheck_security(
         challenge_field_bits: f64,
         folding_pow_bits: usize,
@@ -692,7 +694,9 @@ impl SoundnessCalculator {
     /// Computes WHIR out-of-domain (OOD) security bits.
     ///
     /// OOD error is 2^{m_i - 1} ℓ^2 / |F| where m_i is the log_degree at the start of WHIR round
-    /// `i`. Security bits = |F_ext| - log_degree + 1
+    /// `i`.
+    ///
+    /// Security bits = |F_ext| - log_degree + 1 - 2 * log2(ℓ)
     fn whir_ood_security(
         log2_list_size: f64,
         challenge_field_bits: f64,

--- a/crates/stark-backend/src/soundness.rs
+++ b/crates/stark-backend/src/soundness.rs
@@ -383,6 +383,7 @@ impl SoundnessCalculator {
                     challenge_field_bits,
                     sub_round,
                     whir.folding_pow_bits,
+                    log2_list_size.unwrap(),
                 );
                 min_sumcheck_bits = min_sumcheck_bits.min(sumcheck_bits);
 
@@ -683,9 +684,10 @@ impl SoundnessCalculator {
         challenge_field_bits: f64,
         sub_round: usize,
         folding_pow_bits: usize,
+        log2_list_size: f64,
     ) -> f64 {
         let sumcheck_degree: f64 = if sub_round == 0 { 2.0 } else { 3.0 };
-        challenge_field_bits - sumcheck_degree.log2() + folding_pow_bits as f64
+        challenge_field_bits - sumcheck_degree.log2() - log2_list_size + folding_pow_bits as f64
     }
 
     /// Computes WHIR out-of-domain (OOD) security bits.

--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -125,14 +125,14 @@ pub fn internal_params_with_100_bits_security() -> SystemParams {
 /// Returns `SystemParams` targeting 100 bits of proven RBR security for root circuits.
 ///
 /// # Assumptions for 100-bit security
-/// - **Max trace height**: ≤ 2^21
+/// - **Max trace height**: ≤ 2^20
 /// - **Max constraints per AIR**: ≤ 1,000
 /// - **Num AIRs**: ≤ 50
 /// - **Max interactions per AIR**: ≤ 100
 /// - **Num trace columns** (unstacked, total across all AIRs): ≤ 2,000
-/// - **`w_stack`** = 9, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
+/// - **`w_stack`** = 18, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
 ///
-/// Config: `l_skip=2, n_stack=19, log_blowup=4`.
+/// Config: `l_skip=2, n_stack=18, log_blowup=4`.
 //
 // See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
 // full soundness analysis.

--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -140,12 +140,12 @@ pub fn root_params_with_100_bits_security() -> SystemParams {
     SystemParams::new(
         DEFAULT_ROOT_LOG_BLOWUP,
         2,  // l_skip
-        19, // n_stack
-        9,  // w_stack
+        18, // n_stack
+        18, // w_stack
         WHIR_MAX_LOG_FINAL_POLY_LEN,
         20, // folding pow
         20, // mu pow
-        WhirProximityStrategy::ListDecoding { m: 2 },
+        WhirProximityStrategy::ListDecoding { m: 1 },
         SECURITY_BITS_TARGET,
         log_up_security_params_baby_bear_100_bits(),
     )


### PR DESCRIPTION
The WHIR paper has:
<img width="290" height="160" alt="image" src="https://github.com/user-attachments/assets/7516cb1d-8933-4b3e-8fb9-b8fb3b3419cf" />
for $i > 0$. 

In our soundness calculator, we iterate over `round in 0..` and so our handling should match up to `i = round + 1`.
We have a few discrepancies that are resolved in this PR:
* fold term needed the $d \cdot \ell / |F|$ term
* OOD error and shift error both reference $\ell_{i,0}$ which should be the list size of the _next_ round, since the query error is $\delta_{i-1}$ for the "current" round.

The following is only for convenience to match the paper's theorem statement:
* We update the query soundness to use the weaker Guraswami-Sudan bound, although we believe the strong bound still holds if one propagates a more careful analysis of the proof. To simplify and align with the paper and other calculators that are derived from the paper (e.g., soundcalc), we use the looser bound. This may cause a very small increase to the number of queries.
* To better match the paper, I also removed the `subround == 0` branching since using `d = 3` everywhere is simpler and we don't need the finer analysis.

We adjust the root params so that it still meets the 100 bits security threshold.

ref INT-6720