### PR TITLE
fix: adjust system params for recursion circuit

### DIFF
--- a/crates/stark-backend/tests/soundness.rs
+++ b/crates/stark-backend/tests/soundness.rs
@@ -203,7 +203,7 @@ fn test_leaf_aggregation_security() {
 #[test]
 fn test_internal_aggregation_security() {
     let params = internal_params();
-    let max_log_height = 19;
+    let max_log_height = 20;
     let n_logup = n_logup_bound(
         params.l_skip,
         RECURSION_NUM_AIRS,
@@ -289,7 +289,7 @@ fn test_all_production_configs() {
             &internal,
             RECURSION_MAX_CONSTRAINTS,
             RECURSION_NUM_AIRS,
-            19,
+            20,
             RECURSION_NUM_COLUMNS,
             RECURSION_MAX_INTERACTIONS_PER_AIR,
         ),

--- a/crates/stark-backend/tests/soundness.rs
+++ b/crates/stark-backend/tests/soundness.rs
@@ -203,7 +203,7 @@ fn test_leaf_aggregation_security() {
 #[test]
 fn test_internal_aggregation_security() {
     let params = internal_params();
-    let max_log_height = 20;
+    let max_log_height = 21;
     let n_logup = n_logup_bound(
         params.l_skip,
         RECURSION_NUM_AIRS,
@@ -289,7 +289,7 @@ fn test_all_production_configs() {
             &internal,
             RECURSION_MAX_CONSTRAINTS,
             RECURSION_NUM_AIRS,
-            20,
+            21,
             RECURSION_NUM_COLUMNS,
             RECURSION_MAX_INTERACTIONS_PER_AIR,
         ),

--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -96,14 +96,14 @@ pub fn leaf_params_with_128_bits_security() -> SystemParams {
 /// circuits.
 ///
 /// # Assumptions for 128-bit security
-/// - **Max trace height**: ≤ 2^20
+/// - **Max trace height**: ≤ 2^21
 /// - **Max constraints per AIR**: ≤ 1,000
 /// - **Num AIRs**: ≤ 50
 /// - **Max interactions per AIR**: ≤ 100
 /// - **Num trace columns** (unstacked, total across all AIRs): ≤ 2,000
 /// - **`w_stack`** = 512, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
 ///
-/// Config: `l_skip=2, n_stack=18, log_blowup=3`.
+/// Config: `l_skip=2, n_stack=19, log_blowup=3`.
 //
 // See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
 // full soundness analysis.
@@ -111,10 +111,10 @@ pub fn internal_params_with_128_bits_security() -> SystemParams {
     SystemParams::new(
         DEFAULT_INTERNAL_LOG_BLOWUP,
         2,   // l_skip
-        18,  // n_stack
-        512, // w_stack
+        19,  // n_stack
+        256, // w_stack
         WHIR_MAX_LOG_FINAL_POLY_LEN,
-        13, // folding pow
+        14, // folding pow
         16, // mu pow
         WhirProximityStrategy::ListDecoding { m: 2 },
         SECURITY_BITS_TARGET,

--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -84,7 +84,7 @@ pub fn leaf_params_with_128_bits_security() -> SystemParams {
         17,   // n_stack
         2048, // w_stack
         WHIR_MAX_LOG_FINAL_POLY_LEN,
-        0, // folding pow
+        1, // folding pow
         8, // mu pow
         WhirProximityStrategy::UniqueDecoding,
         SECURITY_BITS_TARGET,
@@ -96,14 +96,14 @@ pub fn leaf_params_with_128_bits_security() -> SystemParams {
 /// circuits.
 ///
 /// # Assumptions for 128-bit security
-/// - **Max trace height**: ≤ 2^19
+/// - **Max trace height**: ≤ 2^20
 /// - **Max constraints per AIR**: ≤ 1,000
 /// - **Num AIRs**: ≤ 50
 /// - **Max interactions per AIR**: ≤ 100
 /// - **Num trace columns** (unstacked, total across all AIRs): ≤ 2,000
 /// - **`w_stack`** = 512, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
 ///
-/// Config: `l_skip=2, n_stack=17, log_blowup=3`.
+/// Config: `l_skip=2, n_stack=18, log_blowup=3`.
 //
 // See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
 // full soundness analysis.
@@ -111,11 +111,11 @@ pub fn internal_params_with_128_bits_security() -> SystemParams {
     SystemParams::new(
         DEFAULT_INTERNAL_LOG_BLOWUP,
         2,   // l_skip
-        17,  // n_stack
+        18,  // n_stack
         512, // w_stack
         WHIR_MAX_LOG_FINAL_POLY_LEN,
-        12, // folding pow
-        15, // mu pow
+        13, // folding pow
+        16, // mu pow
         WhirProximityStrategy::ListDecoding { m: 2 },
         SECURITY_BITS_TARGET,
         log_up_security_params_baby_bear_128_bits(),

--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -101,7 +101,7 @@ pub fn leaf_params_with_128_bits_security() -> SystemParams {
 /// - **Num AIRs**: ≤ 50
 /// - **Max interactions per AIR**: ≤ 100
 /// - **Num trace columns** (unstacked, total across all AIRs): ≤ 2,000
-/// - **`w_stack`** = 512, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
+/// - **`w_stack`** = 256, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
 ///
 /// Config: `l_skip=2, n_stack=19, log_blowup=3`.
 //


### PR DESCRIPTION
### Leaf `folding_pow_bits` increased from 0 to 1

Having `folding_pow_bits == 0` removes an interaction from internal-for-leaf but not for internal-recursive, which breaks vk convergence.

### Internal `n_stack` to 19

Maximum log height for the internal-for-leaf layer is now 20 due to the number of queries increase. `n_stack` was set to 19 because this reduces proof size. `*_pow_bits` have been incremented to make up for the larger max height.