### PR TITLE
chore: set target security bits to 128

### DIFF
--- a/benchmarks/proving/src/main.rs
+++ b/benchmarks/proving/src/main.rs
@@ -27,7 +27,7 @@ use openvm_stark_backend::{
     AirRef, PartitionedBaseAir, StarkEngine,
 };
 use openvm_stark_sdk::config::{
-    app_params_with_100_bits_security,
+    app_params_with_128_bits_security,
     baby_bear_poseidon2::{BabyBearPoseidon2Config, BabyBearPoseidon2RefEngine},
 };
 use p3_air::{Air, AirBuilder, BaseAir, BaseAirWithPublicValues};
@@ -246,7 +246,7 @@ fn run(args: &Args) {
         })
         .collect();
 
-    let params = app_params_with_100_bits_security(args.log_stacked_height);
+    let params = app_params_with_128_bits_security(args.log_stacked_height);
 
     // Keygen (always CPU)
     let keygen_engine: BabyBearPoseidon2RefEngine = StarkEngine::new(params.clone());

--- a/crates/backend-tests/src/lib.rs
+++ b/crates/backend-tests/src/lib.rs
@@ -70,7 +70,7 @@ use openvm_stark_sdk::{
             default_duplex_sponge, default_duplex_sponge_recorder, poseidon2_perm,
             BabyBearPoseidon2Config, BabyBearPoseidon2RefEngine, DuplexSponge, EF, F,
         },
-        log_up_params::log_up_security_params_baby_bear_100_bits,
+        log_up_params::log_up_security_params_baby_bear_128_bits,
     },
     utils::{setup_tracing, setup_tracing_with_log_level},
 };
@@ -164,7 +164,7 @@ pub fn proof_shape_verifier_rng_system_params<E: StarkEngine<SC = SC>>() -> eyre
             w_stack,
             log_blowup,
             whir,
-            logup: log_up_security_params_baby_bear_100_bits(),
+            logup: log_up_security_params_baby_bear_128_bits(),
             max_constraint_degree: 3,
         };
         let engine = E::new(params);
@@ -276,7 +276,7 @@ pub fn fib_air_roundtrip<E: StarkEngine<SC = SC>>(
         w_stack,
         log_blowup,
         whir,
-        logup: log_up_security_params_baby_bear_100_bits(),
+        logup: log_up_security_params_baby_bear_128_bits(),
         max_constraint_degree: 3,
     };
     let fib = FibFixture::new(0, 1, 1 << log_trace_degree);
@@ -1243,7 +1243,7 @@ pub fn whir_single_fib(
         w_stack,
         log_blowup,
         whir,
-        logup: log_up_security_params_baby_bear_100_bits(),
+        logup: log_up_security_params_baby_bear_128_bits(),
         max_constraint_degree: 3,
     };
     run_whir_fib_test(params)
@@ -1277,7 +1277,7 @@ pub fn whir_multiple_commitments() -> eyre::Result<()> {
         w_stack: 64,
         log_blowup: 1,
         whir: whir_test_config(2),
-        logup: log_up_security_params_baby_bear_100_bits(),
+        logup: log_up_security_params_baby_bear_128_bits(),
         max_constraint_degree: 3,
     };
     let config = BabyBearPoseidon2Config::default_from_params(params);
@@ -1358,7 +1358,7 @@ pub fn whir_multiple_commitments_negative() {
         w_stack: 64,
         log_blowup: 1,
         whir: whir_test_config(2),
-        logup: log_up_security_params_baby_bear_100_bits(),
+        logup: log_up_security_params_baby_bear_128_bits(),
         max_constraint_degree: 3,
     };
     let config = BabyBearPoseidon2Config::default_from_params(params);

