### PR TITLE
feat: make synthetic_runner modular wrt. the hash

### DIFF
--- a/benchmarks/synthetic/Cargo.toml
+++ b/benchmarks/synthetic/Cargo.toml
@@ -6,7 +6,11 @@ edition.workspace = true
 
 [dependencies]
 openvm-stark-backend = { workspace = true, features = ["parallel", "metrics"] }
-openvm-stark-sdk = { workspace = true, features = ["parallel", "metrics", "cpu-backend"] }
+openvm-stark-sdk = { workspace = true, features = [
+  "parallel",
+  "metrics",
+  "cpu-backend",
+] }
 openvm-cuda-backend = { workspace = true, optional = true }
 
 p3-air.workspace = true
@@ -23,6 +27,7 @@ serde_json = { workspace = true }
 [features]
 default = []
 cuda = ["dep:openvm-cuda-backend"]
+baby-bear-bn254-poseidon2 = ["openvm-cuda-backend?/baby-bear-bn254-poseidon2"]
 
 # Profile-replay runner: heterogeneous AIRs from a captured profile JSONL.
 # GPU-only (imports openvm-cuda-backend unconditionally).

--- a/benchmarks/synthetic/src/bin/synthetic_runner.rs
+++ b/benchmarks/synthetic/src/bin/synthetic_runner.rs
@@ -30,13 +30,16 @@ use openvm_benchmark_synthetic::{
     segment_profile::{AirShapeRecord, SegmentProfile},
     synthetic_air::{SyntheticAir, SyntheticShape},
 };
-use openvm_cuda_backend::{prelude::SC, BabyBearPoseidon2GpuEngine, GpuBackend};
+#[cfg(feature = "baby-bear-bn254-poseidon2")]
+use openvm_cuda_backend::BabyBearBn254Poseidon2HashScheme;
+#[cfg(not(feature = "baby-bear-bn254-poseidon2"))]
+use openvm_cuda_backend::DefaultHashScheme;
+use openvm_cuda_backend::{GpuEngine, GpuHashScheme};
 use openvm_stark_backend::{
     prover::{AirProvingContext, ColMajorMatrix, DeviceDataTransporter, ProvingContext},
     AirRef, StarkEngine, SystemParams,
 };
 use openvm_stark_sdk::config::app_params_with_100_bits_security;
-use p3_baby_bear::BabyBear;
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 use serde::Serialize;
 
@@ -136,7 +139,10 @@ fn build_params(max_log_height: usize) -> SystemParams {
     app_params_with_100_bits_security(max_log_height)
 }
 
-fn main() -> eyre::Result<()> {
+fn run_on_hash_impl<HS: GpuHashScheme>() -> eyre::Result<()>
+where
+    GpuEngine<HS>: StarkEngine,
+{
     let Args {
         profile: profile_path,
         sample_frac,
@@ -173,7 +179,7 @@ fn main() -> eyre::Result<()> {
     // and VPMM are shared, so per-segment overhead is the host-side
     // keygen and the H2D/D2H transports — not GPU init.
     let params = build_params(max_log_height);
-    let mut engine = BabyBearPoseidon2GpuEngine::new(params);
+    let mut engine = GpuEngine::<HS>::new(params);
     // The captured runs disable this knob for AIRs without
     // interactions; safer default for our heterogeneous workload.
     engine
@@ -212,8 +218,10 @@ fn main() -> eyre::Result<()> {
         let kg_start = Instant::now();
         let (pk, _vk) = engine.keygen(&airs);
         let device = engine.device();
-        let d_pk =
-            <_ as DeviceDataTransporter<SC, GpuBackend>>::transport_pk_to_device(device, &pk);
+        let d_pk = <_ as DeviceDataTransporter<
+            <GpuEngine<HS> as StarkEngine>::SC,
+            <GpuEngine<HS> as StarkEngine>::PB,
+        >>::transport_pk_to_device(device, &pk);
         let keygen_ms = kg_start.elapsed().as_millis();
 
         // Build per-AIR proving contexts with all-zero traces, transport
@@ -221,11 +229,13 @@ fn main() -> eyre::Result<()> {
         let mut total_main_cells: u64 = 0;
         let mut per_trace = Vec::new();
         for (air_id, (s, synth)) in shapes.iter().zip(synths.iter()).enumerate() {
-            let row_trace = synth.generate_trace::<BabyBear>(s.log_height);
+            let row_trace = synth.generate_trace::<_>(s.log_height);
             total_main_cells += (1u64 << s.log_height as u32) * (synth.width() as u64);
-            let d_trace = <_ as DeviceDataTransporter<SC, GpuBackend>>::transport_matrix_to_device(
-                device,
-                &ColMajorMatrix::from_row_major(&row_trace),
+            let d_trace = <_ as DeviceDataTransporter<
+                <GpuEngine<HS> as StarkEngine>::SC,
+                <GpuEngine<HS> as StarkEngine>::PB,
+            >>::transport_matrix_to_device(
+                device, &ColMajorMatrix::from_row_major(&row_trace)
             );
             per_trace.push((air_id, AirProvingContext::simple_no_pis(d_trace)));
         }
@@ -293,5 +303,14 @@ fn main() -> eyre::Result<()> {
     } else {
         println!("\n{}", json);
     }
+    Ok(())
+}
+
+fn main() -> eyre::Result<()> {
+    #[cfg(feature = "baby-bear-bn254-poseidon2")]
+    run_on_hash_impl::<BabyBearBn254Poseidon2HashScheme>()?;
+    #[cfg(not(feature = "baby-bear-bn254-poseidon2"))]
+    run_on_hash_impl::<DefaultHashScheme>()?;
+
     Ok(())
 }

--- a/crates/cpu-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cpu-backend/src/logup_zerocheck/mod.rs
@@ -1047,7 +1047,8 @@ where
                     let row_in_period = i % height;
                     vals[i * 3] = SC::F::from_bool(row_in_period == 0); // is_first
                     vals[i * 3 + 1] = SC::F::from_bool(row_in_period != height - 1); // is_transition
-                    vals[i * 3 + 2] = SC::F::from_bool(row_in_period == height - 1); // is_last
+                    vals[i * 3 + 2] = SC::F::from_bool(row_in_period == height - 1);
+                    // is_last
                 }
                 RowMajorMatrix::new(vals, 3)
             })


### PR DESCRIPTION
Setup:
```
 > cargo build --release -p openvm-benchmark-synthetic --bin synthetic_runner --features="cuda"
> ./target/release/synthetic_runner \
--profile benchmarks/synthetic/reth-block-23992138-profile.jsonl \
--sample-frac 0.1 --seed 42 --max-log-height 22 \
--out nsys-run.json
```

```
> cargo build --release -p openvm-benchmark-synthetic --bin synthetic_runner --features="cuda,baby-bear-bn254-poseidon2"

> ./target/release/synthetic_runner \
--profile benchmarks/synthetic/reth-block-23992138-profile.jsonl \
--sample-frac 0.1 --seed 42 --max-log-height 22 \
--out nsys-run.json
```

As expected the one with baby-bear-bn254 is much slower.


Default:
<img width="1813" height="1243" alt="image" src="https://github.com/user-attachments/assets/7b109813-059b-42df-ba87-7812d67623de" />

Bn254:
<img width="1779" height="1239" alt="image" src="https://github.com/user-attachments/assets/2f14d764-823f-454a-bece-935aa901e1a6" />

Some perf investigation of bn254_grind_kernel is necessary.

Closes INT-7743