### PR TITLE
perf: partial batch GKR input eval CUDA kernels across AIRs

### DIFF
--- a/crates/cuda-backend/cuda/include/block_ctx.cuh
+++ b/crates/cuda-backend/cuda/include/block_ctx.cuh
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+
+// Per-block descriptor for flat-block-list dispatch across heterogeneous AIRs.
+// Used by kernels that pack varying per-AIR block counts into a single 1D grid.
+//
+// `air_idx` is local to the kernel's per-AIR context buffer (not a global AIR index).
+struct BlockCtx {
+    uint32_t local_block_idx_x;
+    uint32_t air_idx;
+};

--- a/crates/cuda-backend/cuda/include/eval_ctx.cuh
+++ b/crates/cuda-backend/cuda/include/eval_ctx.cuh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "block_ctx.cuh"
 #include "fp.h"
 #include "fpext.h"
 #include "matrix.cuh"
@@ -13,11 +14,6 @@ struct EvalCoreCtx {
     const MainMatrixPtrs<FpExt> d_preprocessed;
     const MainMatrixPtrs<FpExt> *__restrict__ d_main;
     const Fp *__restrict__ d_public;
-};
-
-struct BlockCtx {
-    uint32_t local_block_idx_x;
-    uint32_t air_idx;
 };
 
 } // namespace logup_zerocheck_mle

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/gkr_input.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/gkr_input.cu
@@ -384,10 +384,7 @@ __global__ void evaluate_interactions_gkr_batch_kernel(
 }
 
 // Size helper: returns number of FpExt elements needed for intermediates per AIR.