--- a/crates/cpu-backend/benches/keccakf.rs
+++ b/crates/cpu-backend/benches/keccakf.rs
@@ -14,7 +14,7 @@ use openvm_stark_backend::{
     PartitionedBaseAir, StarkEngine, SystemParams,
 };
 use openvm_stark_sdk::config::{
-    app_params_with_100_bits_security,
+    app_params_with_128_bits_security,
     baby_bear_poseidon2::{
         BabyBearPoseidon2CpuEngine, BabyBearPoseidon2RefEngine as ReferenceCpuEngine,
     },
@@ -43,7 +43,7 @@ impl<AB: AirBuilder> Air<AB> for TestAir {
 }
 
 fn make_params() -> SystemParams {
-    app_params_with_100_bits_security(21)
+    app_params_with_128_bits_security(21)
 }
 
 fn generate_inputs() -> Vec<[u64; 25]> {

--- a/crates/cpu-backend/examples/keccakf.rs
+++ b/crates/cpu-backend/examples/keccakf.rs
@@ -11,7 +11,7 @@ use openvm_stark_backend::{
     PartitionedBaseAir, StarkEngine,
 };
 use openvm_stark_sdk::config::{
-    app_params_with_100_bits_security, baby_bear_poseidon2::BabyBearPoseidon2CpuEngine,
+    app_params_with_128_bits_security, baby_bear_poseidon2::BabyBearPoseidon2CpuEngine,
 };
 use p3_air::{Air, AirBuilder, BaseAir, BaseAirWithPublicValues};
 use p3_field::Field;
@@ -42,7 +42,7 @@ fn main() -> eyre::Result<()> {
     // Initialize tracing (reads RUST_LOG env var).
     openvm_stark_sdk::utils::setup_tracing();
 
-    let params = app_params_with_100_bits_security(21);
+    let params = app_params_with_128_bits_security(21);
 
     let mut rng = StdRng::seed_from_u64(42);
     let air = TestAir(KeccakAir {});

--- a/crates/cuda-backend/examples/keccakf.rs
+++ b/crates/cuda-backend/examples/keccakf.rs
@@ -12,7 +12,7 @@ use openvm_stark_backend::{
 };
 use openvm_stark_sdk::{
     config::{
-        app_params_with_100_bits_security,
+        app_params_with_128_bits_security,
         baby_bear_poseidon2::{BabyBearPoseidon2RefEngine, DuplexSponge},
     },
     utils::setup_tracing,
@@ -42,7 +42,7 @@ impl<AB: AirBuilder> Air<AB> for TestAir {
 }
 
 fn make_params() -> SystemParams {
-    app_params_with_100_bits_security(21)
+    app_params_with_128_bits_security(21)
 }
 
 fn main() {

--- a/crates/cuda-backend/src/tests.rs
+++ b/crates/cuda-backend/src/tests.rs
@@ -91,7 +91,7 @@ fn test_bn254_fib_air_roundtrip(l_skip: usize, log_trace_degree: usize) {
     use openvm_stark_backend::{
         test_utils::FibFixture, SystemParams, WhirConfig, WhirParams, WhirProximityStrategy,
     };
-    use openvm_stark_sdk::config::log_up_params::log_up_security_params_baby_bear_100_bits;
+    use openvm_stark_sdk::config::log_up_params::log_up_security_params_baby_bear_128_bits;
 
     setup_tracing_with_log_level(Level::DEBUG);
 
@@ -114,7 +114,7 @@ fn test_bn254_fib_air_roundtrip(l_skip: usize, log_trace_degree: usize) {
         w_stack,
         log_blowup,
         whir,
-        logup: log_up_security_params_baby_bear_100_bits(),
+        logup: log_up_security_params_baby_bear_128_bits(),
         max_constraint_degree: 3,
     };
 

--- a/crates/cuda-backend/src/whir.rs
+++ b/crates/cuda-backend/src/whir.rs
@@ -583,7 +583,7 @@ mod tests {
             baby_bear_poseidon2::{
                 default_duplex_sponge, BabyBearPoseidon2RefEngine, DuplexSponge,
             },
-            log_up_params::log_up_security_params_baby_bear_100_bits,
+            log_up_params::log_up_security_params_baby_bear_128_bits,
         },
         utils::setup_tracing_with_log_level,
     };
@@ -741,7 +741,7 @@ mod tests {
             w_stack,
             log_blowup,
             whir,
-            logup: log_up_security_params_baby_bear_100_bits(),
+            logup: log_up_security_params_baby_bear_128_bits(),
             max_constraint_degree: 3,
         };
         run_whir_fib_test_gpu(params)

--- a/crates/stark-backend/src/soundness.rs
+++ b/crates/stark-backend/src/soundness.rs
@@ -915,7 +915,7 @@ mod tests {
     // ==========================================================================
     // Unit tests
     // ==========================================================================
-    const TARGET_SECURITY_BITS: usize = 100;
+    const TARGET_SECURITY_BITS: usize = 128;
 
     #[test]
     fn test_soundness_calculation() {

--- a/crates/stark-backend/tests/soundness.rs
+++ b/crates/stark-backend/tests/soundness.rs
@@ -4,9 +4,9 @@
 
 use openvm_stark_backend::{soundness::*, SystemParams};
 use openvm_stark_sdk::config::{
-    app_params_with_100_bits_security, internal_params_with_100_bits_security as internal_params,
-    leaf_params_with_100_bits_security as leaf_params,
-    root_params_with_100_bits_security as root_params, MAX_APP_LOG_STACKED_HEIGHT,
+    app_params_with_128_bits_security, internal_params_with_128_bits_security as internal_params,
+    leaf_params_with_128_bits_security as leaf_params,
+    root_params_with_128_bits_security as root_params, MAX_APP_LOG_STACKED_HEIGHT,
 };
 use p3_baby_bear::BabyBear;
 use p3_field::PrimeField64;
@@ -57,14 +57,14 @@ const RECURSION_NUM_AIRS: usize = 50;
 const RECURSION_NUM_COLUMNS: usize = 2000;
 const RECURSION_MAX_INTERACTIONS_PER_AIR: usize = 100; // estimate, needs verification
 
-const TARGET_SECURITY_BITS: usize = 100;
+const TARGET_SECURITY_BITS: usize = 128;
 
 fn babybear_quintic_extension_bits() -> f64 {
     5.0 * (BabyBear::ORDER_U64 as f64).log2()
 }
 
 fn app_params() -> SystemParams {
-    app_params_with_100_bits_security(MAX_APP_LOG_STACKED_HEIGHT)
+    app_params_with_128_bits_security(MAX_APP_LOG_STACKED_HEIGHT)
 }
 
 fn check_soundness(

--- a/crates/stark-sdk/examples/keccakf.rs
+++ b/crates/stark-sdk/examples/keccakf.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use cfg_if::cfg_if;
 use eyre::eyre;
 use openvm_stark_sdk::{
-    config::app_params_with_100_bits_security,
+    config::app_params_with_128_bits_security,
     openvm_stark_backend::{
         p3_air::{Air, AirBuilder, BaseAir, BaseAirWithPublicValues},
         p3_field::Field,
@@ -37,7 +37,7 @@ impl<AB: AirBuilder> Air<AB> for TestAir {
 }
 
 fn main() -> eyre::Result<()> {
-    let params = app_params_with_100_bits_security(21);
+    let params = app_params_with_128_bits_security(21);
     let mut rng = StdRng::seed_from_u64(42);
     let air = TestAir(KeccakAir {});
 

--- a/crates/stark-sdk/src/config/log_up_params.rs
+++ b/crates/stark-sdk/src/config/log_up_params.rs
@@ -8,7 +8,7 @@ pub fn log_up_security_params_baby_bear_128_bits() -> LogUpSecurityParameters {
     let params = LogUpSecurityParameters {
         max_interaction_count: BabyBear::ORDER_U32,
         log_max_message_length: 7,
-        pow_bits: 18,
+        pow_bits: 13,
     };
     assert!(params.bits_of_security::<BinomialExtensionField<BabyBear, 5>>() >= 128);
     params

--- a/crates/stark-sdk/src/config/log_up_params.rs
+++ b/crates/stark-sdk/src/config/log_up_params.rs
@@ -4,12 +4,12 @@ use openvm_stark_backend::{
 };
 use p3_baby_bear::BabyBear;
 
-pub fn log_up_security_params_baby_bear_100_bits() -> LogUpSecurityParameters {
+pub fn log_up_security_params_baby_bear_128_bits() -> LogUpSecurityParameters {
     let params = LogUpSecurityParameters {
         max_interaction_count: BabyBear::ORDER_U32,
         log_max_message_length: 7,
         pow_bits: 18,
     };
-    assert!(params.bits_of_security::<BinomialExtensionField<BabyBear, 5>>() >= 100);
+    assert!(params.bits_of_security::<BinomialExtensionField<BabyBear, 5>>() >= 128);
     params
 }

--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -54,8 +54,8 @@ pub fn app_params_with_128_bits_security(log_stacked_height: usize) -> SystemPar
         log_stacked_height.saturating_sub(DEFAULT_APP_L_SKIP), // n_stack
         2048,                                                  // w_stack
         WHIR_MAX_LOG_FINAL_POLY_LEN,
-        5,  // folding pow
-        15, // mu pow
+        0,  // folding pow
+        10, // mu pow
         WhirProximityStrategy::UniqueDecoding,
         SECURITY_BITS_TARGET,
         log_up_security_params_baby_bear_128_bits(),
@@ -84,8 +84,8 @@ pub fn leaf_params_with_128_bits_security() -> SystemParams {
         17,   // n_stack
         2048, // w_stack
         WHIR_MAX_LOG_FINAL_POLY_LEN,
-        4,  // folding pow
-        13, // mu pow
+        0, // folding pow
+        8, // mu pow
         WhirProximityStrategy::UniqueDecoding,
         SECURITY_BITS_TARGET,
         log_up_security_params_baby_bear_128_bits(),
@@ -114,8 +114,8 @@ pub fn internal_params_with_128_bits_security() -> SystemParams {
         17,  // n_stack
         512, // w_stack
         WHIR_MAX_LOG_FINAL_POLY_LEN,
-        18, // folding pow
-        20, // mu pow
+        12, // folding pow
+        15, // mu pow
         WhirProximityStrategy::ListDecoding { m: 2 },
         SECURITY_BITS_TARGET,
         log_up_security_params_baby_bear_128_bits(),
@@ -143,8 +143,8 @@ pub fn root_params_with_128_bits_security() -> SystemParams {
         18, // n_stack
         19, // w_stack
         WHIR_MAX_LOG_FINAL_POLY_LEN,
-        20, // folding pow
-        20, // mu pow
+        12, // folding pow
+        10, // mu pow
         WhirProximityStrategy::ListDecoding { m: 1 },
         SECURITY_BITS_TARGET,
         log_up_security_params_baby_bear_128_bits(),

--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -68,7 +68,7 @@ pub fn app_params_with_128_bits_security(log_stacked_height: usize) -> SystemPar
 /// - **Max trace height**: ≤ 2^21
 /// - **Max constraints per AIR**: ≤ 1,000
 /// - **Num AIRs**: ≤ 50
-/// - **Max interactions per AIR**: ≤ 128 (maximum number of interactions in a single AIR for a
+/// - **Max interactions per AIR**: ≤ 100 (maximum number of interactions in a single AIR for a
 ///   single row)
 /// - **Num trace columns** (unstacked, total across all AIRs): ≤ 2,000
 /// - **`w_stack`** = 2,048, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
@@ -99,7 +99,7 @@ pub fn leaf_params_with_128_bits_security() -> SystemParams {
 /// - **Max trace height**: ≤ 2^19
 /// - **Max constraints per AIR**: ≤ 1,000
 /// - **Num AIRs**: ≤ 50
-/// - **Max interactions per AIR**: ≤ 128
+/// - **Max interactions per AIR**: ≤ 100
 /// - **Num trace columns** (unstacked, total across all AIRs): ≤ 2,000
 /// - **`w_stack`** = 512, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
 ///
@@ -128,7 +128,7 @@ pub fn internal_params_with_128_bits_security() -> SystemParams {
 /// - **Max trace height**: ≤ 2^20
 /// - **Max constraints per AIR**: ≤ 1,000
 /// - **Num AIRs**: ≤ 50
-/// - **Max interactions per AIR**: ≤ 128
+/// - **Max interactions per AIR**: ≤ 100
 /// - **Num trace columns** (unstacked, total across all AIRs): ≤ 2,000
 /// - **`w_stack`** = 19, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
 ///

--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -1,6 +1,6 @@
 use openvm_stark_backend::{SystemParams, WhirProximityStrategy};
 
-use crate::config::log_up_params::log_up_security_params_baby_bear_100_bits;
+use crate::config::log_up_params::log_up_security_params_baby_bear_128_bits;
 
 /// STARK config where the base field is BabyBear, extension field is BabyBear^5, and the hasher is
 /// `Poseidon2<Bn254>`.
@@ -17,11 +17,11 @@ pub mod log_up_params;
 // ==========================================================================
 // Production configurations
 // ==========================================================================
-// These configurations target 100-bits of proven round-by-round (RBR) security with BabyBear as the
+// These configurations target 128-bits of proven round-by-round (RBR) security with BabyBear as the
 // base field and BabyBear^5 as the extension field.
 
 const WHIR_MAX_LOG_FINAL_POLY_LEN: usize = 10;
-const SECURITY_BITS_TARGET: usize = 100;
+const SECURITY_BITS_TARGET: usize = 128;
 
 pub const DEFAULT_APP_L_SKIP: usize = 4;
 pub const DEFAULT_APP_LOG_BLOWUP: usize = 1;
@@ -31,9 +31,9 @@ pub const DEFAULT_ROOT_LOG_BLOWUP: usize = 4;
 
 pub const MAX_APP_LOG_STACKED_HEIGHT: usize = 24;
 
-/// Returns `SystemParams` targeting 100 bits of proven RBR security for App VM circuits.
+/// Returns `SystemParams` targeting 128 bits of proven RBR security for App VM circuits.
 ///
-/// # Assumptions for 100-bit security
+/// # Assumptions for 128-bit security
 /// - **Max trace height**: `log_stacked_height` ≤ [`MAX_APP_LOG_STACKED_HEIGHT`] (24)
 /// - **Max constraints per AIR**: ≤ 5,000
 /// - **Num AIRs**: ≤ 100
@@ -43,7 +43,7 @@ pub const MAX_APP_LOG_STACKED_HEIGHT: usize = 24;
 //
 // See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
 // full soundness analysis.
-pub fn app_params_with_100_bits_security(log_stacked_height: usize) -> SystemParams {
+pub fn app_params_with_128_bits_security(log_stacked_height: usize) -> SystemParams {
     assert!(
         log_stacked_height <= MAX_APP_LOG_STACKED_HEIGHT,
         "log_stacked_height must be <= {MAX_APP_LOG_STACKED_HEIGHT}",
@@ -58,17 +58,17 @@ pub fn app_params_with_100_bits_security(log_stacked_height: usize) -> SystemPar
         15, // mu pow
         WhirProximityStrategy::UniqueDecoding,
         SECURITY_BITS_TARGET,
-        log_up_security_params_baby_bear_100_bits(),
+        log_up_security_params_baby_bear_128_bits(),
     )
 }
 
-/// Returns `SystemParams` targeting 100 bits of proven RBR security for leaf aggregation circuits.
+/// Returns `SystemParams` targeting 128 bits of proven RBR security for leaf aggregation circuits.
 ///
-/// # Assumptions for 100-bit security
+/// # Assumptions for 128-bit security
 /// - **Max trace height**: ≤ 2^21
 /// - **Max constraints per AIR**: ≤ 1,000
 /// - **Num AIRs**: ≤ 50
-/// - **Max interactions per AIR**: ≤ 100 (maximum number of interactions in a single AIR for a
+/// - **Max interactions per AIR**: ≤ 128 (maximum number of interactions in a single AIR for a
 ///   single row)
 /// - **Num trace columns** (unstacked, total across all AIRs): ≤ 2,000
 /// - **`w_stack`** = 2,048, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
@@ -77,7 +77,7 @@ pub fn app_params_with_100_bits_security(log_stacked_height: usize) -> SystemPar
 //
 // See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
 // full soundness analysis.
-pub fn leaf_params_with_100_bits_security() -> SystemParams {
+pub fn leaf_params_with_128_bits_security() -> SystemParams {
     SystemParams::new(
         DEFAULT_LEAF_LOG_BLOWUP,
         4,    // l_skip
@@ -88,18 +88,18 @@ pub fn leaf_params_with_100_bits_security() -> SystemParams {
         13, // mu pow
         WhirProximityStrategy::UniqueDecoding,
         SECURITY_BITS_TARGET,
-        log_up_security_params_baby_bear_100_bits(),
+        log_up_security_params_baby_bear_128_bits(),
     )
 }
 
-/// Returns `SystemParams` targeting 100 bits of proven RBR security for internal aggregation
+/// Returns `SystemParams` targeting 128 bits of proven RBR security for internal aggregation
 /// circuits.
 ///
-/// # Assumptions for 100-bit security
+/// # Assumptions for 128-bit security
 /// - **Max trace height**: ≤ 2^19
 /// - **Max constraints per AIR**: ≤ 1,000
 /// - **Num AIRs**: ≤ 50
-/// - **Max interactions per AIR**: ≤ 100
+/// - **Max interactions per AIR**: ≤ 128
 /// - **Num trace columns** (unstacked, total across all AIRs): ≤ 2,000
 /// - **`w_stack`** = 512, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
 ///
@@ -107,7 +107,7 @@ pub fn leaf_params_with_100_bits_security() -> SystemParams {
 //
 // See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
 // full soundness analysis.
-pub fn internal_params_with_100_bits_security() -> SystemParams {
+pub fn internal_params_with_128_bits_security() -> SystemParams {
     SystemParams::new(
         DEFAULT_INTERNAL_LOG_BLOWUP,
         2,   // l_skip
@@ -118,17 +118,17 @@ pub fn internal_params_with_100_bits_security() -> SystemParams {
         20, // mu pow
         WhirProximityStrategy::ListDecoding { m: 2 },
         SECURITY_BITS_TARGET,
-        log_up_security_params_baby_bear_100_bits(),
+        log_up_security_params_baby_bear_128_bits(),
     )
 }
 
-/// Returns `SystemParams` targeting 100 bits of proven RBR security for root circuits.
+/// Returns `SystemParams` targeting 128 bits of proven RBR security for root circuits.
 ///
-/// # Assumptions for 100-bit security
+/// # Assumptions for 128-bit security
 /// - **Max trace height**: ≤ 2^20
 /// - **Max constraints per AIR**: ≤ 1,000
 /// - **Num AIRs**: ≤ 50
-/// - **Max interactions per AIR**: ≤ 100
+/// - **Max interactions per AIR**: ≤ 128
 /// - **Num trace columns** (unstacked, total across all AIRs): ≤ 2,000
 /// - **`w_stack`** = 19, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
 ///
@@ -136,7 +136,7 @@ pub fn internal_params_with_100_bits_security() -> SystemParams {
 //
 // See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
 // full soundness analysis.
-pub fn root_params_with_100_bits_security() -> SystemParams {
+pub fn root_params_with_128_bits_security() -> SystemParams {
     SystemParams::new(
         DEFAULT_ROOT_LOG_BLOWUP,
         2,  // l_skip
@@ -147,6 +147,6 @@ pub fn root_params_with_100_bits_security() -> SystemParams {
         20, // mu pow
         WhirProximityStrategy::ListDecoding { m: 1 },
         SECURITY_BITS_TARGET,
-        log_up_security_params_baby_bear_100_bits(),
+        log_up_security_params_baby_bear_128_bits(),
     )
 }


### PR DESCRIPTION
Towards INT-7602.

Sets target bits of security to 128, and correspondingly reduces proof-of-work bit params to slightly optimize.