### PR TITLE
fix: align MultiField32PaddingFreeSponge RATE with new p3 semantics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,31 +57,31 @@ openvm-cuda-common = { path = "crates/cuda-common", default-features = false }
 openvm-cuda-backend = { path = "crates/cuda-backend", default-features = false }
 
 # Plonky3 - we pin the exact version since this dependency is security critical
-p3-air = { version = "=0.4.1", default-features = false }
-p3-field = { version = "=0.4.1", default-features = false }
-p3-commit = { version = "=0.4.1", default-features = false }
-p3-matrix = { version = "=0.4.1", default-features = false }
-p3-baby-bear = { version = "=0.4.1", default-features = false }
-p3-koala-bear = { version = "=0.4.1", default-features = false }
-p3-util = { version = "=0.4.1", default-features = false }
-p3-challenger = { version = "=0.4.1", default-features = false }
-p3-dft = { version = "=0.4.1", default-features = false }
-p3-fri = { version = "=0.4.1", default-features = false }
-p3-goldilocks = { version = "=0.4.1", default-features = false }
-p3-keccak = { version = "=0.4.1", default-features = false }
-p3-keccak-air = { version = "=0.4.1", default-features = false }
-p3-blake3 = { version = "=0.4.1", default-features = false }
-p3-mds = { version = "=0.4.1", default-features = false }
-p3-merkle-tree = { version = "=0.4.1", default-features = false }
-p3-monty-31 = { version = "=0.4.1", default-features = false }
-p3-poseidon = { version = "=0.4.1", default-features = false }
-p3-poseidon2 = { version = "=0.4.1", default-features = false }
-p3-symmetric = { version = "=0.4.1", default-features = false }
-p3-uni-stark = { version = "=0.4.1", default-features = false }
-p3-maybe-rayon = { version = "=0.4.1", default-features = false } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
+p3-air = { version = "=0.4.3", default-features = false }
+p3-field = { version = "=0.4.3", default-features = false }
+p3-commit = { version = "=0.4.3", default-features = false }
+p3-matrix = { version = "=0.4.3", default-features = false }
+p3-baby-bear = { version = "=0.4.3", default-features = false }
+p3-koala-bear = { version = "=0.4.3", default-features = false }
+p3-util = { version = "=0.4.3", default-features = false }
+p3-challenger = { version = "=0.4.3", default-features = false }
+p3-dft = { version = "=0.4.3", default-features = false }
+p3-fri = { version = "=0.4.3", default-features = false }
+p3-goldilocks = { version = "=0.4.3", default-features = false }
+p3-keccak = { version = "=0.4.3", default-features = false }
+p3-keccak-air = { version = "=0.4.3", default-features = false }
+p3-blake3 = { version = "=0.4.3", default-features = false }
+p3-mds = { version = "=0.4.3", default-features = false }
+p3-merkle-tree = { version = "=0.4.3", default-features = false }
+p3-monty-31 = { version = "=0.4.3", default-features = false }
+p3-poseidon = { version = "=0.4.3", default-features = false }
+p3-poseidon2 = { version = "=0.4.3", default-features = false }
+p3-symmetric = { version = "=0.4.3", default-features = false }
+p3-uni-stark = { version = "=0.4.3", default-features = false }
+p3-maybe-rayon = { version = "=0.4.3", default-features = false } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
 
 # Bn254 support
-p3-bn254 = { version = "=0.4.1", default-features = false }
+p3-bn254 = { version = "=0.4.3", default-features = false }
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2.git", rev = "bb476b9" }
 ff = { version = "0.13.0", default-features = false }
 

--- a/crates/stark-sdk/src/config/baby_bear_poseidon2_root.rs
+++ b/crates/stark-sdk/src/config/baby_bear_poseidon2_root.rs
@@ -35,8 +35,7 @@ use crate::{
 };
 
 const WIDTH: usize = 3;
-/// Poseidon rate in F. <Poseidon RATE>(2) * <# of F in a N>(8) = 16
-const RATE: usize = 16;
+const RATE: usize = 2;
 const DIGEST_WIDTH: usize = 1;
 
 /// A configuration for  recursion.


### PR DESCRIPTION
In p3 0.4.3 the MultiField32PaddingFreeSponge RATE switched to mean the true rate of the sponge (in PF elements) from the maximum number of F-elements per absorb block.

Old RATE = 16 (F-elements) corresponds to new RATE = 2 (PF slots) for this BabyBear-into-Bn254 config.