### PR TITLE
chore: increase w_stack in root params

### DIFF
--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -130,7 +130,7 @@ pub fn internal_params_with_100_bits_security() -> SystemParams {
 /// - **Num AIRs**: ≤ 50
 /// - **Max interactions per AIR**: ≤ 100
 /// - **Num trace columns** (unstacked, total across all AIRs): ≤ 2,000
-/// - **`w_stack`** = 18, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
+/// - **`w_stack`** = 19, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
 ///
 /// Config: `l_skip=2, n_stack=18, log_blowup=4`.
 //
@@ -141,7 +141,7 @@ pub fn root_params_with_100_bits_security() -> SystemParams {
         DEFAULT_ROOT_LOG_BLOWUP,
         2,  // l_skip
         18, // n_stack
-        18, // w_stack
+        19, // w_stack
         WHIR_MAX_LOG_FINAL_POLY_LEN,
         20, // folding pow
         20, // mu pow


### PR DESCRIPTION
Towards INT-7602. Updates root `w_stack` to accommodate AIR width increases in the recursion circuit brought about by switching to a quintic extension field.