### PR TITLE
fix: canonize and sanitize Proof encoding/decoding

### DIFF
--- a/crates/stark-backend/src/codec.rs
+++ b/crates/stark-backend/src/codec.rs
@@ -8,6 +8,16 @@ use p3_field::{BasedVectorSpace, PrimeField32};
 
 use crate::StarkProtocolConfig;
 
+/// Upper bound on the capacity eagerly reserved while decoding untrusted
+/// length-prefixed collections.
+pub(crate) const DECODE_PREALLOC_CAP: usize = 1024;
+
+/// Allocates a `Vec` for decoding, capped to avoid attacker-controlled
+/// preallocation from length prefixes.
+pub(crate) fn vec_with_capped_capacity<T>(len: usize) -> Vec<T> {
+    Vec::with_capacity(len.min(DECODE_PREALLOC_CAP))
+}
+
 /// Hardware and language independent encoding.
 /// Uses the Writer pattern for more efficient encoding without intermediate buffers.
 // @dev Trait just for implementation sanity
@@ -119,7 +129,7 @@ pub trait DecodableConfig: StarkProtocolConfig {
 
     /// Decode `n` base field elements (known length, no length prefix).
     fn decode_base_field_n<R: Read>(reader: &mut R, n: usize) -> Result<Vec<Self::F>> {
-        let mut vec = Vec::with_capacity(n);
+        let mut vec = vec_with_capped_capacity(n);
         for _ in 0..n {
             vec.push(Self::decode_base_field(reader)?);
         }
@@ -128,7 +138,7 @@ pub trait DecodableConfig: StarkProtocolConfig {
 
     /// Decode `n` extension field elements (known length, no length prefix).
     fn decode_extension_field_n<R: Read>(reader: &mut R, n: usize) -> Result<Vec<Self::EF>> {
-        let mut vec = Vec::with_capacity(n);
+        let mut vec = vec_with_capped_capacity(n);
         for _ in 0..n {
             vec.push(Self::decode_extension_field(reader)?);
         }
@@ -137,7 +147,7 @@ pub trait DecodableConfig: StarkProtocolConfig {
 
     /// Decode `n` digests (known length, no length prefix).
     fn decode_digest_n<R: Read>(reader: &mut R, n: usize) -> Result<Vec<Self::Digest>> {
-        let mut vec = Vec::with_capacity(n);
+        let mut vec = vec_with_capped_capacity(n);
         for _ in 0..n {
             vec.push(Self::decode_digest(reader)?);
         }
@@ -343,7 +353,7 @@ impl Decode for String {
 
 /// Decodes into a vector given preset length
 pub fn decode_into_vec<T: Decode, R: Read>(reader: &mut R, len: usize) -> Result<Vec<T>> {
-    let mut vec = Vec::with_capacity(len);
+    let mut vec = vec_with_capped_capacity(len);
     for _ in 0..len {
         vec.push(T::decode(reader)?);
     }
@@ -363,7 +373,7 @@ impl<T: Decode + Default, const N: usize> Decode for [T; N] {
 impl<T: Decode> Decode for Vec<T> {
     fn decode<R: Read>(reader: &mut R) -> Result<Self> {
         let len = usize::decode(reader)?;
-        let mut vec = Vec::with_capacity(len);
+        let mut vec = vec_with_capped_capacity(len);
         for _ in 0..len {
             vec.push(T::decode(reader)?);
         }

--- a/crates/stark-backend/src/codec.rs
+++ b/crates/stark-backend/src/codec.rs
@@ -30,7 +30,11 @@ pub trait Decode: Sized {
     fn decode<R: Read>(reader: &mut R) -> Result<Self>;
     fn decode_from_bytes(bytes: &[u8]) -> Result<Self> {
         let mut reader = Cursor::new(bytes);
-        Self::decode(&mut reader)
+        let value = Self::decode(&mut reader)?;
+        if reader.position() != bytes.len() as u64 {
+            return Err(io::Error::other("trailing bytes after decoded value"));
+        }
+        Ok(value)
     }
 }
 

--- a/crates/stark-backend/src/proof.rs
+++ b/crates/stark-backend/src/proof.rs
@@ -635,10 +635,10 @@ impl<SC: DecodableConfig> Decode for WhirProof<SC> {
 
         let decoded_widths = widths.len();
         let mut initial_round_opened_rows = vec_with_capped_capacity(num_commits);
-        for width in widths
-            .into_iter()
-            .chain(std::iter::repeat_n(0, num_commits.saturating_sub(decoded_widths)))
-        {
+        for width in widths.into_iter().chain(std::iter::repeat_n(
+            0,
+            num_commits.saturating_sub(decoded_widths),
+        )) {
             let mut opened_rows = vec_with_capped_capacity(initial_num_whir_queries);
             for _ in 0..initial_num_whir_queries {
                 // Each query has k_whir_exp rows. Each row is a fixed-width list of F elements.

--- a/crates/stark-backend/src/proof.rs
+++ b/crates/stark-backend/src/proof.rs
@@ -5,7 +5,7 @@ use p3_field::PrimeCharacteristicRing;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    codec::{DecodableConfig, Decode, EncodableConfig, Encode},
+    codec::{vec_with_capped_capacity, DecodableConfig, Decode, EncodableConfig, Encode},
     StarkProtocolConfig,
 };
 
@@ -455,11 +455,11 @@ impl<SC: DecodableConfig> Decode for Proof<SC> {
 
         let num_airs = usize::decode(reader)?;
         let bitmap_len = num_airs.div_ceil(8);
-        let mut bitmap: Vec<u8> = Vec::with_capacity(bitmap_len);
+        let mut bitmap: Vec<u8> = vec_with_capped_capacity(bitmap_len);
         for _ in 0..bitmap_len {
             bitmap.push(u8::decode(reader)?);
         }
-        let mut trace_vdata = Vec::with_capacity(num_airs);
+        let mut trace_vdata = vec_with_capped_capacity(num_airs);
         for byte in bitmap {
             for i in 0u8..8 {
                 if trace_vdata.len() >= num_airs {
@@ -479,7 +479,7 @@ impl<SC: DecodableConfig> Decode for Proof<SC> {
 
         // public_values: Vec<Vec<SC::F>>
         let num_pvs = usize::decode(reader)?;
-        let mut public_values = Vec::with_capacity(num_pvs);
+        let mut public_values = vec_with_capped_capacity(num_pvs);
         for _ in 0..num_pvs {
             public_values.push(SC::decode_base_field_vec(reader)?);
         }
@@ -503,10 +503,10 @@ impl<SC: DecodableConfig> Decode for GkrProof<SC> {
         let claims_per_layer = Vec::<GkrLayerClaims<SC>>::decode(reader)?;
 
         let num_sumcheck_polys = claims_per_layer.len().saturating_sub(1);
-        let mut sumcheck_polys = Vec::with_capacity(num_sumcheck_polys);
+        let mut sumcheck_polys = vec_with_capped_capacity(num_sumcheck_polys);
         for round_idx_minus_one in 0..num_sumcheck_polys {
             let n = round_idx_minus_one + 1;
-            let mut round = Vec::with_capacity(n);
+            let mut round = vec_with_capped_capacity(n);
             for _ in 0..n {
                 round.push([
                     SC::decode_extension_field(reader)?,
@@ -535,7 +535,7 @@ impl<SC: DecodableConfig> Decode for BatchConstraintProof<SC> {
         let univariate_round_coeffs = SC::decode_extension_field_vec(reader)?;
 
         let n_max = usize::decode(reader)?;
-        let mut sumcheck_round_polys = Vec::with_capacity(n_max);
+        let mut sumcheck_round_polys = vec_with_capped_capacity(n_max);
         if n_max > 0 {
             let max_degree_plus_one = usize::decode(reader)?;
             for _ in 0..n_max {
@@ -544,11 +544,11 @@ impl<SC: DecodableConfig> Decode for BatchConstraintProof<SC> {
             }
         }
 
-        let mut column_openings = Vec::with_capacity(num_present_airs);
+        let mut column_openings = vec_with_capped_capacity(num_present_airs);
         for _ in 0..num_present_airs {
             // Vec<Vec<SC::EF>>: length-prefixed outer, then each inner
             let num_parts = usize::decode(reader)?;
-            let mut parts = Vec::with_capacity(num_parts);
+            let mut parts = vec_with_capped_capacity(num_parts);
             for _ in 0..num_parts {
                 parts.push(SC::decode_extension_field_vec(reader)?);
             }
@@ -570,7 +570,7 @@ impl<SC: DecodableConfig> Decode for StackingProof<SC> {
         let univariate_round_coeffs = SC::decode_extension_field_vec(reader)?;
         // sumcheck_round_polys: Vec<[SC::EF; 2]>
         let num_rounds = usize::decode(reader)?;
-        let mut sumcheck_round_polys = Vec::with_capacity(num_rounds);
+        let mut sumcheck_round_polys = vec_with_capped_capacity(num_rounds);
         for _ in 0..num_rounds {
             sumcheck_round_polys.push([
                 SC::decode_extension_field(reader)?,
@@ -579,7 +579,7 @@ impl<SC: DecodableConfig> Decode for StackingProof<SC> {
         }
         // stacking_openings: Vec<Vec<SC::EF>>
         let num_openings = usize::decode(reader)?;
-        let mut stacking_openings = Vec::with_capacity(num_openings);
+        let mut stacking_openings = vec_with_capped_capacity(num_openings);
         for _ in 0..num_openings {
             stacking_openings.push(SC::decode_extension_field_vec(reader)?);
         }
@@ -596,7 +596,7 @@ impl<SC: DecodableConfig> Decode for WhirProof<SC> {
         let mu_pow_witness = SC::decode_base_field(reader)?;
         // whir_sumcheck_polys: Vec<[SC::EF; 2]>
         let num_whir_sumcheck_rounds = usize::decode(reader)?;
-        let mut whir_sumcheck_polys = Vec::with_capacity(num_whir_sumcheck_rounds);
+        let mut whir_sumcheck_polys = vec_with_capped_capacity(num_whir_sumcheck_rounds);
         for _ in 0..num_whir_sumcheck_rounds {
             whir_sumcheck_polys.push([
                 SC::decode_extension_field(reader)?,
@@ -626,19 +626,23 @@ impl<SC: DecodableConfig> Decode for WhirProof<SC> {
             merkle_depth = usize::decode(reader)?;
         }
 
-        let mut widths = vec![0usize; num_commits];
+        let mut widths = vec_with_capped_capacity(num_commits);
         if initial_num_whir_queries > 0 {
-            for width in &mut widths {
-                *width = usize::decode(reader)?;
+            for _ in 0..num_commits {
+                widths.push(usize::decode(reader)?);
             }
         }
 
-        let mut initial_round_opened_rows = Vec::with_capacity(num_commits);
-        for width in widths {
-            let mut opened_rows = Vec::with_capacity(initial_num_whir_queries);
+        let decoded_widths = widths.len();
+        let mut initial_round_opened_rows = vec_with_capped_capacity(num_commits);
+        for width in widths
+            .into_iter()
+            .chain(std::iter::repeat(0).take(num_commits.saturating_sub(decoded_widths)))
+        {
+            let mut opened_rows = vec_with_capped_capacity(initial_num_whir_queries);
             for _ in 0..initial_num_whir_queries {
                 // Each query has k_whir_exp rows. Each row is a fixed-width list of F elements.
-                let mut rows = Vec::with_capacity(k_whir_exp);
+                let mut rows = vec_with_capped_capacity(k_whir_exp);
                 for _ in 0..k_whir_exp {
                     rows.push(SC::decode_base_field_n(reader, width)?);
                 }
@@ -647,19 +651,19 @@ impl<SC: DecodableConfig> Decode for WhirProof<SC> {
             initial_round_opened_rows.push(opened_rows);
         }
 
-        let mut initial_round_merkle_proofs = Vec::with_capacity(num_commits);
+        let mut initial_round_merkle_proofs = vec_with_capped_capacity(num_commits);
         for _ in 0..num_commits {
-            let mut merkle_proofs = Vec::with_capacity(initial_num_whir_queries);
+            let mut merkle_proofs = vec_with_capped_capacity(initial_num_whir_queries);
             for _ in 0..initial_num_whir_queries {
                 merkle_proofs.push(SC::decode_digest_n(reader, merkle_depth)?);
             }
             initial_round_merkle_proofs.push(merkle_proofs);
         }
 
-        let mut codeword_opened_values = Vec::with_capacity(num_whir_rounds - 1);
+        let mut codeword_opened_values = vec_with_capped_capacity(num_whir_rounds - 1);
         for _ in 0..num_whir_rounds - 1 {
             let num_queries = usize::decode(reader)?;
-            let mut opened_values = Vec::with_capacity(num_queries);
+            let mut opened_values = vec_with_capped_capacity(num_queries);
             for _ in 0..num_queries {
                 opened_values.push(SC::decode_extension_field_n(reader, k_whir_exp)?);
             }
@@ -667,10 +671,10 @@ impl<SC: DecodableConfig> Decode for WhirProof<SC> {
         }
 
         merkle_depth = usize::decode(reader)?;
-        let mut codeword_merkle_proofs = Vec::with_capacity(num_whir_rounds - 1);
+        let mut codeword_merkle_proofs = vec_with_capped_capacity(num_whir_rounds - 1);
         for opened_values in codeword_opened_values.iter() {
             let num_queries = opened_values.len();
-            let mut merkle_proof: Vec<_> = Vec::with_capacity(num_queries);
+            let mut merkle_proof: Vec<_> = vec_with_capped_capacity(num_queries);
             for _ in 0..num_queries {
                 merkle_proof.push(SC::decode_digest_n(reader, merkle_depth)?);
             }

--- a/crates/stark-backend/src/proof.rs
+++ b/crates/stark-backend/src/proof.rs
@@ -463,6 +463,10 @@ impl<SC: DecodableConfig> Decode for Proof<SC> {
         for byte in bitmap {
             for i in 0u8..8 {
                 if trace_vdata.len() >= num_airs {
+                    // Padding bits must be zero for the encoding to be canonical.
+                    if byte >> i != 0 {
+                        return Err(Error::other("trace_vdata bitmap padding bits set"));
+                    }
                     break;
                 }
                 if byte & (1u8 << i) != 0 {

--- a/crates/stark-backend/src/proof.rs
+++ b/crates/stark-backend/src/proof.rs
@@ -637,7 +637,7 @@ impl<SC: DecodableConfig> Decode for WhirProof<SC> {
         let mut initial_round_opened_rows = vec_with_capped_capacity(num_commits);
         for width in widths
             .into_iter()
-            .chain(std::iter::repeat(0).take(num_commits.saturating_sub(decoded_widths)))
+            .chain(std::iter::repeat_n(0, num_commits.saturating_sub(decoded_widths)))
         {
             let mut opened_rows = vec_with_capped_capacity(initial_num_whir_queries);
             for _ in 0..initial_num_whir_queries {

--- a/crates/stark-sdk/src/config/baby_bear_bn254_poseidon2.rs
+++ b/crates/stark-sdk/src/config/baby_bear_bn254_poseidon2.rs
@@ -29,7 +29,7 @@ use p3_baby_bear::BabyBear;
 // NOTE: plonky3's Bn254 is the type for scalar field of the BN254 curve. It is not the type
 // for the curve itself.
 pub use p3_bn254::Bn254 as Bn254Scalar;
-use p3_field::{extension::BinomialExtensionField, PrimeField};
+use p3_field::{extension::BinomialExtensionField, Field, PrimeField};
 
 use super::bn254_poseidon2::{
     default_bn254_poseidon2_width2, default_bn254_poseidon2_width3, Poseidon2Bn254Width2,
@@ -127,6 +127,10 @@ impl DecodableConfig for BabyBearBn254Poseidon2Config {
             let mut buf = [0u8; 32];
             reader.read_exact(&mut buf)?;
             let big = BigUint::from_bytes_be(&buf);
+            // Reject non-canonical encodings to keep encodings unique.
+            if big >= Bn254Scalar::order() {
+                return Err(io::Error::other("non-canonical Bn254 element >= modulus"));
+            }
             *val = Bn254Scalar::from_biguint(big)
                 .ok_or_else(|| io::Error::other("invalid Bn254 element"))?;
         }


### PR DESCRIPTION
Resolves INT-8249 and INT-8250.

## Overview

This PR hardens proof decoding so serialized proofs have a canonical byte encoding and malformed inputs cannot exploit decoded length fields to trigger large eager allocations.

The changes are intentionally narrow:

- `openvm-stark-backend` rejects non-canonical proof encodings and trailing bytes after `Decode::decode_from_bytes`.
- `openvm-stark-backend` caps decode-time `Vec` preallocation while preserving the decoded structure for valid inputs.
- `openvm-stark-sdk` rejects non-canonical BN254 scalar encodings in `BabyBearBn254Poseidon2Config`.

## Commit Guide

### `9943d9e2` - `fix: ensure Proof has a canonical encoding`

Review focus: canonical encodings for proof data.

- In `crates/stark-backend/src/proof.rs`, `Proof::decode` now rejects set padding bits in the `trace_vdata` bitmap. Since only `num_airs` bits are meaningful, any remaining bits in the final byte must be zero.
- In `crates/stark-sdk/src/config/baby_bear_bn254_poseidon2.rs`, BN254 scalar decoding now rejects 32-byte values greater than or equal to the field modulus before converting them into `Bn254Scalar`.

For reviewers:

- Check that the bitmap padding condition is applied only after all meaningful `trace_vdata` bits have been consumed.
- Check that the BN254 comparison uses the scalar field order and preserves accepted encodings below the modulus.

### `16a060c4` - `fix: Decode::decode_from_bytes errors on trailing bytes`

Review focus: byte-slice decode strictness.

- In `crates/stark-backend/src/codec.rs`, `Decode::decode_from_bytes` now verifies that the decoder consumed the entire input slice.
- Inputs with a valid encoded prefix plus extra trailing bytes now return an error instead of being accepted.

For reviewers:

- Confirm this stricter helper behavior is intended for all `Decode` implementors using `decode_from_bytes`.
- Stream-based `Decode::decode` behavior is unchanged; only the byte-slice convenience method enforces full consumption.

### `c135d797` - `fix: bound Decode vector pre-allocations`

Review focus: memory-exhaustion hardening for untrusted length fields.

- In `crates/stark-backend/src/codec.rs`, `vec_with_capped_capacity` caps initial vector reservation at `DECODE_PREALLOC_CAP`.
- Shared decode helpers now use the capped allocator:
  - `decode_base_field_n`
  - `decode_extension_field_n`
  - `decode_digest_n`
  - `decode_into_vec`
  - `Vec<T>::decode`
- In `crates/stark-backend/src/proof.rs`, proof-specific decode loops now use capped preallocation for nested proof vectors.
- The WHIR `widths` scratch vector no longer uses `vec![0usize; num_commits]`; it decodes widths only when present and otherwise iterates over zero widths without the eager allocation.

For reviewers:

- Confirm loop bounds, decode order, and pushed values are unchanged for valid inputs.
- Pay particular attention to the WHIR `widths` change: when `initial_num_whir_queries == 0`, it should still produce one empty `opened_rows` entry per commit.
- The cap changes allocation behavior only; oversized claimed lengths are still rejected naturally as decoding reaches EOF or grows only with actually decoded elements.
