### PR TITLE
perf(cuda): reduce prover copy and batching overhead

### DIFF
--- a/crates/cuda-backend/src/cuda/stacked_reduction.rs
+++ b/crates/cuda-backend/src/cuda/stacked_reduction.rs
@@ -6,8 +6,8 @@ use openvm_cuda_common::{
 
 use crate::{
     poly::EqEvalSegments,
-    prelude::{D_EF, EF, F},
-    stacked_reduction::{UnstackedSlice, STACKED_REDUCTION_S_DEG},
+    prelude::{EF, F},
+    stacked_reduction::UnstackedSlice,
 };
 
 /// Number of G outputs per z in round 0: G0, G1, G2
@@ -225,22 +225,20 @@ pub unsafe fn stacked_reduction_sumcheck_mle_round(
     k_rot_ns: &EqEvalSegments<EF>,
     unstacked_cols: *const UnstackedSlice,
     lambda_pows: *const EF,
-    output: &mut DeviceBuffer<u64>,
+    output: *mut u64,
     q_height: usize,
     window_len: usize,
     num_y: usize,
     sm_count: u32,
     stream: cudaStream_t,
 ) -> Result<(), CudaError> {
-    debug_assert!(output.len() >= STACKED_REDUCTION_S_DEG * D_EF);
-
     check(_stacked_reduction_sumcheck_mle_round(
         q_evals.as_ptr(),
         eq_r_ns.buffer.as_ptr(),
         k_rot_ns.buffer.as_ptr(),
         unstacked_cols,
         lambda_pows,
-        output.as_mut_ptr(),
+        output,
         q_height as u32,
         window_len as u32,
         num_y as u32,
@@ -259,28 +257,26 @@ pub unsafe fn stacked_reduction_sumcheck_mle_round(
 #[allow(clippy::too_many_arguments)]
 pub unsafe fn stacked_reduction_sumcheck_mle_round_degenerate(
     q_evals: &DeviceBuffer<*const EF>,
-    eq_ub_ptr: &DeviceBuffer<EF>,
+    eq_ub_ptr: *const EF,
     eq_r: EF,
     k_rot_r: EF,
     unstacked_cols: *const UnstackedSlice,
     lambda_pows: *const EF,
-    output: &mut DeviceBuffer<u64>,
+    output: *mut u64,
     q_height: usize,
     window_len: usize,
     l_skip: usize,
     round: usize,
     stream: cudaStream_t,
 ) -> Result<(), CudaError> {
-    debug_assert!(output.len() >= STACKED_REDUCTION_S_DEG * D_EF);
-
     check(_stacked_reduction_sumcheck_mle_round_degenerate(
         q_evals.as_ptr(),
-        eq_ub_ptr.as_ptr(),
+        eq_ub_ptr,
         eq_r,
         k_rot_r,
         unstacked_cols,
         lambda_pows,
-        output.as_mut_ptr(),
+        output,
         q_height as u32,
         window_len as u32,
         l_skip as u32,

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -93,10 +93,16 @@ use round0::evaluate_round0_constraints_gpu;
 /// This ratio can be tuned. Currently it is set to prefer the monomial kernel except for the
 /// Poseidon2Air where the DAG node size is much smaller than number of monomials.
 const DAG_FALLBACK_MONOMIAL_RATIO: usize = 2;
-// Batch MLE launch overhead dominates when the budget follows only the GKR input size.
-// Keep at least the historical non-save-memory batch budget while still allowing larger inputs.
-const BATCH_MLE_MEMORY_LIMIT_FLOOR: usize = 5 << 30; // 5GiB
-const BATCH_MLE_FOLD_MEMORY_LIMIT_FLOOR: usize = 6 << 30; // 6GiB
+// Batch MLE launch overhead dominates in the non-save-memory path, so keep the historical
+// fixed batch budget there.
+const BATCH_MLE_DEFAULT_MEMORY_LIMIT: usize = 6 << 30; // 6GiB
+
+#[inline]
+fn fractional_gkr_peak_memory_bytes(input_len: usize, peak_work_buffer_bytes: usize) -> usize {
+    input_len
+        .saturating_mul(std::mem::size_of::<Frac<EF>>())
+        .saturating_add(peak_work_buffer_bytes)
+}
 
 #[inline]
 pub(crate) fn air_width_for_mat(need_rot: bool, mat_width: usize) -> u32 {
@@ -186,8 +192,12 @@ where
         .emit_metrics_with_label("prover.before_gkr_input_evals");
     prover.mem.reset_peak();
     let sizes = FractionalInputSize::new(real_len, logical_len);
+    let peak_work_buffer_bytes = if has_interactions {
+        sizes.peak_work_buffer_bytes()
+    } else {
+        0
+    };
     let (inputs, alpha) = if has_interactions {
-        let memory_budget_bytes = sizes.peak_work_buffer_bytes();
         log_gkr_input_evals(
             &prover.trace_interactions,
             mpk,
@@ -196,25 +206,21 @@ where
             alpha_logup,
             &prover.d_challenges,
             real_len,
-            memory_budget_bytes,
+            peak_work_buffer_bytes,
             device_ctx,
         )?
     } else {
         (DeviceBuffer::new(), EF::ZERO)
     };
-    // Set memory limit for batch MLE based on inputs buffer size
-    prover.gkr_mem_contribution = inputs.len() * std::mem::size_of::<Frac<EF>>();
+    // Set memory limit for batch MLE based on the fractional-GKR peak: input buffer plus
+    // peak work buffers.
+    prover.gkr_mem_contribution =
+        fractional_gkr_peak_memory_bytes(inputs.len(), peak_work_buffer_bytes);
     prover.memory_limit_bytes = prover.gkr_mem_contribution;
     if !prover.save_memory {
-        if prover.memory_limit_bytes > BATCH_MLE_MEMORY_LIMIT_FLOOR {
-            tracing::warn!(
-                "prover.memory_limit_bytes {} already exceeds 5GiB",
-                prover.memory_limit_bytes
-            );
-        }
-        prover.memory_limit_bytes = BATCH_MLE_MEMORY_LIMIT_FLOOR;
-    } else {
-        prover.memory_limit_bytes = prover.memory_limit_bytes.max(BATCH_MLE_MEMORY_LIMIT_FLOOR);
+        prover.memory_limit_bytes = prover
+            .memory_limit_bytes
+            .max(BATCH_MLE_DEFAULT_MEMORY_LIMIT);
     }
     prover.mem.emit_metrics_with_label("prover.gkr_input_evals");
 
@@ -486,6 +492,7 @@ pub struct LogupZerocheckGpu<'a, HS: GpuHashScheme> {
     mem: MemTracker,
     save_memory: bool,
 
+    /// Fractional-GKR peak budget: input buffer plus peak work buffers.
     gkr_mem_contribution: usize,
     /// Memory limit for batch MLE intermediate buffers (set after GKR input eval)
     memory_limit_bytes: usize,
@@ -999,7 +1006,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
             })
             .collect::<Result<Vec<_>, FoldPleError>>()?;
         if self.save_memory {
-            self.memory_limit_bytes = mem_limit.max(BATCH_MLE_FOLD_MEMORY_LIMIT_FLOOR);
+            self.memory_limit_bytes = mem_limit;
         }
 
         // GPU folding for sels_per_trace (rotate=false, only need offset=0)
@@ -1555,16 +1562,13 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 .collect()
         };
         if self.save_memory {
-            self.memory_limit_bytes = self
-                .gkr_mem_contribution
-                .saturating_sub(
-                    self.mat_evals_per_trace
-                        .iter()
-                        .flatten()
-                        .map(|m| m.buffer().len() * size_of::<EF>())
-                        .sum(),
-                )
-                .max(BATCH_MLE_FOLD_MEMORY_LIMIT_FLOOR);
+            self.memory_limit_bytes = self.gkr_mem_contribution.saturating_sub(
+                self.mat_evals_per_trace
+                    .iter()
+                    .flatten()
+                    .map(|m| m.buffer().len() * size_of::<EF>())
+                    .sum(),
+            );
         }
 
         // Fold sels_per_trace: Vec<DeviceMatrix<EF>>

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -93,6 +93,10 @@ use round0::evaluate_round0_constraints_gpu;
 /// This ratio can be tuned. Currently it is set to prefer the monomial kernel except for the
 /// Poseidon2Air where the DAG node size is much smaller than number of monomials.
 const DAG_FALLBACK_MONOMIAL_RATIO: usize = 2;
+// Batch MLE launch overhead dominates when the budget follows only the GKR input size.
+// Keep at least the historical non-save-memory batch budget while still allowing larger inputs.
+const BATCH_MLE_MEMORY_LIMIT_FLOOR: usize = 5 << 30; // 5GiB
+const BATCH_MLE_FOLD_MEMORY_LIMIT_FLOOR: usize = 6 << 30; // 6GiB
 
 #[inline]
 pub(crate) fn air_width_for_mat(need_rot: bool, mat_width: usize) -> u32 {
@@ -202,14 +206,15 @@ where
     prover.gkr_mem_contribution = inputs.len() * std::mem::size_of::<Frac<EF>>();
     prover.memory_limit_bytes = prover.gkr_mem_contribution;
     if !prover.save_memory {
-        const DEFAULT_MEMORY_LIMIT: usize = 5 << 30; // 5GiB
-        if prover.memory_limit_bytes > DEFAULT_MEMORY_LIMIT {
+        if prover.memory_limit_bytes > BATCH_MLE_MEMORY_LIMIT_FLOOR {
             tracing::warn!(
                 "prover.memory_limit_bytes {} already exceeds 5GiB",
                 prover.memory_limit_bytes
             );
         }
-        prover.memory_limit_bytes = DEFAULT_MEMORY_LIMIT;
+        prover.memory_limit_bytes = BATCH_MLE_MEMORY_LIMIT_FLOOR;
+    } else {
+        prover.memory_limit_bytes = prover.memory_limit_bytes.max(BATCH_MLE_MEMORY_LIMIT_FLOOR);
     }
     prover.mem.emit_metrics_with_label("prover.gkr_input_evals");
 
@@ -720,12 +725,23 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
 
         // PERF[jpw]: we could also build the layers for different n in a transposed way using
         // eq_nonoverlapping_stage_ext, which is more memory efficient
+        let mut eq_xi_one_layer = None;
         for &n in &self.n_per_trace {
             let n_lift = n.max(0) as usize;
             if let Entry::Vacant(entry) = self.eq_xis.entry(n_lift) {
-                let layers = EqEvalLayers::new_rev(
+                let layer_0 = match &eq_xi_one_layer {
+                    Some(layer_0) => Arc::clone(layer_0),
+                    None => {
+                        let layer_0 = EqEvalLayers::one_layer(&self.device_ctx)
+                            .map_err(LogupZerocheckError::EqEvalLayers)?;
+                        eq_xi_one_layer = Some(Arc::clone(&layer_0));
+                        layer_0
+                    }
+                };
+                let layers = EqEvalLayers::new_rev_with_one(
                     n_lift,
                     xi[l_skip..l_skip + n_lift].iter().rev(),
+                    layer_0,
                     &self.device_ctx,
                 )
                 .map_err(LogupZerocheckError::EqEvalLayers)?;
@@ -983,7 +999,7 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
             })
             .collect::<Result<Vec<_>, FoldPleError>>()?;
         if self.save_memory {
-            self.memory_limit_bytes = mem_limit;
+            self.memory_limit_bytes = mem_limit.max(BATCH_MLE_FOLD_MEMORY_LIMIT_FLOOR);
         }
 
         // GPU folding for sels_per_trace (rotate=false, only need offset=0)
@@ -1539,13 +1555,16 @@ impl<'a, HS: GpuHashScheme> LogupZerocheckGpu<'a, HS> {
                 .collect()
         };
         if self.save_memory {
-            self.memory_limit_bytes = self.gkr_mem_contribution.saturating_sub(
-                self.mat_evals_per_trace
-                    .iter()
-                    .flatten()
-                    .map(|m| m.buffer().len() * size_of::<EF>())
-                    .sum(),
-            );
+            self.memory_limit_bytes = self
+                .gkr_mem_contribution
+                .saturating_sub(
+                    self.mat_evals_per_trace
+                        .iter()
+                        .flatten()
+                        .map(|m| m.buffer().len() * size_of::<EF>())
+                        .sum(),
+                )
+                .max(BATCH_MLE_FOLD_MEMORY_LIMIT_FLOOR);
         }
 
         // Fold sels_per_trace: Vec<DeviceMatrix<EF>>

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -93,9 +93,9 @@ use round0::evaluate_round0_constraints_gpu;
 /// This ratio can be tuned. Currently it is set to prefer the monomial kernel except for the
 /// Poseidon2Air where the DAG node size is much smaller than number of monomials.
 const DAG_FALLBACK_MONOMIAL_RATIO: usize = 2;
-// Batch MLE launch overhead dominates in the non-save-memory path, so keep the historical
-// fixed batch budget there.
-const BATCH_MLE_DEFAULT_MEMORY_LIMIT: usize = 6 << 30; // 6GiB
+// Batch MLE launch overhead dominates in the non-save-memory path, so keep at least this
+// much batching budget there.
+const BATCH_MLE_DEFAULT_MEMORY_FLOOR: usize = 6 << 30; // 6GiB
 
 #[inline]
 fn fractional_gkr_peak_memory_bytes(input_len: usize, peak_work_buffer_bytes: usize) -> usize {
@@ -220,7 +220,7 @@ where
     if !prover.save_memory {
         prover.memory_limit_bytes = prover
             .memory_limit_bytes
-            .max(BATCH_MLE_DEFAULT_MEMORY_LIMIT);
+            .max(BATCH_MLE_DEFAULT_MEMORY_FLOOR);
     }
     prover.mem.emit_metrics_with_label("prover.gkr_input_evals");
 

--- a/crates/cuda-backend/src/poly.rs
+++ b/crates/cuda-backend/src/poly.rs
@@ -316,7 +316,7 @@ pub unsafe fn evals_mobius_eq_hypercube(
 /// + 1)`. We define `eq_0 = 1` always.
 #[derive(Getters)]
 pub struct EqEvalSegments<F> {
-    /// Index 0 stores the length-1 equality layer, shared when callers can reuse it.
+    /// Index 0 is unused and initialized to zero. Index 1 stores the length-1 `eq_0 = 1` layer.
     #[getset(get = "pub")]
     pub(crate) buffer: DeviceBuffer<F>,
     #[getset(get_copy = "pub")]
@@ -379,29 +379,8 @@ impl EqEvalSegments<EF> {
 /// dropping layers.
 #[derive(Getters)]
 pub struct EqEvalLayers<F> {
-    /// Layer 0 stores the length-1 equality value and may be shared across trees.
-    pub layers: Vec<EqEvalLayer<F>>,
-}
-
-pub enum EqEvalLayer<F> {
-    Shared(Arc<DeviceBuffer<F>>),
-    Owned(DeviceBuffer<F>),
-}
-
-impl<F> EqEvalLayer<F> {
-    fn len(&self) -> usize {
-        match self {
-            Self::Shared(buffer) => buffer.len(),
-            Self::Owned(buffer) => buffer.len(),
-        }
-    }
-
-    fn as_ptr(&self) -> *const F {
-        match self {
-            Self::Shared(buffer) => buffer.as_ptr(),
-            Self::Owned(buffer) => buffer.as_ptr(),
-        }
-    }
+    /// Layers are reference counted so the length-1 seed layer can be shared across trees.
+    pub layers: Vec<Arc<DeviceBuffer<F>>>,
 }
 
 impl<F> EqEvalLayers<F> {
@@ -415,7 +394,9 @@ impl<F> EqEvalLayers<F> {
 
 // Currently only implement kernels for EF.
 impl EqEvalLayers<EF> {
-    pub fn one_layer(device_ctx: &GpuDeviceCtx) -> Result<Arc<DeviceBuffer<EF>>, KernelError> {
+    pub(crate) fn one_layer(
+        device_ctx: &GpuDeviceCtx,
+    ) -> Result<Arc<DeviceBuffer<EF>>, KernelError> {
         [EF::ONE]
             .to_device_on(device_ctx)
             .map(Arc::new)
@@ -433,14 +414,14 @@ impl EqEvalLayers<EF> {
         Self::new_rev_with_one(n, x, Self::one_layer(device_ctx)?, device_ctx)
     }
 
-    pub fn new_rev_with_one<'a>(
+    pub(crate) fn new_rev_with_one<'a>(
         n: usize,
         x: impl IntoIterator<Item = &'a EF>,
         layer_0: Arc<DeviceBuffer<EF>>,
         device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, KernelError> {
         let mut layers = Vec::with_capacity(n + 1);
-        layers.push(EqEvalLayer::Shared(layer_0));
+        layers.push(layer_0);
         for (i, &x_i) in x.into_iter().enumerate() {
             let step = 1 << i;
             let buffer = DeviceBuffer::with_capacity_on(2 * step, device_ctx);
@@ -458,7 +439,7 @@ impl EqEvalLayers<EF> {
                 )
                 .map_err(KernelError::Kernel)?;
             }
-            layers.push(EqEvalLayer::Owned(buffer));
+            layers.push(Arc::new(buffer));
         }
         Ok(Self { layers })
     }
@@ -475,14 +456,14 @@ impl EqEvalLayers<EF> {
         Self::new_with_one(n, x, Self::one_layer(device_ctx)?, device_ctx)
     }
 
-    pub fn new_with_one<'a>(
+    pub(crate) fn new_with_one<'a>(
         n: usize,
         x: impl IntoIterator<Item = &'a EF>,
         layer_0: Arc<DeviceBuffer<EF>>,
         device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, KernelError> {
         let mut layers = Vec::with_capacity(n + 1);
-        layers.push(EqEvalLayer::Shared(layer_0));
+        layers.push(layer_0);
         for (i, &x_i) in x.into_iter().enumerate() {
             let step = 1 << i;
             let buffer = DeviceBuffer::with_capacity_on(2 * step, device_ctx);
@@ -500,7 +481,7 @@ impl EqEvalLayers<EF> {
                 )
                 .map_err(KernelError::Kernel)?;
             }
-            layers.push(EqEvalLayer::Owned(buffer));
+            layers.push(Arc::new(buffer));
         }
         Ok(Self { layers })
     }

--- a/crates/cuda-backend/src/poly.rs
+++ b/crates/cuda-backend/src/poly.rs
@@ -316,7 +316,7 @@ pub unsafe fn evals_mobius_eq_hypercube(
 /// + 1)`. We define `eq_0 = 1` always.
 #[derive(Getters)]
 pub struct EqEvalSegments<F> {
-    /// Index 0 should never to read, but it will be initialized to zero.
+    /// Index 0 stores the length-1 equality layer, shared when callers can reuse it.
     #[getset(get = "pub")]
     pub(crate) buffer: DeviceBuffer<F>,
     #[getset(get_copy = "pub")]
@@ -379,8 +379,29 @@ impl EqEvalSegments<EF> {
 /// dropping layers.
 #[derive(Getters)]
 pub struct EqEvalLayers<F> {
-    /// Index 0 should never to read, but it will be initialized to zero.
-    pub layers: Vec<DeviceBuffer<F>>,
+    /// Layer 0 stores the length-1 equality value and may be shared across trees.
+    pub layers: Vec<EqEvalLayer<F>>,
+}
+
+pub enum EqEvalLayer<F> {
+    Shared(Arc<DeviceBuffer<F>>),
+    Owned(DeviceBuffer<F>),
+}
+
+impl<F> EqEvalLayer<F> {
+    fn len(&self) -> usize {
+        match self {
+            Self::Shared(buffer) => buffer.len(),
+            Self::Owned(buffer) => buffer.len(),
+        }
+    }
+
+    fn as_ptr(&self) -> *const F {
+        match self {
+            Self::Shared(buffer) => buffer.as_ptr(),
+            Self::Owned(buffer) => buffer.as_ptr(),
+        }
+    }
 }
 
 impl<F> EqEvalLayers<F> {
@@ -394,6 +415,13 @@ impl<F> EqEvalLayers<F> {
 
 // Currently only implement kernels for EF.
 impl EqEvalLayers<EF> {
+    pub fn one_layer(device_ctx: &GpuDeviceCtx) -> Result<Arc<DeviceBuffer<EF>>, KernelError> {
+        [EF::ONE]
+            .to_device_on(device_ctx)
+            .map(Arc::new)
+            .map_err(KernelError::MemCopy)
+    }
+
     /// Creates a new `EqEvalLayers` instance with `layers.len() = x.len() + 1`.
     ///
     /// Inserts `x_i` from the front for each layer.
@@ -402,11 +430,17 @@ impl EqEvalLayers<EF> {
         x: impl IntoIterator<Item = &'a EF>,
         device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, KernelError> {
+        Self::new_rev_with_one(n, x, Self::one_layer(device_ctx)?, device_ctx)
+    }
+
+    pub fn new_rev_with_one<'a>(
+        n: usize,
+        x: impl IntoIterator<Item = &'a EF>,
+        layer_0: Arc<DeviceBuffer<EF>>,
+        device_ctx: &GpuDeviceCtx,
+    ) -> Result<Self, KernelError> {
         let mut layers = Vec::with_capacity(n + 1);
-        let layer_0 = [EF::ONE]
-            .to_device_on(device_ctx)
-            .map_err(KernelError::MemCopy)?;
-        layers.push(layer_0);
+        layers.push(EqEvalLayer::Shared(layer_0));
         for (i, &x_i) in x.into_iter().enumerate() {
             let step = 1 << i;
             let buffer = DeviceBuffer::with_capacity_on(2 * step, device_ctx);
@@ -424,7 +458,7 @@ impl EqEvalLayers<EF> {
                 )
                 .map_err(KernelError::Kernel)?;
             }
-            layers.push(buffer);
+            layers.push(EqEvalLayer::Owned(buffer));
         }
         Ok(Self { layers })
     }
@@ -438,11 +472,17 @@ impl EqEvalLayers<EF> {
         x: impl IntoIterator<Item = &'a EF>,
         device_ctx: &GpuDeviceCtx,
     ) -> Result<Self, KernelError> {
+        Self::new_with_one(n, x, Self::one_layer(device_ctx)?, device_ctx)
+    }
+
+    pub fn new_with_one<'a>(
+        n: usize,
+        x: impl IntoIterator<Item = &'a EF>,
+        layer_0: Arc<DeviceBuffer<EF>>,
+        device_ctx: &GpuDeviceCtx,
+    ) -> Result<Self, KernelError> {
         let mut layers = Vec::with_capacity(n + 1);
-        let layer_0 = [EF::ONE]
-            .to_device_on(device_ctx)
-            .map_err(KernelError::MemCopy)?;
-        layers.push(layer_0);
+        layers.push(EqEvalLayer::Shared(layer_0));
         for (i, &x_i) in x.into_iter().enumerate() {
             let step = 1 << i;
             let buffer = DeviceBuffer::with_capacity_on(2 * step, device_ctx);
@@ -460,7 +500,7 @@ impl EqEvalLayers<EF> {
                 )
                 .map_err(KernelError::Kernel)?;
             }
-            layers.push(buffer);
+            layers.push(EqEvalLayer::Owned(buffer));
         }
         Ok(Self { layers })
     }
@@ -545,8 +585,15 @@ impl SqrtEqLayers {
         let low_n = n / 2;
         let high_n = n - low_n;
 
-        let low = EqEvalLayers::new(low_n, xi[high_n..].iter().rev(), device_ctx)?;
-        let high = EqEvalLayers::new(high_n, xi[..high_n].iter().rev(), device_ctx)?;
+        let layer_0 = EqEvalLayers::one_layer(device_ctx)?;
+        let low = EqEvalLayers::new_with_one(
+            low_n,
+            xi[high_n..].iter().rev(),
+            Arc::clone(&layer_0),
+            device_ctx,
+        )?;
+        let high =
+            EqEvalLayers::new_with_one(high_n, xi[..high_n].iter().rev(), layer_0, device_ctx)?;
 
         Ok(Self { low, high })
     }

--- a/crates/cuda-backend/src/stacked_pcs.rs
+++ b/crates/cuda-backend/src/stacked_pcs.rs
@@ -154,27 +154,45 @@ pub(crate) fn stack_traces_into_expanded(
     buffer
         .fill_zero_on(device_ctx)
         .map_err(StackTracesError::FillZero)?;
-    for (mat_idx, j, s) in &layout.sorted_cols {
+    let mut idx = 0;
+    while idx < layout.sorted_cols.len() {
+        let (mat_idx, j, s) = &layout.sorted_cols[idx];
         let start = s.col_idx * padded_height + s.row_idx;
         let trace = traces[*mat_idx];
         let s_len = s.len(l_skip);
         debug_assert_eq!(trace.height(), 1 << s.log_height());
         if s.log_height() >= l_skip {
             debug_assert_eq!(trace.height(), s_len);
-            // SAFETY: matrix buffers are allocated correctly with respect to dimensions
-            // - `trace.height() = s_len` since `log_height >= l_skip`
-            // - `q_buf` has enough capacity by definition of stacked `layout`
+            let mut copy_len = s_len;
+            let mut end = idx + 1;
+            while end < layout.sorted_cols.len() {
+                let (next_mat_idx, next_j, next_s) = &layout.sorted_cols[end];
+                if *next_mat_idx != *mat_idx || next_s.log_height() != s.log_height() {
+                    break;
+                }
+                let expected_j = *j + (end - idx);
+                let next_len = next_s.len(l_skip);
+                let next_start = next_s.col_idx * padded_height + next_s.row_idx;
+                if *next_j != expected_j || next_len != s_len || next_start != start + copy_len {
+                    break;
+                }
+                copy_len += next_len;
+                end += 1;
+            }
+
+            // SAFETY: matrix buffers are allocated correctly with respect to dimensions.
+            // The grouped columns are contiguous in both source and destination buffers.
             unsafe {
                 let src = trace.buffer().as_ptr().add(*j * s_len);
                 let dst = buffer.as_mut_ptr().add(start);
-                // D2D memcpy
                 cuda_memcpy_on::<true, true>(
                     dst as *mut c_void,
                     src as *const c_void,
-                    s_len * size_of::<F>(),
+                    copy_len * size_of::<F>(),
                     device_ctx,
                 )?;
             }
+            idx = end;
         } else {
             let stride = s.stride(l_skip);
             debug_assert_eq!(stride * trace.height(), s_len);
@@ -195,6 +213,7 @@ pub(crate) fn stack_traces_into_expanded(
                 )
                 .map_err(StackTracesError::BatchExpandPadWide)?;
             }
+            idx += 1;
         }
     }
     Ok(())

--- a/crates/cuda-backend/src/stacked_reduction.rs
+++ b/crates/cuda-backend/src/stacked_reduction.rs
@@ -1060,7 +1060,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         }
         self.device_ctx
             .stream
-            .synchronize()
+            .to_host_sync()
             .map_err(MemCopyError::from)?;
 
         let mut offset = 0;

--- a/crates/cuda-backend/src/stacked_reduction.rs
+++ b/crates/cuda-backend/src/stacked_reduction.rs
@@ -4,6 +4,7 @@ use itertools::{zip_eq, Itertools};
 use openvm_cuda_common::{
     copy::{cuda_memcpy_on, MemCopyD2H, MemCopyH2D},
     d_buffer::DeviceBuffer,
+    error::MemCopyError,
     memory_manager::MemTracker,
     stream::GpuDeviceCtx,
 };
@@ -1041,13 +1042,37 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
 
     #[instrument(level = "debug", skip_all)]
     fn get_stacked_openings(&self) -> Result<Vec<Vec<EF>>, StackedReductionError> {
-        self.q_evals
-            .iter()
-            .map(|q| {
-                q.to_host_on(&self.device_ctx)
-                    .map_err(StackedReductionError::MemCopy)
+        let lengths = self.q_evals.iter().map(DeviceBuffer::len).collect_vec();
+        let total_len = lengths.iter().sum();
+        let mut host = EF::zero_vec(total_len);
+
+        let mut offset = 0;
+        for (q, &len) in zip(&self.q_evals, &lengths) {
+            unsafe {
+                cuda_memcpy_on::<true, false>(
+                    host.as_mut_ptr().add(offset) as *mut c_void,
+                    q.as_ptr() as *const c_void,
+                    len * size_of::<EF>(),
+                    &self.device_ctx,
+                )?;
+            }
+            offset += len;
+        }
+        self.device_ctx
+            .stream
+            .synchronize()
+            .map_err(MemCopyError::from)?;
+
+        let mut offset = 0;
+        Ok(lengths
+            .into_iter()
+            .map(|len| {
+                let next = offset + len;
+                let values = host[offset..next].to_vec();
+                offset = next;
+                values
             })
-            .collect::<Result<Vec<_>, _>>()
+            .collect())
     }
 }
 

--- a/crates/cuda-backend/src/stacked_reduction.rs
+++ b/crates/cuda-backend/src/stacked_reduction.rs
@@ -395,11 +395,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         let d_lambda_pows = lambda_pows.to_device_on(&device_ctx)?;
 
         let d_unstacked_cols = unstacked_cols.to_device_on(&device_ctx)?;
-        let max_window_len = ht_diff_idxs
-            .windows(2)
-            .map(|window| window[1] - window[0])
-            .max()
-            .unwrap_or(0);
+        let num_windows = ht_diff_idxs.len().saturating_sub(1).max(1);
 
         // layout per commit is sorted, first height is largest
         let n_max = r.len() - 1;
@@ -432,12 +428,14 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
         } else {
             DeviceBuffer::with_capacity_on(stacked_per_commit.len(), &device_ctx)
         };
-        let d_accum =
-            DeviceBuffer::<u64>::with_capacity_on(STACKED_REDUCTION_S_DEG * D_EF, &device_ctx);
-        let d_eq_ub = if max_window_len > 0 {
-            DeviceBuffer::with_capacity_on(max_window_len, &device_ctx)
-        } else {
+        let d_accum = DeviceBuffer::<u64>::with_capacity_on(
+            num_windows * STACKED_REDUCTION_S_DEG * D_EF,
+            &device_ctx,
+        );
+        let d_eq_ub = if unstacked_cols.is_empty() {
             DeviceBuffer::new()
+        } else {
+            DeviceBuffer::with_capacity_on(unstacked_cols.len(), &device_ctx)
         };
 
         Ok(Self {
@@ -849,21 +847,34 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 self.k_rot_stable.push(tmp[0]);
             }
         }
-        let mut s_evals_batch = Vec::with_capacity(self.ht_diff_idxs.len() - 1);
-        for window in self.ht_diff_idxs.windows(2) {
+        let accum_stride = STACKED_REDUCTION_S_DEG * D_EF;
+        let num_windows = self.ht_diff_idxs.len() - 1;
+        debug_assert!(self.d_accum.len() >= num_windows * accum_stride);
+
+        self.d_accum
+            .fill_zero_on(&self.device_ctx)
+            .map_err(StackedReductionError::FillZero)?;
+
+        let has_degenerate_window = self.ht_diff_idxs.windows(2).any(|window| {
+            let log_height = self.unstacked_cols[window[0]].log_height as usize;
+            log_height < l_skip + round
+        });
+        if has_degenerate_window {
+            self.eq_ub_per_trace
+                .copy_to_on(&mut self.d_eq_ub, &self.device_ctx)?;
+        }
+
+        for (window_idx, window) in self.ht_diff_idxs.windows(2).enumerate() {
             let window_len = window[1] - window[0];
             // SAFETY: in bounds by construction of ht_diff_idxs
             let unstacked_cols_ptr = unsafe { self.d_unstacked_cols.as_ptr().add(window[0]) };
             // 2 per column for (eq, k_rot)
             // SAFETY: in bounds by construction of lambda_pows
             let lambda_pows_ptr = unsafe { self.d_lambda_pows.as_ptr().add(2 * window[0]) };
+            // SAFETY: `d_accum` has one accumulator slot per window.
+            let output_ptr = unsafe { self.d_accum.as_mut_ptr().add(window_idx * accum_stride) };
 
             let log_height = self.unstacked_cols[window[0]].log_height as usize;
-
-            // Zero-initialize accumulator for atomic adds
-            self.d_accum
-                .fill_zero_on(&self.device_ctx)
-                .map_err(StackedReductionError::FillZero)?;
 
             if log_height < l_skip + round {
                 // We are in the eq, k_rot stable regime
@@ -872,24 +883,19 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                 // interpolate
                 let eq_r = self.eq_stable[log_height];
                 let k_rot_r = self.k_rot_stable[log_height];
-                // PERF[jpw]: most of eq_ub can be incorporated into eq_stable, k_rot_stable, so
-                // this transfer can be minimized.
-                let eq_ub_slice = &self.eq_ub_per_trace[window[0]..window[1]];
-                if eq_ub_slice.len() > self.d_eq_ub.len() {
-                    self.d_eq_ub =
-                        DeviceBuffer::with_capacity_on(eq_ub_slice.len(), &self.device_ctx);
-                }
-                eq_ub_slice.copy_to_on(&mut self.d_eq_ub, &self.device_ctx)?;
+                // SAFETY: the full per-trace buffer was copied above, so this window slice stays
+                // valid while all queued kernels run asynchronously.
+                let eq_ub_ptr = unsafe { self.d_eq_ub.as_ptr().add(window[0]) };
                 let stacked_height = self.stacked_height(round);
                 unsafe {
                     stacked_reduction_sumcheck_mle_round_degenerate(
                         &self.d_q_eval_ptrs,
-                        &self.d_eq_ub,
+                        eq_ub_ptr,
                         eq_r,
                         k_rot_r,
                         unstacked_cols_ptr,
                         lambda_pows_ptr,
-                        &mut self.d_accum,
+                        output_ptr,
                         stacked_height,
                         window_len,
                         l_skip,
@@ -912,7 +918,7 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                         &self.k_rot_ns,
                         unstacked_cols_ptr,
                         lambda_pows_ptr,
-                        &mut self.d_accum,
+                        output_ptr,
                         stacked_height,
                         window_len,
                         num_y,
@@ -922,12 +928,14 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                     .map_err(StackedReductionError::SumcheckMleRound)?;
                 };
             }
-
-            // D2H copy and reduce modulo P
-            let h_accum = self.d_accum.to_host_on(&self.device_ctx)?;
-            let evals = reduce_raw_u64_to_ef(&h_accum);
-            s_evals_batch.push(evals);
         }
+
+        // D2H copy and reduce modulo P once after all window kernels have queued.
+        let h_accum = self.d_accum.to_host_on(&self.device_ctx)?;
+        let s_evals_batch = h_accum[..num_windows * accum_stride]
+            .chunks_exact(accum_stride)
+            .map(reduce_raw_u64_to_ef)
+            .collect_vec();
 
         Ok(from_fn(|i| {
             s_evals_batch.iter().map(|evals| evals[i]).sum::<EF>()

--- a/crates/cuda-common/src/copy.rs
+++ b/crates/cuda-common/src/copy.rs
@@ -117,7 +117,7 @@ impl<T> MemCopyD2H<T> for DeviceBuffer<T> {
                 device_ctx.stream.as_raw(),
             )
         })?;
-        device_ctx.stream.synchronize()?;
+        device_ctx.stream.to_host_sync()?;
         unsafe {
             host_vec.set_len(self.len());
         }

--- a/crates/cuda-common/src/copy.rs
+++ b/crates/cuda-common/src/copy.rs
@@ -117,7 +117,7 @@ impl<T> MemCopyD2H<T> for DeviceBuffer<T> {
                 device_ctx.stream.as_raw(),
             )
         })?;
-        device_ctx.stream.to_host_sync()?;
+        device_ctx.stream.synchronize()?;
         unsafe {
             host_vec.set_len(self.len());
         }


### PR DESCRIPTION
## Summary

This PR contains CUDA prover micro-optimizations on top of the latest `develop-v2` GKR input batching changes:

- Batch contiguous stacked trace blit copies to reduce the number of D2D memcpy launches.
- Batch stacked reduction sumcheck windows by using per-window accumulator slots and doing one D2H accumulator readback after queued kernels.
- Reduce D2H overhead for stacked openings by copying all `q_evals` into one host buffer before splitting by original lengths.
- Reuse the length-1 `EqEvalLayers` seed layer across equality trees to avoid repeated tiny device allocations/copies.
- Preserve larger batch-MLE memory budgets with 5GiB/6GiB floors so the new partial-batched GKR input path does not regress launch batching when `save_memory` changes the input-sized budget.
- Use direct stream synchronization for D2H copies.

The final optimization commit notes retained benchmark improvement on real reth same-21 `stark_prove_excluding_trace`: baseline 6241 ms, final reruns 5613 ms and 5576 ms (>10% improvement).

## Validation

Reviewed against local `develop-v2` at `c68e3923`.

- `cargo check -p openvm-cuda-backend`
- `cargo nextest run -p openvm-cuda-backend --test-threads=4` — 104 passed, 1 skipped
