### PR TITLE
perf(cuda): virtualize GKR input padding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,11 @@ cargo nextest run -p openvm-cuda-backend --test-threads=4
 
 ## Formatting and Linting
 
-Only run before committing.
+Before committing or opening/updating a PR, formatting and clippy must pass for
+the affected crate(s). Do not open a PR with known fmt or clippy failures.
+
 ```bash
-cargo clippy --all-targets --tests -- -D warnings
+cargo clippy -p <crate> --all-targets --tests -- -D warnings
 cargo +nightly fmt          # requires nightly for unstable rustfmt features
 cargo +nightly fmt -- --check  # check only
 ```

--- a/crates/cuda-backend/cuda/include/frac_ext.cuh
+++ b/crates/cuda-backend/cuda/include/frac_ext.cuh
@@ -6,6 +6,10 @@
 struct FracExt {
     FpExt p;
     FpExt q;
+
+    __device__ __forceinline__ static FracExt zero() {
+        return {FpExt(Fp::zero()), FpExt(Fp::zero())};
+    }
 };
 
 __device__ __forceinline__ void frac_add_inplace(FracExt& lhs, FracExt const& rhs) {

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
@@ -1744,20 +1744,19 @@ T bit_rev(T i, unsigned int nbits)
 //   - Extra `alpha` parameter: adds alpha to every denominator after bit-reversing
 //   - Two GKR tree layers (K=2) are computed inside shmem before writing to global mem,
 //     eliminating two separate kernel passes
-//   - __syncwarp() is used unconditionally (original conditionally uses __syncthreads()
-//     when Z_COUNT > WARP_SIZE, which is never true for Z_COUNT=8)
+//   - Masked __syncwarp(subgroup_mask) is used for each 8-lane Z-tile (matching
+//     the original Z_COUNT <= WARP_SIZE path)
 //
 // Output layout for each Z-tile written at base_rev (i*step + base_rev, i=0..7):
 //   [0,1]  : layer-1 results  (tree level 2)
 //   [2,3]  : layer-0 results preserved (tree level 1 right half, for revert of layer 1)
 //   [4..7] : original+alpha preserved (leaves, for revert of layer 0)
 //
-// __launch_bounds__(256): not a correctness constraint — __syncwarp() is safe for any
-// multiple-of-32 bsize because each gid group is Z_COUNT=8 threads (always within one
-// warp) and different warps operate on independent shmem tiles. bsize=256 was chosen after
-// benchmarking: 2× faster than bsize=32 in isolation (1525 vs 754 GB/s at lg=24 on RTX
-// 5090). It requires 64KB dynamic shmem per block, so cudaFuncSetAttribute is used in the
-// launcher — but only once (static local), paid on the first call and never again.
+// __launch_bounds__(256): not a correctness constraint. Sync is per 8-lane Z-tile
+// using subgroup masks because branch predicates are uniform per tile, not per whole
+// warp. bsize=256 was chosen after benchmarking: 2x faster than bsize=32 in isolation
+// (1525 vs 754 GB/s at lg=24 on RTX 5090). It requires 64KB dynamic shmem per block,
+// so cudaFuncSetAttribute is used in the launcher, paid once on the first call.
 __launch_bounds__(256) __global__
 void bit_rev_frac_build_k2_kernel(
     FracExt* inout, uint32_t real_len, uint32_t lg_domain_size, FpExt alpha)
@@ -1772,6 +1771,9 @@ void bit_rev_frac_build_k2_kernel(
     uint32_t gid = threadIdx.x / Z_COUNT;
     uint32_t idx = threadIdx.x % Z_COUNT;
     uint32_t rev = bit_rev(idx, LG_Z_COUNT);
+    uint32_t lane = threadIdx.x & (WARP_SIZE - 1);
+    uint32_t subgroup_base = lane - idx;
+    unsigned subgroup_mask = ((1u << Z_COUNT) - 1u) << subgroup_base;
 
     index_t domain_size = (index_t)1 << lg_domain_size;
     index_t step = (index_t)1 << (lg_domain_size - LG_Z_COUNT);
@@ -1803,7 +1805,7 @@ void bit_rev_frac_build_k2_kernel(
             }
         }
 
-        __syncwarp();
+        __syncwarp(subgroup_mask);
 
         // Apply alpha + tree layers 0 and 1 to transposed tile, then write to base_rev
         {
@@ -1841,13 +1843,13 @@ void bit_rev_frac_build_k2_kernel(
         if (group_idx == group_rev)
             continue;
 
-        __syncwarp();
+        __syncwarp(subgroup_mask);
 
         #pragma unroll
         for (uint32_t i = 0; i < Z_COUNT; i++)
             xchg[gid][i][rev] = regs[i];
 
-        __syncwarp();
+        __syncwarp(subgroup_mask);
 
         // Apply alpha + tree layers 0 and 1 to transposed tile, then write to base_idx
         {

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
@@ -24,10 +24,66 @@ constexpr int GKR_SP_DEG = 2;
 // ============================================================================
 // KERNELS
 // ============================================================================
+__device__ __forceinline__ uint32_t lg_pow2(uint32_t x) {
+    return 31u - __clz(x);
+}
+
+__device__ __forceinline__ FpExt virtual_padding_q(FpExt alpha, uint32_t subtree_len) {
+    FpExt q = alpha;
+    for (uint32_t len = subtree_len; len > 1; len >>= 1) {
+        q = q * q;
+    }
+    return q;
+}
+
+__device__ __forceinline__ FracExt virtual_node_value(
+    const FracExt *__restrict__ layer,
+    uint32_t dense_idx,
+    uint32_t active_size,
+    uint32_t real_len,
+    uint32_t logical_len,
+    FpExt alpha
+) {
+    uint32_t subtree_len = logical_len / active_size;
+    uint32_t start = rev_len(dense_idx, lg_pow2(active_size)) * subtree_len;
+    if (start >= real_len) {
+        return {FpExt(Fp::zero()), virtual_padding_q(alpha, subtree_len)};
+    }
+    if (dense_idx < real_len) {
+        return layer[dense_idx];
+    }
+    // Dense leaf positions beyond R hold real right-sibling leaves. They are kept at their
+    // natural input slot, which is a padding-only hole in the compact tree layout.
+    return layer[start];
+}
+
+__device__ __forceinline__ void virtual_node_store(
+    FracExt *__restrict__ layer,
+    uint32_t dense_idx,
+    uint32_t active_size,
+    uint32_t real_len,
+    uint32_t logical_len,
+    FracExt value
+) {
+    uint32_t subtree_len = logical_len / active_size;
+    uint32_t start = rev_len(dense_idx, lg_pow2(active_size)) * subtree_len;
+    if (start >= real_len) {
+        return;
+    }
+    if (dense_idx < real_len) {
+        layer[dense_idx] = value;
+    } else {
+        // Only leaf-level right siblings can spill beyond the compact buffer.
+        layer[start] = value;
+    }
+}
+
 template <bool revert, bool apply_alpha = false>
 __global__ void frac_build_tree_layer_kernel(
     FracExt *__restrict__ layer,
     uint32_t half,
+    uint32_t real_len,
+    uint32_t logical_len,
     FpExt alpha = FpExt(Fp(0))
 ) {
     uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -35,31 +91,75 @@ __global__ void frac_build_tree_layer_kernel(
         return;
     }
 
+    const uint32_t layer_size = half << 1;
+    const bool virtual_mode = real_len < logical_len;
+    if constexpr (apply_alpha) {
+        if (virtual_mode && layer_size == logical_len) {
+            const uint32_t parent_active_size = half;
+            const uint32_t parent_start =
+                rev_len(idx, lg_pow2(parent_active_size)) << 1;
+
+            FracExt lhs_val = parent_start < real_len
+                ? layer[parent_start]
+                : FracExt{FpExt(Fp::zero()), FpExt(Fp::zero())};
+            FracExt rhs_val = parent_start + 1 < real_len
+                ? layer[parent_start + 1]
+                : FracExt{FpExt(Fp::zero()), FpExt(Fp::zero())};
+            FracExt rhs_leaf = rhs_val;
+            bool has_rhs_leaf = parent_start + 1 < real_len;
+            __syncthreads();
+
+            lhs_val.q = lhs_val.q + alpha;
+            rhs_val.q = rhs_val.q + alpha;
+            frac_add_inplace(lhs_val, rhs_val);
+            virtual_node_store(layer, idx, parent_active_size, real_len, logical_len, lhs_val);
+
+            if (has_rhs_leaf) {
+                rhs_leaf.q = rhs_leaf.q + alpha;
+                virtual_node_store(layer, idx + half, logical_len, real_len, logical_len, rhs_leaf);
+            }
+            return;
+        }
+    }
+
+    uint32_t lhs_active_size = revert ? half : layer_size;
+    FracExt lhs = virtual_mode
+        ? virtual_node_value(layer, idx, lhs_active_size, real_len, logical_len, alpha)
+        : layer[idx];
+    FracExt rhs = virtual_mode
+        ? virtual_node_value(layer, idx | half, layer_size, real_len, logical_len, alpha)
+        : layer[idx | half];
+
     if constexpr (apply_alpha) {
         // When applying alpha, we need to modify both operands before combining
         // Read both values, apply alpha to denominators, then combine
-        FracExt lhs_val = layer[idx];
-        FracExt rhs_val = layer[idx | half];
-        lhs_val.q = lhs_val.q + alpha;
-        rhs_val.q = rhs_val.q + alpha;
-
-        if constexpr (revert) {
-            frac_unadd_inplace(lhs_val, rhs_val);
-        } else {
-            frac_add_inplace(lhs_val, rhs_val);
-        }
-
-        layer[idx] = lhs_val;
-    } else {
-        // Original fast path: use references for in-place modification
-        FracExt &lhs = layer[idx];
-        FracExt const &rhs = layer[idx | half];
+        lhs.q = lhs.q + alpha;
+        rhs.q = rhs.q + alpha;
 
         if constexpr (revert) {
             frac_unadd_inplace(lhs, rhs);
         } else {
             frac_add_inplace(lhs, rhs);
         }
+    } else {
+        if constexpr (revert) {
+            frac_unadd_inplace(lhs, rhs);
+        } else {
+            frac_add_inplace(lhs, rhs);
+        }
+    }
+
+    if (virtual_mode) {
+        virtual_node_store(
+            layer,
+            idx,
+            revert ? layer_size : half,
+            real_len,
+            logical_len,
+            lhs
+        );
+    } else {
+        layer[idx] = lhs;
     }
 }
 
@@ -72,22 +172,6 @@ __device__ __forceinline__ FpExt sqrt_buffer_get(
     uint32_t const idx
 ) {
     return eq_xi_low[idx & ((1u << log_eq_low_cap) - 1)] * eq_xi_high[idx >> log_eq_low_cap];
-}
-
-__device__ __forceinline__ FracExt load_virtual_input_bitrev(
-    const FracExt *__restrict__ input,
-    uint32_t real_len,
-    uint32_t lg_domain_size,
-    uint32_t bitrev_pos,
-    FpExt alpha
-) {
-    uint32_t logical_idx = rev_len(bitrev_pos, lg_domain_size);
-    if (logical_idx < real_len) {
-        FracExt value = input[logical_idx];
-        value.q = value.q + alpha;
-        return value;
-    }
-    return {FpExt(Fp::zero()), alpha};
 }
 
 // Accumulate GKR sumcheck contributions for s'_t(1) and s'_t(2).
@@ -210,28 +294,42 @@ __global__ void compute_round_block_sum_kernel(
     }
 }
 
-// Fold kernel operating on FpExt* view of FracExt buffer.
-// Since FracExt = {p, q} has p and q folded independently with the same formula,
-// we can treat the buffer as FpExt* with 2x the elements.
-//
 // Pairs (idx, idx+quarter) and (idx+half, idx+3*quarter),
 // writes results to dst[idx] and dst[idx+quarter].
 // Safe for src == dst (in-place) because each thread reads before writing to the same index.
-__global__ void fold_ef_columns_kernel(const FpExt *src, FpExt *dst, uint32_t quarter, FpExt r) {
+__global__ void fold_ef_columns_kernel(
+    const FracExt *src,
+    FracExt *dst,
+    uint32_t size,
+    uint32_t real_len,
+    uint32_t logical_len,
+    FpExt r,
+    FpExt alpha
+) {
+    uint32_t quarter = size >> 2;
     uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= quarter) {
         return;
     }
 
-    FpExt v0 = src[idx];
-    FpExt v1 = src[idx | quarter];
-    dst[idx] = v0 + r * (v1 - v0);
-
     uint32_t half = quarter << 1;
+    bool virtual_mode = real_len < logical_len;
 
-    FpExt v2 = src[idx | half];
-    FpExt v3 = src[idx | half | quarter];
-    dst[idx | quarter] = v2 + r * (v3 - v2);
+    FracExt a = virtual_mode
+        ? virtual_node_value(src, idx, size, real_len, logical_len, alpha)
+        : src[idx];
+    FracExt b = virtual_mode
+        ? virtual_node_value(src, idx + quarter, size, real_len, logical_len, alpha)
+        : src[idx + quarter];
+    dst[idx] = {a.p + r * (b.p - a.p), a.q + r * (b.q - a.q)};
+
+    FracExt c = virtual_mode
+        ? virtual_node_value(src, idx + half, size, real_len, logical_len, alpha)
+        : src[idx + half];
+    FracExt d = virtual_mode
+        ? virtual_node_value(src, idx + half + quarter, size, real_len, logical_len, alpha)
+        : src[idx + half + quarter];
+    dst[idx + quarter] = {c.p + r * (d.p - c.p), c.q + r * (d.q - c.q)};
 }
 
 // Fused compute round + fold kernel (OUT-OF-PLACE version).
@@ -253,14 +351,19 @@ __global__ void compute_round_and_fold_kernel(
     const FpExt *__restrict__ eq_xi_high,
     const FracExt *__restrict__ src_pq,  // Pre-fold buffer (2*pq_size FracExt)
     uint32_t num_x,                      // post-fold num_x (= pq_size / 2)
+    uint32_t real_len,
+    uint32_t logical_len,
     uint32_t log_eq_low_cap,
     FpExt lambda,
     FpExt r_prev,                        // Previous round's challenge for folding
+    FpExt alpha,
     FpExt *__restrict__ block_sums,      // Output: [gridDim.x * 2]
     FracExt *__restrict__ dst_pq         // Post-fold buffer (pq_size FracExt)
 ) {
     extern __shared__ FpExt shared[];
     const uint32_t pq_size = 2 * num_x;
+    const uint32_t src_active_size = pq_size << 1;
+    const bool virtual_mode = real_len < logical_len;
 
     // Index offsets for fold pattern (see detailed comments in inplace kernel)
     const uint32_t half = pq_size;              // src_pq_size / 2
@@ -282,32 +385,48 @@ __global__ void compute_round_and_fold_kernel(
         // Load pairs in tight scopes, fold, write immediately to reduce register pressure
         // f00 at post-fold idx
         {
-            FracExt a = src_pq[idx];
-            FracExt b = src_pq[idx + quarter];
+            FracExt a = virtual_mode
+                ? virtual_node_value(src_pq, idx, src_active_size, real_len, logical_len, alpha)
+                : src_pq[idx];
+            FracExt b = virtual_mode
+                ? virtual_node_value(src_pq, idx + quarter, src_active_size, real_len, logical_len, alpha)
+                : src_pq[idx + quarter];
             p0_even = a.p + r_prev * (b.p - a.p);
             q0_even = a.q + r_prev * (b.q - a.q);
             dst_pq[idx] = {p0_even, q0_even};
         }
         // f10 at post-fold idx + quarter
         {
-            FracExt a = src_pq[idx + half];
-            FracExt b = src_pq[idx + half + quarter];
+            FracExt a = virtual_mode
+                ? virtual_node_value(src_pq, idx + half, src_active_size, real_len, logical_len, alpha)
+                : src_pq[idx + half];
+            FracExt b = virtual_mode
+                ? virtual_node_value(src_pq, idx + half + quarter, src_active_size, real_len, logical_len, alpha)
+                : src_pq[idx + half + quarter];
             p1_even = a.p + r_prev * (b.p - a.p);
             q1_even = a.q + r_prev * (b.q - a.q);
             dst_pq[idx + quarter] = {p1_even, q1_even};
         }
         // f01 at post-fold idx + eighth
         {
-            FracExt a = src_pq[idx + eighth];
-            FracExt b = src_pq[idx + three_eighths];
+            FracExt a = virtual_mode
+                ? virtual_node_value(src_pq, idx + eighth, src_active_size, real_len, logical_len, alpha)
+                : src_pq[idx + eighth];
+            FracExt b = virtual_mode
+                ? virtual_node_value(src_pq, idx + three_eighths, src_active_size, real_len, logical_len, alpha)
+                : src_pq[idx + three_eighths];
             p0_odd = a.p + r_prev * (b.p - a.p);
             q0_odd = a.q + r_prev * (b.q - a.q);
             dst_pq[idx + eighth] = {p0_odd, q0_odd};
         }
         // f11 at post-fold idx + three_eighths
         {
-            FracExt a = src_pq[idx + half + eighth];
-            FracExt b = src_pq[idx + half + three_eighths];
+            FracExt a = virtual_mode
+                ? virtual_node_value(src_pq, idx + half + eighth, src_active_size, real_len, logical_len, alpha)
+                : src_pq[idx + half + eighth];
+            FracExt b = virtual_mode
+                ? virtual_node_value(src_pq, idx + half + three_eighths, src_active_size, real_len, logical_len, alpha)
+                : src_pq[idx + half + three_eighths];
             p1_odd = a.p + r_prev * (b.p - a.p);
             q1_odd = a.q + r_prev * (b.q - a.q);
             dst_pq[idx + three_eighths] = {p1_odd, q1_odd};
@@ -341,13 +460,20 @@ __global__ void compute_round_and_fold_inplace_kernel(
     const FpExt *__restrict__ eq_xi_high,
     FracExt *pq,                         // In-place buffer: reads 2*pq_size, writes pq_size
     uint32_t num_x,                      // post-fold num_x (= pq_size / 2)
+    uint32_t real_len,
+    uint32_t logical_len,
+    uint32_t dst_real_len,
+    uint32_t dst_logical_len,
     uint32_t log_eq_low_cap,
     FpExt lambda,
     FpExt r_prev,                        // Previous round's challenge for folding
+    FpExt alpha,
     FpExt *__restrict__ block_sums       // Output: [gridDim.x * 2]
 ) {
     extern __shared__ FpExt shared[];
     const uint32_t pq_size = 2 * num_x;
+    const uint32_t src_active_size = pq_size << 1;
+    const bool virtual_mode = real_len < logical_len;
 
     // Fold pattern analysis:
     // The fold kernel operates on FpExt* view where FracExt[i] = (FpExt[2i], FpExt[2i+1]).
@@ -384,41 +510,94 @@ __global__ void compute_round_and_fold_inplace_kernel(
 
         // Pair 1: f00 (idx -> p0_even, q0_even)
         {
-            FracExt a = pq[idx];
-            FracExt b = pq[idx + quarter];
+            FracExt a = virtual_mode
+                ? virtual_node_value(pq, idx, src_active_size, real_len, logical_len, alpha)
+                : pq[idx];
+            FracExt b = virtual_mode
+                ? virtual_node_value(pq, idx + quarter, src_active_size, real_len, logical_len, alpha)
+                : pq[idx + quarter];
             p0_even = a.p + r_prev * (b.p - a.p);
             q0_even = a.q + r_prev * (b.q - a.q);
         }
 
         // Pair 2: f10 (idx + half -> p1_even, q1_even)
         {
-            FracExt a = pq[idx + half];
-            FracExt b = pq[idx + half + quarter];
+            FracExt a = virtual_mode
+                ? virtual_node_value(pq, idx + half, src_active_size, real_len, logical_len, alpha)
+                : pq[idx + half];
+            FracExt b = virtual_mode
+                ? virtual_node_value(pq, idx + half + quarter, src_active_size, real_len, logical_len, alpha)
+                : pq[idx + half + quarter];
             p1_even = a.p + r_prev * (b.p - a.p);
             q1_even = a.q + r_prev * (b.q - a.q);
         }
 
         // Pair 3: f01 (idx + eighth -> p0_odd, q0_odd)
         {
-            FracExt a = pq[idx + eighth];
-            FracExt b = pq[idx + three_eighths];
+            FracExt a = virtual_mode
+                ? virtual_node_value(pq, idx + eighth, src_active_size, real_len, logical_len, alpha)
+                : pq[idx + eighth];
+            FracExt b = virtual_mode
+                ? virtual_node_value(pq, idx + three_eighths, src_active_size, real_len, logical_len, alpha)
+                : pq[idx + three_eighths];
             p0_odd = a.p + r_prev * (b.p - a.p);
             q0_odd = a.q + r_prev * (b.q - a.q);
         }
 
         // Pair 4: f11 (idx + half + eighth -> p1_odd, q1_odd)
         {
-            FracExt a = pq[idx + half + eighth];
-            FracExt b = pq[idx + half + three_eighths];
+            FracExt a = virtual_mode
+                ? virtual_node_value(pq, idx + half + eighth, src_active_size, real_len, logical_len, alpha)
+                : pq[idx + half + eighth];
+            FracExt b = virtual_mode
+                ? virtual_node_value(pq, idx + half + three_eighths, src_active_size, real_len, logical_len, alpha)
+                : pq[idx + half + three_eighths];
             p1_odd = a.p + r_prev * (b.p - a.p);
             q1_odd = a.q + r_prev * (b.q - a.q);
         }
 
-        // Write all folded values (safe: writes to first half, reads from both halves completed)
-        pq[idx] = {p0_even, q0_even};
-        pq[idx + quarter] = {p1_even, q1_even};
-        pq[idx + eighth] = {p0_odd, q0_odd};
-        pq[idx + three_eighths] = {p1_odd, q1_odd};
+        // Write all folded values (safe: writes to first half, reads from both halves completed).
+        // In compact virtual mode, padding-only output slots are left untouched so they do not race
+        // with spilled real leaves that may still be read by neighboring threads.
+        if (dst_real_len < dst_logical_len) {
+            virtual_node_store(
+                pq,
+                idx,
+                pq_size,
+                dst_real_len,
+                dst_logical_len,
+                {p0_even, q0_even}
+            );
+            virtual_node_store(
+                pq,
+                idx + quarter,
+                pq_size,
+                dst_real_len,
+                dst_logical_len,
+                {p1_even, q1_even}
+            );
+            virtual_node_store(
+                pq,
+                idx + eighth,
+                pq_size,
+                dst_real_len,
+                dst_logical_len,
+                {p0_odd, q0_odd}
+            );
+            virtual_node_store(
+                pq,
+                idx + three_eighths,
+                pq_size,
+                dst_real_len,
+                dst_logical_len,
+                {p1_odd, q1_odd}
+            );
+        } else {
+            pq[idx] = {p0_even, q0_even};
+            pq[idx + quarter] = {p1_even, q1_even};
+            pq[idx + eighth] = {p0_odd, q0_odd};
+            pq[idx + three_eighths] = {p1_odd, q1_odd};
+        }
 
         accumulate_compute_contributions(
             eq_xi_low, eq_xi_high, idx, log_eq_low_cap, lambda,
@@ -455,14 +634,20 @@ __global__ void compute_round_and_revert_kernel(
     const FpExt *__restrict__ eq_xi_high,
     FracExt *__restrict__ layer,         // Tree layer buffer (modified in-place for revert)
     uint32_t num_x,
+    uint32_t real_len,
+    uint32_t logical_len,
     uint32_t log_eq_low_cap,
     FpExt lambda,
+    FpExt alpha,
     FpExt *__restrict__ block_sums       // Output: [gridDim.x * 2]
 ) {
     extern __shared__ FpExt shared[];
     const uint32_t pq_size = 2 * num_x;
     const uint32_t half = pq_size >> 1;     // pq_size / 2
     const uint32_t quarter = pq_size >> 2;  // pq_size / 4
+    const bool virtual_mode = real_len < logical_len;
+    const uint32_t parent_active_size = half;
+    const uint32_t child_active_size = pq_size;
 
     // Use scalar accumulators instead of array to help register allocation
     const FpExt zero(Fp::zero());
@@ -480,78 +665,76 @@ __global__ void compute_round_and_revert_kernel(
 
         // Compute p0_even by reverting with p1_even (frac_unadd)
         {
-            FracExt lhs = layer[idx];
-            FracExt rhs = layer[idx + half];
+            FracExt lhs = virtual_mode
+                ? virtual_node_value(layer, idx, parent_active_size, real_len, logical_len, alpha)
+                : layer[idx];
+            FracExt rhs = virtual_mode
+                ? virtual_node_value(layer, idx + half, child_active_size, real_len, logical_len, alpha)
+                : layer[idx + half];
             FpExt rhs_q_inv = inv(rhs.q);
             q0_even = lhs.q * rhs_q_inv;
             p0_even = (lhs.p - q0_even * rhs.p) * rhs_q_inv;
             p1_even = rhs.p;
             q1_even = rhs.q;
-            layer[idx] = {p0_even, q0_even};
+            if (virtual_mode) {
+                virtual_node_store(
+                    layer,
+                    idx,
+                    pq_size,
+                    real_len,
+                    logical_len,
+                    {p0_even, q0_even}
+                );
+            } else {
+                layer[idx] = {p0_even, q0_even};
+            }
         }
 
         // Compute p0_odd by reverting with p1_odd (frac_unadd)
         {
-            FracExt lhs = layer[idx + quarter];
-            FracExt rhs = layer[idx + half + quarter];
+            FracExt lhs = virtual_mode
+                ? virtual_node_value(
+                    layer,
+                    idx + quarter,
+                    parent_active_size,
+                    real_len,
+                    logical_len,
+                    alpha
+                )
+                : layer[idx + quarter];
+            FracExt rhs = virtual_mode
+                ? virtual_node_value(
+                    layer,
+                    idx + half + quarter,
+                    child_active_size,
+                    real_len,
+                    logical_len,
+                    alpha
+                )
+                : layer[idx + half + quarter];
             FpExt rhs_q_inv = inv(rhs.q);
             q0_odd = lhs.q * rhs_q_inv;
             p0_odd = (lhs.p - q0_odd * rhs.p) * rhs_q_inv;
             p1_odd = rhs.p;
             q1_odd = rhs.q;
-            layer[idx + quarter] = {p0_odd, q0_odd};
+            if (virtual_mode) {
+                virtual_node_store(
+                    layer,
+                    idx + quarter,
+                    pq_size,
+                    real_len,
+                    logical_len,
+                    {p0_odd, q0_odd}
+                );
+            } else {
+                layer[idx + quarter] = {p0_odd, q0_odd};
+            }
         }
 
         accumulate_compute_contributions(
             eq_xi_low, eq_xi_high, idx, log_eq_low_cap, lambda,
             p0_even, q0_even, p0_odd, q0_odd,
             p1_even, q1_even, p1_odd, q1_odd,
-            local0, local1
-        );
-    }
-
-    reduce_block_sums(shared, local0, local1, block_sums);
-}
-
-// Computes the first sumcheck round for the largest GKR layer directly from a
-// natural-order virtual input. This is equivalent to first materializing the
-// dense padded input, adding alpha to every denominator, bit-reversing it, and
-// then running compute_round on the leaf layer.
-__global__ void compute_round_virtual_input_kernel(
-    const FpExt *__restrict__ eq_xi_low,
-    const FpExt *__restrict__ eq_xi_high,
-    const FracExt *__restrict__ input,
-    uint32_t real_len,
-    uint32_t lg_domain_size,
-    uint32_t log_eq_low_cap,
-    FpExt lambda,
-    FpExt alpha,
-    FpExt *__restrict__ block_sums
-) {
-    extern __shared__ FpExt shared[];
-    const uint32_t pq_size = 1u << lg_domain_size;
-    const uint32_t num_x = pq_size >> 1;
-    const uint32_t half = pq_size >> 1;
-    const uint32_t quarter = pq_size >> 2;
-
-    const FpExt zero(Fp::zero());
-    FpExt local0 = zero, local1 = zero;
-    uint32_t idx_base = threadIdx.x + blockIdx.x * blockDim.x;
-
-    for (uint32_t idx = idx_base; idx < num_x / 2; idx += blockDim.x * gridDim.x) {
-        FracExt p0_even_v =
-            load_virtual_input_bitrev(input, real_len, lg_domain_size, idx, alpha);
-        FracExt p1_even_v =
-            load_virtual_input_bitrev(input, real_len, lg_domain_size, idx + half, alpha);
-        FracExt p0_odd_v =
-            load_virtual_input_bitrev(input, real_len, lg_domain_size, idx + quarter, alpha);
-        FracExt p1_odd_v =
-            load_virtual_input_bitrev(input, real_len, lg_domain_size, idx + half + quarter, alpha);
-
-        accumulate_compute_contributions(
-            eq_xi_low, eq_xi_high, idx, log_eq_low_cap, lambda,
-            p0_even_v.p, p0_even_v.q, p0_odd_v.p, p0_odd_v.q,
-            p1_even_v.p, p1_even_v.q, p1_odd_v.p, p1_odd_v.q,
             local0, local1
         );
     }
@@ -576,9 +759,12 @@ constexpr uint32_t PRECOMPUTE_M_TAIL_BATCH = 16;
 template <bool inline_fold, uint32_t W>
 __global__ void precompute_m_build_partial_kernel(
     const FracExt *__restrict__ pq,
+    uint32_t real_len,
+    uint32_t logical_len,
     uint32_t rem_n,          // number of variables AFTER fold (folded rem_n)
     FpExt lambda,
     FpExt r_prev,            // challenge for the inline fold (only used when inline_fold=true)
+    FpExt alpha,
     const FpExt *__restrict__ eq_tail_low,
     const FpExt *__restrict__ eq_tail_high,
     uint32_t log_eq_tail_low_cap,
@@ -598,6 +784,8 @@ __global__ void precompute_m_build_partial_kernel(
     // Otherwise: buffer has rem_n variables (already folded).
     uint32_t fold_half = inline_fold ? (1u << rem_n) : 0;
     uint32_t poly_stride = inline_fold ? (1u << (rem_n + 1)) : (1u << rem_n);
+    uint32_t active_size = poly_stride << 1;
+    bool virtual_mode = real_len < logical_len;
 
     uint32_t b_start = blockIdx.x * tail_tile;
     uint32_t b_end = min(b_start + tail_tile, k);
@@ -639,18 +827,37 @@ __global__ void precompute_m_build_partial_kernel(
             FpExt p0, q0, p1, q1;
             if constexpr (inline_fold) {
                 // Inline fold: val = lo + r_prev * (hi - lo) for each of {p0, q0, p1, q1}.
-                FracExt const &f0_lo = pq[src];
-                FracExt const &f0_hi = pq[src + fold_half];
-                FracExt const &f1_lo = pq[poly_stride + src];
-                FracExt const &f1_hi = pq[poly_stride + src + fold_half];
+                FracExt f0_lo = virtual_mode
+                    ? virtual_node_value(pq, src, active_size, real_len, logical_len, alpha)
+                    : pq[src];
+                FracExt f0_hi = virtual_mode
+                    ? virtual_node_value(pq, src + fold_half, active_size, real_len, logical_len, alpha)
+                    : pq[src + fold_half];
+                FracExt f1_lo = virtual_mode
+                    ? virtual_node_value(pq, poly_stride + src, active_size, real_len, logical_len, alpha)
+                    : pq[poly_stride + src];
+                FracExt f1_hi = virtual_mode
+                    ? virtual_node_value(
+                        pq,
+                        poly_stride + src + fold_half,
+                        active_size,
+                        real_len,
+                        logical_len,
+                        alpha
+                    )
+                    : pq[poly_stride + src + fold_half];
                 p0 = f0_lo.p + r_prev * (f0_hi.p - f0_lo.p);
                 q0 = f0_lo.q + r_prev * (f0_hi.q - f0_lo.q);
                 p1 = f1_lo.p + r_prev * (f1_hi.p - f1_lo.p);
                 q1 = f1_lo.q + r_prev * (f1_hi.q - f1_lo.q);
             } else {
                 // Buffer already folded: read directly.
-                FracExt const &f0 = pq[src];
-                FracExt const &f1 = pq[poly_stride + src];
+                FracExt f0 = virtual_mode
+                    ? virtual_node_value(pq, src, active_size, real_len, logical_len, alpha)
+                    : pq[src];
+                FracExt f1 = virtual_mode
+                    ? virtual_node_value(pq, poly_stride + src, active_size, real_len, logical_len, alpha)
+                    : pq[poly_stride + src];
                 p0 = f0.p; q0 = f0.q;
                 p1 = f1.p; q1 = f1.q;
             }
@@ -680,9 +887,12 @@ template <bool inline_fold, uint32_t W>
 inline void launch_precompute_m_build_partial_kernel(
     dim3 grid,
     const FracExt *pq,
+    uint32_t real_len,
+    uint32_t logical_len,
     uint32_t rem_n,
     FpExt lambda,
     FpExt r_prev,
+    FpExt alpha,
     const FpExt *eq_tail_low,
     const FpExt *eq_tail_high,
     uint32_t log_eq_tail_low_cap,
@@ -697,9 +907,12 @@ inline void launch_precompute_m_build_partial_kernel(
         (4 * sh_stride * PRECOMPUTE_M_TAIL_BATCH + PRECOMPUTE_M_TAIL_BATCH) * sizeof(FpExt);
     precompute_m_build_partial_kernel<inline_fold, W><<<grid, block, shmem_bytes, stream>>>(
         pq,
+        real_len,
+        logical_len,
         rem_n,
         lambda,
         r_prev,
+        alpha,
         eq_tail_low,
         eq_tail_high,
         log_eq_tail_low_cap,
@@ -713,9 +926,12 @@ inline int launch_precompute_m_build_partial_dispatch(
     uint32_t w,
     dim3 grid,
     const FracExt *pq,
+    uint32_t real_len,
+    uint32_t logical_len,
     uint32_t rem_n,
     FpExt lambda,
     FpExt r_prev,
+    FpExt alpha,
     const FpExt *eq_tail_low,
     const FpExt *eq_tail_high,
     uint32_t log_eq_tail_low_cap,
@@ -724,8 +940,8 @@ inline int launch_precompute_m_build_partial_dispatch(
     cudaStream_t stream
 ) {
     using LauncherFn = void (*)(
-        dim3, const FracExt *, uint32_t, FpExt, FpExt, const FpExt *, const FpExt *, uint32_t,
-        uint32_t, FpExt *, cudaStream_t
+        dim3, const FracExt *, uint32_t, uint32_t, uint32_t, FpExt, FpExt, FpExt,
+        const FpExt *, const FpExt *, uint32_t, uint32_t, FpExt *, cudaStream_t
     );
     static constexpr LauncherFn launchers[] = {
         &launch_precompute_m_build_partial_kernel<inline_fold, 1>,
@@ -745,9 +961,12 @@ inline int launch_precompute_m_build_partial_dispatch(
     launchers[w - min_w](
         grid,
         pq,
+        real_len,
+        logical_len,
         rem_n,
         lambda,
         r_prev,
+        alpha,
         eq_tail_low,
         eq_tail_high,
         log_eq_tail_low_cap,
@@ -849,6 +1068,9 @@ __global__ void multifold_kernel(
     const FracExt *src,
     FracExt *dst,
     uint32_t tail_size,
+    uint32_t real_len,
+    uint32_t logical_len,
+    FpExt alpha,
     const FpExt *__restrict__ eq_r_window
 ) {
     constexpr uint32_t beta_size = 1u << W;
@@ -862,11 +1084,18 @@ __global__ void multifold_kernel(
     FpExt acc0_q = zero;
     FpExt acc1_p = zero;
     FpExt acc1_q = zero;
-    const FracExt *src_1 = src + ((size_t)tail_size << W);
+    const uint32_t poly_stride = tail_size << W;
+    const uint32_t active_size = poly_stride << 1;
+    const bool virtual_mode = real_len < logical_len;
+    const FracExt *src_1 = src + poly_stride;
     for (uint32_t beta = 0; beta < beta_size; ++beta) {
         uint32_t idx = beta * tail_size + out_idx;
-        FracExt v0 = src[idx];
-        FracExt v1 = src_1[idx];
+        FracExt v0 = virtual_mode
+            ? virtual_node_value(src, idx, active_size, real_len, logical_len, alpha)
+            : src[idx];
+        FracExt v1 = virtual_mode
+            ? virtual_node_value(src, poly_stride + idx, active_size, real_len, logical_len, alpha)
+            : src_1[idx];
         FpExt eq_r = eq_r_window[beta];
         acc0_p += eq_r * v0.p;
         acc0_q += eq_r * v0.q;
@@ -920,17 +1149,30 @@ __global__ void frac_vector_scalar_multiply_kernel(
 //   Savings:   2 reads + 1 write = ~33% reduction in global memory traffic.
 __global__ void frac_build_tree_two_layers_kernel(
     FracExt *__restrict__ layer,
-    uint32_t half_i1   // = N >> (i+2), where i is the first of the two layers
+    uint32_t half_i1,   // = N >> (i+2), where i is the first of the two layers
+    uint32_t real_len,
+    uint32_t logical_len,
+    FpExt alpha
 ) {
     uint32_t j = blockIdx.x * blockDim.x + threadIdx.x;
     if (j >= half_i1) return;
 
     uint32_t half_i = half_i1 << 1;   // = N >> (i+1)
+    uint32_t layer_size = half_i1 << 2;
+    bool virtual_mode = real_len < logical_len;
 
-    FracExt A = layer[j];
-    FracExt B = layer[j + half_i1];
-    FracExt C = layer[j + half_i];
-    FracExt D = layer[j + half_i + half_i1];
+    FracExt A = virtual_mode
+        ? virtual_node_value(layer, j, layer_size, real_len, logical_len, alpha)
+        : layer[j];
+    FracExt B = virtual_mode
+        ? virtual_node_value(layer, j + half_i1, layer_size, real_len, logical_len, alpha)
+        : layer[j + half_i1];
+    FracExt C = virtual_mode
+        ? virtual_node_value(layer, j + half_i, layer_size, real_len, logical_len, alpha)
+        : layer[j + half_i];
+    FracExt D = virtual_mode
+        ? virtual_node_value(layer, j + half_i + half_i1, layer_size, real_len, logical_len, alpha)
+        : layer[j + half_i + half_i1];
 
     // Layer i: combine A with C and B with D (kept in registers)
     FracExt lhs = frac_add(A, C);
@@ -938,8 +1180,13 @@ __global__ void frac_build_tree_two_layers_kernel(
     // Layer i+1: combine the two layer-i results
     FracExt result = frac_add(lhs, rhs);
 
-    layer[j]         = result;
-    layer[j + half_i1] = rhs;   // Needed for revert of layer i+1
+    if (virtual_mode) {
+        virtual_node_store(layer, j, half_i1, real_len, logical_len, result);
+        virtual_node_store(layer, j + half_i1, half_i, real_len, logical_len, rhs);
+    } else {
+        layer[j]         = result;
+        layer[j + half_i1] = rhs;   // Needed for revert of layer i+1
+    }
     // layer[j + half_i] = C  (unchanged, needed for revert of layer i)
     // layer[j + half_i + half_i1] = D  (unchanged, needed for revert of layer i)
 }
@@ -948,15 +1195,30 @@ __global__ void frac_build_tree_two_layers_kernel(
 // LAUNCHERS
 // ============================================================================
 template <bool revert, bool apply_alpha>
-int launch_frac_build_tree_layer(FracExt *layer, size_t layer_size, FpExt alpha, cudaStream_t stream) {
-    auto [grid, block] = kernel_launch_params(layer_size);
-    frac_build_tree_layer_kernel<revert, apply_alpha><<<grid, block, 0, stream>>>(layer, layer_size, alpha);
+int launch_frac_build_tree_layer(
+    FracExt *layer,
+    size_t half,
+    uint32_t real_len,
+    uint32_t logical_len,
+    FpExt alpha,
+    cudaStream_t stream
+) {
+    auto [grid, block] = kernel_launch_params(half);
+    frac_build_tree_layer_kernel<revert, apply_alpha><<<grid, block, 0, stream>>>(
+        layer,
+        (uint32_t)half,
+        real_len,
+        logical_len,
+        alpha
+    );
     return CHECK_KERNEL();
 }
 
 extern "C" int _frac_build_tree_layer(
     FracExt *layer,
     size_t layer_size,
+    size_t real_len,
+    size_t logical_len,
     bool revert,
     FpExt alpha,
     bool apply_alpha,
@@ -969,20 +1231,41 @@ extern "C" int _frac_build_tree_layer(
     layer_size /= 2;
 
     return DISPATCH_BOOL_PAIR(
-        launch_frac_build_tree_layer, revert, apply_alpha, layer, layer_size, alpha, stream
+        launch_frac_build_tree_layer,
+        revert,
+        apply_alpha,
+        layer,
+        layer_size,
+        (uint32_t)real_len,
+        (uint32_t)logical_len,
+        alpha,
+        stream
     );
 }
 
 // Launcher for fused two-layer tree build.
 // half_i1 = N >> (i+2), where i is the index of the first layer to fuse.
 // Requires half_i1 >= 1 and half_i1 * 4 <= total array size.
-extern "C" int _frac_build_tree_two_layers(FracExt *layer, size_t half_i1, cudaStream_t stream) {
+extern "C" int _frac_build_tree_two_layers(
+    FracExt *layer,
+    size_t half_i1,
+    size_t real_len,
+    size_t logical_len,
+    FpExt alpha,
+    cudaStream_t stream
+) {
     if (half_i1 == 0) return 0;
     // Use 256 threads/block (not 1024) to give the compiler more register headroom.
     // frac_build_tree_two_layers_kernel does 4 FracExt loads + 3 frac_add ops,
     // which has higher register pressure than the single-layer build kernel.
     auto [grid, block] = kernel_launch_params(half_i1, 256);
-    frac_build_tree_two_layers_kernel<<<grid, block, 0, stream>>>(layer, (uint32_t)half_i1);
+    frac_build_tree_two_layers_kernel<<<grid, block, 0, stream>>>(
+        layer,
+        (uint32_t)half_i1,
+        (uint32_t)real_len,
+        (uint32_t)logical_len,
+        alpha
+    );
     return CHECK_KERNEL();
 }
 
@@ -1090,8 +1373,11 @@ extern "C" int _frac_compute_round_and_revert(
     const FpExt *eq_xi_high,
     FracExt *layer,           // Tree layer buffer (modified in-place for revert)
     size_t num_x,
+    size_t real_len,
+    size_t logical_len,
     size_t eq_low_cap,
     FpExt lambda,
+    FpExt alpha,
     FpExt *out,               // Output: [d=2] final results
     FpExt *tmp_block_sums,     // Temporary buffer: [gridDim.x * d]
     cudaStream_t stream
@@ -1107,48 +1393,8 @@ extern "C" int _frac_compute_round_and_revert(
         eq_xi_high,
         layer,
         (uint32_t)num_x,
-        __builtin_ctz((uint32_t)eq_low_cap),
-        lambda,
-        tmp_block_sums
-    );
-    int err = CHECK_KERNEL();
-    if (err != 0)
-        return err;
-
-    // Launch final reduction kernel.
-    return final_reduce_block_sums(tmp_block_sums, out, grid.x, stream);
-}
-
-extern "C" int _frac_compute_round_virtual_input(
-    const FpExt *eq_xi_low,
-    const FpExt *eq_xi_high,
-    const FracExt *input,
-    size_t real_len,
-    size_t logical_len,
-    size_t eq_low_cap,
-    FpExt lambda,
-    FpExt alpha,
-    FpExt *out,
-    FpExt *tmp_block_sums,
-    cudaStream_t stream
-) {
-    assert(logical_len > 2);
-    assert((logical_len & (logical_len - 1)) == 0);
-    assert(real_len > 0 && real_len <= logical_len);
-
-    size_t num_x = logical_len >> 1;
-    auto [grid, block] = frac_compute_round_launch_params((uint32_t)num_x);
-    size_t shmem_bytes = div_ceil(block.x, WARP_SIZE) * sizeof(FpExt);
-    uint32_t lg_domain_size = 0;
-    for (size_t n = logical_len; n > 1; n >>= 1)
-        ++lg_domain_size;
-
-    compute_round_virtual_input_kernel<<<grid, block, shmem_bytes, stream>>>(
-        eq_xi_low,
-        eq_xi_high,
-        input,
         (uint32_t)real_len,
-        lg_domain_size,
+        (uint32_t)logical_len,
         __builtin_ctz((uint32_t)eq_low_cap),
         lambda,
         alpha,
@@ -1158,6 +1404,7 @@ extern "C" int _frac_compute_round_virtual_input(
     if (err != 0)
         return err;
 
+    // Launch final reduction kernel.
     return final_reduce_block_sums(tmp_block_sums, out, grid.x, stream);
 }
 
@@ -1170,9 +1417,12 @@ extern "C" int _frac_compute_round_and_fold(
     const FracExt *src_pq_buffer,
     FracExt *dst_pq_buffer,
     size_t src_pq_size,           // Pre-fold size in FracExt
+    size_t real_len,
+    size_t logical_len,
     size_t eq_low_cap,
     FpExt lambda,
     FpExt r_prev,
+    FpExt alpha,
     FpExt *out,                   // Output: [d=2] final results
     FpExt *tmp_block_sums,         // Temporary buffer: [gridDim.x * d]
     cudaStream_t stream
@@ -1192,9 +1442,12 @@ extern "C" int _frac_compute_round_and_fold(
         eq_xi_high,
         src_pq_buffer,
         (uint32_t)num_x,
+        (uint32_t)real_len,
+        (uint32_t)logical_len,
         __builtin_ctz((uint32_t)eq_low_cap),
         lambda,
         r_prev,
+        alpha,
         tmp_block_sums,
         dst_pq_buffer
     );
@@ -1214,9 +1467,14 @@ extern "C" int _frac_compute_round_and_fold_inplace(
     const FpExt *eq_xi_high,
     FracExt *pq_buffer,           // In-place: reads src_pq_size, writes pq_size
     size_t src_pq_size,           // Pre-fold size in FracExt
+    size_t real_len,
+    size_t logical_len,
+    size_t dst_real_len,
+    size_t dst_logical_len,
     size_t eq_low_cap,
     FpExt lambda,
     FpExt r_prev,
+    FpExt alpha,
     FpExt *out,                   // Output: [d=2] final results
     FpExt *tmp_block_sums,         // Temporary buffer: [gridDim.x * d]
     cudaStream_t stream
@@ -1236,9 +1494,14 @@ extern "C" int _frac_compute_round_and_fold_inplace(
         eq_xi_high,
         pq_buffer,
         (uint32_t)num_x,
+        (uint32_t)real_len,
+        (uint32_t)logical_len,
+        (uint32_t)dst_real_len,
+        (uint32_t)dst_logical_len,
         __builtin_ctz((uint32_t)eq_low_cap),
         lambda,
         r_prev,
+        alpha,
         tmp_block_sums
     );
     int err = CHECK_KERNEL();
@@ -1251,10 +1514,13 @@ extern "C" int _frac_compute_round_and_fold_inplace(
 
 extern "C" int _frac_precompute_m_build(
     const FracExt *pq,
+    size_t real_len,
+    size_t logical_len,
     size_t rem_n,             // folded rem_n
     size_t w,
     FpExt lambda,
     FpExt r_prev,             // challenge for the inline fold (only used when inline_fold=true)
+    FpExt alpha,
     bool inline_fold,         // true: pq is unfolded (rem_n+1 vars), false: pq is already folded
     const FpExt *eq_tail_low,
     const FpExt *eq_tail_high,
@@ -1287,9 +1553,12 @@ extern "C" int _frac_precompute_m_build(
             w_u32,
             grid,
             pq,
+            (uint32_t)real_len,
+            (uint32_t)logical_len,
             rem_n_u32,
             lambda,
             r_prev,
+            alpha,
             eq_tail_low,
             eq_tail_high,
             log_eq_tail_low_cap,
@@ -1302,9 +1571,12 @@ extern "C" int _frac_precompute_m_build(
             w_u32,
             grid,
             pq,
+            (uint32_t)real_len,
+            (uint32_t)logical_len,
             rem_n_u32,
             lambda,
             r_prev,
+            alpha,
             eq_tail_low,
             eq_tail_high,
             log_eq_tail_low_cap,
@@ -1360,8 +1632,11 @@ extern "C" int _frac_precompute_m_eval_round(
 extern "C" int _frac_multifold(
     const FracExt *src,
     FracExt *dst,
+    size_t real_len,
+    size_t logical_len,
     size_t rem_n,
     size_t w,
+    FpExt alpha,
     const FpExt *eq_r_window,
     cudaStream_t stream
 ) {
@@ -1372,7 +1647,15 @@ extern "C" int _frac_multifold(
     auto [grid, block] = kernel_launch_params(out_len, 256);
 
 #define DISPATCH_MULTIFOLD(W) \
-    multifold_kernel<W><<<grid, block, 0, stream>>>(src, dst, (uint32_t)out_len, eq_r_window); \
+    multifold_kernel<W><<<grid, block, 0, stream>>>( \
+        src, \
+        dst, \
+        (uint32_t)out_len, \
+        (uint32_t)real_len, \
+        (uint32_t)logical_len, \
+        alpha, \
+        eq_r_window \
+    ); \
     return CHECK_KERNEL();
 
     switch (w) {
@@ -1385,17 +1668,29 @@ extern "C" int _frac_multifold(
 #undef DISPATCH_MULTIFOLD
 }
 
-extern "C" int _frac_fold_fpext_columns(const FracExt *src, FracExt *dst, size_t size, FpExt r, cudaStream_t stream) {
+extern "C" int _frac_fold_fpext_columns(
+    const FracExt *src,
+    FracExt *dst,
+    size_t size,
+    size_t real_len,
+    size_t logical_len,
+    FpExt r,
+    FpExt alpha,
+    cudaStream_t stream
+) {
     if (size <= 2) {
         return 0;
     }
-    // FracExt = {p, q} = 2 FpExt elements.
-    // size is in FracExt; quarter_fpext is in FpExt.
-    // quarter_fpext = (size / 4) * 2 = size / 2
-    uint32_t quarter_fpext = size >> 1;
-    auto [grid, block] = kernel_launch_params(quarter_fpext);
+    uint32_t quarter = size >> 2;
+    auto [grid, block] = kernel_launch_params(quarter);
     fold_ef_columns_kernel<<<grid, block, 0, stream>>>(
-        reinterpret_cast<const FpExt *>(src), reinterpret_cast<FpExt *>(dst), quarter_fpext, r
+        src,
+        dst,
+        (uint32_t)size,
+        (uint32_t)real_len,
+        (uint32_t)logical_len,
+        r,
+        alpha
     );
     return CHECK_KERNEL();
 }
@@ -1454,7 +1749,7 @@ T bit_rev(T i, unsigned int nbits)
 // launcher — but only once (static local), paid on the first call and never again.
 __launch_bounds__(256) __global__
 void bit_rev_frac_build_k2_kernel(
-    FracExt* inout, uint32_t lg_domain_size, FpExt alpha)
+    FracExt* inout, uint32_t real_len, uint32_t lg_domain_size, FpExt alpha)
 {
     constexpr uint32_t Z_COUNT = 8;
     constexpr uint32_t LG_Z_COUNT = 3;
@@ -1467,8 +1762,11 @@ void bit_rev_frac_build_k2_kernel(
     uint32_t idx = threadIdx.x % Z_COUNT;
     uint32_t rev = bit_rev(idx, LG_Z_COUNT);
 
+    index_t domain_size = (index_t)1 << lg_domain_size;
     index_t step = (index_t)1 << (lg_domain_size - LG_Z_COUNT);
     index_t tid = threadIdx.x + blockDim.x * (index_t)blockIdx.x;
+    bool virtual_mode = real_len < domain_size;
+    FracExt zero_frac{FpExt(Fp::zero()), FpExt(Fp::zero())};
 
     #pragma unroll 1
     do {
@@ -1485,9 +1783,13 @@ void bit_rev_frac_build_k2_kernel(
 
         #pragma unroll
         for (uint32_t i = 0; i < Z_COUNT; i++) {
-            xchg[gid][i][rev] = (regs[i] = inout[i * step + base_idx]);
-            if (group_idx != group_rev)
-                regs[i] = inout[i * step + base_rev];
+            index_t src_idx = i * step + base_idx;
+            FracExt val = src_idx < real_len ? inout[src_idx] : zero_frac;
+            xchg[gid][i][rev] = (regs[i] = val);
+            if (group_idx != group_rev) {
+                index_t rev_src_idx = i * step + base_rev;
+                regs[i] = rev_src_idx < real_len ? inout[rev_src_idx] : zero_frac;
+            }
         }
 
         __syncwarp();
@@ -1506,8 +1808,24 @@ void bit_rev_frac_build_k2_kernel(
                 frac_add_inplace(row[i], row[i + 2]);
         }
         #pragma unroll
-        for (uint32_t i = 0; i < Z_COUNT; i++)
-            inout[i * step + base_rev] = xchg[gid][rev][i];
+        for (uint32_t i = 0; i < Z_COUNT; i++) {
+            index_t out_idx = i * step + base_rev;
+            if (virtual_mode) {
+                uint32_t active_size =
+                    i < 2 ? (uint32_t)(domain_size >> 2)
+                          : (i < 4 ? (uint32_t)(domain_size >> 1) : (uint32_t)domain_size);
+                virtual_node_store(
+                    inout,
+                    (uint32_t)out_idx,
+                    active_size,
+                    real_len,
+                    (uint32_t)domain_size,
+                    xchg[gid][rev][i]
+                );
+            } else {
+                inout[out_idx] = xchg[gid][rev][i];
+            }
+        }
 
         if (group_idx == group_rev)
             continue;
@@ -1534,8 +1852,24 @@ void bit_rev_frac_build_k2_kernel(
                 frac_add_inplace(row[i], row[i + 2]);
         }
         #pragma unroll
-        for (uint32_t i = 0; i < Z_COUNT; i++)
-            inout[i * step + base_idx] = xchg[gid][rev][i];
+        for (uint32_t i = 0; i < Z_COUNT; i++) {
+            index_t out_idx = i * step + base_idx;
+            if (virtual_mode) {
+                uint32_t active_size =
+                    i < 2 ? (uint32_t)(domain_size >> 2)
+                          : (i < 4 ? (uint32_t)(domain_size >> 1) : (uint32_t)domain_size);
+                virtual_node_store(
+                    inout,
+                    (uint32_t)out_idx,
+                    active_size,
+                    real_len,
+                    (uint32_t)domain_size,
+                    xchg[gid][rev][i]
+                );
+            } else {
+                inout[out_idx] = xchg[gid][rev][i];
+            }
+        }
 
     } while ((tid += blockDim.x*gridDim.x) < step);
     // Note: the original bit_rev_permutation_z guards this with "Z_COUNT <= WARP_SIZE &&"
@@ -1546,7 +1880,7 @@ void bit_rev_frac_build_k2_kernel(
 // Requires domain_size >= 256 (uses Z-tile shmem kernel).
 // Applies alpha to denominators and fuses tree layers 0 and 1 in shmem.
 extern "C" int _bit_rev_frac_ext_build_k2(
-    FracExt* inout, uint32_t lg_domain_size, FpExt alpha, cudaStream_t stream)
+    FracExt* inout, size_t real_len, uint32_t lg_domain_size, FpExt alpha, cudaStream_t stream)
 {
     constexpr uint32_t Z_COUNT = 8;
     constexpr uint32_t bsize = 256;
@@ -1562,7 +1896,7 @@ extern "C" int _bit_rev_frac_ext_build_k2(
         return cudaErrorInvalidValue;
     uint32_t grid_x = (uint32_t)(domain_size / Z_COUNT / bsize);
     bit_rev_frac_build_k2_kernel<<<dim3(grid_x), bsize, shmem_bytes, stream>>>(
-        inout, lg_domain_size, alpha);
+        inout, (uint32_t)real_len, lg_domain_size, alpha);
     return CHECK_KERNEL();
 }
 

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
@@ -74,6 +74,22 @@ __device__ __forceinline__ FpExt sqrt_buffer_get(
     return eq_xi_low[idx & ((1u << log_eq_low_cap) - 1)] * eq_xi_high[idx >> log_eq_low_cap];
 }
 
+__device__ __forceinline__ FracExt load_virtual_input_bitrev(
+    const FracExt *__restrict__ input,
+    uint32_t real_len,
+    uint32_t lg_domain_size,
+    uint32_t bitrev_pos,
+    FpExt alpha
+) {
+    uint32_t logical_idx = rev_len(bitrev_pos, lg_domain_size);
+    if (logical_idx < real_len) {
+        FracExt value = input[logical_idx];
+        value.q = value.q + alpha;
+        return value;
+    }
+    return {FpExt(Fp::zero()), alpha};
+}
+
 // Accumulate GKR sumcheck contributions for s'_t(1) and s'_t(2).
 // See docs/cuda-backend/gkr-prover.md § "Sumcheck round implementation".
 __device__ __forceinline__ void accumulate_compute_contributions(
@@ -490,6 +506,52 @@ __global__ void compute_round_and_revert_kernel(
             eq_xi_low, eq_xi_high, idx, log_eq_low_cap, lambda,
             p0_even, q0_even, p0_odd, q0_odd,
             p1_even, q1_even, p1_odd, q1_odd,
+            local0, local1
+        );
+    }
+
+    reduce_block_sums(shared, local0, local1, block_sums);
+}
+
+// Computes the first sumcheck round for the largest GKR layer directly from a
+// natural-order virtual input. This is equivalent to first materializing the
+// dense padded input, adding alpha to every denominator, bit-reversing it, and
+// then running compute_round on the leaf layer.
+__global__ void compute_round_virtual_input_kernel(
+    const FpExt *__restrict__ eq_xi_low,
+    const FpExt *__restrict__ eq_xi_high,
+    const FracExt *__restrict__ input,
+    uint32_t real_len,
+    uint32_t lg_domain_size,
+    uint32_t log_eq_low_cap,
+    FpExt lambda,
+    FpExt alpha,
+    FpExt *__restrict__ block_sums
+) {
+    extern __shared__ FpExt shared[];
+    const uint32_t pq_size = 1u << lg_domain_size;
+    const uint32_t num_x = pq_size >> 1;
+    const uint32_t half = pq_size >> 1;
+    const uint32_t quarter = pq_size >> 2;
+
+    const FpExt zero(Fp::zero());
+    FpExt local0 = zero, local1 = zero;
+    uint32_t idx_base = threadIdx.x + blockIdx.x * blockDim.x;
+
+    for (uint32_t idx = idx_base; idx < num_x / 2; idx += blockDim.x * gridDim.x) {
+        FracExt p0_even_v =
+            load_virtual_input_bitrev(input, real_len, lg_domain_size, idx, alpha);
+        FracExt p1_even_v =
+            load_virtual_input_bitrev(input, real_len, lg_domain_size, idx + half, alpha);
+        FracExt p0_odd_v =
+            load_virtual_input_bitrev(input, real_len, lg_domain_size, idx + quarter, alpha);
+        FracExt p1_odd_v =
+            load_virtual_input_bitrev(input, real_len, lg_domain_size, idx + half + quarter, alpha);
+
+        accumulate_compute_contributions(
+            eq_xi_low, eq_xi_high, idx, log_eq_low_cap, lambda,
+            p0_even_v.p, p0_even_v.q, p0_odd_v.p, p0_odd_v.q,
+            p1_even_v.p, p1_even_v.q, p1_odd_v.p, p1_odd_v.q,
             local0, local1
         );
     }
@@ -1054,6 +1116,48 @@ extern "C" int _frac_compute_round_and_revert(
         return err;
 
     // Launch final reduction kernel.
+    return final_reduce_block_sums(tmp_block_sums, out, grid.x, stream);
+}
+
+extern "C" int _frac_compute_round_virtual_input(
+    const FpExt *eq_xi_low,
+    const FpExt *eq_xi_high,
+    const FracExt *input,
+    size_t real_len,
+    size_t logical_len,
+    size_t eq_low_cap,
+    FpExt lambda,
+    FpExt alpha,
+    FpExt *out,
+    FpExt *tmp_block_sums,
+    cudaStream_t stream
+) {
+    assert(logical_len > 2);
+    assert((logical_len & (logical_len - 1)) == 0);
+    assert(real_len > 0 && real_len <= logical_len);
+
+    size_t num_x = logical_len >> 1;
+    auto [grid, block] = frac_compute_round_launch_params((uint32_t)num_x);
+    size_t shmem_bytes = div_ceil(block.x, WARP_SIZE) * sizeof(FpExt);
+    uint32_t lg_domain_size = 0;
+    for (size_t n = logical_len; n > 1; n >>= 1)
+        ++lg_domain_size;
+
+    compute_round_virtual_input_kernel<<<grid, block, shmem_bytes, stream>>>(
+        eq_xi_low,
+        eq_xi_high,
+        input,
+        (uint32_t)real_len,
+        lg_domain_size,
+        __builtin_ctz((uint32_t)eq_low_cap),
+        lambda,
+        alpha,
+        tmp_block_sums
+    );
+    int err = CHECK_KERNEL();
+    if (err != 0)
+        return err;
+
     return final_reduce_block_sums(tmp_block_sums, out, grid.x, stream);
 }
 

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
@@ -1752,12 +1752,12 @@ T bit_rev(T i, unsigned int nbits)
 //   [2,3]  : layer-0 results preserved (tree level 1 right half, for revert of layer 1)
 //   [4..7] : original+alpha preserved (leaves, for revert of layer 0)
 //
-// __launch_bounds__(256): not a correctness constraint. Sync is per 8-lane Z-tile
-// using subgroup masks because branch predicates are uniform per tile, not per whole
-// warp. bsize=256 was chosen after benchmarking: 2x faster than bsize=32 in isolation
-// (1525 vs 754 GB/s at lg=24 on RTX 5090). It requires 64KB dynamic shmem per block,
-// so cudaFuncSetAttribute is used in the launcher, paid once on the first call.
-__launch_bounds__(256) __global__
+// Sync is per 8-lane Z-tile using subgroup masks because branch predicates are
+// uniform per tile, not per whole warp. The launcher uses bsize=256, chosen after
+// benchmarking: 2x faster than bsize=32 in isolation (1525 vs 754 GB/s at lg=24
+// on RTX 5090). It requires 64KB dynamic shmem per block, so cudaFuncSetAttribute
+// is used in the launcher, paid once on the first call.
+__global__
 void bit_rev_frac_build_k2_kernel(
     FracExt* inout, uint32_t real_len, uint32_t lg_domain_size, FpExt alpha)
 {

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
@@ -31,7 +31,7 @@ __device__ __forceinline__ uint32_t lg_pow2(uint32_t x) {
 __device__ __forceinline__ FpExt virtual_padding_q(FpExt alpha, uint32_t subtree_len) {
     FpExt q = alpha;
     for (uint32_t len = subtree_len; len > 1; len >>= 1) {
-        q = q * q;
+        q *= q;
     }
     return q;
 }
@@ -87,39 +87,50 @@ __global__ void frac_build_tree_layer_kernel(
     FpExt alpha = FpExt(Fp(0))
 ) {
     uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx >= half) {
-        return;
-    }
+    const bool in_range = idx < half;
 
     const uint32_t layer_size = half << 1;
     const bool virtual_mode = real_len < logical_len;
     if constexpr (apply_alpha) {
         if (virtual_mode && layer_size == logical_len) {
             const uint32_t parent_active_size = half;
-            const uint32_t parent_start =
-                rev_len(idx, lg_pow2(parent_active_size)) << 1;
+            FracExt lhs_val = FracExt::zero();
+            FracExt rhs_val = FracExt::zero();
+            FracExt rhs_leaf = FracExt::zero();
+            bool has_rhs_leaf = false;
+            if (in_range) {
+                const uint32_t parent_start =
+                    rev_len(idx, lg_pow2(parent_active_size)) << 1;
 
-            FracExt lhs_val = parent_start < real_len
-                ? layer[parent_start]
-                : FracExt{FpExt(Fp::zero()), FpExt(Fp::zero())};
-            FracExt rhs_val = parent_start + 1 < real_len
-                ? layer[parent_start + 1]
-                : FracExt{FpExt(Fp::zero()), FpExt(Fp::zero())};
-            FracExt rhs_leaf = rhs_val;
-            bool has_rhs_leaf = parent_start + 1 < real_len;
+                if (parent_start < real_len) {
+                    lhs_val = layer[parent_start];
+                }
+                if (parent_start + 1 < real_len) {
+                    rhs_val = layer[parent_start + 1];
+                    rhs_leaf = rhs_val;
+                    has_rhs_leaf = true;
+                }
+            }
             __syncthreads();
+            if (!in_range) {
+                return;
+            }
 
-            lhs_val.q = lhs_val.q + alpha;
-            rhs_val.q = rhs_val.q + alpha;
+            lhs_val.q += alpha;
+            rhs_val.q += alpha;
             frac_add_inplace(lhs_val, rhs_val);
             virtual_node_store(layer, idx, parent_active_size, real_len, logical_len, lhs_val);
 
             if (has_rhs_leaf) {
-                rhs_leaf.q = rhs_leaf.q + alpha;
+                rhs_leaf.q += alpha;
                 virtual_node_store(layer, idx + half, logical_len, real_len, logical_len, rhs_leaf);
             }
             return;
         }
+    }
+
+    if (!in_range) {
+        return;
     }
 
     uint32_t lhs_active_size = revert ? half : layer_size;
@@ -133,8 +144,8 @@ __global__ void frac_build_tree_layer_kernel(
     if constexpr (apply_alpha) {
         // When applying alpha, we need to modify both operands before combining
         // Read both values, apply alpha to denominators, then combine
-        lhs.q = lhs.q + alpha;
-        rhs.q = rhs.q + alpha;
+        lhs.q += alpha;
+        rhs.q += alpha;
 
         if constexpr (revert) {
             frac_unadd_inplace(lhs, rhs);
@@ -1109,7 +1120,7 @@ __global__ void multifold_kernel(
 __global__ void add_alpha_kernel(FracExt *data, size_t len, FpExt alpha) {
     size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx < len) {
-        data[idx].q = data[idx].q + alpha;
+        data[idx].q += alpha;
     }
 }
 
@@ -1766,7 +1777,7 @@ void bit_rev_frac_build_k2_kernel(
     index_t step = (index_t)1 << (lg_domain_size - LG_Z_COUNT);
     index_t tid = threadIdx.x + blockDim.x * (index_t)blockIdx.x;
     bool virtual_mode = real_len < domain_size;
-    FracExt zero_frac{FpExt(Fp::zero()), FpExt(Fp::zero())};
+    FracExt zero_frac = FracExt::zero();
 
     #pragma unroll 1
     do {
@@ -1799,7 +1810,7 @@ void bit_rev_frac_build_k2_kernel(
             FracExt* row = xchg[gid][rev];
             #pragma unroll
             for (uint32_t i = 0; i < Z_COUNT; i++)
-                row[i].q = row[i].q + alpha;
+                row[i].q += alpha;
             #pragma unroll
             for (uint32_t i = 0; i < 4; i++)  // tree layer 0: pairs (0,4),(1,5),(2,6),(3,7)
                 frac_add_inplace(row[i], row[i + 4]);
@@ -1843,7 +1854,7 @@ void bit_rev_frac_build_k2_kernel(
             FracExt* row = xchg[gid][rev];
             #pragma unroll
             for (uint32_t i = 0; i < Z_COUNT; i++)
-                row[i].q = row[i].q + alpha;
+                row[i].q += alpha;
             #pragma unroll
             for (uint32_t i = 0; i < 4; i++)
                 frac_add_inplace(row[i], row[i + 4]);

--- a/crates/cuda-backend/src/bin/bench.rs
+++ b/crates/cuda-backend/src/bin/bench.rs
@@ -47,6 +47,8 @@ fn bench_fractional_sumcheck() -> Result<(), Box<dyn std::error::Error>> {
         let _ = fractional_sumcheck_gpu(
             &mut transcript,
             leaves,
+            1usize << n,
+            1usize << n,
             EF::ZERO,
             false,
             &mut mem,

--- a/crates/cuda-backend/src/bin/bench.rs
+++ b/crates/cuda-backend/src/bin/bench.rs
@@ -1,7 +1,7 @@
 use std::{env, process};
 
 use openvm_cuda_backend::{
-    logup_zerocheck::{fractional_sumcheck_gpu, make_synthetic_leaves},
+    logup_zerocheck::{fractional_sumcheck_gpu, make_synthetic_leaves, FractionalInputSize},
     prelude::EF,
     sponge::DuplexSpongeGpu,
 };
@@ -47,8 +47,7 @@ fn bench_fractional_sumcheck() -> Result<(), Box<dyn std::error::Error>> {
         let _ = fractional_sumcheck_gpu(
             &mut transcript,
             leaves,
-            1usize << n,
-            1usize << n,
+            FractionalInputSize::dense(1usize << n),
             EF::ZERO,
             false,
             &mut mem,

--- a/crates/cuda-backend/src/cuda/logup_zerocheck.rs
+++ b/crates/cuda-backend/src/cuda/logup_zerocheck.rs
@@ -762,7 +762,10 @@ pub unsafe fn fold_ef_frac_columns(
     alpha: EF,
     stream: cudaStream_t,
 ) -> Result<(), CudaError> {
-    debug_assert!(src.len() >= size || size == logical_len || src.len() >= real_len);
+    debug_assert!(
+        src.len() >= real_len,
+        "compact buffer must hold at least real_len entries"
+    );
     debug_assert!(real_len <= logical_len);
     debug_assert!(dst.len() >= size / 2);
     CudaError::from_result(_frac_fold_fpext_columns(
@@ -787,7 +790,10 @@ pub unsafe fn fold_ef_frac_columns_inplace(
     alpha: EF,
     stream: cudaStream_t,
 ) -> Result<(), CudaError> {
-    debug_assert!(buffer.len() >= size || size == logical_len || buffer.len() >= real_len);
+    debug_assert!(
+        buffer.len() >= real_len,
+        "compact buffer must hold at least real_len entries"
+    );
     debug_assert!(real_len <= logical_len);
     debug_assert_eq!(
         real_len, logical_len,

--- a/crates/cuda-backend/src/cuda/logup_zerocheck.rs
+++ b/crates/cuda-backend/src/cuda/logup_zerocheck.rs
@@ -103,6 +103,8 @@ extern "C" {
     fn _frac_build_tree_layer(
         layer: *mut Frac<EF>,
         layer_size: usize,
+        real_len: usize,
+        logical_len: usize,
         revert: bool,
         alpha: EF,
         apply_alpha: bool,
@@ -115,6 +117,9 @@ extern "C" {
     fn _frac_build_tree_two_layers(
         layer: *mut Frac<EF>,
         half_i1: usize,
+        real_len: usize,
+        logical_len: usize,
+        alpha: EF,
         stream: cudaStream_t,
     ) -> i32;
 
@@ -139,20 +144,6 @@ extern "C" {
         eq_xi_high: *const EF,
         layer: *mut Frac<EF>,
         num_x: usize,
-        eq_low_cap: usize,
-        lambda: EF,
-        out_device: *mut EF,
-        tmp_block_sums: *mut EF,
-        stream: cudaStream_t,
-    ) -> i32;
-
-    /// Computes the first sumcheck round for a virtual input layer. The input buffer contains only
-    /// `real_len` natural-order leaves without alpha applied; logical leaves outside that prefix
-    /// are interpreted as `Frac(0, alpha)`.
-    fn _frac_compute_round_virtual_input(
-        eq_xi_low: *const EF,
-        eq_xi_high: *const EF,
-        input: *const Frac<EF>,
         real_len: usize,
         logical_len: usize,
         eq_low_cap: usize,
@@ -167,7 +158,10 @@ extern "C" {
         src: *const Frac<EF>,
         dst: *mut Frac<EF>,
         size: usize,
+        real_len: usize,
+        logical_len: usize,
         r: EF,
+        alpha: EF,
         stream: cudaStream_t,
     ) -> i32;
 
@@ -180,9 +174,12 @@ extern "C" {
         src_pq_buffer: *const Frac<EF>,
         dst_pq_buffer: *mut Frac<EF>,
         src_pq_size: usize,
+        real_len: usize,
+        logical_len: usize,
         eq_low_cap: usize,
         lambda: EF,
         r_prev: EF,
+        alpha: EF,
         out_device: *mut EF,
         tmp_block_sums: *mut EF,
         stream: cudaStream_t,
@@ -196,9 +193,14 @@ extern "C" {
         eq_xi_high: *const EF,
         pq_buffer: *mut Frac<EF>,
         src_pq_size: usize,
+        real_len: usize,
+        logical_len: usize,
+        dst_real_len: usize,
+        dst_logical_len: usize,
         eq_low_cap: usize,
         lambda: EF,
         r_prev: EF,
+        alpha: EF,
         out_device: *mut EF,
         tmp_block_sums: *mut EF,
         stream: cudaStream_t,
@@ -206,10 +208,13 @@ extern "C" {
 
     fn _frac_precompute_m_build(
         pq: *const Frac<EF>,
+        real_len: usize,
+        logical_len: usize,
         rem_n: usize,
         w: usize,
         lambda: EF,
         r_prev: EF,
+        alpha: EF,
         inline_fold: bool,
         eq_tail_low: *const EF,
         eq_tail_high: *const EF,
@@ -234,8 +239,11 @@ extern "C" {
     fn _frac_multifold(
         src: *const Frac<EF>,
         dst: *mut Frac<EF>,
+        real_len: usize,
+        logical_len: usize,
         rem_n: usize,
         w: usize,
+        alpha: EF,
         eq_r_window: *const EF,
         stream: cudaStream_t,
     ) -> i32;
@@ -611,15 +619,18 @@ pub unsafe fn interpolate_columns_gpu(
 pub unsafe fn frac_build_tree_layer(
     layer: &mut DeviceBuffer<Frac<EF>>,
     layer_size: usize,
+    logical_len: usize,
     revert: bool,
     alpha: EF,
     apply_alpha: bool,
     stream: cudaStream_t,
 ) -> Result<(), CudaError> {
-    debug_assert!(layer.len() >= layer_size);
+    debug_assert!(layer.len() >= layer_size || layer_size == logical_len);
     CudaError::from_result(_frac_build_tree_layer(
         layer.as_mut_ptr(),
         layer_size,
+        layer.len(),
+        logical_len,
         revert,
         alpha,
         apply_alpha,
@@ -632,11 +643,16 @@ pub unsafe fn frac_build_tree_layer(
 pub unsafe fn frac_build_tree_two_layers(
     layer: &mut DeviceBuffer<Frac<EF>>,
     half_i1: usize,
+    logical_len: usize,
+    alpha: EF,
     stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_frac_build_tree_two_layers(
         layer.as_mut_ptr(),
         half_i1,
+        layer.len(),
+        logical_len,
+        alpha,
         stream,
     ))
 }
@@ -691,47 +707,6 @@ pub unsafe fn frac_compute_round_and_revert(
     eq_xi: &SqrtEqLayers,
     layer: &mut DeviceBuffer<Frac<EF>>,
     num_x: usize,
-    lambda: EF,
-    out_device: &mut DeviceBuffer<EF>,
-    tmp_block_sums: &mut DeviceBuffer<EF>,
-    stream: cudaStream_t,
-) -> Result<(), CudaError> {
-    let low_n = eq_xi.low_n();
-    let high_n = eq_xi.high_n();
-    debug_assert_eq!(2 << (low_n + high_n), num_x);
-    #[cfg(debug_assertions)]
-    {
-        let len = tmp_block_sums.len();
-        let required = _frac_compute_round_temp_buffer_size(num_x.try_into().unwrap(), stream);
-        assert!(
-            len >= required as usize,
-            "tmp_block_sums len={len} < required={required}"
-        );
-        assert!(layer.len() >= 2 * num_x, "layer too small for pq_size");
-    }
-    CudaError::from_result(_frac_compute_round_and_revert(
-        eq_xi.low.get_ptr(low_n),
-        eq_xi.high.get_ptr(high_n),
-        layer.as_mut_ptr(),
-        num_x,
-        1 << low_n,
-        lambda,
-        out_device.as_mut_ptr(),
-        tmp_block_sums.as_mut_ptr(),
-        stream,
-    ))
-}
-
-/// Computes sumcheck round 0 directly from a virtual input layer.
-///
-/// `input` is natural-order and contains only `real_len` leaves without alpha applied. Missing
-/// logical leaves are synthesized as `Frac(0, alpha)`. The kernel reads the same bit-reversed
-/// logical leaf positions as the dense padded input path.
-#[allow(clippy::too_many_arguments)]
-pub unsafe fn frac_compute_round_virtual_input(
-    eq_xi: &SqrtEqLayers,
-    input: &DeviceBuffer<Frac<EF>>,
-    real_len: usize,
     logical_len: usize,
     lambda: EF,
     alpha: EF,
@@ -741,31 +716,26 @@ pub unsafe fn frac_compute_round_virtual_input(
 ) -> Result<(), CudaError> {
     let low_n = eq_xi.low_n();
     let high_n = eq_xi.high_n();
-    let num_x = logical_len >> 1;
     debug_assert_eq!(2 << (low_n + high_n), num_x);
     #[cfg(debug_assertions)]
     {
-        assert!(logical_len.is_power_of_two());
-        assert!(logical_len > 2);
-        assert!(real_len > 0 && real_len <= logical_len);
-        assert!(
-            input.len() >= real_len,
-            "input too small: {} < {}",
-            input.len(),
-            real_len
-        );
         let len = tmp_block_sums.len();
         let required = _frac_compute_round_temp_buffer_size(num_x.try_into().unwrap(), stream);
         assert!(
             len >= required as usize,
             "tmp_block_sums len={len} < required={required}"
         );
+        assert!(
+            layer.len() >= 2 * num_x || 2 * num_x == logical_len,
+            "layer too small for pq_size"
+        );
     }
-    CudaError::from_result(_frac_compute_round_virtual_input(
+    CudaError::from_result(_frac_compute_round_and_revert(
         eq_xi.low.get_ptr(low_n),
         eq_xi.high.get_ptr(high_n),
-        input.as_ptr(),
-        real_len,
+        layer.as_mut_ptr(),
+        num_x,
+        layer.len(),
         logical_len,
         1 << low_n,
         lambda,
@@ -779,20 +749,28 @@ pub unsafe fn frac_compute_round_virtual_input(
 /// Folds `Frac<EF>` buffer. Pairs (idx, idx+quarter) and (idx+half, idx+3*quarter),
 /// writes results to dst[idx] and dst[idx+quarter]. Output size is `size / 2`.
 /// Safe for src == dst (in-place) because each thread handles disjoint indices.
+#[allow(clippy::too_many_arguments)]
 pub unsafe fn fold_ef_frac_columns(
     src: &DeviceBuffer<Frac<EF>>,
     dst: &mut DeviceBuffer<Frac<EF>>,
     size: usize,
+    real_len: usize,
+    logical_len: usize,
     r: EF,
+    alpha: EF,
     stream: cudaStream_t,
 ) -> Result<(), CudaError> {
-    debug_assert!(src.len() >= size);
+    debug_assert!(src.len() >= size || size == logical_len || src.len() >= real_len);
+    debug_assert!(real_len <= logical_len);
     debug_assert!(dst.len() >= size / 2);
     CudaError::from_result(_frac_fold_fpext_columns(
         src.as_ptr(),
         dst.as_mut_ptr(),
         size,
+        real_len,
+        logical_len,
         r,
+        alpha,
         stream,
     ))
 }
@@ -801,12 +779,25 @@ pub unsafe fn fold_ef_frac_columns(
 pub unsafe fn fold_ef_frac_columns_inplace(
     buffer: &mut DeviceBuffer<Frac<EF>>,
     size: usize,
+    real_len: usize,
+    logical_len: usize,
     r: EF,
+    alpha: EF,
     stream: cudaStream_t,
 ) -> Result<(), CudaError> {
-    debug_assert!(buffer.len() >= size);
+    debug_assert!(buffer.len() >= size || size == logical_len || buffer.len() >= real_len);
+    debug_assert!(real_len <= logical_len);
     let ptr = buffer.as_mut_ptr();
-    CudaError::from_result(_frac_fold_fpext_columns(ptr, ptr, size, r, stream))
+    CudaError::from_result(_frac_fold_fpext_columns(
+        ptr,
+        ptr,
+        size,
+        real_len,
+        logical_len,
+        r,
+        alpha,
+        stream,
+    ))
 }
 
 /// Fused compute round + fold kernel.
@@ -825,8 +816,11 @@ pub unsafe fn frac_compute_round_and_fold(
     src_pq_buffer: &DeviceBuffer<Frac<EF>>,
     dst_pq_buffer: &mut DeviceBuffer<Frac<EF>>,
     src_pq_size: usize,
+    real_len: usize,
+    logical_len: usize,
     lambda: EF,
     r_prev: EF,
+    alpha: EF,
     out_device: &mut DeviceBuffer<EF>,
     tmp_block_sums: &mut DeviceBuffer<EF>,
     stream: cudaStream_t,
@@ -842,7 +836,7 @@ pub unsafe fn frac_compute_round_and_fold(
         let pq_size = src_pq_size >> 1;
         assert!(num_x > 0, "num_x must be > 0");
         assert!(
-            src_pq_buffer.len() >= src_pq_size,
+            src_pq_buffer.len() >= src_pq_size || src_pq_size == logical_len,
             "src_pq_buffer too small: {} < {}",
             src_pq_buffer.len(),
             src_pq_size
@@ -866,9 +860,12 @@ pub unsafe fn frac_compute_round_and_fold(
         src_pq_buffer.as_ptr(),
         dst_pq_buffer.as_mut_ptr(),
         src_pq_size,
+        real_len,
+        logical_len,
         1 << low_n,
         lambda,
         r_prev,
+        alpha,
         out_device.as_mut_ptr(),
         tmp_block_sums.as_mut_ptr(),
         stream,
@@ -887,8 +884,13 @@ pub unsafe fn frac_compute_round_and_fold_inplace(
     eq_xi: &SqrtEqLayers,
     pq_buffer: &mut DeviceBuffer<Frac<EF>>,
     src_pq_size: usize,
+    real_len: usize,
+    logical_len: usize,
+    dst_real_len: usize,
+    dst_logical_len: usize,
     lambda: EF,
     r_prev: EF,
+    alpha: EF,
     out_device: &mut DeviceBuffer<EF>,
     tmp_block_sums: &mut DeviceBuffer<EF>,
     stream: cudaStream_t,
@@ -903,7 +905,7 @@ pub unsafe fn frac_compute_round_and_fold_inplace(
         assert!(src_pq_size > 2, "src_pq_size must be > 2");
         assert!(num_x > 0, "num_x must be > 0");
         assert!(
-            pq_buffer.len() >= src_pq_size,
+            pq_buffer.len() >= src_pq_size || src_pq_size == logical_len,
             "pq_buffer too small: {} < {}",
             pq_buffer.len(),
             src_pq_size
@@ -920,9 +922,14 @@ pub unsafe fn frac_compute_round_and_fold_inplace(
         eq_xi.high.get_ptr(high_n),
         pq_buffer.as_mut_ptr(),
         src_pq_size,
+        real_len,
+        logical_len,
+        dst_real_len,
+        dst_logical_len,
         1 << low_n,
         lambda,
         r_prev,
+        alpha,
         out_device.as_mut_ptr(),
         tmp_block_sums.as_mut_ptr(),
         stream,
@@ -932,10 +939,13 @@ pub unsafe fn frac_compute_round_and_fold_inplace(
 #[allow(clippy::too_many_arguments)]
 pub unsafe fn frac_precompute_m_build_raw(
     pq: *const Frac<EF>,
+    real_len: usize,
+    logical_len: usize,
     rem_n: usize,
     w: usize,
     lambda: EF,
     r_prev: EF,
+    alpha: EF,
     inline_fold: bool,
     eq_tail_low: *const EF,
     eq_tail_high: *const EF,
@@ -952,10 +962,13 @@ pub unsafe fn frac_precompute_m_build_raw(
     debug_assert!(tail_tile > 0);
     CudaError::from_result(_frac_precompute_m_build(
         pq,
+        real_len,
+        logical_len,
         rem_n,
         w,
         lambda,
         r_prev,
+        alpha,
         inline_fold,
         eq_tail_low,
         eq_tail_high,
@@ -991,17 +1004,31 @@ pub unsafe fn frac_precompute_m_eval_round_raw(
     ))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub unsafe fn frac_multifold_raw(
     src: *const Frac<EF>,
     dst: *mut Frac<EF>,
+    real_len: usize,
+    logical_len: usize,
     rem_n: usize,
     w: usize,
+    alpha: EF,
     eq_r_window: *const EF,
     stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     debug_assert!(rem_n > 0);
     debug_assert!(w > 0 && w <= rem_n);
-    CudaError::from_result(_frac_multifold(src, dst, rem_n, w, eq_r_window, stream))
+    CudaError::from_result(_frac_multifold(
+        src,
+        dst,
+        real_len,
+        logical_len,
+        rem_n,
+        w,
+        alpha,
+        eq_r_window,
+        stream,
+    ))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/cuda-backend/src/cuda/logup_zerocheck.rs
+++ b/crates/cuda-backend/src/cuda/logup_zerocheck.rs
@@ -748,7 +748,9 @@ pub unsafe fn frac_compute_round_and_revert(
 
 /// Folds `Frac<EF>` buffer. Pairs (idx, idx+quarter) and (idx+half, idx+3*quarter),
 /// writes results to dst[idx] and dst[idx+quarter]. Output size is `size / 2`.
-/// Safe for src == dst (in-place) because each thread handles disjoint indices.
+/// Dense folds are safe for src == dst because each thread handles disjoint indices.
+/// Compact virtual folds must use an out-of-place destination because virtual reads can
+/// recover source values from physical slots in the output range.
 #[allow(clippy::too_many_arguments)]
 pub unsafe fn fold_ef_frac_columns(
     src: &DeviceBuffer<Frac<EF>>,
@@ -787,6 +789,10 @@ pub unsafe fn fold_ef_frac_columns_inplace(
 ) -> Result<(), CudaError> {
     debug_assert!(buffer.len() >= size || size == logical_len || buffer.len() >= real_len);
     debug_assert!(real_len <= logical_len);
+    debug_assert_eq!(
+        real_len, logical_len,
+        "virtual compact folds must use an out-of-place destination"
+    );
     let ptr = buffer.as_mut_ptr();
     CudaError::from_result(_frac_fold_fpext_columns(
         ptr,

--- a/crates/cuda-backend/src/cuda/logup_zerocheck.rs
+++ b/crates/cuda-backend/src/cuda/logup_zerocheck.rs
@@ -146,6 +146,23 @@ extern "C" {
         stream: cudaStream_t,
     ) -> i32;
 
+    /// Computes the first sumcheck round for a virtual input layer. The input buffer contains only
+    /// `real_len` natural-order leaves without alpha applied; logical leaves outside that prefix
+    /// are interpreted as `Frac(0, alpha)`.
+    fn _frac_compute_round_virtual_input(
+        eq_xi_low: *const EF,
+        eq_xi_high: *const EF,
+        input: *const Frac<EF>,
+        real_len: usize,
+        logical_len: usize,
+        eq_low_cap: usize,
+        lambda: EF,
+        alpha: EF,
+        out_device: *mut EF,
+        tmp_block_sums: *mut EF,
+        stream: cudaStream_t,
+    ) -> i32;
+
     fn _frac_fold_fpext_columns(
         src: *const Frac<EF>,
         dst: *mut Frac<EF>,
@@ -699,6 +716,60 @@ pub unsafe fn frac_compute_round_and_revert(
         num_x,
         1 << low_n,
         lambda,
+        out_device.as_mut_ptr(),
+        tmp_block_sums.as_mut_ptr(),
+        stream,
+    ))
+}
+
+/// Computes sumcheck round 0 directly from a virtual input layer.
+///
+/// `input` is natural-order and contains only `real_len` leaves without alpha applied. Missing
+/// logical leaves are synthesized as `Frac(0, alpha)`. The kernel reads the same bit-reversed
+/// logical leaf positions as the dense padded input path.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn frac_compute_round_virtual_input(
+    eq_xi: &SqrtEqLayers,
+    input: &DeviceBuffer<Frac<EF>>,
+    real_len: usize,
+    logical_len: usize,
+    lambda: EF,
+    alpha: EF,
+    out_device: &mut DeviceBuffer<EF>,
+    tmp_block_sums: &mut DeviceBuffer<EF>,
+    stream: cudaStream_t,
+) -> Result<(), CudaError> {
+    let low_n = eq_xi.low_n();
+    let high_n = eq_xi.high_n();
+    let num_x = logical_len >> 1;
+    debug_assert_eq!(2 << (low_n + high_n), num_x);
+    #[cfg(debug_assertions)]
+    {
+        assert!(logical_len.is_power_of_two());
+        assert!(logical_len > 2);
+        assert!(real_len > 0 && real_len <= logical_len);
+        assert!(
+            input.len() >= real_len,
+            "input too small: {} < {}",
+            input.len(),
+            real_len
+        );
+        let len = tmp_block_sums.len();
+        let required = _frac_compute_round_temp_buffer_size(num_x.try_into().unwrap(), stream);
+        assert!(
+            len >= required as usize,
+            "tmp_block_sums len={len} < required={required}"
+        );
+    }
+    CudaError::from_result(_frac_compute_round_virtual_input(
+        eq_xi.low.get_ptr(low_n),
+        eq_xi.high.get_ptr(high_n),
+        input.as_ptr(),
+        real_len,
+        logical_len,
+        1 << low_n,
+        lambda,
+        alpha,
         out_device.as_mut_ptr(),
         tmp_block_sums.as_mut_ptr(),
         stream,

--- a/crates/cuda-backend/src/cuda/ntt.rs
+++ b/crates/cuda-backend/src/cuda/ntt.rs
@@ -79,6 +79,7 @@ extern "C" {
     /// Requires domain_size >= 256.
     fn _bit_rev_frac_ext_build_k2(
         inout: *mut std::ffi::c_void,
+        real_len: usize,
         lg_domain_size: u32,
         alpha: EF,
         stream: cudaStream_t,
@@ -141,12 +142,14 @@ pub unsafe fn bit_rev_frac_ext(
 
 pub unsafe fn bit_rev_frac_ext_build_k2(
     inout: &DeviceBuffer<(EF, EF)>,
+    real_len: usize,
     lg_domain_size: u32,
     alpha: EF,
     stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_bit_rev_frac_ext_build_k2(
         inout.as_mut_raw_ptr(),
+        real_len,
         lg_domain_size,
         alpha,
         stream,

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -1,7 +1,7 @@
 use std::{array::from_fn, convert::TryInto, env, ffi::c_void, mem::transmute};
 
 use openvm_cuda_common::{
-    copy::{cuda_memcpy_on, MemCopyD2H},
+    copy::{cuda_memcpy_on, MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
     stream::GpuDeviceCtx,
@@ -23,8 +23,8 @@ use crate::{
             _frac_compute_round_temp_buffer_size, fold_ef_frac_columns,
             fold_ef_frac_columns_inplace, frac_build_tree_layer, frac_build_tree_two_layers,
             frac_compute_round, frac_compute_round_and_fold, frac_compute_round_and_fold_inplace,
-            frac_compute_round_and_revert, frac_multifold_raw, frac_precompute_m_build_raw,
-            frac_precompute_m_eval_round_raw,
+            frac_compute_round_and_revert, frac_compute_round_virtual_input, frac_multifold_raw,
+            frac_precompute_m_build_raw, frac_precompute_m_eval_round_raw,
         },
         ntt::{bit_rev_frac_ext, bit_rev_frac_ext_build_k2},
     },
@@ -505,12 +505,163 @@ where
     )
 }
 
+fn bit_reverse_usize(value: usize, bits: usize) -> usize {
+    if bits == 0 {
+        0
+    } else {
+        value.reverse_bits() >> (usize::BITS as usize - bits)
+    }
+}
+
+fn virtual_input_leaf(leaves: &[Frac<EF>], logical_idx: usize, alpha: EF) -> Frac<EF> {
+    if let Some(leaf) = leaves.get(logical_idx) {
+        Frac {
+            p: leaf.p,
+            q: leaf.q + alpha,
+        }
+    } else {
+        Frac {
+            p: EF::ZERO,
+            q: alpha,
+        }
+    }
+}
+
+fn virtual_input_bitrev_leaf(
+    leaves: &[Frac<EF>],
+    bitrev_pos: usize,
+    total_rounds: usize,
+    alpha: EF,
+) -> Frac<EF> {
+    virtual_input_leaf(leaves, bit_reverse_usize(bitrev_pos, total_rounds), alpha)
+}
+
+fn fold_frac(a: Frac<EF>, b: Frac<EF>, r: EF) -> Frac<EF> {
+    Frac {
+        p: a.p + r * (b.p - a.p),
+        q: a.q + r * (b.q - a.q),
+    }
+}
+
+fn virtual_input_parent_layer(
+    leaves: &[Frac<EF>],
+    logical_len: usize,
+    alpha: EF,
+) -> Vec<Frac<EF>> {
+    let parent_len = logical_len / 2;
+    (0..parent_len)
+        .map(|idx| {
+            virtual_input_leaf(leaves, 2 * idx, alpha)
+                + virtual_input_leaf(leaves, 2 * idx + 1, alpha)
+        })
+        .collect()
+}
+
+fn virtual_input_folded_layer(
+    leaves: &[Frac<EF>],
+    logical_len: usize,
+    total_rounds: usize,
+    alpha: EF,
+    r: EF,
+) -> Vec<Frac<EF>> {
+    let half = logical_len / 2;
+    let quarter = logical_len / 4;
+    let mut out = vec![Frac::default(); half];
+    for idx in 0..quarter {
+        out[idx] = fold_frac(
+            virtual_input_bitrev_leaf(leaves, idx, total_rounds, alpha),
+            virtual_input_bitrev_leaf(leaves, idx + quarter, total_rounds, alpha),
+            r,
+        );
+        out[idx + quarter] = fold_frac(
+            virtual_input_bitrev_leaf(leaves, idx + half, total_rounds, alpha),
+            virtual_input_bitrev_leaf(leaves, idx + half + quarter, total_rounds, alpha),
+            r,
+        );
+    }
+    out
+}
+
+fn build_dense_segment_tree(
+    layer: &mut DeviceBuffer<Frac<EF>>,
+    total_leaves: usize,
+    total_rounds: usize,
+    alpha: EF,
+    apply_alpha: bool,
+    stream: openvm_cuda_common::stream::cudaStream_t,
+) -> Result<(), FractionalSumcheckError> {
+    if total_rounds == 0 {
+        return Ok(());
+    }
+    debug_assert!(total_leaves.is_power_of_two());
+    debug_assert_eq!(total_rounds, log2_strict_usize(total_leaves));
+    debug_assert!(layer.len() >= total_leaves);
+
+    // For the dense LogUp input path, the large kernel fuses bit-reversal, alpha application, and
+    // two tree layers. For already-alpha-applied virtual parent layers, use the generic bit-rev
+    // plus tree-build path.
+    let start_layer_i = if apply_alpha && total_leaves > 1024 {
+        unsafe {
+            // SAFETY: Frac<EF> has exact same memory layout and alignment as (EF, EF).
+            let buf = transmute::<&DeviceBuffer<Frac<EF>>, &DeviceBuffer<(EF, EF)>>(layer);
+            bit_rev_frac_ext_build_k2(buf, total_rounds as u32, alpha, stream)
+                .map_err(FractionalSumcheckError::BitReversal)?;
+        }
+        2
+    } else {
+        unsafe {
+            let buf = transmute::<&DeviceBuffer<Frac<EF>>, &DeviceBuffer<(EF, EF)>>(layer);
+            bit_rev_frac_ext(
+                buf,
+                buf,
+                total_rounds as u32,
+                total_leaves.try_into().unwrap(),
+                1,
+                stream,
+            )
+            .map_err(FractionalSumcheckError::BitReversal)?;
+            frac_build_tree_layer(layer, total_leaves, false, alpha, apply_alpha, stream)
+                .map_err(FractionalSumcheckError::SegmentTree)?;
+            if apply_alpha {
+                use crate::cuda::logup_zerocheck::frac_add_alpha;
+                let half = total_leaves / 2;
+                let second_half_ptr = layer.as_mut_raw_ptr() as *mut Frac<EF>;
+                let second_half_buf =
+                    DeviceBuffer::<Frac<EF>>::from_raw_parts(second_half_ptr.add(half), half);
+                frac_add_alpha(&second_half_buf, alpha, stream)
+                    .map_err(FractionalSumcheckError::SegmentTree)?;
+                std::mem::forget(second_half_buf);
+            }
+        }
+        1
+    };
+
+    let mut i = start_layer_i;
+    while i + 1 < total_rounds {
+        let half_i1 = total_leaves >> (i + 2);
+        unsafe {
+            frac_build_tree_two_layers(layer, half_i1, stream)
+                .map_err(FractionalSumcheckError::SegmentTree)?;
+        }
+        i += 2;
+    }
+    if i < total_rounds {
+        unsafe {
+            frac_build_tree_layer(layer, total_leaves >> i, false, EF::ZERO, false, stream)
+                .map_err(FractionalSumcheckError::SegmentTree)?;
+        }
+    }
+    Ok(())
+}
+
 /// GKR fractional sumcheck prover. See `docs/cuda-backend/gkr-prover.md` (repo root) for the
 /// protocol and implementation details.
 #[instrument(skip_all)]
 pub fn fractional_sumcheck_gpu<SC, TS>(
     transcript: &mut TS,
     leaves: DeviceBuffer<Frac<EF>>,
+    real_len: usize,
+    logical_len: usize,
     alpha: EF,
     assert_zero: bool,
     mem: &mut MemTracker,
@@ -531,86 +682,52 @@ where
             vec![],
         ));
     };
+    assert_eq!(
+        layer.len(),
+        real_len,
+        "fractional_sumcheck_gpu input length must equal real_len"
+    );
+    assert!(real_len > 0, "real_len must be nonzero");
+    assert!(logical_len.is_power_of_two(), "logical_len must be a power of two");
+    assert!(
+        real_len <= logical_len,
+        "real_len must not exceed logical_len"
+    );
+    assert!(
+        logical_len / 2 <= real_len,
+        "virtual input requires logical_len / 2 <= real_len"
+    );
     let stream = device_ctx.stream.as_raw();
-    let total_leaves = layer.len();
+    let total_leaves = logical_len;
+    let virtual_input = real_len < logical_len;
     // total_rounds = l_skip + n_logup
     let total_rounds = log2_strict_usize(total_leaves);
     assert!(total_rounds > 0, "n_logup > 0 when there are interactions");
-    // Build segment tree.
-    // - We only maintain the current layer
-    // - Input layer uses separate F and EF buffers to save memory
-    // - First tree layer converts (F, EF) to FracExt (EF, EF)
 
-    // We store it in bit-reversal order for coalesced memory accesses.
-    // For large N (> 1024), fuse bitrev + tree layers 0 and 1 into a single kernel pass,
-    // eliminating ~1.5N global memory reads. For small N, fall back to separate operations.
-    let start_layer_i = if total_leaves > 1024 {
-        unsafe {
-            // SAFETY: Frac<EF> has exact same memory layout and alignment as (EF, EF).
-            let buf = transmute::<&DeviceBuffer<Frac<EF>>, &DeviceBuffer<(EF, EF)>>(&layer);
-            bit_rev_frac_ext_build_k2(buf, total_rounds as u32, alpha, stream)
-                .map_err(FractionalSumcheckError::BitReversal)?;
-        }
-        2 // layers 0+1 already done
+    let host_input_leaves = if virtual_input {
+        Some(layer.to_host_on(device_ctx)?)
     } else {
-        // Fallback: separate bitrev + layer 0.
-        unsafe {
-            let buf = transmute::<&DeviceBuffer<Frac<EF>>, &DeviceBuffer<(EF, EF)>>(&layer);
-            bit_rev_frac_ext(
-                buf,
-                buf,
-                total_rounds as u32,
-                total_leaves.try_into().unwrap(),
-                1,
-                stream,
-            )
-            .map_err(FractionalSumcheckError::BitReversal)?;
-            frac_build_tree_layer(&mut layer, total_leaves, false, alpha, true, stream)
-                .map_err(FractionalSumcheckError::SegmentTree)?;
-            use crate::cuda::logup_zerocheck::frac_add_alpha;
-            let half = total_leaves / 2;
-            let second_half_ptr = layer.as_mut_raw_ptr() as *mut Frac<EF>;
-            let second_half_buf =
-                DeviceBuffer::<Frac<EF>>::from_raw_parts(second_half_ptr.add(half), half);
-            frac_add_alpha(&second_half_buf, alpha, stream)
-                .map_err(FractionalSumcheckError::SegmentTree)?;
-            std::mem::forget(second_half_buf);
-        }
-        1 // layer 0 done; continue from layer 1
+        None
     };
 
-    // Remaining layers: fuse consecutive pairs via two-layer kernel (~33% traffic savings).
-    let mut i = start_layer_i;
-    while i + 1 < total_rounds {
-        let half_i1 = total_leaves >> (i + 2);
-        unsafe {
-            frac_build_tree_two_layers(&mut layer, half_i1, stream)
-                .map_err(FractionalSumcheckError::SegmentTree)?;
-        }
-        i += 2;
-    }
-    // Remaining single layer (if odd number of layers left).
-    if i < total_rounds {
-        unsafe {
-            frac_build_tree_layer(
-                &mut layer,
-                total_leaves >> i,
-                false,
-                EF::ZERO,
-                false,
-                stream,
-            )
-            .map_err(FractionalSumcheckError::SegmentTree)?;
-        }
+    if let Some(host_leaves) = &host_input_leaves {
+        let parent_layer = virtual_input_parent_layer(host_leaves, logical_len, alpha);
+        parent_layer.copy_to_on(&mut layer, device_ctx)?;
+        build_dense_segment_tree(
+            &mut layer,
+            logical_len / 2,
+            total_rounds - 1,
+            EF::ZERO,
+            false,
+            stream,
+        )?;
+    } else {
+        build_dense_segment_tree(&mut layer, total_leaves, total_rounds, alpha, true, stream)?;
     }
     mem.emit_metrics_with_label("frac_sumcheck.segment_tree");
     mem.tracing_info("fractional_sumcheck_gkr: after building segment tree");
     let mut copy_scratch = DeviceBuffer::<Frac<EF>>::with_capacity_on(1, device_ctx);
     let root = copy_from_device(&layer, 0, &mut copy_scratch, device_ctx)?;
-    unsafe {
-        frac_build_tree_layer(&mut layer, 2, true, EF::ZERO, false, stream)
-            .map_err(FractionalSumcheckError::SegmentTree)?;
-    }
     if assert_zero {
         if root.p != EF::ZERO {
             return Err(FractionalSumcheckError::NonzeroRootSum {
@@ -626,8 +743,22 @@ where
     let mut claims_per_layer = Vec::with_capacity(total_rounds);
     let mut sumcheck_polys = Vec::with_capacity(total_rounds);
 
-    let first_left = copy_from_device(&layer, 0, &mut copy_scratch, device_ctx)?;
-    let first_right = copy_from_device(&layer, 1, &mut copy_scratch, device_ctx)?;
+    let (first_left, first_right) = if total_rounds == 1 && virtual_input {
+        let host_leaves = host_input_leaves.as_ref().unwrap();
+        (
+            virtual_input_leaf(host_leaves, 0, alpha),
+            virtual_input_leaf(host_leaves, 1, alpha),
+        )
+    } else {
+        unsafe {
+            frac_build_tree_layer(&mut layer, 2, true, EF::ZERO, false, stream)
+                .map_err(FractionalSumcheckError::SegmentTree)?;
+        }
+        (
+            copy_from_device(&layer, 0, &mut copy_scratch, device_ctx)?,
+            copy_from_device(&layer, 1, &mut copy_scratch, device_ctx)?,
+        )
+    };
     claims_per_layer.push(GkrLayerClaims {
         p_xi_0: first_left.p,
         q_xi_0: first_left.q,
@@ -644,6 +775,16 @@ where
     }
     let mu_1 = transcript.sample_ext();
     let mut xi_prev = vec![mu_1];
+    if total_rounds == 1 {
+        return Ok((
+            FracSumcheckProof {
+                fractional_sum: (root.p, root.q),
+                claims_per_layer,
+                sumcheck_polys,
+            },
+            xi_prev,
+        ));
+    }
     let mut d_sum_evals = DeviceBuffer::<EF>::with_capacity_on(2, device_ctx);
 
     let precompute_m_env = precompute_m_enabled();
@@ -727,31 +868,126 @@ where
             reduce_to_single_evaluation(claims_per_layer.last().unwrap(), /* mu */ xi_prev[0]);
         let mut prev_s_eval = numer_claim + lambda * denom_claim;
         let mut eq_r_acc = EF::ONE;
-
-        // Round 0: compute + revert fused. The pq_buffer fold will be fused into next round's
-        // compute. This fuses frac_build_tree_layer(revert=true) with the first inner round
-        // compute.
-        let r0 = do_sumcheck_round_and_revert(
-            &mut eq_buffer,
-            &mut layer,
-            pq_size,
-            lambda,
-            transcript,
-            &mut d_sum_evals,
-            &mut tmp_block_sums,
-            &mut round_polys_eval,
-            &mut r_vec,
-            &mut prev_s_eval,
-            xi_prev[0],
-            &mut eq_r_acc,
-            device_ctx,
-        )?;
-
-        // Fused rounds 1..(round-1): compute + fold using prev_r.
-        let mut prev_r = r0;
+        let virtual_input_round = virtual_input && last_outer_round;
         let active: &mut DeviceBuffer<Frac<EF>>;
 
-        match backend {
+        if virtual_input_round {
+            let host_leaves = host_input_leaves.as_ref().unwrap();
+            host_leaves.copy_to_on(&mut layer, device_ctx)?;
+
+            unsafe {
+                frac_compute_round_virtual_input(
+                    &eq_buffer,
+                    &layer,
+                    real_len,
+                    logical_len,
+                    lambda,
+                    alpha,
+                    &mut d_sum_evals,
+                    &mut tmp_block_sums,
+                    stream,
+                )
+                .map_err(FractionalSumcheckError::ComputeRound)?;
+            }
+            eq_buffer.drop_layer();
+            let mut prev_r = observe_and_update(
+                &d_sum_evals,
+                transcript,
+                &mut round_polys_eval,
+                &mut r_vec,
+                &mut prev_s_eval,
+                xi_prev[0],
+                &mut eq_r_acc,
+                device_ctx,
+            )?;
+
+            let folded = virtual_input_folded_layer(
+                host_leaves,
+                logical_len,
+                total_rounds,
+                alpha,
+                prev_r,
+            );
+            folded.copy_to_on(&mut layer, device_ctx)?;
+            pq_size >>= 1;
+
+            if let Some(&xi_j) = xi_prev.get(1) {
+                unsafe {
+                    frac_compute_round(
+                        &eq_buffer,
+                        &layer,
+                        pq_size / 2,
+                        lambda,
+                        &mut d_sum_evals,
+                        &mut tmp_block_sums,
+                        stream,
+                    )
+                    .map_err(FractionalSumcheckError::ComputeRound)?;
+                }
+                eq_buffer.drop_layer();
+                prev_r = observe_and_update(
+                    &d_sum_evals,
+                    transcript,
+                    &mut round_polys_eval,
+                    &mut r_vec,
+                    &mut prev_s_eval,
+                    xi_j,
+                    &mut eq_r_acc,
+                    device_ctx,
+                )?;
+
+                for &xi_j in xi_prev.iter().skip(2) {
+                    let src_pq_size = pq_size;
+                    prev_r = do_fused_sumcheck_round_inplace(
+                        &mut eq_buffer,
+                        &mut layer,
+                        src_pq_size,
+                        lambda,
+                        prev_r,
+                        transcript,
+                        &mut d_sum_evals,
+                        &mut tmp_block_sums,
+                        &mut round_polys_eval,
+                        &mut r_vec,
+                        &mut prev_s_eval,
+                        xi_j,
+                        &mut eq_r_acc,
+                        device_ctx,
+                    )?;
+                    pq_size >>= 1;
+                }
+
+                unsafe {
+                    fold_ef_frac_columns_inplace(&mut layer, pq_size, prev_r, stream)
+                        .map_err(FractionalSumcheckError::FoldColumns)?;
+                }
+                pq_size >>= 1;
+            }
+            active = &mut layer;
+        } else {
+            // Round 0: compute + revert fused. The pq_buffer fold will be fused into next round's
+            // compute. This fuses frac_build_tree_layer(revert=true) with the first inner round
+            // compute.
+            let r0 = do_sumcheck_round_and_revert(
+                &mut eq_buffer,
+                &mut layer,
+                pq_size,
+                lambda,
+                transcript,
+                &mut d_sum_evals,
+                &mut tmp_block_sums,
+                &mut round_polys_eval,
+                &mut r_vec,
+                &mut prev_s_eval,
+                xi_prev[0],
+                &mut eq_r_acc,
+                device_ctx,
+            )?;
+
+            // Fused rounds 1..(round-1): compute + fold using prev_r.
+            let mut prev_r = r0;
+
+            match backend {
             GkrRoundStrategy::FoldEval => {
                 // Existing fused path.
                 let mut scheduler = BufferScheduler::new(max_work_size);
@@ -1113,6 +1349,7 @@ where
                 pq_size >>= 1;
             }
         }
+        }
 
         let pq_host = [
             copy_from_device(active, 0, &mut copy_scratch, device_ctx)?,
@@ -1254,14 +1491,16 @@ pub fn make_synthetic_leaves(
 mod tests {
     use openvm_cuda_common::{
         common::get_device,
+        copy::MemCopyH2D,
         memory_manager::MemTracker,
         stream::{CudaStream, GpuDeviceCtx, StreamGuard},
     };
     use p3_field::PrimeCharacteristicRing;
+    use rand::{rngs::StdRng, Rng, SeedableRng};
 
     use super::{
-        fractional_sumcheck_gpu, make_synthetic_leaves, FractionalSumcheckError, GkrRoundStrategy,
-        EF,
+        fractional_sumcheck_gpu, make_synthetic_leaves, Frac, FractionalSumcheckError,
+        GkrRoundStrategy, EF,
     };
     use crate::{prelude::SC, sponge::DuplexSpongeGpu};
 
@@ -1292,6 +1531,8 @@ mod tests {
         let result = fractional_sumcheck_gpu(
             &mut transcript,
             leaves,
+            1usize << n,
+            1usize << n,
             EF::ZERO,
             false,
             &mut mem,
@@ -1318,6 +1559,55 @@ mod tests {
             "sumcheck_polys mismatch"
         );
         assert_eq!(a.1, b.1, "final randomness mismatch");
+    }
+
+    fn make_host_leaves(len: usize) -> Vec<Frac<EF>> {
+        let mut rng = StdRng::seed_from_u64(20260429);
+        (0..len)
+            .map(|_| Frac {
+                p: rng.random::<EF>(),
+                q: rng.random::<EF>(),
+            })
+            .collect()
+    }
+
+    fn run_from_host(
+        host: &[Frac<EF>],
+        real_len: usize,
+        logical_len: usize,
+        alpha: EF,
+    ) -> Result<(super::FracSumcheckProof<SC>, Vec<EF>), FractionalSumcheckError> {
+        let device_ctx = test_ctx();
+        let leaves = host.to_device_on(&device_ctx)?;
+        let mut transcript = DuplexSpongeGpu::default();
+        let mut mem = MemTracker::start("test.virtual_input_padding");
+        let result = fractional_sumcheck_gpu(
+            &mut transcript,
+            leaves,
+            real_len,
+            logical_len,
+            alpha,
+            false,
+            &mut mem,
+            &device_ctx,
+        )?;
+        device_ctx.stream.synchronize().expect("sync");
+        Ok(result)
+    }
+
+    #[test]
+    fn test_virtual_input_padding_matches_dense_padding() -> Result<(), FractionalSumcheckError> {
+        for (real_len, logical_len) in [(2, 4), (4, 8), (5, 8), (1500, 2048)] {
+            let real = make_host_leaves(real_len);
+            let mut dense = real.clone();
+            dense.resize(logical_len, Frac::default());
+
+            let alpha = EF::ONE;
+            let virtual_proof = run_from_host(&real, real_len, logical_len, alpha)?;
+            let dense_proof = run_from_host(&dense, logical_len, logical_len, alpha)?;
+            assert_proofs_equal(&virtual_proof, &dense_proof);
+        }
+        Ok(())
     }
 
     /// Compares precompute-M against FoldEval at n=24,25,26.

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -44,6 +44,8 @@ pub struct FractionalInputSize {
 
 impl FractionalInputSize {
     pub fn new(real_len: usize, logical_len: usize) -> Self {
+        debug_assert!(real_len <= logical_len);
+        debug_assert!(logical_len.is_power_of_two() || real_len == logical_len);
         Self {
             real_len,
             logical_len,

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -1,7 +1,7 @@
 use std::{array::from_fn, convert::TryInto, env, ffi::c_void, mem::transmute};
 
 use openvm_cuda_common::{
-    copy::{cuda_memcpy_on, MemCopyD2H, MemCopyH2D},
+    copy::{cuda_memcpy_on, MemCopyD2H},
     d_buffer::DeviceBuffer,
     memory_manager::MemTracker,
     stream::GpuDeviceCtx,
@@ -23,8 +23,8 @@ use crate::{
             _frac_compute_round_temp_buffer_size, fold_ef_frac_columns,
             fold_ef_frac_columns_inplace, frac_build_tree_layer, frac_build_tree_two_layers,
             frac_compute_round, frac_compute_round_and_fold, frac_compute_round_and_fold_inplace,
-            frac_compute_round_and_revert, frac_compute_round_virtual_input, frac_multifold_raw,
-            frac_precompute_m_build_raw, frac_precompute_m_eval_round_raw,
+            frac_compute_round_and_revert, frac_multifold_raw, frac_precompute_m_build_raw,
+            frac_precompute_m_eval_round_raw,
         },
         ntt::{bit_rev_frac_ext, bit_rev_frac_ext_build_k2},
     },
@@ -341,6 +341,51 @@ fn copy_to_device_ptr<T: Copy>(
     Ok(())
 }
 
+fn bit_reverse_usize(value: usize, bits: usize) -> usize {
+    if bits == 0 {
+        0
+    } else {
+        value.reverse_bits() >> (usize::BITS as usize - bits)
+    }
+}
+
+fn virtual_padding_q(alpha: EF, subtree_len: usize) -> EF {
+    let mut q = alpha;
+    let mut len = subtree_len;
+    while len > 1 {
+        q *= q;
+        len >>= 1;
+    }
+    q
+}
+
+#[allow(clippy::too_many_arguments)]
+fn copy_compact_node_from_device(
+    layer: &DeviceBuffer<Frac<EF>>,
+    dense_idx: usize,
+    active_size: usize,
+    real_len: usize,
+    logical_len: usize,
+    alpha: EF,
+    copy_scratch: &mut DeviceBuffer<Frac<EF>>,
+    device_ctx: &GpuDeviceCtx,
+) -> Result<Frac<EF>, FractionalSumcheckError> {
+    let subtree_len = logical_len / active_size;
+    let start = bit_reverse_usize(dense_idx, log2_strict_usize(active_size)) * subtree_len;
+    if start >= real_len {
+        return Ok(Frac {
+            p: EF::ZERO,
+            q: virtual_padding_q(alpha, subtree_len),
+        });
+    }
+    let physical_idx = if dense_idx < real_len {
+        dense_idx
+    } else {
+        start
+    };
+    copy_from_device(layer, physical_idx, copy_scratch, device_ctx)
+}
+
 /// Observes s_evals in transcript, updates accumulators, and returns the sampled challenge.
 #[allow(clippy::too_many_arguments)]
 fn observe_and_update<SC, TS>(
@@ -383,7 +428,9 @@ fn do_sumcheck_round_and_revert<SC, TS>(
     eq_buffer: &mut SqrtEqLayers,
     layer: &mut DeviceBuffer<Frac<EF>>,
     pq_size: usize,
+    total_leaves: usize,
     lambda: EF,
+    alpha: EF,
     transcript: &mut TS,
     d_sum_evals: &mut DeviceBuffer<EF>,
     tmp_block_sums: &mut DeviceBuffer<EF>,
@@ -404,7 +451,9 @@ where
             eq_buffer,
             layer,
             pq_size / 2,
+            total_leaves,
             lambda,
+            alpha,
             d_sum_evals,
             tmp_block_sums,
             stream,
@@ -434,8 +483,11 @@ fn do_fused_sumcheck_round<SC, TS>(
     src_pq_buffer: &DeviceBuffer<Frac<EF>>,
     dst_pq_buffer: &mut DeviceBuffer<Frac<EF>>,
     src_pq_size: usize,
+    src_real_len: usize,
+    total_leaves: usize,
     lambda: EF,
     r_prev: EF,
+    alpha: EF,
     transcript: &mut TS,
     d_sum_evals: &mut DeviceBuffer<EF>,
     tmp_block_sums: &mut DeviceBuffer<EF>,
@@ -457,8 +509,11 @@ where
             src_pq_buffer,
             dst_pq_buffer,
             src_pq_size,
+            src_real_len,
+            total_leaves,
             lambda,
             r_prev,
+            alpha,
             d_sum_evals,
             tmp_block_sums,
             stream,
@@ -484,8 +539,13 @@ fn do_fused_sumcheck_round_inplace<SC, TS>(
     eq_buffer: &mut SqrtEqLayers,
     pq_buffer: &mut DeviceBuffer<Frac<EF>>,
     src_pq_size: usize,
+    src_real_len: usize,
+    src_logical_len: usize,
+    dst_real_len: usize,
+    dst_logical_len: usize,
     lambda: EF,
     r_prev: EF,
+    alpha: EF,
     transcript: &mut TS,
     d_sum_evals: &mut DeviceBuffer<EF>,
     tmp_block_sums: &mut DeviceBuffer<EF>,
@@ -506,8 +566,13 @@ where
             eq_buffer,
             pq_buffer,
             src_pq_size,
+            src_real_len,
+            src_logical_len,
+            dst_real_len,
+            dst_logical_len,
             lambda,
             r_prev,
+            alpha,
             d_sum_evals,
             tmp_block_sums,
             stream,
@@ -525,151 +590,6 @@ where
         eq_r_acc,
         device_ctx,
     )
-}
-
-fn bit_reverse_usize(value: usize, bits: usize) -> usize {
-    if bits == 0 {
-        0
-    } else {
-        value.reverse_bits() >> (usize::BITS as usize - bits)
-    }
-}
-
-fn virtual_input_leaf(leaves: &[Frac<EF>], logical_idx: usize, alpha: EF) -> Frac<EF> {
-    if let Some(leaf) = leaves.get(logical_idx) {
-        Frac {
-            p: leaf.p,
-            q: leaf.q + alpha,
-        }
-    } else {
-        Frac {
-            p: EF::ZERO,
-            q: alpha,
-        }
-    }
-}
-
-fn virtual_input_bitrev_leaf(
-    leaves: &[Frac<EF>],
-    bitrev_pos: usize,
-    total_rounds: usize,
-    alpha: EF,
-) -> Frac<EF> {
-    virtual_input_leaf(leaves, bit_reverse_usize(bitrev_pos, total_rounds), alpha)
-}
-
-fn fold_frac(a: Frac<EF>, b: Frac<EF>, r: EF) -> Frac<EF> {
-    Frac {
-        p: a.p + r * (b.p - a.p),
-        q: a.q + r * (b.q - a.q),
-    }
-}
-
-fn virtual_input_parent_layer(leaves: &[Frac<EF>], logical_len: usize, alpha: EF) -> Vec<Frac<EF>> {
-    let parent_len = logical_len / 2;
-    (0..parent_len)
-        .map(|idx| {
-            virtual_input_leaf(leaves, 2 * idx, alpha)
-                + virtual_input_leaf(leaves, 2 * idx + 1, alpha)
-        })
-        .collect()
-}
-
-fn virtual_input_folded_layer(
-    leaves: &[Frac<EF>],
-    logical_len: usize,
-    total_rounds: usize,
-    alpha: EF,
-    r: EF,
-) -> Vec<Frac<EF>> {
-    let half = logical_len / 2;
-    let quarter = logical_len / 4;
-    let mut out = vec![Frac::default(); half];
-    for idx in 0..quarter {
-        out[idx] = fold_frac(
-            virtual_input_bitrev_leaf(leaves, idx, total_rounds, alpha),
-            virtual_input_bitrev_leaf(leaves, idx + quarter, total_rounds, alpha),
-            r,
-        );
-        out[idx + quarter] = fold_frac(
-            virtual_input_bitrev_leaf(leaves, idx + half, total_rounds, alpha),
-            virtual_input_bitrev_leaf(leaves, idx + half + quarter, total_rounds, alpha),
-            r,
-        );
-    }
-    out
-}
-
-fn build_dense_segment_tree(
-    layer: &mut DeviceBuffer<Frac<EF>>,
-    total_leaves: usize,
-    total_rounds: usize,
-    alpha: EF,
-    apply_alpha: bool,
-    stream: openvm_cuda_common::stream::cudaStream_t,
-) -> Result<(), FractionalSumcheckError> {
-    if total_rounds == 0 {
-        return Ok(());
-    }
-    debug_assert!(total_leaves.is_power_of_two());
-    debug_assert_eq!(total_rounds, log2_strict_usize(total_leaves));
-    debug_assert!(layer.len() >= total_leaves);
-
-    // For the dense LogUp input path, the large kernel fuses bit-reversal, alpha application, and
-    // two tree layers. For already-alpha-applied virtual parent layers, use the generic bit-rev
-    // plus tree-build path.
-    let start_layer_i = if apply_alpha && total_leaves > 1024 {
-        unsafe {
-            // SAFETY: Frac<EF> has exact same memory layout and alignment as (EF, EF).
-            let buf = transmute::<&DeviceBuffer<Frac<EF>>, &DeviceBuffer<(EF, EF)>>(layer);
-            bit_rev_frac_ext_build_k2(buf, total_rounds as u32, alpha, stream)
-                .map_err(FractionalSumcheckError::BitReversal)?;
-        }
-        2
-    } else {
-        unsafe {
-            let buf = transmute::<&DeviceBuffer<Frac<EF>>, &DeviceBuffer<(EF, EF)>>(layer);
-            bit_rev_frac_ext(
-                buf,
-                buf,
-                total_rounds as u32,
-                total_leaves.try_into().unwrap(),
-                1,
-                stream,
-            )
-            .map_err(FractionalSumcheckError::BitReversal)?;
-            frac_build_tree_layer(layer, total_leaves, false, alpha, apply_alpha, stream)
-                .map_err(FractionalSumcheckError::SegmentTree)?;
-            if apply_alpha {
-                use crate::cuda::logup_zerocheck::frac_add_alpha;
-                let half = total_leaves / 2;
-                let second_half_ptr = layer.as_mut_raw_ptr() as *mut Frac<EF>;
-                let second_half_buf =
-                    DeviceBuffer::<Frac<EF>>::from_raw_parts(second_half_ptr.add(half), half);
-                frac_add_alpha(&second_half_buf, alpha, stream)
-                    .map_err(FractionalSumcheckError::SegmentTree)?;
-                std::mem::forget(second_half_buf);
-            }
-        }
-        1
-    };
-
-    let mut i = start_layer_i;
-    while i + 1 < total_rounds {
-        let half_i1 = total_leaves >> (i + 2);
-        unsafe {
-            frac_build_tree_two_layers(layer, half_i1, stream)
-                .map_err(FractionalSumcheckError::SegmentTree)?;
-        }
-        i += 2;
-    }
-    if i < total_rounds {
-        unsafe {
-            frac_build_tree_layer(layer, total_leaves >> i, false, EF::ZERO, false, stream)
-                .map_err(FractionalSumcheckError::SegmentTree)?;
-        }
-    }
-    Ok(())
 }
 
 /// GKR fractional sumcheck prover. See `docs/cuda-backend/gkr-prover.md` (repo root) for the
@@ -699,8 +619,9 @@ where
             vec![],
         ));
     };
+    let stream = device_ctx.stream.as_raw();
     let real_len = sizes.real_len;
-    let logical_len = sizes.logical_len;
+    let total_leaves = sizes.logical_len;
     assert_eq!(
         layer.len(),
         real_len,
@@ -708,48 +629,109 @@ where
     );
     assert!(real_len > 0, "real_len must be nonzero");
     assert!(
-        logical_len.is_power_of_two(),
+        total_leaves.is_power_of_two(),
         "logical_len must be a power of two"
     );
     assert!(
-        real_len <= logical_len,
+        real_len <= total_leaves,
         "real_len must not exceed logical_len"
     );
     assert!(
-        logical_len / 2 <= real_len,
-        "virtual input requires logical_len / 2 <= real_len"
+        total_leaves / 2 <= real_len,
+        "virtual padding requires logical_len / 2 <= real_len"
     );
-    let stream = device_ctx.stream.as_raw();
-    let total_leaves = logical_len;
-    let virtual_input = real_len < logical_len;
     // total_rounds = l_skip + n_logup
     let total_rounds = log2_strict_usize(total_leaves);
     assert!(total_rounds > 0, "n_logup > 0 when there are interactions");
+    // Build segment tree.
+    // - We only maintain the current layer
+    // - Input layer uses separate F and EF buffers to save memory
+    // - First tree layer converts (F, EF) to FracExt (EF, EF)
 
-    let host_input_leaves = if virtual_input {
-        Some(layer.to_host_on(device_ctx)?)
+    // We store it in bit-reversal order for coalesced memory accesses.
+    // For large N (> 1024), fuse bitrev + tree layers 0 and 1 into a single kernel pass,
+    // eliminating ~1.5N global memory reads. For small N, fall back to separate operations.
+    let virtual_input = real_len < total_leaves;
+    let start_layer_i = if total_leaves > 1024 {
+        unsafe {
+            // SAFETY: Frac<EF> has exact same memory layout and alignment as (EF, EF).
+            let buf = transmute::<&DeviceBuffer<Frac<EF>>, &DeviceBuffer<(EF, EF)>>(&layer);
+            bit_rev_frac_ext_build_k2(buf, real_len, total_rounds as u32, alpha, stream)
+                .map_err(FractionalSumcheckError::BitReversal)?;
+        }
+        2 // layers 0+1 already done
     } else {
-        None
+        // Fallback: separate bitrev + layer 0.
+        unsafe {
+            if !virtual_input {
+                let buf = transmute::<&DeviceBuffer<Frac<EF>>, &DeviceBuffer<(EF, EF)>>(&layer);
+                bit_rev_frac_ext(
+                    buf,
+                    buf,
+                    total_rounds as u32,
+                    total_leaves.try_into().unwrap(),
+                    1,
+                    stream,
+                )
+                .map_err(FractionalSumcheckError::BitReversal)?;
+            }
+            frac_build_tree_layer(
+                &mut layer,
+                total_leaves,
+                total_leaves,
+                false,
+                alpha,
+                true,
+                stream,
+            )
+            .map_err(FractionalSumcheckError::SegmentTree)?;
+            use crate::cuda::logup_zerocheck::frac_add_alpha;
+            if !virtual_input {
+                let half = total_leaves / 2;
+                let second_half_ptr = layer.as_mut_raw_ptr() as *mut Frac<EF>;
+                let second_half_buf =
+                    DeviceBuffer::<Frac<EF>>::from_raw_parts(second_half_ptr.add(half), half);
+                frac_add_alpha(&second_half_buf, alpha, stream)
+                    .map_err(FractionalSumcheckError::SegmentTree)?;
+                std::mem::forget(second_half_buf);
+            }
+        }
+        1 // layer 0 done; continue from layer 1
     };
 
-    if let Some(host_leaves) = &host_input_leaves {
-        let parent_layer = virtual_input_parent_layer(host_leaves, logical_len, alpha);
-        parent_layer.copy_to_on(&mut layer, device_ctx)?;
-        build_dense_segment_tree(
-            &mut layer,
-            logical_len / 2,
-            total_rounds - 1,
-            EF::ZERO,
-            false,
-            stream,
-        )?;
-    } else {
-        build_dense_segment_tree(&mut layer, total_leaves, total_rounds, alpha, true, stream)?;
+    // Remaining layers: fuse consecutive pairs via two-layer kernel (~33% traffic savings).
+    let mut i = start_layer_i;
+    while i + 1 < total_rounds {
+        let half_i1 = total_leaves >> (i + 2);
+        unsafe {
+            frac_build_tree_two_layers(&mut layer, half_i1, total_leaves, alpha, stream)
+                .map_err(FractionalSumcheckError::SegmentTree)?;
+        }
+        i += 2;
+    }
+    // Remaining single layer (if odd number of layers left).
+    if i < total_rounds {
+        unsafe {
+            frac_build_tree_layer(
+                &mut layer,
+                total_leaves >> i,
+                total_leaves,
+                false,
+                alpha,
+                false,
+                stream,
+            )
+            .map_err(FractionalSumcheckError::SegmentTree)?;
+        }
     }
     mem.emit_metrics_with_label("frac_sumcheck.segment_tree");
     mem.tracing_info("fractional_sumcheck_gkr: after building segment tree");
     let mut copy_scratch = DeviceBuffer::<Frac<EF>>::with_capacity_on(1, device_ctx);
     let root = copy_from_device(&layer, 0, &mut copy_scratch, device_ctx)?;
+    unsafe {
+        frac_build_tree_layer(&mut layer, 2, total_leaves, true, alpha, false, stream)
+            .map_err(FractionalSumcheckError::SegmentTree)?;
+    }
     if assert_zero {
         if root.p != EF::ZERO {
             return Err(FractionalSumcheckError::NonzeroRootSum {
@@ -765,22 +747,26 @@ where
     let mut claims_per_layer = Vec::with_capacity(total_rounds);
     let mut sumcheck_polys = Vec::with_capacity(total_rounds);
 
-    let (first_left, first_right) = if total_rounds == 1 && virtual_input {
-        let host_leaves = host_input_leaves.as_ref().unwrap();
-        (
-            virtual_input_leaf(host_leaves, 0, alpha),
-            virtual_input_leaf(host_leaves, 1, alpha),
-        )
-    } else {
-        unsafe {
-            frac_build_tree_layer(&mut layer, 2, true, EF::ZERO, false, stream)
-                .map_err(FractionalSumcheckError::SegmentTree)?;
-        }
-        (
-            copy_from_device(&layer, 0, &mut copy_scratch, device_ctx)?,
-            copy_from_device(&layer, 1, &mut copy_scratch, device_ctx)?,
-        )
-    };
+    let first_left = copy_compact_node_from_device(
+        &layer,
+        0,
+        2,
+        real_len,
+        total_leaves,
+        alpha,
+        &mut copy_scratch,
+        device_ctx,
+    )?;
+    let first_right = copy_compact_node_from_device(
+        &layer,
+        1,
+        2,
+        real_len,
+        total_leaves,
+        alpha,
+        &mut copy_scratch,
+        device_ctx,
+    )?;
     claims_per_layer.push(GkrLayerClaims {
         p_xi_0: first_left.p,
         q_xi_0: first_left.q,
@@ -797,16 +783,6 @@ where
     }
     let mu_1 = transcript.sample_ext();
     let mut xi_prev = vec![mu_1];
-    if total_rounds == 1 {
-        return Ok((
-            FracSumcheckProof {
-                fractional_sum: (root.p, root.q),
-                claims_per_layer,
-                sumcheck_polys,
-            },
-            xi_prev,
-        ));
-    }
     let mut d_sum_evals = DeviceBuffer::<EF>::with_capacity_on(2, device_ctx);
 
     let precompute_m_env = precompute_m_enabled();
@@ -890,496 +866,479 @@ where
             reduce_to_single_evaluation(claims_per_layer.last().unwrap(), /* mu */ xi_prev[0]);
         let mut prev_s_eval = numer_claim + lambda * denom_claim;
         let mut eq_r_acc = EF::ONE;
-        let virtual_input_round = virtual_input && last_outer_round;
+
+        // Round 0: compute + revert fused. The pq_buffer fold will be fused into next round's
+        // compute. This fuses frac_build_tree_layer(revert=true) with the first inner round
+        // compute.
+        let r0 = do_sumcheck_round_and_revert(
+            &mut eq_buffer,
+            &mut layer,
+            pq_size,
+            total_leaves,
+            lambda,
+            alpha,
+            transcript,
+            &mut d_sum_evals,
+            &mut tmp_block_sums,
+            &mut round_polys_eval,
+            &mut r_vec,
+            &mut prev_s_eval,
+            xi_prev[0],
+            &mut eq_r_acc,
+            device_ctx,
+        )?;
+
+        // Fused rounds 1..(round-1): compute + fold using prev_r.
+        let mut prev_r = r0;
         let active: &mut DeviceBuffer<Frac<EF>>;
 
-        if virtual_input_round {
-            let host_leaves = host_input_leaves.as_ref().unwrap();
-            host_leaves.copy_to_on(&mut layer, device_ctx)?;
-
-            unsafe {
-                frac_compute_round_virtual_input(
-                    &eq_buffer,
-                    &layer,
-                    real_len,
-                    logical_len,
-                    lambda,
-                    alpha,
-                    &mut d_sum_evals,
-                    &mut tmp_block_sums,
-                    stream,
-                )
-                .map_err(FractionalSumcheckError::ComputeRound)?;
-            }
-            eq_buffer.drop_layer();
-            let mut prev_r = observe_and_update(
-                &d_sum_evals,
-                transcript,
-                &mut round_polys_eval,
-                &mut r_vec,
-                &mut prev_s_eval,
-                xi_prev[0],
-                &mut eq_r_acc,
-                device_ctx,
-            )?;
-
-            let folded =
-                virtual_input_folded_layer(host_leaves, logical_len, total_rounds, alpha, prev_r);
-            folded.copy_to_on(&mut layer, device_ctx)?;
-            pq_size >>= 1;
-
-            if let Some(&xi_j) = xi_prev.get(1) {
-                unsafe {
-                    frac_compute_round(
-                        &eq_buffer,
-                        &layer,
-                        pq_size / 2,
-                        lambda,
-                        &mut d_sum_evals,
-                        &mut tmp_block_sums,
-                        stream,
-                    )
-                    .map_err(FractionalSumcheckError::ComputeRound)?;
-                }
-                eq_buffer.drop_layer();
-                prev_r = observe_and_update(
-                    &d_sum_evals,
-                    transcript,
-                    &mut round_polys_eval,
-                    &mut r_vec,
-                    &mut prev_s_eval,
-                    xi_j,
-                    &mut eq_r_acc,
-                    device_ctx,
-                )?;
-
-                for &xi_j in xi_prev.iter().skip(2) {
+        match backend {
+            GkrRoundStrategy::FoldEval => {
+                // Existing fused path.
+                let mut scheduler = BufferScheduler::new(max_work_size);
+                let mut source_real_len = real_len;
+                let mut source_logical_len = total_leaves;
+                for &xi_j in xi_prev.iter().skip(1) {
                     let src_pq_size = pq_size;
-                    prev_r = do_fused_sumcheck_round_inplace(
-                        &mut eq_buffer,
-                        &mut layer,
-                        src_pq_size,
-                        lambda,
-                        prev_r,
-                        transcript,
-                        &mut d_sum_evals,
-                        &mut tmp_block_sums,
-                        &mut round_polys_eval,
-                        &mut r_vec,
-                        &mut prev_s_eval,
-                        xi_j,
-                        &mut eq_r_acc,
-                        device_ctx,
-                    )?;
-                    pq_size >>= 1;
-                }
-
-                unsafe {
-                    fold_ef_frac_columns_inplace(&mut layer, pq_size, prev_r, stream)
-                        .map_err(FractionalSumcheckError::FoldColumns)?;
-                }
-                pq_size >>= 1;
-            }
-            active = &mut layer;
-        } else {
-            // Round 0: compute + revert fused. The pq_buffer fold will be fused into next round's
-            // compute. This fuses frac_build_tree_layer(revert=true) with the first inner round
-            // compute.
-            let r0 = do_sumcheck_round_and_revert(
-                &mut eq_buffer,
-                &mut layer,
-                pq_size,
-                lambda,
-                transcript,
-                &mut d_sum_evals,
-                &mut tmp_block_sums,
-                &mut round_polys_eval,
-                &mut r_vec,
-                &mut prev_s_eval,
-                xi_prev[0],
-                &mut eq_r_acc,
-                device_ctx,
-            )?;
-
-            // Fused rounds 1..(round-1): compute + fold using prev_r.
-            let mut prev_r = r0;
-
-            match backend {
-                GkrRoundStrategy::FoldEval => {
-                    // Existing fused path.
-                    let mut scheduler = BufferScheduler::new(max_work_size);
-                    for &xi_j in xi_prev.iter().skip(1) {
-                        let src_pq_size = pq_size;
-                        let post_fold_size = pq_size >> 1;
-
-                        let r = match scheduler.next_target(post_fold_size, last_outer_round) {
-                            BufferTarget::LayerToWork => do_fused_sumcheck_round(
-                                &mut eq_buffer,
-                                &layer,
-                                &mut work_buffer,
-                                src_pq_size,
-                                lambda,
-                                prev_r,
-                                transcript,
-                                &mut d_sum_evals,
-                                &mut tmp_block_sums,
-                                &mut round_polys_eval,
-                                &mut r_vec,
-                                &mut prev_s_eval,
-                                xi_j,
-                                &mut eq_r_acc,
-                                device_ctx,
-                            )?,
-                            BufferTarget::WorkToLayer => do_fused_sumcheck_round(
-                                &mut eq_buffer,
-                                &work_buffer,
-                                &mut layer,
-                                src_pq_size,
-                                lambda,
-                                prev_r,
-                                transcript,
-                                &mut d_sum_evals,
-                                &mut tmp_block_sums,
-                                &mut round_polys_eval,
-                                &mut r_vec,
-                                &mut prev_s_eval,
-                                xi_j,
-                                &mut eq_r_acc,
-                                device_ctx,
-                            )?,
-                            BufferTarget::InPlaceLayer => do_fused_sumcheck_round_inplace(
-                                &mut eq_buffer,
-                                &mut layer,
-                                src_pq_size,
-                                lambda,
-                                prev_r,
-                                transcript,
-                                &mut d_sum_evals,
-                                &mut tmp_block_sums,
-                                &mut round_polys_eval,
-                                &mut r_vec,
-                                &mut prev_s_eval,
-                                xi_j,
-                                &mut eq_r_acc,
-                                device_ctx,
-                            )?,
-                            BufferTarget::InPlaceWork => do_fused_sumcheck_round_inplace(
-                                &mut eq_buffer,
-                                &mut work_buffer,
-                                src_pq_size,
-                                lambda,
-                                prev_r,
-                                transcript,
-                                &mut d_sum_evals,
-                                &mut tmp_block_sums,
-                                &mut round_polys_eval,
-                                &mut r_vec,
-                                &mut prev_s_eval,
-                                xi_j,
-                                &mut eq_r_acc,
-                                device_ctx,
-                            )?,
-                        };
-
-                        pq_size >>= 1;
-                        prev_r = r;
-                    }
-
-                    // Final fold after last r (no next compute to fuse with).
-                    active = match scheduler.final_fold_target(last_outer_round) {
-                        BufferTarget::InPlaceWork => {
-                            unsafe {
-                                fold_ef_frac_columns_inplace(
-                                    &mut work_buffer,
-                                    pq_size,
-                                    prev_r,
-                                    stream,
-                                )
-                                .map_err(FractionalSumcheckError::FoldColumns)?;
-                            }
-                            &mut work_buffer
-                        }
-                        BufferTarget::InPlaceLayer => {
-                            unsafe {
-                                fold_ef_frac_columns_inplace(&mut layer, pq_size, prev_r, stream)
-                                    .map_err(FractionalSumcheckError::FoldColumns)?;
-                            }
-                            &mut layer
-                        }
-                        BufferTarget::LayerToWork => {
-                            unsafe {
-                                fold_ef_frac_columns(
-                                    &layer,
-                                    &mut work_buffer,
-                                    pq_size,
-                                    prev_r,
-                                    stream,
-                                )
-                                .map_err(FractionalSumcheckError::FoldColumns)?;
-                            }
-                            &mut work_buffer
-                        }
-                        BufferTarget::WorkToLayer => unreachable!(),
-                    };
-                    pq_size >>= 1;
-                }
-                GkrRoundStrategy::PrecomputeM => {
-                    let base = 1usize;
-                    let stop = round.div_ceil(2);
-
-                    // First window reads from `layer` with pending_fold=true
-                    // (M-build folds prev_r inline). Multifold writes to
-                    // `active_pq` (work_buffer for non-last rounds, layer for
-                    // last). After the first window, subsequent windows
-                    // read/write active_pq with pending_fold=false.
-                    let mut pending_fold = true;
-                    let layer_read_ptr = layer.as_ptr();
-                    let active_pq = if last_outer_round {
-                        &mut layer
+                    let post_fold_size = pq_size >> 1;
+                    let target = scheduler.next_target(post_fold_size, last_outer_round);
+                    let source_support_len = if source_logical_len == total_leaves && virtual_input
+                    {
+                        let subtree_len = total_leaves / src_pq_size;
+                        real_len.div_ceil(subtree_len)
                     } else {
-                        &mut work_buffer
+                        source_real_len
+                    };
+                    let compact_inplace_layer = matches!(target, BufferTarget::InPlaceLayer)
+                        && source_logical_len == total_leaves
+                        && virtual_input;
+                    let dst_real_len = if compact_inplace_layer {
+                        source_support_len.div_ceil(2)
+                    } else {
+                        post_fold_size
+                    };
+                    let dst_logical_len = post_fold_size;
+
+                    let r = match target {
+                        BufferTarget::LayerToWork => do_fused_sumcheck_round(
+                            &mut eq_buffer,
+                            &layer,
+                            &mut work_buffer,
+                            src_pq_size,
+                            source_real_len,
+                            source_logical_len,
+                            lambda,
+                            prev_r,
+                            alpha,
+                            transcript,
+                            &mut d_sum_evals,
+                            &mut tmp_block_sums,
+                            &mut round_polys_eval,
+                            &mut r_vec,
+                            &mut prev_s_eval,
+                            xi_j,
+                            &mut eq_r_acc,
+                            device_ctx,
+                        )?,
+                        BufferTarget::WorkToLayer => do_fused_sumcheck_round(
+                            &mut eq_buffer,
+                            &work_buffer,
+                            &mut layer,
+                            src_pq_size,
+                            source_real_len,
+                            source_logical_len,
+                            lambda,
+                            prev_r,
+                            alpha,
+                            transcript,
+                            &mut d_sum_evals,
+                            &mut tmp_block_sums,
+                            &mut round_polys_eval,
+                            &mut r_vec,
+                            &mut prev_s_eval,
+                            xi_j,
+                            &mut eq_r_acc,
+                            device_ctx,
+                        )?,
+                        BufferTarget::InPlaceLayer => do_fused_sumcheck_round_inplace(
+                            &mut eq_buffer,
+                            &mut layer,
+                            src_pq_size,
+                            source_real_len,
+                            source_logical_len,
+                            dst_real_len,
+                            dst_logical_len,
+                            lambda,
+                            prev_r,
+                            alpha,
+                            transcript,
+                            &mut d_sum_evals,
+                            &mut tmp_block_sums,
+                            &mut round_polys_eval,
+                            &mut r_vec,
+                            &mut prev_s_eval,
+                            xi_j,
+                            &mut eq_r_acc,
+                            device_ctx,
+                        )?,
+                        BufferTarget::InPlaceWork => do_fused_sumcheck_round_inplace(
+                            &mut eq_buffer,
+                            &mut work_buffer,
+                            src_pq_size,
+                            source_real_len,
+                            source_logical_len,
+                            dst_real_len,
+                            dst_logical_len,
+                            lambda,
+                            prev_r,
+                            alpha,
+                            transcript,
+                            &mut d_sum_evals,
+                            &mut tmp_block_sums,
+                            &mut round_polys_eval,
+                            &mut r_vec,
+                            &mut prev_s_eval,
+                            xi_j,
+                            &mut eq_r_acc,
+                            device_ctx,
+                        )?,
                     };
 
-                    // w+1 to accommodate r_prev prepended to window challenges
-                    // on the first iteration (inline fold on last outer round).
-                    let mut eq_r_window_host = vec![EF::ZERO; 1 << (GKR_WINDOW_SIZE + 1)];
-                    let mut eq_r_prefix_host = vec![EF::ZERO; 1 << GKR_WINDOW_SIZE];
-                    let mut eq_suffix_host = vec![EF::ZERO; 1 << GKR_WINDOW_SIZE];
+                    pq_size >>= 1;
+                    prev_r = r;
+                    source_real_len = dst_real_len;
+                    source_logical_len = dst_logical_len;
+                }
 
-                    if eq_r_prefix_buffer.is_empty() {
-                        eq_r_prefix_buffer = DeviceBuffer::<EF>::with_capacity_on(
-                            1usize << GKR_WINDOW_SIZE,
-                            device_ctx,
-                        );
-                    }
-                    if eq_suffix_buffer.is_empty() {
-                        eq_suffix_buffer = DeviceBuffer::<EF>::with_capacity_on(
-                            1usize << GKR_WINDOW_SIZE,
-                            device_ctx,
-                        );
-                    }
-
-                    let mut base = base;
-                    while base < stop {
-                        let rem_n = round - base;
-                        let rounds_left = stop - base;
-                        let Some(w) = choose_precompute_m_window_w(
-                            rem_n,
-                            rounds_left,
-                            precompute_m_min_blocks_threshold,
-                            precompute_m_target_blocks,
-                            precompute_m_tail_tile_override,
-                            precompute_m_min_n,
-                        ) else {
-                            break;
-                        };
-                        if m_buffer.is_empty() {
-                            let max_m_len = 1usize << (2 * GKR_WINDOW_SIZE);
-                            m_buffer = DeviceBuffer::<EF>::with_capacity_on(max_m_len, device_ctx);
-                        }
-                        let m_ptr = m_buffer.as_mut_ptr();
-                        // Reuse tmp_block_sums for eq_r_window upload.
-                        // Safe: M eval rounds finish before multifold needs eq_r_window,
-                        // and tmp_block_sums is not needed until next fold-eval round.
-                        let max_eq_r_window_len = 1usize << (GKR_WINDOW_SIZE + 1);
-                        debug_assert!(
-                            tmp_block_sums.len() >= max_eq_r_window_len,
-                            "tmp_block_sums too small for eq_r_window: {} < {}",
-                            tmp_block_sums.len(),
-                            max_eq_r_window_len,
-                        );
-                        let d_eq_r_window = tmp_block_sums.as_mut_ptr();
-
-                        // When pending_fold is true, the buffer has rem_n+1 variables
-                        // and the kernel folds inline. The effective tail dimension
-                        // for tiling is the same either way (rem_n - w).
-                        let tail_tile = precompute_m_build_tail_tile(
-                            rem_n,
-                            w,
-                            precompute_m_min_blocks_threshold,
-                            precompute_m_target_blocks,
-                            precompute_m_tail_tile_override,
-                        );
-                        let num_blocks = precompute_m_num_tail_blocks(rem_n, w, tail_tile);
-                        let m_len = (1usize << w) * (1usize << w);
-                        let partial_len = num_blocks * m_len;
-                        if partial_len > m_partial_buffer.len() {
-                            m_partial_buffer =
-                                DeviceBuffer::<EF>::with_capacity_on(partial_len, device_ctx);
-                        }
-
-                        let (eq_tail_low, eq_tail_high, eq_low_cap, _) =
-                            eq_tail_ptrs(&eq_buffer, w - 1);
-
-                        let r_fold = prev_r; // save before eval loop overwrites prev_r
-                        let build_src = if pending_fold {
-                            layer_read_ptr
-                        } else {
-                            active_pq.as_ptr()
-                        };
+                // Final fold after last r (no next compute to fuse with).
+                active = match scheduler.final_fold_target(last_outer_round) {
+                    BufferTarget::InPlaceWork => {
                         unsafe {
-                            frac_precompute_m_build_raw(
-                                build_src,
-                                rem_n,
-                                w,
-                                lambda,
-                                r_fold,
-                                pending_fold, // inline fold only on first iteration
-                                eq_tail_low,
-                                eq_tail_high,
-                                eq_low_cap,
-                                tail_tile,
-                                m_partial_buffer.as_mut_ptr(),
-                                partial_len,
-                                m_ptr,
-                                stream,
-                            )
-                            .map_err(FractionalSumcheckError::ComputeRound)?;
-                        }
-
-                        let mut window_rs = Vec::with_capacity(w);
-                        for t in 0..w {
-                            let prefix_bits = t;
-                            let suffix_bits = w - t - 1;
-                            eval_mle_table(&window_rs, &mut eq_r_prefix_host);
-                            eval_mle_table(&xi_prev[base + t + 1..base + w], &mut eq_suffix_host);
-
-                            copy_to_device_ptr(
-                                eq_r_prefix_buffer.as_mut_ptr(),
-                                &eq_r_prefix_host[..(1usize << prefix_bits)],
-                                device_ctx,
-                            )?;
-                            copy_to_device_ptr(
-                                eq_suffix_buffer.as_mut_ptr(),
-                                &eq_suffix_host[..(1usize << suffix_bits)],
-                                device_ctx,
-                            )?;
-                            unsafe {
-                                frac_precompute_m_eval_round_raw(
-                                    m_ptr,
-                                    w,
-                                    t,
-                                    eq_r_prefix_buffer.as_ptr(),
-                                    eq_suffix_buffer.as_ptr(),
-                                    d_sum_evals.as_mut_ptr(),
-                                    stream,
-                                )
-                                .map_err(FractionalSumcheckError::ComputeRound)?;
-                            }
-                            eq_buffer.drop_layer();
-                            let r = observe_and_update(
-                                &d_sum_evals,
-                                transcript,
-                                &mut round_polys_eval,
-                                &mut r_vec,
-                                &mut prev_s_eval,
-                                xi_prev[base + t],
-                                &mut eq_r_acc,
-                                device_ctx,
-                            )?;
-                            prev_r = r;
-                            window_rs.push(r);
-                        }
-
-                        // Compute eq_r_window for the multifold.
-                        let (buf_vars, w_fold) = if pending_fold {
-                            let mut all_rs = Vec::with_capacity(w + 1);
-                            all_rs.push(r_fold);
-                            all_rs.extend_from_slice(&window_rs);
-                            eval_mle_table(&all_rs, &mut eq_r_window_host);
-                            copy_to_device_ptr(
-                                d_eq_r_window,
-                                &eq_r_window_host[..(1 << (w + 1))],
-                                device_ctx,
-                            )?;
-                            (rem_n + 1, w + 1)
-                        } else {
-                            eval_mle_table(&window_rs, &mut eq_r_window_host);
-                            copy_to_device_ptr(
-                                d_eq_r_window,
-                                &eq_r_window_host[..(1 << w)],
-                                device_ctx,
-                            )?;
-                            (rem_n, w)
-                        };
-
-                        let multifold_src = if pending_fold {
-                            layer_read_ptr
-                        } else {
-                            active_pq.as_ptr()
-                        };
-                        unsafe {
-                            frac_multifold_raw(
-                                multifold_src,
-                                active_pq.as_mut_ptr(),
-                                buf_vars,
-                                w_fold,
-                                d_eq_r_window,
+                            fold_ef_frac_columns_inplace(
+                                &mut work_buffer,
+                                pq_size,
+                                source_real_len,
+                                source_logical_len,
+                                prev_r,
+                                alpha,
                                 stream,
                             )
                             .map_err(FractionalSumcheckError::FoldColumns)?;
                         }
-                        pq_size >>= w_fold;
-                        pending_fold = false;
-                        base += w;
+                        &mut work_buffer
+                    }
+                    BufferTarget::InPlaceLayer => {
+                        unsafe {
+                            fold_ef_frac_columns_inplace(
+                                &mut layer,
+                                pq_size,
+                                source_real_len,
+                                source_logical_len,
+                                prev_r,
+                                alpha,
+                                stream,
+                            )
+                            .map_err(FractionalSumcheckError::FoldColumns)?;
+                        }
+                        &mut layer
+                    }
+                    BufferTarget::LayerToWork => {
+                        unsafe {
+                            fold_ef_frac_columns(
+                                &layer,
+                                &mut work_buffer,
+                                pq_size,
+                                source_real_len,
+                                source_logical_len,
+                                prev_r,
+                                alpha,
+                                stream,
+                            )
+                            .map_err(FractionalSumcheckError::FoldColumns)?;
+                        }
+                        &mut work_buffer
+                    }
+                    BufferTarget::WorkToLayer => unreachable!(),
+                };
+                pq_size >>= 1;
+            }
+            GkrRoundStrategy::PrecomputeM => {
+                let base = 1usize;
+                let stop = round.div_ceil(2);
+
+                // First window reads from `layer` with pending_fold=true
+                // (M-build folds prev_r inline). Multifold writes to
+                // `active_pq` (work_buffer for non-last rounds, layer for
+                // last). After the first window, subsequent windows
+                // read/write active_pq with pending_fold=false.
+                let mut pending_fold = true;
+                let layer_read_ptr = layer.as_ptr();
+                let active_pq = if last_outer_round {
+                    &mut layer
+                } else {
+                    &mut work_buffer
+                };
+
+                // w+1 to accommodate r_prev prepended to window challenges
+                // on the first iteration (inline fold on last outer round).
+                let mut eq_r_window_host = vec![EF::ZERO; 1 << (GKR_WINDOW_SIZE + 1)];
+                let mut eq_r_prefix_host = vec![EF::ZERO; 1 << GKR_WINDOW_SIZE];
+                let mut eq_suffix_host = vec![EF::ZERO; 1 << GKR_WINDOW_SIZE];
+
+                if eq_r_prefix_buffer.is_empty() {
+                    eq_r_prefix_buffer =
+                        DeviceBuffer::<EF>::with_capacity_on(1usize << GKR_WINDOW_SIZE, device_ctx);
+                }
+                if eq_suffix_buffer.is_empty() {
+                    eq_suffix_buffer =
+                        DeviceBuffer::<EF>::with_capacity_on(1usize << GKR_WINDOW_SIZE, device_ctx);
+                }
+
+                let mut base = base;
+                while base < stop {
+                    let rem_n = round - base;
+                    let rounds_left = stop - base;
+                    let Some(w) = choose_precompute_m_window_w(
+                        rem_n,
+                        rounds_left,
+                        precompute_m_min_blocks_threshold,
+                        precompute_m_target_blocks,
+                        precompute_m_tail_tile_override,
+                        precompute_m_min_n,
+                    ) else {
+                        break;
+                    };
+                    if m_buffer.is_empty() {
+                        let max_m_len = 1usize << (2 * GKR_WINDOW_SIZE);
+                        m_buffer = DeviceBuffer::<EF>::with_capacity_on(max_m_len, device_ctx);
+                    }
+                    let m_ptr = m_buffer.as_mut_ptr();
+                    // Reuse tmp_block_sums for eq_r_window upload.
+                    // Safe: M eval rounds finish before multifold needs eq_r_window,
+                    // and tmp_block_sums is not needed until next fold-eval round.
+                    let max_eq_r_window_len = 1usize << (GKR_WINDOW_SIZE + 1);
+                    debug_assert!(
+                        tmp_block_sums.len() >= max_eq_r_window_len,
+                        "tmp_block_sums too small for eq_r_window: {} < {}",
+                        tmp_block_sums.len(),
+                        max_eq_r_window_len,
+                    );
+                    let d_eq_r_window = tmp_block_sums.as_mut_ptr();
+
+                    // When pending_fold is true, the buffer has rem_n+1 variables
+                    // and the kernel folds inline. The effective tail dimension
+                    // for tiling is the same either way (rem_n - w).
+                    let tail_tile = precompute_m_build_tail_tile(
+                        rem_n,
+                        w,
+                        precompute_m_min_blocks_threshold,
+                        precompute_m_target_blocks,
+                        precompute_m_tail_tile_override,
+                    );
+                    let num_blocks = precompute_m_num_tail_blocks(rem_n, w, tail_tile);
+                    let m_len = (1usize << w) * (1usize << w);
+                    let partial_len = num_blocks * m_len;
+                    if partial_len > m_partial_buffer.len() {
+                        m_partial_buffer =
+                            DeviceBuffer::<EF>::with_capacity_on(partial_len, device_ctx);
                     }
 
-                    if base < round {
-                        // First tail round is standalone compute,
-                        // subsequent rounds are fold+compute.
+                    let (eq_tail_low, eq_tail_high, eq_low_cap, _) =
+                        eq_tail_ptrs(&eq_buffer, w - 1);
+
+                    let r_fold = prev_r; // save before eval loop overwrites prev_r
+                    let build_src = if pending_fold {
+                        layer_read_ptr
+                    } else {
+                        active_pq.as_ptr()
+                    };
+                    let build_real_len = if pending_fold {
+                        real_len
+                    } else {
+                        active_pq.len()
+                    };
+                    let build_logical_len = if pending_fold { total_leaves } else { pq_size };
+                    unsafe {
+                        frac_precompute_m_build_raw(
+                            build_src,
+                            build_real_len,
+                            build_logical_len,
+                            rem_n,
+                            w,
+                            lambda,
+                            r_fold,
+                            alpha,
+                            pending_fold, // inline fold only on first iteration
+                            eq_tail_low,
+                            eq_tail_high,
+                            eq_low_cap,
+                            tail_tile,
+                            m_partial_buffer.as_mut_ptr(),
+                            partial_len,
+                            m_ptr,
+                            stream,
+                        )
+                        .map_err(FractionalSumcheckError::ComputeRound)?;
+                    }
+
+                    let mut window_rs = Vec::with_capacity(w);
+                    for t in 0..w {
+                        let prefix_bits = t;
+                        let suffix_bits = w - t - 1;
+                        eval_mle_table(&window_rs, &mut eq_r_prefix_host);
+                        eval_mle_table(&xi_prev[base + t + 1..base + w], &mut eq_suffix_host);
+
+                        copy_to_device_ptr(
+                            eq_r_prefix_buffer.as_mut_ptr(),
+                            &eq_r_prefix_host[..(1usize << prefix_bits)],
+                            device_ctx,
+                        )?;
+                        copy_to_device_ptr(
+                            eq_suffix_buffer.as_mut_ptr(),
+                            &eq_suffix_host[..(1usize << suffix_bits)],
+                            device_ctx,
+                        )?;
                         unsafe {
-                            frac_compute_round(
-                                &eq_buffer,
-                                active_pq,
-                                pq_size / 2,
-                                lambda,
-                                &mut d_sum_evals,
-                                &mut tmp_block_sums,
+                            frac_precompute_m_eval_round_raw(
+                                m_ptr,
+                                w,
+                                t,
+                                eq_r_prefix_buffer.as_ptr(),
+                                eq_suffix_buffer.as_ptr(),
+                                d_sum_evals.as_mut_ptr(),
                                 stream,
                             )
                             .map_err(FractionalSumcheckError::ComputeRound)?;
                         }
                         eq_buffer.drop_layer();
-                        prev_r = observe_and_update(
+                        let r = observe_and_update(
                             &d_sum_evals,
                             transcript,
                             &mut round_polys_eval,
                             &mut r_vec,
                             &mut prev_s_eval,
-                            xi_prev[base],
+                            xi_prev[base + t],
                             &mut eq_r_acc,
                             device_ctx,
                         )?;
-
-                        for &xi_j in xi_prev.iter().skip(base + 1) {
-                            let src_pq_size = pq_size;
-                            prev_r = do_fused_sumcheck_round_inplace(
-                                &mut eq_buffer,
-                                active_pq,
-                                src_pq_size,
-                                lambda,
-                                prev_r,
-                                transcript,
-                                &mut d_sum_evals,
-                                &mut tmp_block_sums,
-                                &mut round_polys_eval,
-                                &mut r_vec,
-                                &mut prev_s_eval,
-                                xi_j,
-                                &mut eq_r_acc,
-                                device_ctx,
-                            )?;
-                            pq_size >>= 1;
-                        }
+                        prev_r = r;
+                        window_rs.push(r);
                     }
 
+                    // Compute eq_r_window for the multifold.
+                    let (buf_vars, w_fold) = if pending_fold {
+                        let mut all_rs = Vec::with_capacity(w + 1);
+                        all_rs.push(r_fold);
+                        all_rs.extend_from_slice(&window_rs);
+                        eval_mle_table(&all_rs, &mut eq_r_window_host);
+                        copy_to_device_ptr(
+                            d_eq_r_window,
+                            &eq_r_window_host[..(1 << (w + 1))],
+                            device_ctx,
+                        )?;
+                        (rem_n + 1, w + 1)
+                    } else {
+                        eval_mle_table(&window_rs, &mut eq_r_window_host);
+                        copy_to_device_ptr(
+                            d_eq_r_window,
+                            &eq_r_window_host[..(1 << w)],
+                            device_ctx,
+                        )?;
+                        (rem_n, w)
+                    };
+
+                    let multifold_src = if pending_fold {
+                        layer_read_ptr
+                    } else {
+                        active_pq.as_ptr()
+                    };
+                    let multifold_real_len = if pending_fold {
+                        real_len
+                    } else {
+                        active_pq.len()
+                    };
+                    let multifold_logical_len = if pending_fold { total_leaves } else { pq_size };
                     unsafe {
-                        fold_ef_frac_columns_inplace(active_pq, pq_size, prev_r, stream)
-                            .map_err(FractionalSumcheckError::FoldColumns)?;
+                        frac_multifold_raw(
+                            multifold_src,
+                            active_pq.as_mut_ptr(),
+                            multifold_real_len,
+                            multifold_logical_len,
+                            buf_vars,
+                            w_fold,
+                            alpha,
+                            d_eq_r_window,
+                            stream,
+                        )
+                        .map_err(FractionalSumcheckError::FoldColumns)?;
                     }
-                    active = active_pq;
-                    pq_size >>= 1;
+                    pq_size >>= w_fold;
+                    pending_fold = false;
+                    base += w;
                 }
+
+                if base < round {
+                    // First tail round is standalone compute,
+                    // subsequent rounds are fold+compute.
+                    unsafe {
+                        frac_compute_round(
+                            &eq_buffer,
+                            active_pq,
+                            pq_size / 2,
+                            lambda,
+                            &mut d_sum_evals,
+                            &mut tmp_block_sums,
+                            stream,
+                        )
+                        .map_err(FractionalSumcheckError::ComputeRound)?;
+                    }
+                    eq_buffer.drop_layer();
+                    prev_r = observe_and_update(
+                        &d_sum_evals,
+                        transcript,
+                        &mut round_polys_eval,
+                        &mut r_vec,
+                        &mut prev_s_eval,
+                        xi_prev[base],
+                        &mut eq_r_acc,
+                        device_ctx,
+                    )?;
+
+                    for &xi_j in xi_prev.iter().skip(base + 1) {
+                        let src_pq_size = pq_size;
+                        prev_r = do_fused_sumcheck_round_inplace(
+                            &mut eq_buffer,
+                            active_pq,
+                            src_pq_size,
+                            pq_size,
+                            pq_size,
+                            pq_size >> 1,
+                            pq_size >> 1,
+                            lambda,
+                            prev_r,
+                            alpha,
+                            transcript,
+                            &mut d_sum_evals,
+                            &mut tmp_block_sums,
+                            &mut round_polys_eval,
+                            &mut r_vec,
+                            &mut prev_s_eval,
+                            xi_j,
+                            &mut eq_r_acc,
+                            device_ctx,
+                        )?;
+                        pq_size >>= 1;
+                    }
+                }
+
+                unsafe {
+                    fold_ef_frac_columns_inplace(
+                        active_pq, pq_size, pq_size, pq_size, prev_r, alpha, stream,
+                    )
+                    .map_err(FractionalSumcheckError::FoldColumns)?;
+                }
+                active = active_pq;
+                pq_size >>= 1;
             }
         }
 
@@ -1608,6 +1567,10 @@ mod tests {
         logical_len: usize,
         alpha: EF,
     ) -> Result<(super::FracSumcheckProof<SC>, Vec<EF>), FractionalSumcheckError> {
+        // SAFETY: test sets process env; run with --test-threads=1.
+        unsafe {
+            std::env::set_var("SWIRL_CUDA_GKR_PRECOMPUTE_M", "0");
+        }
         let device_ctx = test_ctx();
         let leaves = host.to_device_on(&device_ctx)?;
         let mut transcript = DuplexSpongeGpu::default();
@@ -1627,7 +1590,7 @@ mod tests {
 
     #[test]
     fn test_virtual_input_padding_matches_dense_padding() -> Result<(), FractionalSumcheckError> {
-        for (real_len, logical_len) in [(2, 4), (4, 8), (5, 8), (1500, 2048)] {
+        for (real_len, logical_len) in [(2, 4), (4, 8), (5, 8), (8, 16), (9, 16), (1500, 2048)] {
             let real = make_host_leaves(real_len);
             let mut dense = real.clone();
             dense.resize(logical_len, Frac::default());

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -801,11 +801,12 @@ where
     // Work buffer to avoid revert operations on layer. Only needed for non-last rounds.
     // For the last round (round == total_rounds - 1), we fold in-place on layer.
     // When precompute-M is active, the first multifold folds w+1 variables at once
-    // (pending r_prev + w window challenges), so the output is total_leaves >> (2 + w).
+    // (pending r_prev + w window challenges). The largest case is the last outer round:
+    // input pq_size = total_leaves, output pq_size = total_leaves >> (1 + w).
     // Fold-eval fallback rounds (rem_n < min_n) need at most 2^min_n elements.
     let max_work_size = if total_rounds > 2 {
         if precompute_m_env {
-            (total_leaves >> (2 + GKR_WINDOW_SIZE)).max(1 << GKR_WINDOW_DEFAULT_MIN_N)
+            (total_leaves >> (1 + GKR_WINDOW_SIZE)).max(1 << GKR_WINDOW_DEFAULT_MIN_N)
         } else {
             total_leaves >> 2
         }
@@ -828,6 +829,7 @@ where
     } else {
         DeviceBuffer::new()
     };
+    let mut final_fold_buffer = DeviceBuffer::<Frac<EF>>::new();
     let precompute_m_min_blocks_threshold = precompute_m_min_blocks_threshold();
     let precompute_m_target_blocks = precompute_m_target_blocks();
     let precompute_m_tail_tile_override = precompute_m_tail_tile_override();
@@ -1022,7 +1024,50 @@ where
                 }
 
                 // Final fold after last r (no next compute to fuse with).
+                let compact_virtual_final_fold = source_real_len < source_logical_len;
                 active = match scheduler.final_fold_target(last_outer_round) {
+                    BufferTarget::InPlaceWork if compact_virtual_final_fold => {
+                        let output_len = pq_size / 2;
+                        if final_fold_buffer.len() < output_len {
+                            final_fold_buffer =
+                                DeviceBuffer::<Frac<EF>>::with_capacity_on(output_len, device_ctx);
+                        }
+                        unsafe {
+                            fold_ef_frac_columns(
+                                &work_buffer,
+                                &mut final_fold_buffer,
+                                pq_size,
+                                source_real_len,
+                                source_logical_len,
+                                prev_r,
+                                alpha,
+                                stream,
+                            )
+                            .map_err(FractionalSumcheckError::FoldColumns)?;
+                        }
+                        &mut final_fold_buffer
+                    }
+                    BufferTarget::InPlaceLayer if compact_virtual_final_fold => {
+                        let output_len = pq_size / 2;
+                        if final_fold_buffer.len() < output_len {
+                            final_fold_buffer =
+                                DeviceBuffer::<Frac<EF>>::with_capacity_on(output_len, device_ctx);
+                        }
+                        unsafe {
+                            fold_ef_frac_columns(
+                                &layer,
+                                &mut final_fold_buffer,
+                                pq_size,
+                                source_real_len,
+                                source_logical_len,
+                                prev_r,
+                                alpha,
+                                stream,
+                            )
+                            .map_err(FractionalSumcheckError::FoldColumns)?;
+                        }
+                        &mut final_fold_buffer
+                    }
                     BufferTarget::InPlaceWork => {
                         unsafe {
                             fold_ef_frac_columns_inplace(
@@ -1283,6 +1328,12 @@ where
                     } else {
                         active_logical_len
                     };
+                    debug_assert!(
+                        active_pq.len() >= (pq_size >> w_fold),
+                        "active_pq too small for multifold output: {} < {}",
+                        active_pq.len(),
+                        pq_size >> w_fold
+                    );
                     unsafe {
                         frac_multifold_raw(
                             multifold_src,

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -36,6 +36,28 @@ const GKR_S_DEG: usize = 3;
 const GKR_WINDOW_SIZE: usize = 3;
 const GKR_WINDOW_DEFAULT_MIN_N: usize = 22;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FractionalInputSize {
+    pub real_len: usize,
+    pub logical_len: usize,
+}
+
+impl FractionalInputSize {
+    pub fn new(real_len: usize, logical_len: usize) -> Self {
+        Self {
+            real_len,
+            logical_len,
+        }
+    }
+
+    pub fn dense(len: usize) -> Self {
+        Self {
+            real_len: len,
+            logical_len: len,
+        }
+    }
+}
+
 /// Describes which buffer operation to use for the next fused compute+fold round.
 #[derive(Debug, Clone, Copy)]
 enum BufferTarget {
@@ -543,11 +565,7 @@ fn fold_frac(a: Frac<EF>, b: Frac<EF>, r: EF) -> Frac<EF> {
     }
 }
 
-fn virtual_input_parent_layer(
-    leaves: &[Frac<EF>],
-    logical_len: usize,
-    alpha: EF,
-) -> Vec<Frac<EF>> {
+fn virtual_input_parent_layer(leaves: &[Frac<EF>], logical_len: usize, alpha: EF) -> Vec<Frac<EF>> {
     let parent_len = logical_len / 2;
     (0..parent_len)
         .map(|idx| {
@@ -660,8 +678,7 @@ fn build_dense_segment_tree(
 pub fn fractional_sumcheck_gpu<SC, TS>(
     transcript: &mut TS,
     leaves: DeviceBuffer<Frac<EF>>,
-    real_len: usize,
-    logical_len: usize,
+    sizes: FractionalInputSize,
     alpha: EF,
     assert_zero: bool,
     mem: &mut MemTracker,
@@ -682,13 +699,18 @@ where
             vec![],
         ));
     };
+    let real_len = sizes.real_len;
+    let logical_len = sizes.logical_len;
     assert_eq!(
         layer.len(),
         real_len,
         "fractional_sumcheck_gpu input length must equal real_len"
     );
     assert!(real_len > 0, "real_len must be nonzero");
-    assert!(logical_len.is_power_of_two(), "logical_len must be a power of two");
+    assert!(
+        logical_len.is_power_of_two(),
+        "logical_len must be a power of two"
+    );
     assert!(
         real_len <= logical_len,
         "real_len must not exceed logical_len"
@@ -901,13 +923,8 @@ where
                 device_ctx,
             )?;
 
-            let folded = virtual_input_folded_layer(
-                host_leaves,
-                logical_len,
-                total_rounds,
-                alpha,
-                prev_r,
-            );
+            let folded =
+                virtual_input_folded_layer(host_leaves, logical_len, total_rounds, alpha, prev_r);
             folded.copy_to_on(&mut layer, device_ctx)?;
             pq_size >>= 1;
 
@@ -988,367 +1005,382 @@ where
             let mut prev_r = r0;
 
             match backend {
-            GkrRoundStrategy::FoldEval => {
-                // Existing fused path.
-                let mut scheduler = BufferScheduler::new(max_work_size);
-                for &xi_j in xi_prev.iter().skip(1) {
-                    let src_pq_size = pq_size;
-                    let post_fold_size = pq_size >> 1;
+                GkrRoundStrategy::FoldEval => {
+                    // Existing fused path.
+                    let mut scheduler = BufferScheduler::new(max_work_size);
+                    for &xi_j in xi_prev.iter().skip(1) {
+                        let src_pq_size = pq_size;
+                        let post_fold_size = pq_size >> 1;
 
-                    let r = match scheduler.next_target(post_fold_size, last_outer_round) {
-                        BufferTarget::LayerToWork => do_fused_sumcheck_round(
-                            &mut eq_buffer,
-                            &layer,
-                            &mut work_buffer,
-                            src_pq_size,
-                            lambda,
-                            prev_r,
-                            transcript,
-                            &mut d_sum_evals,
-                            &mut tmp_block_sums,
-                            &mut round_polys_eval,
-                            &mut r_vec,
-                            &mut prev_s_eval,
-                            xi_j,
-                            &mut eq_r_acc,
-                            device_ctx,
-                        )?,
-                        BufferTarget::WorkToLayer => do_fused_sumcheck_round(
-                            &mut eq_buffer,
-                            &work_buffer,
-                            &mut layer,
-                            src_pq_size,
-                            lambda,
-                            prev_r,
-                            transcript,
-                            &mut d_sum_evals,
-                            &mut tmp_block_sums,
-                            &mut round_polys_eval,
-                            &mut r_vec,
-                            &mut prev_s_eval,
-                            xi_j,
-                            &mut eq_r_acc,
-                            device_ctx,
-                        )?,
-                        BufferTarget::InPlaceLayer => do_fused_sumcheck_round_inplace(
-                            &mut eq_buffer,
-                            &mut layer,
-                            src_pq_size,
-                            lambda,
-                            prev_r,
-                            transcript,
-                            &mut d_sum_evals,
-                            &mut tmp_block_sums,
-                            &mut round_polys_eval,
-                            &mut r_vec,
-                            &mut prev_s_eval,
-                            xi_j,
-                            &mut eq_r_acc,
-                            device_ctx,
-                        )?,
-                        BufferTarget::InPlaceWork => do_fused_sumcheck_round_inplace(
-                            &mut eq_buffer,
-                            &mut work_buffer,
-                            src_pq_size,
-                            lambda,
-                            prev_r,
-                            transcript,
-                            &mut d_sum_evals,
-                            &mut tmp_block_sums,
-                            &mut round_polys_eval,
-                            &mut r_vec,
-                            &mut prev_s_eval,
-                            xi_j,
-                            &mut eq_r_acc,
-                            device_ctx,
-                        )?,
+                        let r = match scheduler.next_target(post_fold_size, last_outer_round) {
+                            BufferTarget::LayerToWork => do_fused_sumcheck_round(
+                                &mut eq_buffer,
+                                &layer,
+                                &mut work_buffer,
+                                src_pq_size,
+                                lambda,
+                                prev_r,
+                                transcript,
+                                &mut d_sum_evals,
+                                &mut tmp_block_sums,
+                                &mut round_polys_eval,
+                                &mut r_vec,
+                                &mut prev_s_eval,
+                                xi_j,
+                                &mut eq_r_acc,
+                                device_ctx,
+                            )?,
+                            BufferTarget::WorkToLayer => do_fused_sumcheck_round(
+                                &mut eq_buffer,
+                                &work_buffer,
+                                &mut layer,
+                                src_pq_size,
+                                lambda,
+                                prev_r,
+                                transcript,
+                                &mut d_sum_evals,
+                                &mut tmp_block_sums,
+                                &mut round_polys_eval,
+                                &mut r_vec,
+                                &mut prev_s_eval,
+                                xi_j,
+                                &mut eq_r_acc,
+                                device_ctx,
+                            )?,
+                            BufferTarget::InPlaceLayer => do_fused_sumcheck_round_inplace(
+                                &mut eq_buffer,
+                                &mut layer,
+                                src_pq_size,
+                                lambda,
+                                prev_r,
+                                transcript,
+                                &mut d_sum_evals,
+                                &mut tmp_block_sums,
+                                &mut round_polys_eval,
+                                &mut r_vec,
+                                &mut prev_s_eval,
+                                xi_j,
+                                &mut eq_r_acc,
+                                device_ctx,
+                            )?,
+                            BufferTarget::InPlaceWork => do_fused_sumcheck_round_inplace(
+                                &mut eq_buffer,
+                                &mut work_buffer,
+                                src_pq_size,
+                                lambda,
+                                prev_r,
+                                transcript,
+                                &mut d_sum_evals,
+                                &mut tmp_block_sums,
+                                &mut round_polys_eval,
+                                &mut r_vec,
+                                &mut prev_s_eval,
+                                xi_j,
+                                &mut eq_r_acc,
+                                device_ctx,
+                            )?,
+                        };
+
+                        pq_size >>= 1;
+                        prev_r = r;
+                    }
+
+                    // Final fold after last r (no next compute to fuse with).
+                    active = match scheduler.final_fold_target(last_outer_round) {
+                        BufferTarget::InPlaceWork => {
+                            unsafe {
+                                fold_ef_frac_columns_inplace(
+                                    &mut work_buffer,
+                                    pq_size,
+                                    prev_r,
+                                    stream,
+                                )
+                                .map_err(FractionalSumcheckError::FoldColumns)?;
+                            }
+                            &mut work_buffer
+                        }
+                        BufferTarget::InPlaceLayer => {
+                            unsafe {
+                                fold_ef_frac_columns_inplace(&mut layer, pq_size, prev_r, stream)
+                                    .map_err(FractionalSumcheckError::FoldColumns)?;
+                            }
+                            &mut layer
+                        }
+                        BufferTarget::LayerToWork => {
+                            unsafe {
+                                fold_ef_frac_columns(
+                                    &layer,
+                                    &mut work_buffer,
+                                    pq_size,
+                                    prev_r,
+                                    stream,
+                                )
+                                .map_err(FractionalSumcheckError::FoldColumns)?;
+                            }
+                            &mut work_buffer
+                        }
+                        BufferTarget::WorkToLayer => unreachable!(),
                     };
-
                     pq_size >>= 1;
-                    prev_r = r;
                 }
+                GkrRoundStrategy::PrecomputeM => {
+                    let base = 1usize;
+                    let stop = round.div_ceil(2);
 
-                // Final fold after last r (no next compute to fuse with).
-                active = match scheduler.final_fold_target(last_outer_round) {
-                    BufferTarget::InPlaceWork => {
-                        unsafe {
-                            fold_ef_frac_columns_inplace(&mut work_buffer, pq_size, prev_r, stream)
-                                .map_err(FractionalSumcheckError::FoldColumns)?;
-                        }
-                        &mut work_buffer
-                    }
-                    BufferTarget::InPlaceLayer => {
-                        unsafe {
-                            fold_ef_frac_columns_inplace(&mut layer, pq_size, prev_r, stream)
-                                .map_err(FractionalSumcheckError::FoldColumns)?;
-                        }
+                    // First window reads from `layer` with pending_fold=true
+                    // (M-build folds prev_r inline). Multifold writes to
+                    // `active_pq` (work_buffer for non-last rounds, layer for
+                    // last). After the first window, subsequent windows
+                    // read/write active_pq with pending_fold=false.
+                    let mut pending_fold = true;
+                    let layer_read_ptr = layer.as_ptr();
+                    let active_pq = if last_outer_round {
                         &mut layer
-                    }
-                    BufferTarget::LayerToWork => {
-                        unsafe {
-                            fold_ef_frac_columns(&layer, &mut work_buffer, pq_size, prev_r, stream)
-                                .map_err(FractionalSumcheckError::FoldColumns)?;
-                        }
-                        &mut work_buffer
-                    }
-                    BufferTarget::WorkToLayer => unreachable!(),
-                };
-                pq_size >>= 1;
-            }
-            GkrRoundStrategy::PrecomputeM => {
-                let base = 1usize;
-                let stop = round.div_ceil(2);
-
-                // First window reads from `layer` with pending_fold=true
-                // (M-build folds prev_r inline). Multifold writes to
-                // `active_pq` (work_buffer for non-last rounds, layer for
-                // last). After the first window, subsequent windows
-                // read/write active_pq with pending_fold=false.
-                let mut pending_fold = true;
-                let layer_read_ptr = layer.as_ptr();
-                let active_pq = if last_outer_round {
-                    &mut layer
-                } else {
-                    &mut work_buffer
-                };
-
-                // w+1 to accommodate r_prev prepended to window challenges
-                // on the first iteration (inline fold on last outer round).
-                let mut eq_r_window_host = vec![EF::ZERO; 1 << (GKR_WINDOW_SIZE + 1)];
-                let mut eq_r_prefix_host = vec![EF::ZERO; 1 << GKR_WINDOW_SIZE];
-                let mut eq_suffix_host = vec![EF::ZERO; 1 << GKR_WINDOW_SIZE];
-
-                if eq_r_prefix_buffer.is_empty() {
-                    eq_r_prefix_buffer =
-                        DeviceBuffer::<EF>::with_capacity_on(1usize << GKR_WINDOW_SIZE, device_ctx);
-                }
-                if eq_suffix_buffer.is_empty() {
-                    eq_suffix_buffer =
-                        DeviceBuffer::<EF>::with_capacity_on(1usize << GKR_WINDOW_SIZE, device_ctx);
-                }
-
-                let mut base = base;
-                while base < stop {
-                    let rem_n = round - base;
-                    let rounds_left = stop - base;
-                    let Some(w) = choose_precompute_m_window_w(
-                        rem_n,
-                        rounds_left,
-                        precompute_m_min_blocks_threshold,
-                        precompute_m_target_blocks,
-                        precompute_m_tail_tile_override,
-                        precompute_m_min_n,
-                    ) else {
-                        break;
-                    };
-                    if m_buffer.is_empty() {
-                        let max_m_len = 1usize << (2 * GKR_WINDOW_SIZE);
-                        m_buffer = DeviceBuffer::<EF>::with_capacity_on(max_m_len, device_ctx);
-                    }
-                    let m_ptr = m_buffer.as_mut_ptr();
-                    // Reuse tmp_block_sums for eq_r_window upload.
-                    // Safe: M eval rounds finish before multifold needs eq_r_window,
-                    // and tmp_block_sums is not needed until next fold-eval round.
-                    let max_eq_r_window_len = 1usize << (GKR_WINDOW_SIZE + 1);
-                    debug_assert!(
-                        tmp_block_sums.len() >= max_eq_r_window_len,
-                        "tmp_block_sums too small for eq_r_window: {} < {}",
-                        tmp_block_sums.len(),
-                        max_eq_r_window_len,
-                    );
-                    let d_eq_r_window = tmp_block_sums.as_mut_ptr();
-
-                    // When pending_fold is true, the buffer has rem_n+1 variables
-                    // and the kernel folds inline. The effective tail dimension
-                    // for tiling is the same either way (rem_n - w).
-                    let tail_tile = precompute_m_build_tail_tile(
-                        rem_n,
-                        w,
-                        precompute_m_min_blocks_threshold,
-                        precompute_m_target_blocks,
-                        precompute_m_tail_tile_override,
-                    );
-                    let num_blocks = precompute_m_num_tail_blocks(rem_n, w, tail_tile);
-                    let m_len = (1usize << w) * (1usize << w);
-                    let partial_len = num_blocks * m_len;
-                    if partial_len > m_partial_buffer.len() {
-                        m_partial_buffer =
-                            DeviceBuffer::<EF>::with_capacity_on(partial_len, device_ctx);
-                    }
-
-                    let (eq_tail_low, eq_tail_high, eq_low_cap, _) =
-                        eq_tail_ptrs(&eq_buffer, w - 1);
-
-                    let r_fold = prev_r; // save before eval loop overwrites prev_r
-                    let build_src = if pending_fold {
-                        layer_read_ptr
                     } else {
-                        active_pq.as_ptr()
+                        &mut work_buffer
                     };
-                    unsafe {
-                        frac_precompute_m_build_raw(
-                            build_src,
+
+                    // w+1 to accommodate r_prev prepended to window challenges
+                    // on the first iteration (inline fold on last outer round).
+                    let mut eq_r_window_host = vec![EF::ZERO; 1 << (GKR_WINDOW_SIZE + 1)];
+                    let mut eq_r_prefix_host = vec![EF::ZERO; 1 << GKR_WINDOW_SIZE];
+                    let mut eq_suffix_host = vec![EF::ZERO; 1 << GKR_WINDOW_SIZE];
+
+                    if eq_r_prefix_buffer.is_empty() {
+                        eq_r_prefix_buffer = DeviceBuffer::<EF>::with_capacity_on(
+                            1usize << GKR_WINDOW_SIZE,
+                            device_ctx,
+                        );
+                    }
+                    if eq_suffix_buffer.is_empty() {
+                        eq_suffix_buffer = DeviceBuffer::<EF>::with_capacity_on(
+                            1usize << GKR_WINDOW_SIZE,
+                            device_ctx,
+                        );
+                    }
+
+                    let mut base = base;
+                    while base < stop {
+                        let rem_n = round - base;
+                        let rounds_left = stop - base;
+                        let Some(w) = choose_precompute_m_window_w(
+                            rem_n,
+                            rounds_left,
+                            precompute_m_min_blocks_threshold,
+                            precompute_m_target_blocks,
+                            precompute_m_tail_tile_override,
+                            precompute_m_min_n,
+                        ) else {
+                            break;
+                        };
+                        if m_buffer.is_empty() {
+                            let max_m_len = 1usize << (2 * GKR_WINDOW_SIZE);
+                            m_buffer = DeviceBuffer::<EF>::with_capacity_on(max_m_len, device_ctx);
+                        }
+                        let m_ptr = m_buffer.as_mut_ptr();
+                        // Reuse tmp_block_sums for eq_r_window upload.
+                        // Safe: M eval rounds finish before multifold needs eq_r_window,
+                        // and tmp_block_sums is not needed until next fold-eval round.
+                        let max_eq_r_window_len = 1usize << (GKR_WINDOW_SIZE + 1);
+                        debug_assert!(
+                            tmp_block_sums.len() >= max_eq_r_window_len,
+                            "tmp_block_sums too small for eq_r_window: {} < {}",
+                            tmp_block_sums.len(),
+                            max_eq_r_window_len,
+                        );
+                        let d_eq_r_window = tmp_block_sums.as_mut_ptr();
+
+                        // When pending_fold is true, the buffer has rem_n+1 variables
+                        // and the kernel folds inline. The effective tail dimension
+                        // for tiling is the same either way (rem_n - w).
+                        let tail_tile = precompute_m_build_tail_tile(
                             rem_n,
                             w,
-                            lambda,
-                            r_fold,
-                            pending_fold, // inline fold only on first iteration
-                            eq_tail_low,
-                            eq_tail_high,
-                            eq_low_cap,
-                            tail_tile,
-                            m_partial_buffer.as_mut_ptr(),
-                            partial_len,
-                            m_ptr,
-                            stream,
-                        )
-                        .map_err(FractionalSumcheckError::ComputeRound)?;
+                            precompute_m_min_blocks_threshold,
+                            precompute_m_target_blocks,
+                            precompute_m_tail_tile_override,
+                        );
+                        let num_blocks = precompute_m_num_tail_blocks(rem_n, w, tail_tile);
+                        let m_len = (1usize << w) * (1usize << w);
+                        let partial_len = num_blocks * m_len;
+                        if partial_len > m_partial_buffer.len() {
+                            m_partial_buffer =
+                                DeviceBuffer::<EF>::with_capacity_on(partial_len, device_ctx);
+                        }
+
+                        let (eq_tail_low, eq_tail_high, eq_low_cap, _) =
+                            eq_tail_ptrs(&eq_buffer, w - 1);
+
+                        let r_fold = prev_r; // save before eval loop overwrites prev_r
+                        let build_src = if pending_fold {
+                            layer_read_ptr
+                        } else {
+                            active_pq.as_ptr()
+                        };
+                        unsafe {
+                            frac_precompute_m_build_raw(
+                                build_src,
+                                rem_n,
+                                w,
+                                lambda,
+                                r_fold,
+                                pending_fold, // inline fold only on first iteration
+                                eq_tail_low,
+                                eq_tail_high,
+                                eq_low_cap,
+                                tail_tile,
+                                m_partial_buffer.as_mut_ptr(),
+                                partial_len,
+                                m_ptr,
+                                stream,
+                            )
+                            .map_err(FractionalSumcheckError::ComputeRound)?;
+                        }
+
+                        let mut window_rs = Vec::with_capacity(w);
+                        for t in 0..w {
+                            let prefix_bits = t;
+                            let suffix_bits = w - t - 1;
+                            eval_mle_table(&window_rs, &mut eq_r_prefix_host);
+                            eval_mle_table(&xi_prev[base + t + 1..base + w], &mut eq_suffix_host);
+
+                            copy_to_device_ptr(
+                                eq_r_prefix_buffer.as_mut_ptr(),
+                                &eq_r_prefix_host[..(1usize << prefix_bits)],
+                                device_ctx,
+                            )?;
+                            copy_to_device_ptr(
+                                eq_suffix_buffer.as_mut_ptr(),
+                                &eq_suffix_host[..(1usize << suffix_bits)],
+                                device_ctx,
+                            )?;
+                            unsafe {
+                                frac_precompute_m_eval_round_raw(
+                                    m_ptr,
+                                    w,
+                                    t,
+                                    eq_r_prefix_buffer.as_ptr(),
+                                    eq_suffix_buffer.as_ptr(),
+                                    d_sum_evals.as_mut_ptr(),
+                                    stream,
+                                )
+                                .map_err(FractionalSumcheckError::ComputeRound)?;
+                            }
+                            eq_buffer.drop_layer();
+                            let r = observe_and_update(
+                                &d_sum_evals,
+                                transcript,
+                                &mut round_polys_eval,
+                                &mut r_vec,
+                                &mut prev_s_eval,
+                                xi_prev[base + t],
+                                &mut eq_r_acc,
+                                device_ctx,
+                            )?;
+                            prev_r = r;
+                            window_rs.push(r);
+                        }
+
+                        // Compute eq_r_window for the multifold.
+                        let (buf_vars, w_fold) = if pending_fold {
+                            let mut all_rs = Vec::with_capacity(w + 1);
+                            all_rs.push(r_fold);
+                            all_rs.extend_from_slice(&window_rs);
+                            eval_mle_table(&all_rs, &mut eq_r_window_host);
+                            copy_to_device_ptr(
+                                d_eq_r_window,
+                                &eq_r_window_host[..(1 << (w + 1))],
+                                device_ctx,
+                            )?;
+                            (rem_n + 1, w + 1)
+                        } else {
+                            eval_mle_table(&window_rs, &mut eq_r_window_host);
+                            copy_to_device_ptr(
+                                d_eq_r_window,
+                                &eq_r_window_host[..(1 << w)],
+                                device_ctx,
+                            )?;
+                            (rem_n, w)
+                        };
+
+                        let multifold_src = if pending_fold {
+                            layer_read_ptr
+                        } else {
+                            active_pq.as_ptr()
+                        };
+                        unsafe {
+                            frac_multifold_raw(
+                                multifold_src,
+                                active_pq.as_mut_ptr(),
+                                buf_vars,
+                                w_fold,
+                                d_eq_r_window,
+                                stream,
+                            )
+                            .map_err(FractionalSumcheckError::FoldColumns)?;
+                        }
+                        pq_size >>= w_fold;
+                        pending_fold = false;
+                        base += w;
                     }
 
-                    let mut window_rs = Vec::with_capacity(w);
-                    for t in 0..w {
-                        let prefix_bits = t;
-                        let suffix_bits = w - t - 1;
-                        eval_mle_table(&window_rs, &mut eq_r_prefix_host);
-                        eval_mle_table(&xi_prev[base + t + 1..base + w], &mut eq_suffix_host);
-
-                        copy_to_device_ptr(
-                            eq_r_prefix_buffer.as_mut_ptr(),
-                            &eq_r_prefix_host[..(1usize << prefix_bits)],
-                            device_ctx,
-                        )?;
-                        copy_to_device_ptr(
-                            eq_suffix_buffer.as_mut_ptr(),
-                            &eq_suffix_host[..(1usize << suffix_bits)],
-                            device_ctx,
-                        )?;
+                    if base < round {
+                        // First tail round is standalone compute,
+                        // subsequent rounds are fold+compute.
                         unsafe {
-                            frac_precompute_m_eval_round_raw(
-                                m_ptr,
-                                w,
-                                t,
-                                eq_r_prefix_buffer.as_ptr(),
-                                eq_suffix_buffer.as_ptr(),
-                                d_sum_evals.as_mut_ptr(),
+                            frac_compute_round(
+                                &eq_buffer,
+                                active_pq,
+                                pq_size / 2,
+                                lambda,
+                                &mut d_sum_evals,
+                                &mut tmp_block_sums,
                                 stream,
                             )
                             .map_err(FractionalSumcheckError::ComputeRound)?;
                         }
                         eq_buffer.drop_layer();
-                        let r = observe_and_update(
+                        prev_r = observe_and_update(
                             &d_sum_evals,
                             transcript,
                             &mut round_polys_eval,
                             &mut r_vec,
                             &mut prev_s_eval,
-                            xi_prev[base + t],
+                            xi_prev[base],
                             &mut eq_r_acc,
                             device_ctx,
                         )?;
-                        prev_r = r;
-                        window_rs.push(r);
+
+                        for &xi_j in xi_prev.iter().skip(base + 1) {
+                            let src_pq_size = pq_size;
+                            prev_r = do_fused_sumcheck_round_inplace(
+                                &mut eq_buffer,
+                                active_pq,
+                                src_pq_size,
+                                lambda,
+                                prev_r,
+                                transcript,
+                                &mut d_sum_evals,
+                                &mut tmp_block_sums,
+                                &mut round_polys_eval,
+                                &mut r_vec,
+                                &mut prev_s_eval,
+                                xi_j,
+                                &mut eq_r_acc,
+                                device_ctx,
+                            )?;
+                            pq_size >>= 1;
+                        }
                     }
 
-                    // Compute eq_r_window for the multifold.
-                    let (buf_vars, w_fold) = if pending_fold {
-                        let mut all_rs = Vec::with_capacity(w + 1);
-                        all_rs.push(r_fold);
-                        all_rs.extend_from_slice(&window_rs);
-                        eval_mle_table(&all_rs, &mut eq_r_window_host);
-                        copy_to_device_ptr(
-                            d_eq_r_window,
-                            &eq_r_window_host[..(1 << (w + 1))],
-                            device_ctx,
-                        )?;
-                        (rem_n + 1, w + 1)
-                    } else {
-                        eval_mle_table(&window_rs, &mut eq_r_window_host);
-                        copy_to_device_ptr(
-                            d_eq_r_window,
-                            &eq_r_window_host[..(1 << w)],
-                            device_ctx,
-                        )?;
-                        (rem_n, w)
-                    };
-
-                    let multifold_src = if pending_fold {
-                        layer_read_ptr
-                    } else {
-                        active_pq.as_ptr()
-                    };
                     unsafe {
-                        frac_multifold_raw(
-                            multifold_src,
-                            active_pq.as_mut_ptr(),
-                            buf_vars,
-                            w_fold,
-                            d_eq_r_window,
-                            stream,
-                        )
-                        .map_err(FractionalSumcheckError::FoldColumns)?;
+                        fold_ef_frac_columns_inplace(active_pq, pq_size, prev_r, stream)
+                            .map_err(FractionalSumcheckError::FoldColumns)?;
                     }
-                    pq_size >>= w_fold;
-                    pending_fold = false;
-                    base += w;
+                    active = active_pq;
+                    pq_size >>= 1;
                 }
-
-                if base < round {
-                    // First tail round is standalone compute,
-                    // subsequent rounds are fold+compute.
-                    unsafe {
-                        frac_compute_round(
-                            &eq_buffer,
-                            active_pq,
-                            pq_size / 2,
-                            lambda,
-                            &mut d_sum_evals,
-                            &mut tmp_block_sums,
-                            stream,
-                        )
-                        .map_err(FractionalSumcheckError::ComputeRound)?;
-                    }
-                    eq_buffer.drop_layer();
-                    prev_r = observe_and_update(
-                        &d_sum_evals,
-                        transcript,
-                        &mut round_polys_eval,
-                        &mut r_vec,
-                        &mut prev_s_eval,
-                        xi_prev[base],
-                        &mut eq_r_acc,
-                        device_ctx,
-                    )?;
-
-                    for &xi_j in xi_prev.iter().skip(base + 1) {
-                        let src_pq_size = pq_size;
-                        prev_r = do_fused_sumcheck_round_inplace(
-                            &mut eq_buffer,
-                            active_pq,
-                            src_pq_size,
-                            lambda,
-                            prev_r,
-                            transcript,
-                            &mut d_sum_evals,
-                            &mut tmp_block_sums,
-                            &mut round_polys_eval,
-                            &mut r_vec,
-                            &mut prev_s_eval,
-                            xi_j,
-                            &mut eq_r_acc,
-                            device_ctx,
-                        )?;
-                        pq_size >>= 1;
-                    }
-                }
-
-                unsafe {
-                    fold_ef_frac_columns_inplace(active_pq, pq_size, prev_r, stream)
-                        .map_err(FractionalSumcheckError::FoldColumns)?;
-                }
-                active = active_pq;
-                pq_size >>= 1;
             }
-        }
         }
 
         let pq_host = [
@@ -1499,8 +1531,8 @@ mod tests {
     use rand::{rngs::StdRng, Rng, SeedableRng};
 
     use super::{
-        fractional_sumcheck_gpu, make_synthetic_leaves, Frac, FractionalSumcheckError,
-        GkrRoundStrategy, EF,
+        fractional_sumcheck_gpu, make_synthetic_leaves, Frac, FractionalInputSize,
+        FractionalSumcheckError, GkrRoundStrategy, EF,
     };
     use crate::{prelude::SC, sponge::DuplexSpongeGpu};
 
@@ -1531,8 +1563,7 @@ mod tests {
         let result = fractional_sumcheck_gpu(
             &mut transcript,
             leaves,
-            1usize << n,
-            1usize << n,
+            FractionalInputSize::dense(1usize << n),
             EF::ZERO,
             false,
             &mut mem,
@@ -1584,8 +1615,7 @@ mod tests {
         let result = fractional_sumcheck_gpu(
             &mut transcript,
             leaves,
-            real_len,
-            logical_len,
+            FractionalInputSize::new(real_len, logical_len),
             alpha,
             false,
             &mut mem,

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -359,6 +359,17 @@ fn virtual_padding_q(alpha: EF, subtree_len: usize) -> EF {
     q
 }
 
+fn folded_virtual_support_len(source_support_len: usize) -> usize {
+    if source_support_len == 0 {
+        return 0;
+    }
+    // The first GKR fold drops bit 1 of the logical input index under the bit-reversed
+    // layout. The compact threshold is therefore the max prefix index after removing
+    // that bit from any real source position.
+    let last = source_support_len - 1;
+    2 * (last / 4) + if last.is_multiple_of(4) { 1 } else { 2 }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn copy_compact_node_from_device(
     layer: &DeviceBuffer<Frac<EF>>,
@@ -913,7 +924,7 @@ where
                         && source_logical_len == total_leaves
                         && virtual_input;
                     let dst_real_len = if compact_inplace_layer {
-                        source_support_len.div_ceil(2)
+                        folded_virtual_support_len(source_support_len)
                     } else {
                         post_fold_size
                     };
@@ -1073,11 +1084,17 @@ where
                 // read/write active_pq with pending_fold=false.
                 let mut pending_fold = true;
                 let layer_read_ptr = layer.as_ptr();
-                let active_pq = if last_outer_round {
+                // Virtual compact reads can recover spilled real entries from compact source slots
+                // that are not owned by the output thread. Dense in-place multifold is safe, but
+                // virtual last-round multifold must write to the existing work buffer to avoid
+                // clobbering a source slot before another block reads it.
+                let active_pq = if last_outer_round && !virtual_input {
                     &mut layer
                 } else {
                     &mut work_buffer
                 };
+                let mut active_real_len = 0usize;
+                let mut active_logical_len = 0usize;
 
                 // w+1 to accommodate r_prev prepended to window challenges
                 // on the first iteration (inline fold on last outer round).
@@ -1155,9 +1172,13 @@ where
                     let build_real_len = if pending_fold {
                         real_len
                     } else {
-                        active_pq.len()
+                        active_real_len
                     };
-                    let build_logical_len = if pending_fold { total_leaves } else { pq_size };
+                    let build_logical_len = if pending_fold {
+                        total_leaves
+                    } else {
+                        active_logical_len
+                    };
                     unsafe {
                         frac_precompute_m_build_raw(
                             build_src,
@@ -1255,9 +1276,13 @@ where
                     let multifold_real_len = if pending_fold {
                         real_len
                     } else {
-                        active_pq.len()
+                        active_real_len
                     };
-                    let multifold_logical_len = if pending_fold { total_leaves } else { pq_size };
+                    let multifold_logical_len = if pending_fold {
+                        total_leaves
+                    } else {
+                        active_logical_len
+                    };
                     unsafe {
                         frac_multifold_raw(
                             multifold_src,
@@ -1273,6 +1298,8 @@ where
                         .map_err(FractionalSumcheckError::FoldColumns)?;
                     }
                     pq_size >>= w_fold;
+                    active_real_len = pq_size;
+                    active_logical_len = pq_size;
                     pending_fold = false;
                     base += w;
                 }
@@ -1536,19 +1563,45 @@ mod tests {
         a: &(super::FracSumcheckProof<SC>, Vec<EF>),
         b: &(super::FracSumcheckProof<SC>, Vec<EF>),
     ) {
+        assert_proofs_equal_with_context(a, b, "proof");
+    }
+
+    fn assert_proofs_equal_with_context(
+        a: &(super::FracSumcheckProof<SC>, Vec<EF>),
+        b: &(super::FracSumcheckProof<SC>, Vec<EF>),
+        context: &str,
+    ) {
         assert_eq!(
             a.0.fractional_sum, b.0.fractional_sum,
-            "fractional_sum mismatch"
+            "{context}: fractional_sum mismatch"
         );
         assert_eq!(
             a.0.claims_per_layer, b.0.claims_per_layer,
-            "claims_per_layer mismatch"
+            "{context}: claims_per_layer mismatch"
         );
         assert_eq!(
             a.0.sumcheck_polys, b.0.sumcheck_polys,
-            "sumcheck_polys mismatch"
+            "{context}: sumcheck_polys mismatch"
         );
-        assert_eq!(a.1, b.1, "final randomness mismatch");
+        assert_eq!(a.1, b.1, "{context}: final randomness mismatch");
+    }
+
+    fn assert_virtual_matches_dense(
+        real: &[Frac<EF>],
+        real_len: usize,
+        logical_len: usize,
+        alpha: EF,
+        strategy: GkrRoundStrategy,
+    ) -> Result<(), FractionalSumcheckError> {
+        let mut dense = real.to_vec();
+        dense.resize(logical_len, Frac::default());
+
+        let virtual_proof = run_from_host(real, real_len, logical_len, alpha, strategy)?;
+        let dense_proof = run_from_host(&dense, logical_len, logical_len, alpha, strategy)?;
+        let context =
+            format!("strategy={strategy:?}, real_len={real_len}, logical_len={logical_len}");
+        assert_proofs_equal_with_context(&virtual_proof, &dense_proof, &context);
+        Ok(())
     }
 
     fn make_host_leaves(len: usize) -> Vec<Frac<EF>> {
@@ -1561,15 +1614,31 @@ mod tests {
             .collect()
     }
 
+    fn virtual_padding_test_alpha() -> EF {
+        EF::from_u32(7)
+    }
+
     fn run_from_host(
         host: &[Frac<EF>],
         real_len: usize,
         logical_len: usize,
         alpha: EF,
+        strategy: GkrRoundStrategy,
     ) -> Result<(super::FracSumcheckProof<SC>, Vec<EF>), FractionalSumcheckError> {
         // SAFETY: test sets process env; run with --test-threads=1.
+        let enable_precompute_m = matches!(strategy, GkrRoundStrategy::PrecomputeM);
         unsafe {
-            std::env::set_var("SWIRL_CUDA_GKR_PRECOMPUTE_M", "0");
+            std::env::set_var(
+                "SWIRL_CUDA_GKR_PRECOMPUTE_M",
+                if enable_precompute_m { "1" } else { "0" },
+            );
+            if enable_precompute_m {
+                std::env::set_var("SWIRL_CUDA_GKR_PRECOMPUTE_M_MIN_BLOCKS", "1");
+                std::env::set_var("SWIRL_CUDA_GKR_PRECOMPUTE_M_MIN_N", "4");
+            } else {
+                std::env::remove_var("SWIRL_CUDA_GKR_PRECOMPUTE_M_MIN_BLOCKS");
+                std::env::remove_var("SWIRL_CUDA_GKR_PRECOMPUTE_M_MIN_N");
+            }
         }
         let device_ctx = test_ctx();
         let leaves = host.to_device_on(&device_ctx)?;
@@ -1590,15 +1659,47 @@ mod tests {
 
     #[test]
     fn test_virtual_input_padding_matches_dense_padding() -> Result<(), FractionalSumcheckError> {
-        for (real_len, logical_len) in [(2, 4), (4, 8), (5, 8), (8, 16), (9, 16), (1500, 2048)] {
+        let small_cases = [4, 8, 16, 32].into_iter().flat_map(|logical_len| {
+            (logical_len / 2..logical_len).map(move |real_len| (real_len, logical_len))
+        });
+        for (real_len, logical_len) in small_cases.chain([(1500, 2048)]) {
             let real = make_host_leaves(real_len);
-            let mut dense = real.clone();
-            dense.resize(logical_len, Frac::default());
+            assert_virtual_matches_dense(
+                &real,
+                real_len,
+                logical_len,
+                virtual_padding_test_alpha(),
+                GkrRoundStrategy::FoldEval,
+            )?;
+        }
+        Ok(())
+    }
 
-            let alpha = EF::ONE;
-            let virtual_proof = run_from_host(&real, real_len, logical_len, alpha)?;
-            let dense_proof = run_from_host(&dense, logical_len, logical_len, alpha)?;
-            assert_proofs_equal(&virtual_proof, &dense_proof);
+    #[test]
+    fn test_virtual_input_padding_matches_dense_padding_precompute_m(
+    ) -> Result<(), FractionalSumcheckError> {
+        for (real_len, logical_len) in [
+            (33, 64),
+            (47, 64),
+            (63, 64),
+            (65, 128),
+            (96, 128),
+            (127, 128),
+            (1025, 2048),
+            (1500, 2048),
+            (2047, 2048),
+            (32769, 65536),
+            (49153, 65536),
+            (65535, 65536),
+        ] {
+            let real = make_host_leaves(real_len);
+            assert_virtual_matches_dense(
+                &real,
+                real_len,
+                logical_len,
+                virtual_padding_test_alpha(),
+                GkrRoundStrategy::PrecomputeM,
+            )?;
         }
         Ok(())
     }

--- a/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
@@ -84,7 +84,8 @@ pub fn collect_trace_interactions<HS: GpuHashScheme>(
 }
 
 /// Evaluate interactions from trace evaluation matrices to get (p, q) fractional sumcheck input.
-/// Returns leaves buffer (WITHOUT alpha applied) and alpha value to be applied in first tree layer.
+/// Returns the real leaves buffer (WITHOUT alpha applied) and alpha value to be applied by the GKR
+/// prover. Virtual padding is not written to this buffer.
 #[instrument(name = "prover.rap_constraints.logup_gkr.input_evals", skip_all)]
 #[allow(clippy::too_many_arguments)]
 pub fn log_gkr_input_evals<HS: GpuHashScheme>(
@@ -94,14 +95,14 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
     l_skip: usize,
     alpha_logup: EF,
     d_challenges: &DeviceBuffer<EF>,
-    total_leaves: usize,
+    real_len: usize,
     device_ctx: &GpuDeviceCtx,
 ) -> Result<(DeviceBuffer<Frac<EF>>, EF), InteractionGpuError> {
     if trace_interactions.iter().all(|meta| meta.is_none()) {
         return Ok((DeviceBuffer::new(), alpha_logup));
     }
 
-    let leaves = DeviceBuffer::<Frac<EF>>::with_capacity_on(total_leaves, device_ctx);
+    let leaves = DeviceBuffer::<Frac<EF>>::with_capacity_on(real_len, device_ctx);
     leaves.fill_zero_on(device_ctx)?;
     let null_preprocessed = DeviceBuffer::<F>::new();
 

--- a/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
@@ -84,8 +84,8 @@ pub fn collect_trace_interactions<HS: GpuHashScheme>(
 }
 
 /// Evaluate interactions from trace evaluation matrices to get (p, q) fractional sumcheck input.
-/// Returns the real leaves buffer (WITHOUT alpha applied) and alpha value to be applied by the GKR
-/// prover. Virtual padding is not written to this buffer.
+/// Returns real leaves buffer (WITHOUT alpha applied) and alpha value to be applied in first tree
+/// layer. Virtual padding is not materialized.
 #[instrument(name = "prover.rap_constraints.logup_gkr.input_evals", skip_all)]
 #[allow(clippy::too_many_arguments)]
 pub fn log_gkr_input_evals<HS: GpuHashScheme>(

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -83,7 +83,7 @@ use batch_mle_monomial::{
     ZerocheckMonomialBatch, ZerocheckMonomialParYBatch,
 };
 pub use errors::*;
-pub use fractional::{fractional_sumcheck_gpu, make_synthetic_leaves};
+pub use fractional::{fractional_sumcheck_gpu, make_synthetic_leaves, FractionalInputSize};
 use gkr_input::{collect_trace_interactions, log_gkr_input_evals};
 use round0::evaluate_round0_constraints_gpu;
 
@@ -209,17 +209,15 @@ where
     }
     prover.mem.emit_metrics_with_label("prover.gkr_input_evals");
 
-    let (frac_sum_proof, mut xi) =
-        fractional_sumcheck_gpu(
-            transcript,
-            inputs,
-            real_len,
-            logical_len,
-            alpha,
-            true,
-            &mut prover.mem,
-            device_ctx,
-        )?;
+    let (frac_sum_proof, mut xi) = fractional_sumcheck_gpu(
+        transcript,
+        inputs,
+        FractionalInputSize::new(real_len, logical_len),
+        alpha,
+        true,
+        &mut prover.mem,
+        device_ctx,
+    )?;
     while xi.len() != l_skip + n_global {
         xi.push(transcript.sample_ext());
     }

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -172,7 +172,10 @@ where
     )?;
     let n_global = prover.n_global;
 
-    let total_leaves = 1 << (l_skip + n_logup);
+    let real_len: usize = total_interactions
+        .try_into()
+        .expect("total interactions should fit in usize");
+    let logical_len = 1 << (l_skip + n_logup);
     prover
         .mem
         .emit_metrics_with_label("prover.before_gkr_input_evals");
@@ -185,7 +188,7 @@ where
             l_skip,
             alpha_logup,
             &prover.d_challenges,
-            total_leaves,
+            real_len,
             device_ctx,
         )?
     } else {
@@ -207,7 +210,16 @@ where
     prover.mem.emit_metrics_with_label("prover.gkr_input_evals");
 
     let (frac_sum_proof, mut xi) =
-        fractional_sumcheck_gpu(transcript, inputs, alpha, true, &mut prover.mem, device_ctx)?;
+        fractional_sumcheck_gpu(
+            transcript,
+            inputs,
+            real_len,
+            logical_len,
+            alpha,
+            true,
+            &mut prover.mem,
+            device_ctx,
+        )?;
     while xi.len() != l_skip + n_global {
         xi.push(transcript.sample_ext());
     }


### PR DESCRIPTION
## Summary

This PR virtualizes CUDA fractional-sumcheck GKR input padding. The GKR input eval buffer is allocated at the real interaction length `R` instead of the logical power-of-two length `L`, and the existing fused CUDA kernel structure is preserved by recovering virtual padding values on demand.

It also keeps the safety fixes found during review and reth benchmarking:

- compact virtual final folds avoid in-place mutation when virtual reads can alias compact source slots;
- the precompute-M work buffer is sized for the largest virtual last-round multifold output;
- `AGENTS.md` now requires `cargo +nightly fmt` and crate-scoped `cargo clippy ... -D warnings` before committing or opening/updating a PR.

## What Changed

### Rust orchestration

- `FractionalInputSize { real_len, logical_len }` now carries both the compact real input length and the logical dense domain length into `fractional_sumcheck_gpu`.
- `log_gkr_input_evals` allocates only `real_len` `Frac<EF>` entries for the input evals and no longer materializes padding entries up to `logical_len`.
- `fractional_sumcheck_gpu` validates `real_len <= logical_len`, `logical_len.is_power_of_two()`, and `logical_len / 2 <= real_len`, then threads both lengths through tree build, revert, fold, fused compute+fold, precompute-M, and multifold paths.
- The final compact FoldEval fold uses a tiny out-of-place scratch when `source_real_len < source_logical_len`; this prevents an in-place write from overwriting a compact source slot that another lane still needs to recover virtually.
- The precompute-M work buffer formula was corrected for the first virtual last-round multifold. The first precompute-M multifold folds `w + 1` variables, so its largest output is `L >> (1 + w)`, not `L >> (2 + w)`.

### CUDA kernels and FFI

- Existing GKR kernels were edited in place; no duplicate kernels were introduced.
- The CUDA FFI wrappers now pass `real_len`, `logical_len`, `dst_real_len`, `dst_logical_len`, and `alpha` where needed.
- `virtual_node_value` reconstructs logical entries that are not physically stored:
  - all-padding subtrees return `(0, alpha^subtree_len)`;
  - compact real spill entries are read from their physical compact slot;
  - physically present entries are read directly.
- `virtual_node_store` writes only entries that have compact physical storage and skips all-padding outputs.
- The following existing kernels now use the virtual read/store helpers where applicable:
  - tree layer build and fused two-layer build;
  - fused bit-reversal + K=2 tree build;
  - first-round revert + compute;
  - fold and fused compute+fold;
  - precompute-M build;
  - multifold.
- Dense in-place folds remain in-place. Compact virtual folds must be out-of-place when virtual reads can map into the destination range; the Rust wrapper now has a debug assertion documenting this invariant.

### Tests and tooling

- Added dense-vs-virtual fractional GKR proof-equivalence tests, including nontrivial `alpha` and forced precompute-M coverage.
- Updated `bench.rs` and CUDA NTT helper wiring as needed for the new compact/virtual path.

## Example Walkthrough

Take `real_len = R = 9` and `logical_len = L = 16`.

Before this PR, the input evals buffer had 16 entries: 9 real entries plus 7 materialized padding entries. With this PR, the input evals buffer has only entries `0..8`.

When a kernel asks for logical dense entry `dense_idx`, it computes:

```text
subtree_len = logical_len / active_size
start = bit_reverse(dense_idx, log2(active_size)) * subtree_len
```

Then:

- if `start >= R`, the whole subtree is virtual padding, so the value is recovered as `(0, alpha^subtree_len)` and no memory is read;
- if `dense_idx < R`, the value is physically present at `layer[dense_idx]`;
- otherwise, the logical slot is a compact-layout hole whose real value is stored at `layer[start]`.

For example with `active_size = 16`:

- `dense_idx = 15` gives `start = 15 >= 9`, so the value is virtual padding: `(0, alpha)`.
- `dense_idx = 10` gives `start = 5 < 9`, so the logical slot is recovered from compact physical entry `layer[5]` instead of reading missing entry `layer[10]`.

Stores use the same mapping. Padding-only outputs are skipped, and mixed real/padding outputs are stored in their compact physical slot. This lets the GKR tree/fold kernels behave as if the dense `L`-sized buffer existed without actually allocating or filling it.

The important in-place caveat is that compact virtual reads can map a later logical source entry into an early physical slot. If a fold writes that early slot before every lane has consumed it, the dense-vs-virtual semantics diverge. The final FoldEval compact fold therefore writes to a small scratch buffer instead of mutating the compact source in place.

## Fractional GKR Peak Memory Formula

Let:

```text
R = real interaction count
L = logical GKR length = 1 << (l_skip + n_logup), with L / 2 <= R <= L
w = GKR_WINDOW_SIZE = 3
N_min = GKR_WINDOW_DEFAULT_MIN_N = 22
S_frac = sizeof(Frac<EF>)
S_ef = sizeof(EF) = S_frac / 2
```

The dominant `Frac<EF>` allocations inside fractional-sumcheck GKR are now:

```text
layer = R

work_buffer =
  FoldEval:    L / 4
  PrecomputeM: max(L / 16, 2^N_min)

final_fold_buffer <= 2
```

So the `Frac<EF>` contribution is:

```text
FoldEval peak Frac entries    = R + L / 4 + O(1)
PrecomputeM peak Frac entries = R + max(L / 16, 2^22) + O(1)
```

Because virtual padding requires `L / 2 <= R`, the variable precompute-M work-buffer term satisfies:

```text
L / 16 <= R / 8
```

The `2^22` minimum is inherited from the existing precompute-M fallback sizing and can dominate smaller `L`; for the reth benchmark run, this minimum already dominated on `develop-v2`, so the corrected `L / 16` bound did not increase the allocated work buffer for that run.

Precompute-M also uses EF-only auxiliary buffers:

```text
m_total        = 2^(2w) EF entries
m_partial      = ceil(2^(rem_n - w) / tail_tile) * 2^(2w) EF entries, max over active windows
eq_prefix      = 2^w EF entries
eq_suffix      = 2^w EF entries
eq_r_window    = reused tmp_block_sums storage, no separate allocation
```

Thus the precompute-M EF auxiliary contribution is:

```text
M_precompute_EF =
  2^(2w)
  + max_window(ceil(2^(rem_n - w) / tail_tile) * 2^(2w))
  + 2^(w + 1)
```

In bytes, the fractional-sumcheck GKR contribution from the new compact layer/work-buffer scheme is:

```text
Peak bytes ~= S_frac * (R + work_buffer + final_fold_buffer)
           + S_ef * M_precompute_EF
           + existing eq/tmp round buffers
```

The key change is that the main GKR input/layer buffer is `R`, not `L`; the PR does not allocate an `L`-sized dense padded input buffer.

## Validation

- `cargo +nightly fmt -- --check`
- `cargo check -p openvm-cuda-backend`
- `cargo test -p openvm-cuda-backend test_virtual_input_padding_matches_dense_padding -- --nocapture --test-threads=1`
- `cargo clippy -p openvm-cuda-backend --all-targets --tests -- -D warnings`
- Patched `../openvm-eth` to use this local `stark-backend`, rebuilt `openvm-reth-benchmark` with `cuda,aot`, and ran the reth benchmark in `prove-stark` + CUDA mode.

Reth benchmark result:

```text
block: 23992138
segments: 149
peak GPU memory: 15.66 GB
proof size: 315223 bytes
compressed proof size: 279121 bytes
exit code: 0
```
