### PR TITLE
feat: hook params with 128 bits security

### DIFF
--- a/crates/stark-backend/tests/soundness.rs
+++ b/crates/stark-backend/tests/soundness.rs
@@ -4,7 +4,8 @@
 
 use openvm_stark_backend::{soundness::*, SystemParams};
 use openvm_stark_sdk::config::{
-    app_params_with_128_bits_security, internal_params_with_128_bits_security as internal_params,
+    app_params_with_128_bits_security, hook_params_with_128_bits_security as hook_params,
+    internal_params_with_128_bits_security as internal_params,
     leaf_params_with_128_bits_security as leaf_params,
     root_params_with_128_bits_security as root_params, MAX_APP_LOG_STACKED_HEIGHT,
 };
@@ -230,7 +231,7 @@ fn test_internal_aggregation_security() {
 #[test]
 fn test_root_aggregation_security() {
     let params = root_params();
-    let max_log_height = 21;
+    let max_log_height = 20;
     let n_logup = n_logup_bound(
         params.l_skip,
         RECURSION_NUM_AIRS,
@@ -255,6 +256,33 @@ fn test_root_aggregation_security() {
 }
 
 #[test]
+fn test_hook_aggregation_security() {
+    let params = hook_params();
+    let max_log_height = 20;
+    let n_logup = n_logup_bound(
+        params.l_skip,
+        RECURSION_NUM_AIRS,
+        RECURSION_MAX_INTERACTIONS_PER_AIR,
+        max_log_height,
+        params.logup.max_interaction_count as usize,
+    );
+    let soundness = check_soundness(
+        "Deferral Hook Aggregation",
+        &params,
+        RECURSION_MAX_CONSTRAINTS,
+        RECURSION_NUM_AIRS,
+        max_log_height,
+        RECURSION_NUM_COLUMNS,
+        n_logup,
+    );
+    assert!(
+        soundness.total_bits >= TARGET_SECURITY_BITS as f64,
+        "Deferral Hook: got {:.1} bits",
+        soundness.total_bits
+    );
+}
+
+#[test]
 fn test_all_production_configs() {
     println!("\n========== ALL PRODUCTION CONFIGS ==========");
 
@@ -262,6 +290,7 @@ fn test_all_production_configs() {
     let leaf = leaf_params();
     let internal = internal_params();
     let root = root_params();
+    let hook = hook_params();
 
     // (name, params, max_constraints, num_airs, max_log_height, num_columns,
     // max_interactions_per_air)
@@ -296,6 +325,15 @@ fn test_all_production_configs() {
         (
             "Root",
             &root,
+            RECURSION_MAX_CONSTRAINTS,
+            RECURSION_NUM_AIRS,
+            20,
+            RECURSION_NUM_COLUMNS,
+            RECURSION_MAX_INTERACTIONS_PER_AIR,
+        ),
+        (
+            "Deferral Hook",
+            &hook,
             RECURSION_MAX_CONSTRAINTS,
             RECURSION_NUM_AIRS,
             20,

--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -28,6 +28,7 @@ pub const DEFAULT_APP_LOG_BLOWUP: usize = 1;
 pub const DEFAULT_LEAF_LOG_BLOWUP: usize = 2;
 pub const DEFAULT_INTERNAL_LOG_BLOWUP: usize = 3;
 pub const DEFAULT_ROOT_LOG_BLOWUP: usize = 4;
+pub const DEFAULT_HOOK_LOG_BLOWUP: usize = 2;
 
 pub const MAX_APP_LOG_STACKED_HEIGHT: usize = 24;
 
@@ -130,7 +131,7 @@ pub fn internal_params_with_128_bits_security() -> SystemParams {
 /// - **Num AIRs**: ≤ 50
 /// - **Max interactions per AIR**: ≤ 100
 /// - **Num trace columns** (unstacked, total across all AIRs): ≤ 2,000
-/// - **`w_stack`** = 19, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
+/// - **`w_stack`** = 24, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
 ///
 /// Config: `l_skip=2, n_stack=18, log_blowup=4`.
 //
@@ -141,10 +142,39 @@ pub fn root_params_with_128_bits_security() -> SystemParams {
         DEFAULT_ROOT_LOG_BLOWUP,
         2,  // l_skip
         18, // n_stack
-        19, // w_stack
+        24, // w_stack
         WHIR_MAX_LOG_FINAL_POLY_LEN,
         12, // folding pow
-        10, // mu pow
+        11, // mu pow
+        WhirProximityStrategy::ListDecoding { m: 1 },
+        SECURITY_BITS_TARGET,
+        log_up_security_params_baby_bear_128_bits(),
+    )
+}
+
+/// Returns `SystemParams` targeting 128 bits of proven RBR security for deferral hook circuits.
+///
+/// # Assumptions for 128-bit security
+/// - **Max trace height**: ≤ 2^20
+/// - **Max constraints per AIR**: ≤ 1,000
+/// - **Num AIRs**: ≤ 50
+/// - **Max interactions per AIR**: ≤ 100
+/// - **Num trace columns** (unstacked, total across all AIRs): ≤ 2,000
+/// - **`w_stack`** = 80, bounding total stacked cells to `w_stack × 2^(n_stack + l_skip)`
+///
+/// Config: `l_skip=2, n_stack=18, log_blowup=2`.
+//
+// See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
+// full soundness analysis.
+pub fn hook_params_with_128_bits_security() -> SystemParams {
+    SystemParams::new(
+        DEFAULT_HOOK_LOG_BLOWUP,
+        2,  // l_skip
+        18, // n_stack
+        80, // w_stack
+        WHIR_MAX_LOG_FINAL_POLY_LEN,
+        12, // folding pow
+        8,  // mu pow
         WhirProximityStrategy::ListDecoding { m: 1 },
         SECURITY_BITS_TARGET,
         log_up_security_params_baby_bear_128_bits(),


### PR DESCRIPTION
Introduces default deferral hook system params and increases root params `w_stack` to 24.