-extern "C" size_t _gkr_input_batch_intermediates_buffer_size(
-    uint32_t buffer_size,
-    cudaStream_t stream
-) {
+extern "C" size_t _gkr_input_batch_intermediates_buffer_size(uint32_t buffer_size) {
     return (size_t)TASK_SIZE * buffer_size;
 }
 

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/gkr_input.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/gkr_input.cu
@@ -1,3 +1,4 @@
+#include "block_ctx.cuh"
 #include "codec.cuh"
 #include "fp.h"
 #include "fpext.h"
@@ -13,10 +14,14 @@ namespace logup_gkr_input_evaluation {
 // KERNELS
 // ============================================================================
 
-constexpr uint32_t TASK_SIZE = 1 << 16;
-
 // Per-AIR context for GKR input eval. The kernel processes multiple AIRs in a single launch
 // and always uses global intermediates (no local fallback).
+//
+// `task_stride` is the per-AIR thread count = `num_blocks_x * blockDim.x`. It also serves as
+// the column stride for the per-AIR intermediates buffer (one slot per active thread, per
+// DAG-buffered intermediate). Each AIR is sized independently: small AIRs get just enough
+// blocks to cover their height, large AIRs are capped (host-side) so the per-AIR intermediates
+// buffer stays bounded.
 struct GkrInputCtx {
     FracExt *d_fracs;
     const Fp *d_preprocessed;
@@ -29,6 +34,7 @@ struct GkrInputCtx {
     const uint32_t *d_pair_idxs;
     size_t used_nodes_len;
     uint32_t height;
+    uint32_t task_stride;
     uint32_t num_rows_per_tile;
 };
 
@@ -41,7 +47,7 @@ __device__ __forceinline__ FpExt evaluate_dag_entry_gkr(
     const Fp *d_public_values,
     const FpExt *d_challenges,
     const FpExt *d_intermediates,
-    const uint32_t intermediate_stride,
+    const uint32_t task_stride,
     const uint32_t height
 ) {
     FpExt result(0);
@@ -61,7 +67,7 @@ __device__ __forceinline__ FpExt evaluate_dag_entry_gkr(
         result = d_challenges[src.index];
         break;
     case SRC_INTERMEDIATE:
-        result = d_intermediates[intermediate_stride * src.index];
+        result = d_intermediates[task_stride * src.index];
         break;
     case SRC_CONSTANT:
         result = FpExt(Fp(src.index));
@@ -82,104 +88,106 @@ __device__ __forceinline__ FpExt evaluate_dag_entry_gkr(
 }
 
 __global__ void evaluate_interactions_gkr_kernel(
-    const GkrInputCtx *__restrict__ d_ctxs,
-    uint32_t num_airs
+    const BlockCtx *__restrict__ d_block_ctxs,
+    const GkrInputCtx *__restrict__ d_ctxs
 ) {
-    uint32_t task_offset = blockIdx.x * blockDim.x + threadIdx.x;
-    uint32_t task_stride = gridDim.x * blockDim.x;
+    // Flat-block-list dispatch: each block descriptor tells us which AIR this block serves and
+    // its sub-block index within that AIR. Small AIRs contribute just a few blocks; large ones
+    // (height > task_stride) get the full per-AIR allotment plus per-thread row tiling. This
+    // avoids the wasted blocks the prior 1D/2D-by-AIR shapes paid for height << TASK_SIZE AIRs.
+    BlockCtx block_ctx = d_block_ctxs[blockIdx.x];
+    GkrInputCtx ctx = d_ctxs[block_ctx.air_idx];
 
-    for (uint32_t air = 0; air < num_airs; air++) {
-        GkrInputCtx ctx = d_ctxs[air];
+    uint32_t task_offset = block_ctx.local_block_idx_x * blockDim.x + threadIdx.x;
+    uint32_t task_stride = ctx.task_stride;
 
-        // d_intermediates may be null for AIRs with buffer_size == 0; avoid UB pointer arithmetic.
-        FpExt *intermediates_ptr =
-            ctx.d_intermediates ? ctx.d_intermediates + task_offset : nullptr;
-        uint32_t intermediate_stride = task_stride;
+    // d_intermediates may be null for AIRs with buffer_size == 0; avoid UB pointer arithmetic.
+    FpExt *intermediates_ptr =
+        ctx.d_intermediates ? ctx.d_intermediates + task_offset : nullptr;
 
-        for (uint32_t j = 0; j < ctx.num_rows_per_tile; j++) {
-            uint32_t row = task_offset + j * task_stride;
+    for (uint32_t j = 0; j < ctx.num_rows_per_tile; j++) {
+        uint32_t row = task_offset + j * task_stride;
 
-            if (row < ctx.height) {
-                uint32_t rules_evaluated = 0;
-                for (uint32_t used_idx = 0; used_idx < ctx.used_nodes_len; used_idx++) {
-                    uint32_t node_idx = ctx.d_used_nodes[used_idx];
-                    FpExt result(0);
-                    if (node_idx < rules_evaluated) {
-                        Rule rule = ctx.d_rules[node_idx];
-                        RuleHeader header = decode_rule_header(rule);
-                        if (header.op == OP_VAR) {
-                            result = evaluate_dag_entry_gkr(
-                                header.x, row,
-                                ctx.d_preprocessed, ctx.d_main, ctx.d_public_values,
-                                ctx.d_challenges, intermediates_ptr, intermediate_stride, ctx.height
-                            );
-                        } else {
-                            uint32_t z_index = decode_z_index(rule);
-                            result = intermediates_ptr[z_index * intermediate_stride];
-                        }
+        if (row < ctx.height) {
+            uint32_t rules_evaluated = 0;
+            for (uint32_t used_idx = 0; used_idx < ctx.used_nodes_len; used_idx++) {
+                uint32_t node_idx = ctx.d_used_nodes[used_idx];
+                FpExt result(0);
+                if (node_idx < rules_evaluated) {
+                    Rule rule = ctx.d_rules[node_idx];
+                    RuleHeader header = decode_rule_header(rule);
+                    if (header.op == OP_VAR) {
+                        result = evaluate_dag_entry_gkr(
+                            header.x, row,
+                            ctx.d_preprocessed, ctx.d_main, ctx.d_public_values,
+                            ctx.d_challenges, intermediates_ptr, task_stride, ctx.height
+                        );
                     } else {
-                        for (; rules_evaluated <= node_idx; rules_evaluated++) {
-                            Rule rule = ctx.d_rules[rules_evaluated];
-                            RuleHeader header = decode_rule_header(rule);
+                        uint32_t z_index = decode_z_index(rule);
+                        result = intermediates_ptr[z_index * task_stride];
+                    }
+                } else {
+                    for (; rules_evaluated <= node_idx; rules_evaluated++) {
+                        Rule rule = ctx.d_rules[rules_evaluated];
+                        RuleHeader header = decode_rule_header(rule);
 
-                            FpExt x = evaluate_dag_entry_gkr(
-                                header.x, row,
+                        FpExt x = evaluate_dag_entry_gkr(
+                            header.x, row,
+                            ctx.d_preprocessed, ctx.d_main, ctx.d_public_values,
+                            ctx.d_challenges, intermediates_ptr, task_stride, ctx.height
+                        );
+                        FpExt y;
+
+                        switch (header.op) {
+                        case OP_ADD:
+                            y = evaluate_dag_entry_gkr(
+                                decode_y(rule), row,
                                 ctx.d_preprocessed, ctx.d_main, ctx.d_public_values,
-                                ctx.d_challenges, intermediates_ptr, intermediate_stride, ctx.height
+                                ctx.d_challenges, intermediates_ptr, task_stride,
+                                ctx.height
                             );
-                            FpExt y;
+                            result = x + y;
+                            break;
+                        case OP_SUB:
+                            y = evaluate_dag_entry_gkr(
+                                decode_y(rule), row,
+                                ctx.d_preprocessed, ctx.d_main, ctx.d_public_values,
+                                ctx.d_challenges, intermediates_ptr, task_stride,
+                                ctx.height
+                            );
+                            result = x - y;
+                            break;
+                        case OP_MUL:
+                            y = evaluate_dag_entry_gkr(
+                                decode_y(rule), row,
+                                ctx.d_preprocessed, ctx.d_main, ctx.d_public_values,
+                                ctx.d_challenges, intermediates_ptr, task_stride,
+                                ctx.height
+                            );
+                            x *= y;
+                            result = x;
+                            break;
+                        case OP_NEG:
+                            result = -x;
+                            break;
+                        case OP_VAR:
+                            result = x;
+                            break;
+                        default:
+                            assert(0);
+                        }
 
-                            switch (header.op) {
-                            case OP_ADD:
-                                y = evaluate_dag_entry_gkr(
-                                    decode_y(rule), row,
-                                    ctx.d_preprocessed, ctx.d_main, ctx.d_public_values,
-                                    ctx.d_challenges, intermediates_ptr, intermediate_stride,
-                                    ctx.height
-                                );
-                                result = x + y;
-                                break;
-                            case OP_SUB:
-                                y = evaluate_dag_entry_gkr(
-                                    decode_y(rule), row,
-                                    ctx.d_preprocessed, ctx.d_main, ctx.d_public_values,
-                                    ctx.d_challenges, intermediates_ptr, intermediate_stride,
-                                    ctx.height
-                                );
-                                result = x - y;
-                                break;
-                            case OP_MUL:
-                                y = evaluate_dag_entry_gkr(
-                                    decode_y(rule), row,
-                                    ctx.d_preprocessed, ctx.d_main, ctx.d_public_values,
-                                    ctx.d_challenges, intermediates_ptr, intermediate_stride,
-                                    ctx.height
-                                );
-                                x *= y;
-                                result = x;
-                                break;
-                            case OP_NEG:
-                                result = -x;
-                                break;
-                            case OP_VAR:
-                                result = x;
-                                break;
-                            default:
-                                assert(0);
-                            }
-
-                            if (header.buffer_result) {
-                                uint32_t z_index = decode_z_index(rule);
-                                intermediates_ptr[z_index * intermediate_stride] = result;
-                            }
+                        if (header.buffer_result) {
+                            uint32_t z_index = decode_z_index(rule);
+                            intermediates_ptr[z_index * task_stride] = result;
                         }
                     }
-
-                    uint32_t pair_idx = ctx.d_pair_idxs[used_idx];
-                    size_t interaction_idx = pair_idx >> 1;
-                    size_t out_idx = (interaction_idx * ctx.height + row) * 2;
-                    reinterpret_cast<FpExt *>(ctx.d_fracs)[out_idx + (pair_idx & 1)] = result;
                 }
+
+                uint32_t pair_idx = ctx.d_pair_idxs[used_idx];
+                size_t interaction_idx = pair_idx >> 1;
+                size_t out_idx = (interaction_idx * ctx.height + row) * 2;
+                reinterpret_cast<FpExt *>(ctx.d_fracs)[out_idx + (pair_idx & 1)] = result;
             }
         }
     }
@@ -189,18 +197,19 @@ __global__ void evaluate_interactions_gkr_kernel(
 // LAUNCHERS
 // ============================================================================
 
-// Size helper: returns number of FpExt elements needed for intermediates per AIR.
-extern "C" size_t _gkr_input_intermediates_buffer_size(uint32_t buffer_size) {
-    return (size_t)TASK_SIZE * buffer_size;
-}
-
 extern "C" int _logup_gkr_input_eval(
+    const BlockCtx *d_block_ctxs,
     const GkrInputCtx *d_ctxs,
-    uint32_t num_airs,
+    uint32_t num_blocks,
+    uint32_t threads_per_block,
     cudaStream_t stream
 ) {
-    auto [grid, block] = kernel_launch_params(TASK_SIZE, 256);
-    evaluate_interactions_gkr_kernel<<<grid, block, 0, stream>>>(d_ctxs, num_airs);
+    if (num_blocks == 0) {
+        return cudaSuccess;
+    }
+    dim3 grid(num_blocks);
+    dim3 block(threads_per_block);
+    evaluate_interactions_gkr_kernel<<<grid, block, 0, stream>>>(d_block_ctxs, d_ctxs);
     return CHECK_KERNEL();
 }
 

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/gkr_input.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/gkr_input.cu
@@ -13,6 +13,25 @@ namespace logup_gkr_input_evaluation {
 // KERNELS
 // ============================================================================
 
+constexpr uint32_t TASK_SIZE = 1 << 16;
+
+// Per-AIR context for GKR input eval. The kernel processes multiple AIRs in a single launch
+// and always uses global intermediates (no local fallback).
+struct GkrInputCtx {
+    FracExt *d_fracs;
+    const Fp *d_preprocessed;
+    const uint64_t *d_main;
+    const Fp *d_public_values;
+    const FpExt *d_challenges;
+    FpExt *d_intermediates;
+    const Rule *d_rules;
+    const size_t *d_used_nodes;
+    const uint32_t *d_pair_idxs;
+    size_t used_nodes_len;
+    uint32_t height;
+    uint32_t num_rows_per_tile;
+};
+
 // GKR phase interactions kernel (for permutation evaluation)
 __device__ __forceinline__ FpExt evaluate_dag_entry_gkr(
     const SourceInfo &src,
@@ -62,226 +81,7 @@ __device__ __forceinline__ FpExt evaluate_dag_entry_gkr(
     return result;
 }
 
-template <bool GLOBAL>
 __global__ void evaluate_interactions_gkr_kernel(
-    FracExt *__restrict__ d_fracs,
-    const Fp *__restrict__ d_preprocessed,
-    const uint64_t *__restrict__ d_main,
-    const Fp *__restrict__ d_public_values,
-    const FpExt *__restrict__ d_challenges,
-    const FpExt *__restrict__ d_intermediates,
-    const Rule *__restrict__ d_rules,
-    const size_t *__restrict__ d_used_nodes,
-    const uint32_t *__restrict__ d_pair_idxs,
-    const size_t used_nodes_len,
-    const uint32_t permutation_height,
-    const uint32_t num_rows_per_tile
-) {
-    uint32_t task_offset = blockIdx.x * blockDim.x + threadIdx.x;
-    uint32_t task_stride = gridDim.x * blockDim.x;
-
-    FpExt *intermediates_ptr;
-    uint32_t intermediate_stride;
-    if constexpr (GLOBAL) {
-        intermediates_ptr = (FpExt *)d_intermediates + task_offset;
-        intermediate_stride = task_stride;
-    } else {
-        FpExt intermediates[10];
-        intermediates_ptr = intermediates;
-        intermediate_stride = 1;
-    }
-
-    for (uint32_t j = 0; j < num_rows_per_tile; j++) {
-        uint32_t row = task_offset + j * task_stride;
-
-        if (row < permutation_height) {
-            uint32_t rules_evaluated = 0;
-            // Iterate through used_nodes (alternates: numer, denom, numer, denom, ...)
-            for (uint32_t used_idx = 0; used_idx < used_nodes_len; used_idx++) {
-                uint32_t node_idx = d_used_nodes[used_idx];
-                FpExt result(0);
-                if (node_idx < rules_evaluated) {
-                    Rule rule = d_rules[node_idx];
-                    RuleHeader header = decode_rule_header(rule);
-                    if (header.op == OP_VAR) {
-                        result = evaluate_dag_entry_gkr(
-                            header.x,
-                            row,
-                            d_preprocessed,
-                            d_main,
-                            d_public_values,
-                            d_challenges,
-                            intermediates_ptr,
-                            intermediate_stride,
-                            permutation_height
-                        );
-                    } else {
-                        uint32_t z_index = decode_z_index(rule);
-                        result = intermediates_ptr[z_index * intermediate_stride];
-                    }
-                } else {
-                    for (; rules_evaluated <= node_idx; rules_evaluated++) {
-                        Rule rule = d_rules[rules_evaluated];
-                        RuleHeader header = decode_rule_header(rule);
-
-                        FpExt x = evaluate_dag_entry_gkr(
-                            header.x,
-                            row,
-                            d_preprocessed,
-                            d_main,
-                            d_public_values,
-                            d_challenges,
-                            intermediates_ptr,
-                            intermediate_stride,
-                            permutation_height
-                        );
-                        FpExt y;
-
-                        switch (header.op) {
-                        case OP_ADD:
-                            y = evaluate_dag_entry_gkr(
-                                decode_y(rule),
-                                row,
-                                d_preprocessed,
-                                d_main,
-                                d_public_values,
-                                d_challenges,
-                                intermediates_ptr,
-                                intermediate_stride,
-                                permutation_height
-                            );
-                            result = x + y;
-                            break;
-                        case OP_SUB:
-                            y = evaluate_dag_entry_gkr(
-                                decode_y(rule),
-                                row,
-                                d_preprocessed,
-                                d_main,
-                                d_public_values,
-                                d_challenges,
-                                intermediates_ptr,
-                                intermediate_stride,
-                                permutation_height
-                            );
-                            result = x - y;
-                            break;
-                        case OP_MUL:
-                            y = evaluate_dag_entry_gkr(
-                                decode_y(rule),
-                                row,
-                                d_preprocessed,
-                                d_main,
-                                d_public_values,
-                                d_challenges,
-                                intermediates_ptr,
-                                intermediate_stride,
-                                permutation_height
-                            );
-                            x *= y;
-                            result = x;
-                            break;
-                        case OP_NEG:
-                            result = -x;
-                            break;
-                        case OP_VAR:
-                            result = x;
-                            break;
-                        default:
-                            assert(0);
-                        }
-
-                        if (header.buffer_result) {
-                            uint32_t z_index = decode_z_index(rule);
-                            intermediates_ptr[z_index * intermediate_stride] = result;
-                        }
-                    }
-                }
-
-                uint32_t pair_idx = d_pair_idxs[used_idx];
-                size_t interaction_idx = pair_idx >> 1;
-                size_t out_idx = (interaction_idx * permutation_height + row) * 2;
-                reinterpret_cast<FpExt *>(d_fracs)[out_idx + (pair_idx & 1)] = result;
-            }
-        }
-    }
-}
-
-// ============================================================================
-// LAUNCHERS
-// ============================================================================
-
-constexpr uint32_t TASK_SIZE = 1 << 16;
-
-extern "C" int _logup_gkr_input_eval(
-    bool is_global,
-    FracExt *d_fracs,
-    const Fp *d_preprocessed,
-    const uint64_t *d_main,
-    const Fp *d_public_values,
-    const FpExt *d_challenges,
-    const FpExt *d_intermediates,
-    const Rule *d_rules,
-    const size_t *d_used_nodes,
-    const uint32_t *d_pair_idxs,
-    size_t used_nodes_len,
-    uint32_t permutation_height,
-    uint32_t num_rows_per_tile, cudaStream_t stream) {
-    auto count = is_global ? TASK_SIZE : permutation_height;
-    auto [grid, block] = kernel_launch_params(count, 256);
-    if (is_global) {
-        evaluate_interactions_gkr_kernel<true><<<grid, block, 0, stream>>>(
-            d_fracs,
-            d_preprocessed,
-            d_main,
-            d_public_values,
-            d_challenges,
-            d_intermediates,
-            d_rules,
-            d_used_nodes,
-            d_pair_idxs,
-            used_nodes_len,
-            permutation_height,
-            num_rows_per_tile
-        );
-    } else {
-        evaluate_interactions_gkr_kernel<false><<<grid, block, 0, stream>>>(
-            d_fracs,
-            d_preprocessed,
-            d_main,
-            d_public_values,
-            d_challenges,
-            d_intermediates,
-            d_rules,
-            d_used_nodes,
-            d_pair_idxs,
-            used_nodes_len,
-            permutation_height,
-            num_rows_per_tile
-        );
-    }
-    return CHECK_KERNEL();
-}
-
-// Batch kernel for GKR input eval: processes multiple AIRs in a single kernel launch.
-// Always uses global intermediates (no local fallback) since we batch across AIRs.
-
-struct GkrInputCtx {
-    FracExt *d_fracs;
-    const Fp *d_preprocessed;
-    const uint64_t *d_main;
-    const Fp *d_public_values;
-    const FpExt *d_challenges;
-    FpExt *d_intermediates;
-    const Rule *d_rules;
-    const size_t *d_used_nodes;
-    const uint32_t *d_pair_idxs;
-    size_t used_nodes_len;
-    uint32_t height;
-    uint32_t num_rows_per_tile;
-};
-
-__global__ void evaluate_interactions_gkr_batch_kernel(
     const GkrInputCtx *__restrict__ d_ctxs,
     uint32_t num_airs
 ) {
@@ -383,18 +183,22 @@ __global__ void evaluate_interactions_gkr_batch_kernel(
     }
 }
 
+// ============================================================================
+// LAUNCHERS
+// ============================================================================
+
 // Size helper: returns number of FpExt elements needed for intermediates per AIR.
-extern "C" size_t _gkr_input_batch_intermediates_buffer_size(uint32_t buffer_size) {
+extern "C" size_t _gkr_input_intermediates_buffer_size(uint32_t buffer_size) {
     return (size_t)TASK_SIZE * buffer_size;
 }
 
-extern "C" int _logup_batch_gkr_input_eval(
+extern "C" int _logup_gkr_input_eval(
     const GkrInputCtx *d_ctxs,
     uint32_t num_airs,
     cudaStream_t stream
 ) {
     auto [grid, block] = kernel_launch_params(TASK_SIZE, 256);
-    evaluate_interactions_gkr_batch_kernel<<<grid, block, 0, stream>>>(d_ctxs, num_airs);
+    evaluate_interactions_gkr_kernel<<<grid, block, 0, stream>>>(d_ctxs, num_airs);
     return CHECK_KERNEL();
 }
 

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/gkr_input.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/gkr_input.cu
@@ -263,4 +263,142 @@ extern "C" int _logup_gkr_input_eval(
     return CHECK_KERNEL();
 }
 
+// Batch kernel for GKR input eval: processes multiple AIRs in a single kernel launch.
+// Always uses global intermediates (no local fallback) since we batch across AIRs.
+
+struct GkrInputCtx {
+    FracExt *d_fracs;
+    const Fp *d_preprocessed;
+    const uint64_t *d_main;
+    const Fp *d_public_values;
+    const FpExt *d_challenges;
+    FpExt *d_intermediates;
+    const Rule *d_rules;
+    const size_t *d_used_nodes;
+    const uint32_t *d_pair_idxs;
+    size_t used_nodes_len;
+    uint32_t height;
+    uint32_t num_rows_per_tile;
+};
+
+__global__ void evaluate_interactions_gkr_batch_kernel(
+    const GkrInputCtx *__restrict__ d_ctxs,
+    uint32_t num_airs
+) {
+    uint32_t task_offset = blockIdx.x * blockDim.x + threadIdx.x;
+    uint32_t task_stride = gridDim.x * blockDim.x;
+
+    for (uint32_t air = 0; air < num_airs; air++) {
+        GkrInputCtx ctx = d_ctxs[air];
+
+        FpExt *intermediates_ptr = ctx.d_intermediates + task_offset;
+        uint32_t intermediate_stride = task_stride;
+
+        for (uint32_t j = 0; j < ctx.num_rows_per_tile; j++) {
+            uint32_t row = task_offset + j * task_stride;
+
+            if (row < ctx.height) {
+                uint32_t rules_evaluated = 0;
+                for (uint32_t used_idx = 0; used_idx < ctx.used_nodes_len; used_idx++) {
+                    uint32_t node_idx = ctx.d_used_nodes[used_idx];
+                    FpExt result(0);
+                    if (node_idx < rules_evaluated) {
+                        Rule rule = ctx.d_rules[node_idx];
+                        RuleHeader header = decode_rule_header(rule);
+                        if (header.op == OP_VAR) {
+                            result = evaluate_dag_entry_gkr(
+                                header.x, row,
+                                ctx.d_preprocessed, ctx.d_main, ctx.d_public_values,
+                                ctx.d_challenges, intermediates_ptr, intermediate_stride, ctx.height
+                            );
+                        } else {
+                            uint32_t z_index = decode_z_index(rule);
+                            result = intermediates_ptr[z_index * intermediate_stride];
+                        }
+                    } else {
+                        for (; rules_evaluated <= node_idx; rules_evaluated++) {
+                            Rule rule = ctx.d_rules[rules_evaluated];
+                            RuleHeader header = decode_rule_header(rule);
+
+                            FpExt x = evaluate_dag_entry_gkr(
+                                header.x, row,
+                                ctx.d_preprocessed, ctx.d_main, ctx.d_public_values,
+                                ctx.d_challenges, intermediates_ptr, intermediate_stride, ctx.height
+                            );
+                            FpExt y;
+
+                            switch (header.op) {
+                            case OP_ADD:
+                                y = evaluate_dag_entry_gkr(
+                                    decode_y(rule), row,
+                                    ctx.d_preprocessed, ctx.d_main, ctx.d_public_values,
+                                    ctx.d_challenges, intermediates_ptr, intermediate_stride,
+                                    ctx.height
+                                );
+                                result = x + y;
+                                break;
+                            case OP_SUB:
+                                y = evaluate_dag_entry_gkr(
+                                    decode_y(rule), row,
+                                    ctx.d_preprocessed, ctx.d_main, ctx.d_public_values,
+                                    ctx.d_challenges, intermediates_ptr, intermediate_stride,
+                                    ctx.height
+                                );
+                                result = x - y;
+                                break;
+                            case OP_MUL:
+                                y = evaluate_dag_entry_gkr(
+                                    decode_y(rule), row,
+                                    ctx.d_preprocessed, ctx.d_main, ctx.d_public_values,
+                                    ctx.d_challenges, intermediates_ptr, intermediate_stride,
+                                    ctx.height
+                                );
+                                x *= y;
+                                result = x;
+                                break;
+                            case OP_NEG:
+                                result = -x;
+                                break;
+                            case OP_VAR:
+                                result = x;
+                                break;
+                            default:
+                                assert(0);
+                            }
+
+                            if (header.buffer_result) {
+                                uint32_t z_index = decode_z_index(rule);
+                                intermediates_ptr[z_index * intermediate_stride] = result;
+                            }
+                        }
+                    }
+
+                    uint32_t pair_idx = ctx.d_pair_idxs[used_idx];
+                    size_t interaction_idx = pair_idx >> 1;
+                    size_t out_idx = (interaction_idx * ctx.height + row) * 2;
+                    reinterpret_cast<FpExt *>(ctx.d_fracs)[out_idx + (pair_idx & 1)] = result;
+                }
+            }
+        }
+    }
+}
+
+// Size helper: returns number of FpExt elements needed for intermediates per AIR.
+extern "C" size_t _gkr_input_batch_intermediates_buffer_size(
+    uint32_t buffer_size,
+    cudaStream_t stream
+) {
+    return (size_t)TASK_SIZE * buffer_size;
+}
+
+extern "C" int _logup_batch_gkr_input_eval(
+    const GkrInputCtx *d_ctxs,
+    uint32_t num_airs,
+    cudaStream_t stream
+) {
+    auto [grid, block] = kernel_launch_params(TASK_SIZE, 256);
+    evaluate_interactions_gkr_batch_kernel<<<grid, block, 0, stream>>>(d_ctxs, num_airs);
+    return CHECK_KERNEL();
+}
+
 } // namespace logup_gkr_input_evaluation

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/gkr_input.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/gkr_input.cu
@@ -91,7 +91,9 @@ __global__ void evaluate_interactions_gkr_kernel(
     for (uint32_t air = 0; air < num_airs; air++) {
         GkrInputCtx ctx = d_ctxs[air];
 
-        FpExt *intermediates_ptr = ctx.d_intermediates + task_offset;
+        // d_intermediates may be null for AIRs with buffer_size == 0; avoid UB pointer arithmetic.
+        FpExt *intermediates_ptr =
+            ctx.d_intermediates ? ctx.d_intermediates + task_offset : nullptr;
         uint32_t intermediate_stride = task_stride;
 
         for (uint32_t j = 0; j < ctx.num_rows_per_tile; j++) {

--- a/crates/cuda-backend/src/cuda/logup_zerocheck.rs
+++ b/crates/cuda-backend/src/cuda/logup_zerocheck.rs
@@ -97,7 +97,13 @@ pub struct LogupMonomialCtx {
     pub num_monomials: u32,
 }
 
-/// Per-AIR context for GKR input evaluation.
+/// Per-AIR context for GKR input evaluation. Dispatched via a flat `BlockCtx` block list:
+/// each block reads its `air_idx` and `local_block_idx_x` from the `BlockCtx` table and
+/// then loads this struct for the AIR's pointers + sizing.
+///
+/// `task_stride` is the per-AIR thread count = `num_blocks_x * THREADS_PER_BLOCK`. It also
+/// serves as the column stride for `d_intermediates`, which must hold at least
+/// `task_stride * buffer_size` `EF` elements.
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct GkrInputCtx {
@@ -112,6 +118,7 @@ pub struct GkrInputCtx {
     pub d_pair_idxs: *const u32,
     pub used_nodes_len: usize,
     pub height: u32,
+    pub task_stride: u32,
     pub num_rows_per_tile: u32,
 }
 
@@ -325,11 +332,11 @@ extern "C" {
     ) -> i32;
 
     // gkr_input.cu
-    fn _gkr_input_intermediates_buffer_size(buffer_size: u32) -> usize;
-
     fn _logup_gkr_input_eval(
+        d_block_ctxs: *const BlockCtx,
         d_ctxs: *const GkrInputCtx,
-        num_airs: u32,
+        num_blocks: u32,
+        threads_per_block: u32,
         stream: cudaStream_t,
     ) -> i32;
 
@@ -1080,22 +1087,29 @@ pub unsafe fn fold_ple_from_evals(
     ))
 }
 
-/// GKR input eval that processes multiple AIRs in a single kernel launch.
+/// GKR input eval that processes multiple AIRs in a single kernel launch via a flat block list.
+///
+/// Each entry of `d_block_ctxs` describes one block in the launch (which AIR it serves and its
+/// sub-block index within that AIR's allotment). Per-AIR sizing lives in `d_ctxs[air_idx]`.
 ///
 /// # Safety
-/// - `d_ctxs` must point to device memory containing `num_airs` valid `GkrInputCtx` structs.
-/// - All referenced device pointers in each ctx must be valid.
+/// - `d_block_ctxs` must contain exactly `num_blocks` valid `BlockCtx` entries.
+/// - `d_ctxs` must contain a valid `GkrInputCtx` for every distinct `air_idx` referenced by
+///   `d_block_ctxs`. All referenced device pointers in each ctx must be valid.
 pub unsafe fn logup_gkr_input_eval(
+    d_block_ctxs: &DeviceBuffer<BlockCtx>,
     d_ctxs: &DeviceBuffer<GkrInputCtx>,
-    num_airs: u32,
+    num_blocks: u32,
+    threads_per_block: u32,
     stream: cudaStream_t,
 ) -> Result<(), CudaError> {
-    CudaError::from_result(_logup_gkr_input_eval(d_ctxs.as_ptr(), num_airs, stream))
-}
-
-/// Number of `FpExt` elements needed for the per-AIR intermediates buffer.
-pub fn gkr_input_intermediates_buffer_size(buffer_size: u32) -> usize {
-    unsafe { _gkr_input_intermediates_buffer_size(buffer_size) }
+    CudaError::from_result(_logup_gkr_input_eval(
+        d_block_ctxs.as_ptr(),
+        d_ctxs.as_ptr(),
+        num_blocks,
+        threads_per_block,
+        stream,
+    ))
 }
 
 pub unsafe fn frac_add_alpha(

--- a/crates/cuda-backend/src/cuda/logup_zerocheck.rs
+++ b/crates/cuda-backend/src/cuda/logup_zerocheck.rs
@@ -341,7 +341,7 @@ extern "C" {
         stream: cudaStream_t,
     ) -> i32;
 
-    fn _gkr_input_batch_intermediates_buffer_size(buffer_size: u32, stream: cudaStream_t) -> usize;
+    fn _gkr_input_batch_intermediates_buffer_size(buffer_size: u32) -> usize;
 
     fn _logup_batch_gkr_input_eval(
         d_ctxs: *const GkrInputCtx,
@@ -1153,11 +1153,8 @@ pub unsafe fn logup_batch_gkr_input_eval(
 
 /// Computes the number of FpExt elements needed for intermediates in the batch GKR input eval
 /// kernel.
-pub unsafe fn gkr_input_batch_intermediates_buffer_size(
-    buffer_size: u32,
-    stream: cudaStream_t,
-) -> usize {
-    _gkr_input_batch_intermediates_buffer_size(buffer_size, stream)
+pub fn gkr_input_batch_intermediates_buffer_size(buffer_size: u32) -> usize {
+    unsafe { _gkr_input_batch_intermediates_buffer_size(buffer_size) }
 }
 
 pub unsafe fn frac_add_alpha(

--- a/crates/cuda-backend/src/cuda/logup_zerocheck.rs
+++ b/crates/cuda-backend/src/cuda/logup_zerocheck.rs
@@ -96,6 +96,24 @@ pub struct LogupMonomialCtx {
     pub d_combinations: *const EF,
     pub num_monomials: u32,
 }
+/// Per-AIR context for batched GKR input evaluation.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct GkrInputCtx {
+    pub d_fracs: *mut Frac<EF>,
+    pub d_preprocessed: *const F,
+    pub d_main: *const u64,
+    pub d_public_values: *const F,
+    pub d_challenges: *const EF,
+    pub d_intermediates: *mut EF,
+    pub d_rules: *const std::ffi::c_void,
+    pub d_used_nodes: *const usize,
+    pub d_pair_idxs: *const u32,
+    pub used_nodes_len: usize,
+    pub height: u32,
+    pub num_rows_per_tile: u32,
+}
+
 // end of types for batch MLE
 
 extern "C" {
@@ -320,6 +338,14 @@ extern "C" {
         used_nodes_len: usize,
         height: u32,
         num_rows_per_tile: u32,
+        stream: cudaStream_t,
+    ) -> i32;
+
+    fn _gkr_input_batch_intermediates_buffer_size(buffer_size: u32, stream: cudaStream_t) -> usize;
+
+    fn _logup_batch_gkr_input_eval(
+        d_ctxs: *const GkrInputCtx,
+        num_airs: u32,
         stream: cudaStream_t,
     ) -> i32;
 
@@ -1106,6 +1132,32 @@ pub unsafe fn logup_gkr_input_eval(
         num_rows_per_tile,
         stream,
     ))
+}
+
+/// Batch version of GKR input eval that processes multiple AIRs in a single kernel launch.
+///
+/// # Safety
+/// - `d_ctxs` must point to device memory containing `num_airs` valid `GkrInputCtx` structs.
+/// - All referenced device pointers in each ctx must be valid.
+pub unsafe fn logup_batch_gkr_input_eval(
+    d_ctxs: &DeviceBuffer<GkrInputCtx>,
+    num_airs: u32,
+    stream: cudaStream_t,
+) -> Result<(), CudaError> {
+    CudaError::from_result(_logup_batch_gkr_input_eval(
+        d_ctxs.as_ptr(),
+        num_airs,
+        stream,
+    ))
+}
+
+/// Computes the number of FpExt elements needed for intermediates in the batch GKR input eval
+/// kernel.
+pub unsafe fn gkr_input_batch_intermediates_buffer_size(
+    buffer_size: u32,
+    stream: cudaStream_t,
+) -> usize {
+    _gkr_input_batch_intermediates_buffer_size(buffer_size, stream)
 }
 
 pub unsafe fn frac_add_alpha(

--- a/crates/cuda-backend/src/cuda/logup_zerocheck.rs
+++ b/crates/cuda-backend/src/cuda/logup_zerocheck.rs
@@ -96,7 +96,8 @@ pub struct LogupMonomialCtx {
     pub d_combinations: *const EF,
     pub num_monomials: u32,
 }
-/// Per-AIR context for batched GKR input evaluation.
+
+/// Per-AIR context for GKR input evaluation.
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct GkrInputCtx {
@@ -324,26 +325,9 @@ extern "C" {
     ) -> i32;
 
     // gkr_input.cu
+    fn _gkr_input_intermediates_buffer_size(buffer_size: u32) -> usize;
+
     fn _logup_gkr_input_eval(
-        is_global: bool,
-        fracs: *mut Frac<EF>,
-        preprocessed: *const F,
-        partitioned_main: *const u64,
-        public_values: *const F,
-        challenges: *const EF,
-        intermediates: *const EF,
-        rules: *const std::ffi::c_void,
-        used_nodes: *const usize,
-        pair_idxs: *const u32,
-        used_nodes_len: usize,
-        height: u32,
-        num_rows_per_tile: u32,
-        stream: cudaStream_t,
-    ) -> i32;
-
-    fn _gkr_input_batch_intermediates_buffer_size(buffer_size: u32) -> usize;
-
-    fn _logup_batch_gkr_input_eval(
         d_ctxs: *const GkrInputCtx,
         num_airs: u32,
         stream: cudaStream_t,
@@ -1096,65 +1080,22 @@ pub unsafe fn fold_ple_from_evals(
     ))
 }
 
-/// # Safety
-/// - `fracs` must be a pointer to a device buffer with capacity at least `num_interactions *
-///   height`.
-#[allow(clippy::too_many_arguments)]
-pub unsafe fn logup_gkr_input_eval(
-    is_global: bool,
-    fracs: *mut Frac<EF>,
-    preprocessed: &DeviceBuffer<F>,
-    partitioned_main: &DeviceBuffer<u64>,
-    public_values: &DeviceBuffer<F>,
-    challenges: &DeviceBuffer<EF>,
-    intermediates: &DeviceBuffer<EF>,
-    rules: &DeviceBuffer<u128>,
-    used_nodes: &DeviceBuffer<usize>,
-    pair_idxs: &DeviceBuffer<u32>,
-    height: u32,
-    num_rows_per_tile: u32,
-    stream: cudaStream_t,
-) -> Result<(), CudaError> {
-    debug_assert_eq!(used_nodes.len(), pair_idxs.len());
-    CudaError::from_result(_logup_gkr_input_eval(
-        is_global,
-        fracs,
-        preprocessed.as_ptr(),
-        partitioned_main.as_ptr(),
-        public_values.as_ptr(),
-        challenges.as_ptr(),
-        intermediates.as_ptr(),
-        rules.as_raw_ptr(),
-        used_nodes.as_ptr(),
-        pair_idxs.as_ptr(),
-        used_nodes.len(),
-        height,
-        num_rows_per_tile,
-        stream,
-    ))
-}
-
-/// Batch version of GKR input eval that processes multiple AIRs in a single kernel launch.
+/// GKR input eval that processes multiple AIRs in a single kernel launch.
 ///
 /// # Safety
 /// - `d_ctxs` must point to device memory containing `num_airs` valid `GkrInputCtx` structs.
 /// - All referenced device pointers in each ctx must be valid.
-pub unsafe fn logup_batch_gkr_input_eval(
+pub unsafe fn logup_gkr_input_eval(
     d_ctxs: &DeviceBuffer<GkrInputCtx>,
     num_airs: u32,
     stream: cudaStream_t,
 ) -> Result<(), CudaError> {
-    CudaError::from_result(_logup_batch_gkr_input_eval(
-        d_ctxs.as_ptr(),
-        num_airs,
-        stream,
-    ))
+    CudaError::from_result(_logup_gkr_input_eval(d_ctxs.as_ptr(), num_airs, stream))
 }
 
-/// Computes the number of FpExt elements needed for intermediates in the batch GKR input eval
-/// kernel.
-pub fn gkr_input_batch_intermediates_buffer_size(buffer_size: u32) -> usize {
-    unsafe { _gkr_input_batch_intermediates_buffer_size(buffer_size) }
+/// Number of `FpExt` elements needed for the per-AIR intermediates buffer.
+pub fn gkr_input_intermediates_buffer_size(buffer_size: u32) -> usize {
+    unsafe { _gkr_input_intermediates_buffer_size(buffer_size) }
 }
 
 pub unsafe fn frac_add_alpha(

--- a/crates/cuda-backend/src/logup_zerocheck/batch_mle.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/batch_mle.rs
@@ -22,6 +22,7 @@ use crate::{
     hash_scheme::GpuHashScheme,
     logup_zerocheck::{
         batch_mle_monomial::{LogupCombinations, LogupMonomialBatch},
+        block_ctxs::build_block_ctxs,
         mle_round::{evaluate_mle_constraints_gpu, evaluate_mle_interactions_gpu},
     },
     prelude::{EF, F},
@@ -159,21 +160,8 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
         let max_num_y = traces.iter().map(|t| t.num_y).max().unwrap_or(0);
         let threads_per_block = max_num_y.min(MAX_THREADS_PER_BLOCK);
 
-        // Build block_ctxs and air_offsets
-        let mut block_ctxs_h: Vec<BlockCtx> = Vec::new();
-        let mut air_offsets: Vec<u32> = Vec::with_capacity(traces.len() + 1);
-        air_offsets.push(0);
-
-        for (local_air, t) in traces.iter().enumerate() {
-            let nb = t.num_y.div_ceil(threads_per_block);
-            for b in 0..nb {
-                block_ctxs_h.push(BlockCtx {
-                    local_block_idx_x: b,
-                    air_idx: local_air as u32,
-                });
-            }
-            air_offsets.push(block_ctxs_h.len() as u32);
-        }
+        let (block_ctxs_h, air_offsets) =
+            build_block_ctxs(traces.iter().map(|t| t.num_y.div_ceil(threads_per_block)));
 
         // Build ZerocheckCtx for each trace
         let mut intermediates_keepalive: Vec<DeviceBuffer<EF>> = Vec::new();
@@ -316,21 +304,8 @@ impl<'a> LogupMleBatchBuilder<'a> {
         let max_num_y = traces.iter().map(|t| t.num_y).max().unwrap_or(0);
         let threads_per_block = max_num_y.min(MAX_THREADS_PER_BLOCK);
 
-        // Build block_ctxs and air_offsets
-        let mut block_ctxs_h: Vec<BlockCtx> = Vec::new();
-        let mut air_offsets: Vec<u32> = Vec::with_capacity(traces.len() + 1);
-        air_offsets.push(0);
-
-        for (local_air, t) in traces.iter().enumerate() {
-            let nb = t.num_y.div_ceil(threads_per_block);
-            for b in 0..nb {
-                block_ctxs_h.push(BlockCtx {
-                    local_block_idx_x: b,
-                    air_idx: local_air as u32,
-                });
-            }
-            air_offsets.push(block_ctxs_h.len() as u32);
-        }
+        let (block_ctxs_h, air_offsets) =
+            build_block_ctxs(traces.iter().map(|t| t.num_y.div_ceil(threads_per_block)));
 
         // Build LogupCtx for each trace
         let mut intermediates_keepalive: Vec<DeviceBuffer<EF>> = Vec::new();

--- a/crates/cuda-backend/src/logup_zerocheck/batch_mle_monomial.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/batch_mle_monomial.rs
@@ -23,7 +23,7 @@ use crate::{
     error::KernelError,
     gpu_backend::GenericGpuBackend,
     hash_scheme::GpuHashScheme,
-    logup_zerocheck::batch_mle::TraceCtx,
+    logup_zerocheck::{batch_mle::TraceCtx, block_ctxs::build_block_ctxs},
     prelude::EF,
 };
 
@@ -149,30 +149,18 @@ impl<'a> ZerocheckMonomialBatch<'a> {
 
         let threads_per_block = THREADS_PER_BLOCK;
 
-        // Build block_ctxs and air_offsets
-        // For each AIR: total_blocks = ceil(num_monomials / tpb) * num_y
-        // local_block_idx_x encodes (y_int * mono_blocks + mono_block_idx)
-        let mut block_ctxs_h: Vec<BlockCtx> = Vec::new();
-        let mut air_offsets: Vec<u32> = Vec::with_capacity(traces.len() + 1);
-        air_offsets.push(0);
-
-        for (local_air, t) in traces.iter().enumerate() {
+        // Block layout: each AIR contributes `mono_blocks * num_y` blocks, where
+        // `mono_blocks = ceil(num_monomials / tpb)`. `local_block_idx_x` runs `0..total_blocks`
+        // and the kernel decodes it as `y_int * mono_blocks + mono_block_idx`.
+        let (block_ctxs_h, air_offsets) = build_block_ctxs(traces.iter().map(|t| {
             let monomials = pk.per_air[t.air_idx]
                 .other_data
                 .zerocheck_monomials
                 .as_ref()
                 .unwrap();
             let mono_blocks = monomials.num_monomials.div_ceil(threads_per_block);
-            let total_blocks = mono_blocks * t.num_y;
-
-            for local_idx in 0..total_blocks {
-                block_ctxs_h.push(BlockCtx {
-                    local_block_idx_x: local_idx,
-                    air_idx: local_air as u32,
-                });
-            }
-            air_offsets.push(block_ctxs_h.len() as u32);
-        }
+            mono_blocks * t.num_y
+        }));
 
         // Build MonomialAirCtx for each trace
         let air_ctxs_h: Vec<MonomialAirCtx> = traces
@@ -381,26 +369,14 @@ impl<'a> ZerocheckMonomialParYBatch<'a> {
             chunk_size = (chunk_size / 2).max(1);
         }
 
-        // Build block_ctxs with per-AIR encoding
-        // Encoding: local_block_idx_x = y_block * air_mono_chunks + mono_chunk
-        let mut block_ctxs_h: Vec<BlockCtx> = Vec::new();
-        let mut air_offsets: Vec<u32> = Vec::with_capacity(traces.len() + 1);
-        air_offsets.push(0);
-
-        for (local_air, (y_blocks, num_mono)) in per_air_info.iter().enumerate() {
-            let air_mono_chunks = num_mono.div_ceil(chunk_size);
-
-            for y_block in 0..*y_blocks {
-                for mono_chunk in 0..air_mono_chunks {
-                    let local_idx = y_block * air_mono_chunks + mono_chunk;
-                    block_ctxs_h.push(BlockCtx {
-                        local_block_idx_x: local_idx,
-                        air_idx: local_air as u32,
-                    });
-                }
-            }
-            air_offsets.push(block_ctxs_h.len() as u32);
-        }
+        // Block layout: each AIR contributes `y_blocks * air_mono_chunks` blocks.
+        // `local_block_idx_x` runs `0..total_blocks` and the kernel decodes it as
+        // `y_block * air_mono_chunks + mono_chunk`.
+        let (block_ctxs_h, air_offsets) =
+            build_block_ctxs(per_air_info.iter().map(|(y_blocks, num_mono)| {
+                let air_mono_chunks = num_mono.div_ceil(chunk_size);
+                y_blocks * air_mono_chunks
+            }));
 
         let num_blocks = block_ctxs_h.len() as u32;
 
@@ -648,13 +624,11 @@ impl<'a> LogupMonomialBatch<'a> {
 
         let threads_per_block = THREADS_PER_BLOCK_LOGUP;
 
-        // Build block_ctxs: one block per (y_int, mono_block) per trace
-        // local_block_idx_x = y_int * mono_blocks + mono_block
-        let mut block_ctxs_h: Vec<BlockCtx> = Vec::new();
-        let mut air_offsets: Vec<u32> = Vec::with_capacity(traces.len() + 1);
-        air_offsets.push(0);
-
-        for (local_air, t) in traces.iter().enumerate() {
+        // Block layout: each AIR contributes `num_y * mono_blocks` blocks, where `mono_blocks`
+        // covers the larger of numerator/denominator monomial counts.
+        // `local_block_idx_x` runs `0..total_blocks` and the kernel decodes it as
+        // `y_int * mono_blocks + mono_block`.
+        let (block_ctxs_h, air_offsets) = build_block_ctxs(traces.iter().map(|t| {
             let monomials = pk.per_air[t.air_idx]
                 .other_data
                 .interaction_monomials
@@ -664,16 +638,8 @@ impl<'a> LogupMonomialBatch<'a> {
                 .num_numer_monomials
                 .max(monomials.num_denom_monomials);
             let mono_blocks = max_monomials.div_ceil(threads_per_block).max(1);
-            for y_int in 0..t.num_y {
-                for mono_block in 0..mono_blocks {
-                    block_ctxs_h.push(BlockCtx {
-                        local_block_idx_x: y_int * mono_blocks + mono_block,
-                        air_idx: local_air as u32,
-                    });
-                }
-            }
-            air_offsets.push(block_ctxs_h.len() as u32);
-        }
+            t.num_y * mono_blocks
+        }));
 
         let num_blocks = block_ctxs_h.len() as u32;
 

--- a/crates/cuda-backend/src/logup_zerocheck/block_ctxs.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/block_ctxs.rs
@@ -1,0 +1,30 @@
+//! Shared helper for building per-batch `BlockCtx` lists for flat-block-list dispatch.
+
+use crate::cuda::logup_zerocheck::BlockCtx;
+
+/// Builds a flat `Vec<BlockCtx>` from per-AIR block counts, plus the prefix-sum offsets
+/// (`air_offsets`) that mark each AIR's range in the flat list.
+///
+/// Block ordering is the contract for kernels using this list: the kernel does
+/// `block_ctxs[blockIdx.x]` directly, so block descriptors are emitted grouped by AIR in input
+/// order. Within each AIR, `local_block_idx_x` runs from `0` to `n_blocks - 1`.
+///
+/// `air_offsets` has length `blocks_per_air.len() + 1`; `air_offsets[i]` is the index of the
+/// first block for AIR `i` and `air_offsets.last()` is the total block count. Callers without
+/// batched reductions can ignore the second tuple slot.
+pub(super) fn build_block_ctxs(
+    blocks_per_air: impl IntoIterator<Item = u32>,
+) -> (Vec<BlockCtx>, Vec<u32>) {
+    let mut block_ctxs: Vec<BlockCtx> = Vec::new();
+    let mut air_offsets: Vec<u32> = vec![0];
+    for (air_idx, n_blocks) in blocks_per_air.into_iter().enumerate() {
+        for local_idx in 0..n_blocks {
+            block_ctxs.push(BlockCtx {
+                local_block_idx_x: local_idx,
+                air_idx: air_idx as u32,
+            });
+        }
+        air_offsets.push(block_ctxs.len() as u32);
+    }
+    (block_ctxs, air_offsets)
+}

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -91,7 +91,7 @@ impl FractionalInputSize {
         // Conservative estimate for M_precompute_EF: m_total + m_partial bound + eq_prefix/suffix.
         // In practice the max_window term is ceil(2^(rem_n - w) / tail_tile) * 2^(2w) EF elems;
         // use 2 * 2^(2w) as a safe floor (tail_tile >= 1, rem_n bounded by total_rounds).
-        let precompute_ef = (1 << (2 * w + 1) + (1 << (w + 1))) * s_ef;
+        let precompute_ef = ((1 << (2 * w + 1)) + (1 << (w + 1))) * s_ef;
 
         fold_eval.max(precompute_f + precompute_ef)
     }

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -58,6 +58,43 @@ impl FractionalInputSize {
             logical_len: len,
         }
     }
+
+    /// Peak work-buffer bytes (excluding the `S_frac * real_len` layer/input buffer).
+    ///
+    /// This must stay in sync with `max_work_size` in `fractional_sumcheck_gpu` and the
+    /// precompute-M EF auxiliary allocations. If the sumcheck implementation changes, this
+    /// method must be updated as well — it is the source of truth for batching budgets that
+    /// depend on the fractional-GKR peak.
+    ///
+    /// ## Formula (FoldEval path, dominates for large inputs)
+    ///
+    /// ```text
+    /// work_buffer = logical_len / 4   Frac entries → S_frac * L/4 bytes
+    /// ```
+    ///
+    /// For the precompute-M path (`max_work_size` in `fractional_sumcheck_gpu`):
+    ///
+    /// ```text
+    /// work_buffer = max(L >> (1 + GKR_WINDOW_SIZE), 2^22)   Frac entries
+    /// + S_ef * (2^(2w) + max_window(m_partial) + 2^(w+1))  EF bytes
+    /// ```
+    ///
+    /// This method returns the maximum over both paths to give a conservative budget.
+    pub fn peak_work_buffer_bytes(&self) -> usize {
+        let s_frac = std::mem::size_of::<Frac<EF>>();
+        let fold_eval = (self.logical_len / 4) * s_frac;
+
+        let s_ef = std::mem::size_of::<EF>();
+        let w = GKR_WINDOW_SIZE;
+        let precompute_f =
+            (self.logical_len >> (1 + w)).max(1 << GKR_WINDOW_DEFAULT_MIN_N) * s_frac;
+        // Conservative estimate for M_precompute_EF: m_total + m_partial bound + eq_prefix/suffix.
+        // In practice the max_window term is ceil(2^(rem_n - w) / tail_tile) * 2^(2w) EF elems;
+        // use 2 * 2^(2w) as a safe floor (tail_tile >= 1, rem_n bounded by total_rounds).
+        let precompute_ef = (2 * (1 << (2 * w)) + (1 << (w + 1))) * s_ef;
+
+        fold_eval.max(precompute_f + precompute_ef)
+    }
 }
 
 /// Describes which buffer operation to use for the next fused compute+fold round.

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -91,7 +91,7 @@ impl FractionalInputSize {
         // Conservative estimate for M_precompute_EF: m_total + m_partial bound + eq_prefix/suffix.
         // In practice the max_window term is ceil(2^(rem_n - w) / tail_tile) * 2^(2w) EF elems;
         // use 2 * 2^(2w) as a safe floor (tail_tile >= 1, rem_n bounded by total_rounds).
-        let precompute_ef = (2 * (1 << (2 * w)) + (1 << (w + 1))) * s_ef;
+        let precompute_ef = (1 << (2 * w + 1) + (1 << (w + 1))) * s_ef;
 
         fold_eval.max(precompute_f + precompute_ef)
     }

--- a/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
@@ -213,7 +213,11 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
             let main_ptr = d_main_ptrs.as_ptr();
             main_ptrs_keepalive.push(d_main_ptrs);
 
-            let d_public_values = air_ctx.public_values.to_device_on(device_ctx)?;
+            let d_public_values = if air_ctx.public_values.is_empty() {
+                DeviceBuffer::<F>::new()
+            } else {
+                air_ctx.public_values.to_device_on(device_ctx)?
+            };
             let public_ptr = d_public_values.as_ptr();
             public_keepalive.push(d_public_values);
 

--- a/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
@@ -14,7 +14,7 @@ use super::errors::InteractionGpuError;
 use crate::{
     cuda::logup_zerocheck::{
         frac_matrix_vertically_repeat, frac_vector_scalar_multiply_ext_fp,
-        gkr_input_batch_intermediates_buffer_size, logup_batch_gkr_input_eval, GkrInputCtx,
+        gkr_input_intermediates_buffer_size, logup_gkr_input_eval, GkrInputCtx,
     },
     gpu_backend::GenericGpuBackend,
     hash_scheme::GpuHashScheme,
@@ -119,10 +119,9 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
 
     // Pre-compute per-AIR batch planning info
     struct AirPlan {
-        air_idx: usize,
         height: usize,
         num_interactions: usize,
-        buffer_size: u32,
+        intermediate_elements: usize,
         intermediate_bytes: usize,
         lifted_height: usize,
         dst_offset: usize,
@@ -130,14 +129,14 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
     }
 
     let mut plans: Vec<AirPlan> = Vec::with_capacity(metas.len());
-    for (i, meta) in metas.iter().enumerate() {
+    for meta in &metas {
         let air_ctx = &proving_ctx.per_trace[meta.trace_idx].1;
         let pk_air = &pk.per_air[meta.air_idx];
         let height = air_ctx.height();
         let num_interactions = pk_air.vk.symbolic_constraints.interactions.len();
         let buffer_size = pk_air.other_data.interaction_rules.inner.buffer_size;
 
-        let intermediate_elements = gkr_input_batch_intermediates_buffer_size(buffer_size);
+        let intermediate_elements = gkr_input_intermediates_buffer_size(buffer_size);
         let intermediate_bytes = intermediate_elements * std::mem::size_of::<EF>();
 
         let slice = meta.layout_slices.first().unwrap();
@@ -149,10 +148,9 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
         debug_assert_eq!(slice.len(l_skip), lifted_height);
 
         plans.push(AirPlan {
-            air_idx: i,
             height,
             num_interactions,
-            buffer_size,
+            intermediate_elements,
             intermediate_bytes,
             lifted_height,
             dst_offset,
@@ -186,7 +184,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
 
         for i in 0..count {
             let plan = &plans[plan_start + i];
-            let meta = metas[plan.air_idx];
+            let meta = metas[plan_start + i];
             let air_ctx = &proving_ctx.per_trace[meta.trace_idx].1;
             let pk_air = &pk.per_air[meta.air_idx];
 
@@ -220,10 +218,9 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
             let public_ptr = d_public_values.as_ptr();
             public_keepalive.push(d_public_values);
 
-            let intermediates = if plan.buffer_size > 0 {
-                let intermediate_elements =
-                    gkr_input_batch_intermediates_buffer_size(plan.buffer_size);
-                let buf = DeviceBuffer::<EF>::with_capacity_on(intermediate_elements, device_ctx);
+            let intermediates = if plan.intermediate_elements > 0 {
+                let buf =
+                    DeviceBuffer::<EF>::with_capacity_on(plan.intermediate_elements, device_ctx);
                 let ptr = buf.as_mut_ptr();
                 intermediates_keepalive.push(buf);
                 ptr
@@ -262,7 +259,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
 
         let d_ctxs = ctxs_host.to_device_on(device_ctx)?;
         unsafe {
-            logup_batch_gkr_input_eval(&d_ctxs, count as u32, stream)?;
+            logup_gkr_input_eval(&d_ctxs, count as u32, stream)?;
         }
 
         // Handle lifting (normalization + vertical repeat) for AIRs that need it

--- a/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
@@ -137,8 +137,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
         let num_interactions = pk_air.vk.symbolic_constraints.interactions.len();
         let buffer_size = pk_air.other_data.interaction_rules.inner.buffer_size;
 
-        let intermediate_elements =
-            unsafe { gkr_input_batch_intermediates_buffer_size(buffer_size, stream) };
+        let intermediate_elements = gkr_input_batch_intermediates_buffer_size(buffer_size);
         let intermediate_bytes = intermediate_elements * std::mem::size_of::<EF>();
 
         let slice = meta.layout_slices.first().unwrap();
@@ -223,7 +222,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
 
             let intermediates = if plan.buffer_size > 0 {
                 let intermediate_elements =
-                    unsafe { gkr_input_batch_intermediates_buffer_size(plan.buffer_size, stream) };
+                    gkr_input_batch_intermediates_buffer_size(plan.buffer_size);
                 let buf = DeviceBuffer::<EF>::with_capacity_on(intermediate_elements, device_ctx);
                 let ptr = buf.as_mut_ptr();
                 intermediates_keepalive.push(buf);

--- a/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
@@ -13,14 +13,18 @@ use tracing::instrument;
 use super::errors::InteractionGpuError;
 use crate::{
     cuda::logup_zerocheck::{
-        frac_matrix_vertically_repeat, frac_vector_scalar_multiply_ext_fp,
-        gkr_input_intermediates_buffer_size, logup_gkr_input_eval, GkrInputCtx,
+        frac_matrix_vertically_repeat, frac_vector_scalar_multiply_ext_fp, logup_gkr_input_eval,
+        BlockCtx, GkrInputCtx,
     },
     gpu_backend::GenericGpuBackend,
     hash_scheme::GpuHashScheme,
     prelude::{EF, F},
 };
 
+/// Threads per launched block.
+const THREADS_PER_BLOCK: u32 = 256;
+/// Per-AIR thread-count cap. Bounds the per-AIR intermediates buffer for tall AIRs;
+/// rows beyond this are picked up by the kernel's `num_rows_per_tile` inner loop.
 const TASK_SIZE: u32 = 65536;
 
 #[allow(dead_code)]
@@ -121,6 +125,12 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
     struct AirPlan {
         height: usize,
         num_interactions: usize,
+        /// Per-AIR thread count = `num_blocks_x * THREADS_PER_BLOCK`. Capped at `TASK_SIZE` for
+        /// tall AIRs (the kernel's `num_rows_per_tile` loop covers rows beyond `task_stride`).
+        /// Doubles as the column stride of the per-AIR intermediates buffer.
+        task_stride: usize,
+        num_blocks_x: usize,
+        num_rows_per_tile: usize,
         intermediate_elements: usize,
         intermediate_bytes: usize,
         lifted_height: usize,
@@ -134,9 +144,20 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
         let pk_air = &pk.per_air[meta.air_idx];
         let height = air_ctx.height();
         let num_interactions = pk_air.vk.symbolic_constraints.interactions.len();
-        let buffer_size = pk_air.other_data.interaction_rules.inner.buffer_size;
+        let buffer_size = pk_air.other_data.interaction_rules.inner.buffer_size as usize;
 
-        let intermediate_elements = gkr_input_intermediates_buffer_size(buffer_size);
+        // Size each AIR's launch to its own height: enough threads to cover the height
+        // (rounded up to a block), capped at TASK_SIZE so the per-AIR intermediates buffer stays
+        // bounded. AIRs taller than the cap pick up the rest via `num_rows_per_tile`. The lower
+        // clamp at THREADS_PER_BLOCK keeps both `num_blocks_x` and `intermediate_elements` from
+        // degenerating to zero for height==0 AIRs (the kernel's row-bound check makes their
+        // threads no-op anyway, but the launch still needs at least one block).
+        let raw_threads = height.div_ceil(THREADS_PER_BLOCK as usize) * THREADS_PER_BLOCK as usize;
+        let task_stride = raw_threads.clamp(THREADS_PER_BLOCK as usize, TASK_SIZE as usize);
+        let num_blocks_x = task_stride / THREADS_PER_BLOCK as usize;
+        let num_rows_per_tile = height.div_ceil(task_stride).max(1);
+
+        let intermediate_elements = task_stride * buffer_size;
         let intermediate_bytes = intermediate_elements * std::mem::size_of::<EF>();
 
         let slice = meta.layout_slices.first().unwrap();
@@ -150,6 +171,9 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
         plans.push(AirPlan {
             height,
             num_interactions,
+            task_stride,
+            num_blocks_x,
+            num_rows_per_tile,
             intermediate_elements,
             intermediate_bytes,
             lifted_height,
@@ -186,8 +210,15 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
             .then(|| DeviceBuffer::<Frac<EF>>::with_capacity_on(total_lift_elements, device_ctx));
         let mut tmp_offset: usize = 0;
 
-        // Build GkrInputCtx for each AIR in this batch
+        // Build GkrInputCtx for each AIR in this batch, plus a flat BlockCtx list that maps each
+        // launched block to its AIR + sub-block index (mirrors the dispatch pattern in
+        // `batch_mle.cu`).
+        let total_blocks: usize = plans[plan_start..batch_end]
+            .iter()
+            .map(|p| p.num_blocks_x)
+            .sum();
         let mut ctxs_host: Vec<GkrInputCtx> = Vec::with_capacity(count);
+        let mut block_ctxs_host: Vec<BlockCtx> = Vec::with_capacity(total_blocks);
         let mut intermediates_keepalive: Vec<DeviceBuffer<EF>> = Vec::with_capacity(count);
         let mut main_ptrs_keepalive: Vec<DeviceBuffer<u64>> = Vec::with_capacity(count);
         let mut public_keepalive: Vec<DeviceBuffer<F>> = Vec::with_capacity(count);
@@ -246,8 +277,16 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
                 unsafe { leaves.as_mut_ptr().add(plan.dst_offset) }
             };
 
-            let num_rows_per_tile = plan.height.div_ceil(TASK_SIZE as usize).max(1);
             let rules = &pk_air.other_data.interaction_rules;
+
+            // Push order is the contract: the kernel does `block_ctxs[blockIdx.x]` directly, so
+            // blocks must appear grouped by air_idx in the same order as ctxs_host.
+            for b in 0..plan.num_blocks_x {
+                block_ctxs_host.push(BlockCtx {
+                    local_block_idx_x: b as u32,
+                    air_idx: i as u32,
+                });
+            }
 
             ctxs_host.push(GkrInputCtx {
                 d_fracs: trace_output_ptr,
@@ -261,13 +300,24 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
                 d_pair_idxs: rules.d_pair_idxs.as_ptr(),
                 used_nodes_len: rules.inner.d_used_nodes.len(),
                 height: plan.height as u32,
-                num_rows_per_tile: num_rows_per_tile as u32,
+                task_stride: plan.task_stride as u32,
+                num_rows_per_tile: plan.num_rows_per_tile as u32,
             });
         }
 
         let d_ctxs = ctxs_host.to_device_on(device_ctx)?;
+        let d_block_ctxs = block_ctxs_host.to_device_on(device_ctx)?;
+        let total_blocks_u32: u32 = total_blocks
+            .try_into()
+            .expect("total_blocks fits in u32 (sum of per-AIR num_blocks_x)");
         unsafe {
-            logup_gkr_input_eval(&d_ctxs, count as u32, stream)?;
+            logup_gkr_input_eval(
+                &d_block_ctxs,
+                &d_ctxs,
+                total_blocks_u32,
+                THREADS_PER_BLOCK,
+                stream,
+            )?;
         }
 
         // Handle lifting (normalization + vertical repeat) for AIRs that need it

--- a/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
@@ -5,7 +5,7 @@ use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer, stream::GpuDe
 use openvm_stark_backend::prover::{
     fractional_sumcheck_gkr::Frac,
     stacked_pcs::{StackedLayout, StackedSlice},
-    DeviceMultiStarkProvingKey, MatrixDimensions, ProvingContext,
+    DeviceMultiStarkProvingKey, ProvingContext,
 };
 use p3_field::{Field, PrimeCharacteristicRing};
 use tracing::instrument;
@@ -13,7 +13,8 @@ use tracing::instrument;
 use super::errors::InteractionGpuError;
 use crate::{
     cuda::logup_zerocheck::{
-        frac_matrix_vertically_repeat, frac_vector_scalar_multiply_ext_fp, logup_gkr_input_eval,
+        frac_matrix_vertically_repeat, frac_vector_scalar_multiply_ext_fp,
+        gkr_input_batch_intermediates_buffer_size, logup_batch_gkr_input_eval, GkrInputCtx,
     },
     gpu_backend::GenericGpuBackend,
     hash_scheme::GpuHashScheme,
@@ -86,6 +87,10 @@ pub fn collect_trace_interactions<HS: GpuHashScheme>(
 /// Evaluate interactions from trace evaluation matrices to get (p, q) fractional sumcheck input.
 /// Returns real leaves buffer (WITHOUT alpha applied) and alpha value to be applied in first tree
 /// layer. Virtual padding is not materialized.
+///
+/// Uses partial batching: groups AIRs into batches that fit within a memory budget to increase
+/// GPU parallelism without increasing peak memory usage. The batch kernel always uses global
+/// intermediates, so the memory budget controls peak usage.
 #[instrument(name = "prover.rap_constraints.logup_gkr.input_evals", skip_all)]
 #[allow(clippy::too_many_arguments)]
 pub fn log_gkr_input_evals<HS: GpuHashScheme>(
@@ -96,6 +101,7 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
     alpha_logup: EF,
     d_challenges: &DeviceBuffer<EF>,
     real_len: usize,
+    memory_budget_bytes: usize,
     device_ctx: &GpuDeviceCtx,
 ) -> Result<(DeviceBuffer<Frac<EF>>, EF), InteractionGpuError> {
     if trace_interactions.iter().all(|meta| meta.is_none()) {
@@ -107,60 +113,33 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
     let null_preprocessed = DeviceBuffer::<F>::new();
 
     let stream = device_ctx.stream.as_raw();
-    let mut d_partition_ptrs = DeviceBuffer::<u64>::new();
-    let mut tmp = DeviceBuffer::<Frac<EF>>::new();
-    for meta in trace_interactions.iter().flatten() {
+
+    // Collect all AIRs with interactions
+    let metas: Vec<&TraceInteractionMeta> = trace_interactions.iter().flatten().collect();
+
+    // Pre-compute per-AIR batch planning info
+    struct AirPlan {
+        air_idx: usize,
+        height: usize,
+        num_interactions: usize,
+        buffer_size: u32,
+        intermediate_bytes: usize,
+        lifted_height: usize,
+        dst_offset: usize,
+        needs_lifting: bool,
+    }
+
+    let mut plans: Vec<AirPlan> = Vec::with_capacity(metas.len());
+    for (i, meta) in metas.iter().enumerate() {
         let air_ctx = &proving_ctx.per_trace[meta.trace_idx].1;
         let pk_air = &pk.per_air[meta.air_idx];
-
-        let preprocessed_matrix = pk_air
-            .preprocessed_data
-            .as_ref()
-            .map(|committed| &committed.trace);
-
-        let mut partitioned_main = Vec::with_capacity(air_ctx.cached_mains.len() + 1);
-        for committed in &air_ctx.cached_mains {
-            partitioned_main.push(&committed.trace);
-        }
-        partitioned_main.push(&air_ctx.common_main);
-
-        let rules = &pk_air.other_data.interaction_rules;
-        let num_interactions = pk_air.vk.symbolic_constraints.interactions.len();
-
-        let d_preprocessed = preprocessed_matrix
-            .as_ref()
-            .map(|m| m.buffer())
-            .unwrap_or(&null_preprocessed);
-        let d_public_values = if air_ctx.public_values.is_empty() {
-            DeviceBuffer::<F>::new()
-        } else {
-            air_ctx.public_values.to_device_on(device_ctx)?
-        };
-
         let height = air_ctx.height();
-        debug_assert_eq!(height, partitioned_main[0].height());
-        let partition_ptrs = partitioned_main
-            .iter()
-            .map(|m| m.buffer().as_ptr() as u64)
-            .collect_vec();
-        if partition_ptrs.len() > d_partition_ptrs.len() {
-            d_partition_ptrs = DeviceBuffer::with_capacity_on(partition_ptrs.len(), device_ctx);
-        }
-        partition_ptrs.copy_to_on(&mut d_partition_ptrs, device_ctx)?;
+        let num_interactions = pk_air.vk.symbolic_constraints.interactions.len();
+        let buffer_size = pk_air.other_data.interaction_rules.inner.buffer_size;
 
-        let buffer_size = rules.inner.buffer_size;
-        // TODO[jpw]: remove magic 10
-        let is_global = buffer_size > 10;
-        let intermediates = if is_global {
-            DeviceBuffer::<EF>::with_capacity_on(
-                (TASK_SIZE as usize) * buffer_size as usize,
-                device_ctx,
-            )
-        } else {
-            DeviceBuffer::<EF>::with_capacity_on(1, device_ctx)
-        };
-
-        let num_rows_per_tile = height.div_ceil(TASK_SIZE as usize).max(1);
+        let intermediate_elements =
+            unsafe { gkr_input_batch_intermediates_buffer_size(buffer_size, stream) };
+        let intermediate_bytes = intermediate_elements * std::mem::size_of::<EF>();
 
         let slice = meta.layout_slices.first().unwrap();
         if slice.col_idx != 0 {
@@ -169,60 +148,152 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
         let dst_offset = slice.row_idx;
         let lifted_height = max(height, 1 << l_skip);
         debug_assert_eq!(slice.len(l_skip), lifted_height);
-        // SAFETY: by definition of interactions stacked layout, `leaves` has enough capacity
-        let leaves_ptr = unsafe { leaves.as_mut_ptr().add(dst_offset) };
 
-        let trace_output = if height != lifted_height {
-            let required = height * num_interactions;
-            if required > tmp.len() {
-                tmp = DeviceBuffer::with_capacity_on(required, device_ctx);
+        plans.push(AirPlan {
+            air_idx: i,
+            height,
+            num_interactions,
+            buffer_size,
+            intermediate_bytes,
+            lifted_height,
+            dst_offset,
+            needs_lifting: height != lifted_height,
+        });
+    }
+
+    let mut plan_start: usize = 0;
+    while plan_start < plans.len() {
+        // Greedy batching: add AIRs while cumulative intermediates fit within budget
+        let mut batch_end = plan_start + 1;
+        let mut batch_intermediate_bytes = plans[plan_start].intermediate_bytes;
+        while batch_end < plans.len() {
+            let next_bytes = batch_intermediate_bytes + plans[batch_end].intermediate_bytes;
+            if next_bytes > memory_budget_bytes {
+                break;
             }
-            tmp.as_mut_ptr()
-        } else {
-            leaves_ptr
-        };
+            batch_intermediate_bytes = next_bytes;
+            batch_end += 1;
+        }
+
+        let count = batch_end - plan_start;
+
+        // Build GkrInputCtx for each AIR in this batch
+        let mut ctxs_host: Vec<GkrInputCtx> = Vec::with_capacity(count);
+        let mut intermediates_keepalive: Vec<DeviceBuffer<EF>> = Vec::with_capacity(count);
+        let mut main_ptrs_keepalive: Vec<DeviceBuffer<u64>> = Vec::with_capacity(count);
+        let mut public_keepalive: Vec<DeviceBuffer<F>> = Vec::with_capacity(count);
+        // Per-AIR tmp buffers for lifting AIRs (must be separate to avoid overwriting)
+        let mut tmp_per_air: Vec<DeviceBuffer<Frac<EF>>> = Vec::new();
+
+        for i in 0..count {
+            let plan = &plans[plan_start + i];
+            let meta = metas[plan.air_idx];
+            let air_ctx = &proving_ctx.per_trace[meta.trace_idx].1;
+            let pk_air = &pk.per_air[meta.air_idx];
+
+            let preprocessed_matrix = pk_air
+                .preprocessed_data
+                .as_ref()
+                .map(|committed| &committed.trace);
+            let d_preprocessed = preprocessed_matrix
+                .as_ref()
+                .map(|m| m.buffer())
+                .unwrap_or(&null_preprocessed);
+
+            let mut partitioned_main = Vec::with_capacity(air_ctx.cached_mains.len() + 1);
+            for committed in &air_ctx.cached_mains {
+                partitioned_main.push(&committed.trace);
+            }
+            partitioned_main.push(&air_ctx.common_main);
+            let main_ptrs: Vec<u64> = partitioned_main
+                .iter()
+                .map(|m| m.buffer().as_ptr() as u64)
+                .collect_vec();
+            let d_main_ptrs = main_ptrs.to_device_on(device_ctx)?;
+            let main_ptr = d_main_ptrs.as_ptr();
+            main_ptrs_keepalive.push(d_main_ptrs);
+
+            let d_public_values = air_ctx.public_values.to_device_on(device_ctx)?;
+            let public_ptr = d_public_values.as_ptr();
+            public_keepalive.push(d_public_values);
+
+            let intermediates = if plan.buffer_size > 0 {
+                let intermediate_elements =
+                    unsafe { gkr_input_batch_intermediates_buffer_size(plan.buffer_size, stream) };
+                let buf = DeviceBuffer::<EF>::with_capacity_on(intermediate_elements, device_ctx);
+                let ptr = buf.as_mut_ptr();
+                intermediates_keepalive.push(buf);
+                ptr
+            } else {
+                std::ptr::null_mut()
+            };
+
+            let trace_output_ptr = if plan.needs_lifting {
+                let required = plan.height * plan.num_interactions;
+                let buf = DeviceBuffer::<Frac<EF>>::with_capacity_on(required, device_ctx);
+                let ptr = buf.as_mut_ptr();
+                tmp_per_air.push(buf);
+                ptr
+            } else {
+                unsafe { leaves.as_mut_ptr().add(plan.dst_offset) }
+            };
+
+            let num_rows_per_tile = plan.height.div_ceil(TASK_SIZE as usize).max(1);
+            let rules = &pk_air.other_data.interaction_rules;
+
+            ctxs_host.push(GkrInputCtx {
+                d_fracs: trace_output_ptr,
+                d_preprocessed: d_preprocessed.as_ptr(),
+                d_main: main_ptr,
+                d_public_values: public_ptr,
+                d_challenges: d_challenges.as_ptr(),
+                d_intermediates: intermediates,
+                d_rules: rules.inner.d_rules.as_raw_ptr(),
+                d_used_nodes: rules.inner.d_used_nodes.as_ptr(),
+                d_pair_idxs: rules.d_pair_idxs.as_ptr(),
+                used_nodes_len: rules.inner.d_used_nodes.len(),
+                height: plan.height as u32,
+                num_rows_per_tile: num_rows_per_tile as u32,
+            });
+        }
+
+        let d_ctxs = ctxs_host.to_device_on(device_ctx)?;
         unsafe {
-            logup_gkr_input_eval(
-                is_global,
-                trace_output,
-                d_preprocessed,
-                &d_partition_ptrs,
-                &d_public_values,
-                d_challenges,
-                &intermediates,
-                &rules.inner.d_rules,
-                &rules.inner.d_used_nodes,
-                &rules.d_pair_idxs,
-                height as u32,
-                num_rows_per_tile as u32,
-                stream,
-            )?;
+            logup_batch_gkr_input_eval(&d_ctxs, count as u32, stream)?;
         }
-        if height != lifted_height {
-            debug_assert_eq!(lifted_height % height, 0);
-            debug_assert!(!tmp.is_empty());
-            let norm_factor_denom = lifted_height / height;
-            let norm_factor = F::from_usize(norm_factor_denom).inverse();
-            unsafe {
-                // SAFETY: scaling within buffer length
-                frac_vector_scalar_multiply_ext_fp(
-                    tmp.as_mut_ptr(),
-                    norm_factor,
-                    tmp.len() as u32,
-                    stream,
-                )?;
-                // SAFETY: stacked interaction layout is defined with respect to lifted height, and
-                // the vertical-repeat kernel guards rounded-up tail threads beyond lifted_height.
-                frac_matrix_vertically_repeat(
-                    leaves_ptr,
-                    tmp.as_ptr(),
-                    num_interactions as u32,
-                    lifted_height as u32,
-                    height as u32,
-                    stream,
-                )?;
+
+        // Handle lifting (normalization + vertical repeat) for AIRs that need it
+        let mut tmp_idx: usize = 0;
+        for i in 0..count {
+            let plan = &plans[plan_start + i];
+            if plan.needs_lifting {
+                let tmp_buf = &tmp_per_air[tmp_idx];
+                tmp_idx += 1;
+                debug_assert_eq!(tmp_buf.len(), plan.height * plan.num_interactions);
+                debug_assert_eq!(plan.lifted_height % plan.height, 0);
+                let norm_factor_denom = plan.lifted_height / plan.height;
+                let norm_factor = F::from_usize(norm_factor_denom).inverse();
+                let leaves_ptr = unsafe { leaves.as_mut_ptr().add(plan.dst_offset) };
+                unsafe {
+                    frac_vector_scalar_multiply_ext_fp(
+                        tmp_buf.as_mut_ptr(),
+                        norm_factor,
+                        tmp_buf.len() as u32,
+                        stream,
+                    )?;
+                    frac_matrix_vertically_repeat(
+                        leaves_ptr,
+                        tmp_buf.as_ptr(),
+                        plan.num_interactions as u32,
+                        plan.lifted_height as u32,
+                        plan.height as u32,
+                        stream,
+                    )?;
+                }
             }
         }
+
+        plan_start = batch_end;
     }
 
     // NOTE: alpha is NO LONGER applied here - it will be fused into the first tree layer

--- a/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
@@ -14,10 +14,11 @@ use super::errors::InteractionGpuError;
 use crate::{
     cuda::logup_zerocheck::{
         frac_matrix_vertically_repeat, frac_vector_scalar_multiply_ext_fp, logup_gkr_input_eval,
-        BlockCtx, GkrInputCtx,
+        GkrInputCtx,
     },
     gpu_backend::GenericGpuBackend,
     hash_scheme::GpuHashScheme,
+    logup_zerocheck::block_ctxs::build_block_ctxs,
     prelude::{EF, F},
 };
 
@@ -210,15 +211,16 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
             .then(|| DeviceBuffer::<Frac<EF>>::with_capacity_on(total_lift_elements, device_ctx));
         let mut tmp_offset: usize = 0;
 
-        // Build GkrInputCtx for each AIR in this batch, plus a flat BlockCtx list that maps each
-        // launched block to its AIR + sub-block index (mirrors the dispatch pattern in
-        // `batch_mle.cu`).
-        let total_blocks: usize = plans[plan_start..batch_end]
-            .iter()
-            .map(|p| p.num_blocks_x)
-            .sum();
+        // Flat BlockCtx list — one entry per launched block, grouped by AIR. Mirrors the
+        // dispatch pattern in `batch_mle.cu`.
+        let (block_ctxs_host, _air_offsets) = build_block_ctxs(
+            plans[plan_start..batch_end]
+                .iter()
+                .map(|p| p.num_blocks_x as u32),
+        );
+        let total_blocks = block_ctxs_host.len();
+
         let mut ctxs_host: Vec<GkrInputCtx> = Vec::with_capacity(count);
-        let mut block_ctxs_host: Vec<BlockCtx> = Vec::with_capacity(total_blocks);
         let mut intermediates_keepalive: Vec<DeviceBuffer<EF>> = Vec::with_capacity(count);
         let mut main_ptrs_keepalive: Vec<DeviceBuffer<u64>> = Vec::with_capacity(count);
         let mut public_keepalive: Vec<DeviceBuffer<F>> = Vec::with_capacity(count);
@@ -278,15 +280,6 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
             };
 
             let rules = &pk_air.other_data.interaction_rules;
-
-            // Push order is the contract: the kernel does `block_ctxs[blockIdx.x]` directly, so
-            // blocks must appear grouped by air_idx in the same order as ctxs_host.
-            for b in 0..plan.num_blocks_x {
-                block_ctxs_host.push(BlockCtx {
-                    local_block_idx_x: b as u32,
-                    air_idx: i as u32,
-                });
-            }
 
             ctxs_host.push(GkrInputCtx {
                 d_fracs: trace_output_ptr,

--- a/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/gkr_input.rs
@@ -174,13 +174,23 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
 
         let count = batch_end - plan_start;
 
+        // Single tmp allocation per batch, partitioned across lifting AIRs by offset.
+        // (One alloc beats N separate `with_capacity_on` calls; lifting AIRs in the same batch
+        // can't share one buffer because the kernel writes them concurrently.)
+        let total_lift_elements: usize = plans[plan_start..batch_end]
+            .iter()
+            .filter(|p| p.needs_lifting)
+            .map(|p| p.height * p.num_interactions)
+            .sum();
+        let tmp_buf = (total_lift_elements > 0)
+            .then(|| DeviceBuffer::<Frac<EF>>::with_capacity_on(total_lift_elements, device_ctx));
+        let mut tmp_offset: usize = 0;
+
         // Build GkrInputCtx for each AIR in this batch
         let mut ctxs_host: Vec<GkrInputCtx> = Vec::with_capacity(count);
         let mut intermediates_keepalive: Vec<DeviceBuffer<EF>> = Vec::with_capacity(count);
         let mut main_ptrs_keepalive: Vec<DeviceBuffer<u64>> = Vec::with_capacity(count);
         let mut public_keepalive: Vec<DeviceBuffer<F>> = Vec::with_capacity(count);
-        // Per-AIR tmp buffers for lifting AIRs (must be separate to avoid overwriting)
-        let mut tmp_per_air: Vec<DeviceBuffer<Frac<EF>>> = Vec::new();
 
         for i in 0..count {
             let plan = &plans[plan_start + i];
@@ -229,10 +239,8 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
             };
 
             let trace_output_ptr = if plan.needs_lifting {
-                let required = plan.height * plan.num_interactions;
-                let buf = DeviceBuffer::<Frac<EF>>::with_capacity_on(required, device_ctx);
-                let ptr = buf.as_mut_ptr();
-                tmp_per_air.push(buf);
+                let ptr = unsafe { tmp_buf.as_ref().unwrap().as_mut_ptr().add(tmp_offset) };
+                tmp_offset += plan.height * plan.num_interactions;
                 ptr
             } else {
                 unsafe { leaves.as_mut_ptr().add(plan.dst_offset) }
@@ -263,27 +271,22 @@ pub fn log_gkr_input_evals<HS: GpuHashScheme>(
         }
 
         // Handle lifting (normalization + vertical repeat) for AIRs that need it
-        let mut tmp_idx: usize = 0;
+        let mut lift_offset: usize = 0;
         for i in 0..count {
             let plan = &plans[plan_start + i];
             if plan.needs_lifting {
-                let tmp_buf = &tmp_per_air[tmp_idx];
-                tmp_idx += 1;
-                debug_assert_eq!(tmp_buf.len(), plan.height * plan.num_interactions);
+                let len = plan.height * plan.num_interactions;
                 debug_assert_eq!(plan.lifted_height % plan.height, 0);
                 let norm_factor_denom = plan.lifted_height / plan.height;
                 let norm_factor = F::from_usize(norm_factor_denom).inverse();
                 let leaves_ptr = unsafe { leaves.as_mut_ptr().add(plan.dst_offset) };
+                let slice_ptr = unsafe { tmp_buf.as_ref().unwrap().as_mut_ptr().add(lift_offset) };
+                lift_offset += len;
                 unsafe {
-                    frac_vector_scalar_multiply_ext_fp(
-                        tmp_buf.as_mut_ptr(),
-                        norm_factor,
-                        tmp_buf.len() as u32,
-                        stream,
-                    )?;
+                    frac_vector_scalar_multiply_ext_fp(slice_ptr, norm_factor, len as u32, stream)?;
                     frac_matrix_vertically_repeat(
                         leaves_ptr,
-                        tmp_buf.as_ptr(),
+                        slice_ptr,
                         plan.num_interactions as u32,
                         plan.lifted_height as u32,
                         plan.height as u32,

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -180,7 +180,9 @@ where
         .mem
         .emit_metrics_with_label("prover.before_gkr_input_evals");
     prover.mem.reset_peak();
+    let sizes = FractionalInputSize::new(real_len, logical_len);
     let (inputs, alpha) = if has_interactions {
+        let memory_budget_bytes = sizes.peak_work_buffer_bytes();
         log_gkr_input_evals(
             &prover.trace_interactions,
             mpk,
@@ -189,6 +191,7 @@ where
             alpha_logup,
             &prover.d_challenges,
             real_len,
+            memory_budget_bytes,
             device_ctx,
         )?
     } else {
@@ -212,7 +215,7 @@ where
     let (frac_sum_proof, mut xi) = fractional_sumcheck_gpu(
         transcript,
         inputs,
-        FractionalInputSize::new(real_len, logical_len),
+        sizes,
         alpha,
         true,
         &mut prover.mem,

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -66,6 +66,7 @@ use crate::{
 
 pub(crate) mod batch_mle;
 pub(crate) mod batch_mle_monomial;
+mod block_ctxs;
 mod errors;
 pub(crate) mod fold_ple;
 /// Fraction sumcheck via GKR


### PR DESCRIPTION
## Summary
- Launch a single CUDA kernel per batch instead of one kernel per AIR for GKR input eval, increasing GPU parallelism
- Use partial batching controlled by a memory budget derived from the fractional-sumcheck GKR work-buffer peak, so batched intermediates never push total peak memory beyond what the non-batched code already uses
- Add `FractionalInputSize::peak_work_buffer_bytes()` co-located with the sumcheck work-buffer sizing so future changes to fractional sumcheck GKR stay in sync

## Changes
- `cuda/src/logup_zerocheck/gkr_input.cu` — batch kernel `evaluate_interactions_gkr_batch_kernel` reusing the existing DAG evaluation helper
- `src/cuda/logup_zerocheck.rs` — `GkrInputCtx` FFI struct and wrapper functions
- `src/logup_zerocheck/gkr_input.rs` — rewritten `log_gkr_input_evals` with two-phase greedy batching and per-AIR buffer keepalive
- `src/logup_zerocheck/fractional.rs` — `peak_work_buffer_bytes()` on `FractionalInputSize`
- `src/logup_zerocheck/mod.rs` — compute and pass the budget to `log_gkr_input_evals`