### PR TITLE
Add `air_id` label to keygen metrics

### DIFF
--- a/crates/stark-backend/src/keygen/mod.rs
+++ b/crates/stark-backend/src/keygen/mod.rs
@@ -112,7 +112,7 @@ impl<SC: StarkProtocolConfig> MultiStarkKeygenBuilder<SC> {
                 let labels = [
                     ("air_name", pk.air_name.clone()),
                     ("air_id", air_id.to_string()),
-                ];                
+                ];
                 metrics::counter!("constraint_deg", &labels)
                     .absolute(pk.vk.max_constraint_degree as u64);
                 // column info will be logged by prover later

--- a/crates/stark-backend/src/keygen/mod.rs
+++ b/crates/stark-backend/src/keygen/mod.rs
@@ -86,7 +86,8 @@ impl<SC: StarkProtocolConfig> MultiStarkKeygenBuilder<SC> {
             .collect::<Result<Vec<_>, KeygenError>>()?;
 
         let mut air_max_constraint_degree = 0;
-        for pk in pk_per_air.iter() {
+        #[allow(unused)]
+        for (air_id, pk) in pk_per_air.iter().enumerate() {
             let width = &pk.vk.params.width;
             tracing::info!("{:<20} | Constraint Deg = {:<2} | Prep Cols = {:<2} | Main Cols = {:<8} | {:4} Constraints | {:3} Interactions",
                 pk.air_name,
@@ -108,7 +109,10 @@ impl<SC: StarkProtocolConfig> MultiStarkKeygenBuilder<SC> {
             );
             #[cfg(feature = "metrics")]
             {
-                let labels = [("air_name", pk.air_name.clone())];
+                let labels = [
+                    ("air_name", pk.air_name.clone()),
+                    ("air_id", air_id.to_string()),
+                ];                
                 metrics::counter!("constraint_deg", &labels)
                     .absolute(pk.vk.max_constraint_degree as u64);
                 // column info will be logged by prover later


### PR DESCRIPTION
The AIR name comes from [`get_air_name`](https://github.com/openvm-org/stark-backend/blob/f36fefe5c4bf1e89163adaf6c77e52f155678b9f/crates/stark-backend/src/any_air.rs#L68-L93), which derives it from the AIR's type. For powdr autoprecompiles, this type is always the same, so AIR names are not unique. In this PR, we add the AIR ID to the labels as well.

Together with #325, this completes upstreaming the [changes we need to `stark-backend`](https://github.com/openvm-org/stark-backend/compare/v2.0.0-beta.2...powdr-labs:stark-backend:v2-powdr-beta.2-remove-columns-air#diff-d76a887b1efdb4a6b77ca9d03cfb0ba301c20d4f2d389e119211cf9f208a6ecaR35).