### PR TITLE
fix: security calculator adjustments

### DIFF
--- a/crates/backend-tests/src/lib.rs
+++ b/crates/backend-tests/src/lib.rs
@@ -164,7 +164,7 @@ pub fn proof_shape_verifier_rng_system_params<E: StarkEngine<SC = SC>>() -> eyre
             w_stack,
             log_blowup,
             whir,
-            logup: log_up_security_params_baby_bear_100_bits(),
+            logup: log_up_security_params_baby_bear_100_bits(0.0),
             max_constraint_degree: 3,
         };
         let engine = E::new(params);
@@ -276,7 +276,7 @@ pub fn fib_air_roundtrip<E: StarkEngine<SC = SC>>(
         w_stack,
         log_blowup,
         whir,
-        logup: log_up_security_params_baby_bear_100_bits(),
+        logup: log_up_security_params_baby_bear_100_bits(0.0),
         max_constraint_degree: 3,
     };
     let fib = FibFixture::new(0, 1, 1 << log_trace_degree);
@@ -1243,7 +1243,7 @@ pub fn whir_single_fib(
         w_stack,
         log_blowup,
         whir,
-        logup: log_up_security_params_baby_bear_100_bits(),
+        logup: log_up_security_params_baby_bear_100_bits(0.0),
         max_constraint_degree: 3,
     };
     run_whir_fib_test(params)
@@ -1277,7 +1277,7 @@ pub fn whir_multiple_commitments() -> eyre::Result<()> {
         w_stack: 64,
         log_blowup: 1,
         whir: whir_test_config(2),
-        logup: log_up_security_params_baby_bear_100_bits(),
+        logup: log_up_security_params_baby_bear_100_bits(0.0),
         max_constraint_degree: 3,
     };
     let config = BabyBearPoseidon2Config::default_from_params(params);
@@ -1358,7 +1358,7 @@ pub fn whir_multiple_commitments_negative() {
         w_stack: 64,
         log_blowup: 1,
         whir: whir_test_config(2),
-        logup: log_up_security_params_baby_bear_100_bits(),
+        logup: log_up_security_params_baby_bear_100_bits(0.0),
         max_constraint_degree: 3,
     };
     let config = BabyBearPoseidon2Config::default_from_params(params);

--- a/crates/cuda-backend/src/tests.rs
+++ b/crates/cuda-backend/src/tests.rs
@@ -116,7 +116,7 @@ fn test_bn254_fib_air_roundtrip(l_skip: usize, log_trace_degree: usize) {
         w_stack,
         log_blowup,
         whir,
-        logup: log_up_security_params_baby_bear_100_bits(),
+        logup: log_up_security_params_baby_bear_100_bits(0.0),
         max_constraint_degree: 3,
     };
 

--- a/crates/cuda-backend/src/whir.rs
+++ b/crates/cuda-backend/src/whir.rs
@@ -741,7 +741,7 @@ mod tests {
             w_stack,
             log_blowup,
             whir,
-            logup: log_up_security_params_baby_bear_100_bits(),
+            logup: log_up_security_params_baby_bear_100_bits(0.0),
             max_constraint_degree: 3,
         };
         run_whir_fib_test_gpu(params)

--- a/crates/stark-backend/src/config.rs
+++ b/crates/stark-backend/src/config.rs
@@ -242,14 +242,13 @@ pub enum ProximityRegime {
 }
 
 impl ProximityRegime {
-    /// Returns total security bits for `num_queries` WHIR queries.
+    /// Maximum fraction of the RS domain on which a far word can agree with a codeword (the
+    /// per-query evasion probability under ideal uniform query sampling).
     ///
-    /// This treats the per-query error as an upper bound on the maximum agreement.
-    ///
-    /// - `UniqueDecoding`: max agreement is `(1 + ρ) / 2`.
+    /// - `UniqueDecoding`: `(1 + ρ) / 2`.
     /// - `ListDecoding { m }`: finite-multiplicity Guruswami-Sudan threshold, `sqrt(ρ) (1 +
-    ///   1/(2m)).
-    pub fn whir_query_security_bits(&self, num_queries: usize, log_inv_rate: usize) -> f64 {
+    ///   1/(2m))`.
+    pub fn max_agreement(&self, log_inv_rate: usize) -> f64 {
         let rho = 2.0_f64.powf(-(log_inv_rate as f64));
         let max_agreement = match *self {
             ProximityRegime::UniqueDecoding => (1.0 + rho) / 2.0,
@@ -261,10 +260,15 @@ impl ProximityRegime {
                 rho.sqrt() * (1.0 + 1.0 / (2.0 * m))
             }
         };
-
         // Keep the `log2` well-defined.
-        let max_agreement = max_agreement.clamp(f64::MIN_POSITIVE, 1.0);
-        -(num_queries as f64) * max_agreement.log2()
+        max_agreement.clamp(f64::MIN_POSITIVE, 1.0)
+    }
+
+    /// Returns total security bits for `num_queries` WHIR queries under ideal (uniform) query
+    /// sampling. See [`crate::soundness::SoundnessCalculator`] for the variant that additionally
+    /// charges the `sample_bits` sampling bias.
+    pub fn whir_query_security_bits(&self, num_queries: usize, log_inv_rate: usize) -> f64 {
+        -(num_queries as f64) * self.max_agreement(log_inv_rate).log2()
     }
 
     /// Returns the per-query security bits for WHIR query sampling.

--- a/crates/stark-backend/src/config.rs
+++ b/crates/stark-backend/src/config.rs
@@ -149,6 +149,12 @@ impl SystemParams {
 }
 
 /// Configurable parameters that are used to determine the [WhirConfig] for a target security level.
+///
+/// The `*_pow_bits` fields set proof-of-work grinding difficulty in *bits*, i.e. hash evaluations.
+/// The security those bits provide depends on the cost of the grinding hash (the transcript hash):
+/// cheaper hashes make each grinding attempt cheaper for an attacker. When changing the
+/// configuration—especially the hash function—revisit the PoW difficulty so it still meets the
+/// intended security against an attacker grinding with that hash. See [`crate::soundness`].
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WhirParams {
     pub k: usize,

--- a/crates/stark-backend/src/interaction/mod.rs
+++ b/crates/stark-backend/src/interaction/mod.rs
@@ -229,7 +229,7 @@ pub struct LogUpSecurityParameters {
 }
 
 impl LogUpSecurityParameters {
-    /// The number of bits of security with grinding.
+    /// The number of LogUp bits of security with grinding, before any PCS list-size union bound.
     pub fn bits_of_security<F: Field>(&self) -> u32 {
         // See Section 4 of [docs/Soundness_of_Interactions_via_LogUp.pdf].
         let log_order = u32::try_from(F::order().bits() - 1).unwrap();

--- a/crates/stark-backend/src/interaction/mod.rs
+++ b/crates/stark-backend/src/interaction/mod.rs
@@ -2,7 +2,6 @@ use std::fmt::Debug;
 
 use p3_air::AirBuilder;
 use p3_field::{Field, PrimeCharacteristicRing};
-use p3_util::log2_ceil_usize;
 use serde::{Deserialize, Serialize};
 
 use crate::air_builders::symbolic::symbolic_expression::SymbolicExpression;
@@ -229,15 +228,6 @@ pub struct LogUpSecurityParameters {
 }
 
 impl LogUpSecurityParameters {
-    /// The number of LogUp bits of security with grinding, before any PCS list-size union bound.
-    pub fn bits_of_security<F: Field>(&self) -> u32 {
-        // See Section 4 of [docs/Soundness_of_Interactions_via_LogUp.pdf].
-        let log_order = u32::try_from(F::order().bits() - 1).unwrap();
-        log_order
-            - log2_ceil_usize(2 * self.max_interaction_count as usize) as u32  // multiply by two to account for the poles as well
-            - self.log_max_message_length
-            + u32::try_from(self.pow_bits).unwrap()
-    }
     pub fn max_message_length(&self) -> usize {
         2usize
             .checked_pow(self.log_max_message_length)

--- a/crates/stark-backend/src/soundness.rs
+++ b/crates/stark-backend/src/soundness.rs
@@ -979,17 +979,19 @@ pub fn min_whir_queries(
 
 #[cfg(test)]
 mod tests {
+    use openvm_stark_sdk::config::baby_bear_poseidon2::EF;
     use p3_baby_bear::BabyBear;
-    use p3_field::PrimeField64;
+    use p3_field::{BasedVectorSpace, PrimeField64};
 
     use super::*;
     use crate::{config::WhirRoundConfig, interaction::LogUpSecurityParameters};
 
-    fn babybear_quartic_extension_bits() -> f64 {
-        4.0 * (BabyBear::ORDER_U64 as f64).log2()
+    fn challenge_field_bits() -> f64 {
+        const D_EF: usize = <EF as BasedVectorSpace<BabyBear>>::DIMENSION;
+        D_EF as f64 * (BabyBear::ORDER_U64 as f64).log2()
     }
 
-    fn babybear_base_field_order() -> f64 {
+    fn base_field_order() -> f64 {
         BabyBear::ORDER_U64 as f64
     }
     // ==========================================================================
@@ -1032,8 +1034,8 @@ mod tests {
         let params = test_params();
         let soundness = SoundnessCalculator::calculate(
             &params,
-            babybear_base_field_order(),
-            babybear_quartic_extension_bits(),
+            base_field_order(),
+            challenge_field_bits(),
             1000,
             50,
             4,
@@ -1072,15 +1074,13 @@ mod tests {
     #[test]
     fn test_logup_soundness() {
         let logup = test_params().logup;
-        let security = SoundnessCalculator::logup_soundness(
-            logup.max_interaction_count,
-            logup.log_max_message_length,
-            babybear_quartic_extension_bits(),
-            0.0,
-        ) + SoundnessCalculator::effective_pow_bits(
-            logup.pow_bits,
-            babybear_base_field_order(),
-        );
+        let security =
+            SoundnessCalculator::logup_soundness(
+                logup.max_interaction_count,
+                logup.log_max_message_length,
+                challenge_field_bits(),
+                0.0,
+            ) + SoundnessCalculator::effective_pow_bits(logup.pow_bits, base_field_order());
         assert!(security > TARGET_SECURITY_BITS as f64);
     }
 
@@ -1090,14 +1090,14 @@ mod tests {
         let no_list = SoundnessCalculator::logup_soundness(
             logup.max_interaction_count,
             logup.log_max_message_length,
-            babybear_quartic_extension_bits(),
+            challenge_field_bits(),
             0.0,
         );
         let list_size_bits = 5.0;
         let with_list = SoundnessCalculator::logup_soundness(
             logup.max_interaction_count,
             logup.log_max_message_length,
-            babybear_quartic_extension_bits(),
+            challenge_field_bits(),
             list_size_bits,
         );
         assert!((no_list - with_list - list_size_bits).abs() < 1e-9);

--- a/crates/stark-backend/src/soundness.rs
+++ b/crates/stark-backend/src/soundness.rs
@@ -20,13 +20,13 @@ use crate::{
 pub struct SoundnessCalculator {
     /// Security bits from LogUp α/β sampling and PoW.
     pub logup_bits: f64,
-    /// Security bits from GKR sumcheck rounds.
+    /// Security bits from ordinary GKR sumcheck rounds.
     pub gkr_sumcheck_bits: f64,
     /// Security bits from GKR μ/λ batching per layer.
     pub gkr_batching_bits: f64,
-    /// Security bits from ZeroCheck sumcheck (univariate and multilinear rounds).
+    /// Security bits from ZeroCheck sumcheck after the fused input-layer boundary.
     pub zerocheck_sumcheck_bits: f64,
-    /// Security bits from constraint batching (λ and μ via Schwartz-Zippel).
+    /// Security bits from the fused GKR/ZeroCheck input boundary and constraint batching.
     pub constraint_batching_bits: f64,
     /// Security bits from stacked reduction sumcheck.
     pub stacked_reduction_bits: f64,
@@ -114,7 +114,6 @@ impl SoundnessCalculator {
             challenge_field_bits,
             max_constraint_degree,
             params.l_skip,
-            max_log_trace_height,
             log2_list_size,
         );
 
@@ -122,6 +121,9 @@ impl SoundnessCalculator {
             challenge_field_bits,
             max_num_constraints_per_air,
             num_airs,
+            params.l_skip,
+            max_log_trace_height,
+            n_logup,
             log2_list_size,
         );
 
@@ -169,7 +171,8 @@ impl SoundnessCalculator {
     /// - β: Random challenge for compressing interaction messages into field elements. Degeneracy
     ///   would allow distinct message tuples to collide.
     ///
-    /// Security = |F_ext| - log₂(2 × max_interaction_count) - log_max_message_length + pow_bits
+    /// Security = |F_ext| - log₂(2 × max_interaction_count) - log_max_message_length
+    ///            - log₂(L_PCS) + pow_bits
     ///
     /// Reference: Section 4 of docs/Soundness_of_Interactions_via_LogUp.pdf
     fn calculate_logup_soundness(
@@ -180,16 +183,19 @@ impl SoundnessCalculator {
         let logup = &params.logup;
         let max_interaction_count_bits = (2.0 * logup.max_interaction_count as f64).log2();
 
-        log2_list_size + challenge_field_bits
+        challenge_field_bits
             - max_interaction_count_bits
             - logup.log_max_message_length as f64
+            - log2_list_size
             + logup.pow_bits as f64
     }
 
-    /// GKR sumcheck soundness (per-round).
+    /// Ordinary GKR sumcheck soundness (per-round).
     ///
     /// The GKR protocol has a triangular sumcheck structure where round j has j sub-rounds.
     /// Each sub-round uses degree-3 interpolation, giving per-round error = 3 / |F_ext|.
+    /// The final input-layer boundary shared with ZeroCheck is accounted for in
+    /// [`Self::calculate_constraint_batching_soundness`].
     ///
     /// Security is determined by the worst round: |F_ext| - log₂(3)
     fn calculate_gkr_sumcheck_soundness(
@@ -222,9 +228,12 @@ impl SoundnessCalculator {
         challenge_field_bits - (degree as f64).log2()
     }
 
-    /// ZeroCheck sumcheck soundness (per-round).
+    /// ZeroCheck sumcheck soundness after the fused input-layer boundary.
     ///
-    /// Two phases with different per-round degrees:
+    /// The input-point identity test is fused with the last LogUp-GKR input-layer challenge and
+    /// the first ZeroCheck batching challenges in
+    /// [`Self::calculate_constraint_batching_soundness`]. After that boundary, the remaining
+    /// batch sumcheck has two per-round degree sources:
     ///
     /// 1. **Univariate round** over coset domain (size 2^l_skip):
     ///    - Degree: (max_constraint_degree + 1) × (2^l_skip - 1)
@@ -232,53 +241,58 @@ impl SoundnessCalculator {
     /// 2. **Multilinear rounds** (n_max = max_log_trace_height - l_skip):
     ///    - Per-round degree: max_constraint_degree + 1
     ///
-    /// 3. **Polynomial identity testing at r**: After sumcheck completes, trace polynomials are
-    ///    evaluated at random r. If the prover's trace differs from the committed trace, this is
-    ///    caught by Schwartz-Zippel. Trace polynomials have deg_Z ≤ 2^l_skip - 1 and deg_{X_i} ≤ 1.
-    ///    Error ≤ (2^l_skip - 1 + n_max) / |F_ext|
+    /// The full-protocol bound applies the list-size union bound over `L_PCS` candidate traces.
     fn calculate_zerocheck_sumcheck_soundness(
         challenge_field_bits: f64,
         max_constraint_degree: usize,
         l_skip: usize,
-        max_log_trace_height: usize,
         log2_list_size: f64,
     ) -> f64 {
         let univariate_degree = (max_constraint_degree + 1) * ((1 << l_skip) - 1);
         let multilinear_degree = max_constraint_degree + 1;
 
         let worst_degree = univariate_degree.max(multilinear_degree);
-        let sumcheck_bits = challenge_field_bits - (worst_degree as f64).log2();
-
-        // Polynomial identity testing: trace polynomial has deg_Z ≤ 2^l_skip - 1, deg_{X_i} ≤ 1
-        // n_max = max_log_trace_height - l_skip multilinear variables
-        let n_max = max_log_trace_height.saturating_sub(l_skip);
-        let poly_degree_sum = (1 << l_skip) - 1 + n_max;
-        let poly_identity_bits = challenge_field_bits - (poly_degree_sum as f64).log2();
-
-        log2_list_size + sumcheck_bits.min(poly_identity_bits)
+        challenge_field_bits - (worst_degree as f64).log2() - log2_list_size
     }
 
-    /// Constraint batching soundness via Schwartz-Zippel.
+    /// Fused batch-constraint boundary soundness via Schwartz-Zippel.
     ///
-    /// Two batching levels:
-    /// - λ: Within each AIR, batching n constraints. Error ≤ n / |F_ext|
-    /// - μ: Across AIRs, batching 3k sum claims (ZeroCheck + LogUp numerator + LogUp denominator
-    ///   per AIR). Error ≤ 3k / |F_ext|
+    /// This is the first term of the batch-constraint theorem after fusing the last LogUp-GKR
+    /// input-layer challenge with ZeroCheck's input-point and batching challenges:
+    ///
+    /// `max(3, n_extra) + (2^l_skip - 1) + (N_C - 1) + (3|T| - 1)`.
+    ///
+    /// The full-protocol bound applies the list-size union bound over `L_PCS` candidate traces.
     fn calculate_constraint_batching_soundness(
         challenge_field_bits: f64,
         max_num_constraints_per_air: usize,
         num_airs: usize,
+        l_skip: usize,
+        max_log_trace_height: usize,
+        n_logup: usize,
         log2_list_size: f64,
     ) -> f64 {
-        let lambda_batching_bits =
-            challenge_field_bits - (max_num_constraints_per_air as f64).log2();
+        assert!(
+            max_num_constraints_per_air > 0,
+            "batch-constraint soundness requires at least one constraint"
+        );
+        assert!(
+            num_airs > 0,
+            "batch-constraint soundness requires at least one nonempty AIR"
+        );
+
+        let n_trace = max_log_trace_height.saturating_sub(l_skip);
+        let n_extra = n_trace.saturating_sub(n_logup);
+        let skip_degree = (1 << l_skip) - 1;
+
         // Each AIR contributes 3 sum claims to the batch sumcheck:
         // 1. ZeroCheck (constraint satisfaction)
         // 2. LogUp numerator (p̂(ξ) input layer)
         // 3. LogUp denominator (q̂(ξ) input layer)
-        let mu_batching_bits = challenge_field_bits - (3.0 * num_airs as f64).log2();
+        let fused_boundary_degree =
+            n_extra.max(3) + skip_degree + (max_num_constraints_per_air - 1) + (3 * num_airs - 1);
 
-        log2_list_size + lambda_batching_bits.min(mu_batching_bits)
+        challenge_field_bits - (fused_boundary_degree as f64).log2() - log2_list_size
     }
 
     /// Stacked reduction soundness.
@@ -307,7 +321,7 @@ impl SoundnessCalculator {
         // Degree 2 per round => log2(2) = 1.
         let multilinear_bits = challenge_field_bits - 1.0;
 
-        log2_list_size + batching_bits.min(univariate_bits).min(multilinear_bits)
+        batching_bits.min(univariate_bits).min(multilinear_bits) - log2_list_size
     }
 
     /// WHIR soundness analysis based on the WHIR paper (ePrint 2024/1586).
@@ -809,7 +823,7 @@ pub fn print_soundness_report(
         soundness.zerocheck_sumcheck_bits
     );
     println!(
-        "  Constraint batching:         {:.1}",
+        "  Fused boundary/batching:     {:.1}",
         soundness.constraint_batching_bits
     );
     println!(
@@ -966,6 +980,39 @@ mod tests {
             0.0,
         );
         assert!(security > TARGET_SECURITY_BITS as f64);
+    }
+
+    #[test]
+    fn test_logup_list_size_is_security_penalty() {
+        let params = test_params();
+        let no_list = SoundnessCalculator::calculate_logup_soundness(
+            &params,
+            babybear_quartic_extension_bits(),
+            0.0,
+        );
+        let list_size_bits = 5.0;
+        let with_list = SoundnessCalculator::calculate_logup_soundness(
+            &params,
+            babybear_quartic_extension_bits(),
+            list_size_bits,
+        );
+        assert!((no_list - with_list - list_size_bits).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_fused_batch_constraint_boundary_soundness() {
+        let security = SoundnessCalculator::calculate_constraint_batching_soundness(
+            100.0, // challenge field bits
+            11,    // N_C
+            7,     // |T|
+            3,     // l_skip, so 2^l_skip - 1 = 7
+            10,    // max_log_trace_height, so n_T = 7
+            4,     // n_logup, so n_extra = 3
+            2.0,   // log2(L_PCS)
+        );
+        let expected_degree: f64 = 3.0 + 7.0 + 10.0 + 20.0;
+        let expected = 100.0 - expected_degree.log2() - 2.0;
+        assert!((security - expected).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/stark-backend/src/soundness.rs
+++ b/crates/stark-backend/src/soundness.rs
@@ -274,7 +274,9 @@ impl SoundnessCalculator {
     /// This is the first term of the batch-constraint theorem after fusing the last LogUp-GKR
     /// input-layer challenge with ZeroCheck's input-point and batching challenges:
     ///
-    /// `max(3, n_extra) + (2^l_skip - 1) + (N_C - 1) + (3|T| - 1)`.
+    /// `max(3, n_extra) + (2^l_skip - 1) + (N_C - 1)`.
+    ///
+    /// The remaining batch-sumcheck batching round contributes a separate `3|T| - 1` term.
     ///
     /// The full-protocol bound applies the list-size union bound over `L_PCS` candidate traces.
     fn calculate_constraint_batching_soundness(
@@ -304,9 +306,14 @@ impl SoundnessCalculator {
         // 2. LogUp numerator (p̂(ξ) input layer)
         // 3. LogUp denominator (q̂(ξ) input layer)
         let fused_boundary_degree =
-            n_extra.max(3) + skip_degree + (max_num_constraints_per_air - 1) + (3 * num_airs - 1);
+            n_extra.max(3) + skip_degree + (max_num_constraints_per_air - 1);
+        let batch_sumcheck_batching_degree = 3 * num_airs - 1;
 
-        challenge_field_bits - (fused_boundary_degree as f64).log2() - log2_list_size
+        let fused_boundary_bits = challenge_field_bits - (fused_boundary_degree as f64).log2();
+        let batch_sumcheck_batching_bits =
+            challenge_field_bits - (batch_sumcheck_batching_degree as f64).log2();
+
+        fused_boundary_bits.min(batch_sumcheck_batching_bits) - log2_list_size
     }
 
     /// Stacked reduction soundness.
@@ -1114,7 +1121,7 @@ mod tests {
             4,     // n_logup, so n_extra = 3
             2.0,   // log2(L_PCS)
         );
-        let expected_degree: f64 = 3.0 + 7.0 + 10.0 + 20.0;
+        let expected_degree: f64 = (3.0_f64 + 7.0 + 10.0).max(20.0);
         let expected = 100.0 - expected_degree.log2() - 2.0;
         assert!((security - expected).abs() < 1e-9);
     }

--- a/crates/stark-backend/src/soundness.rs
+++ b/crates/stark-backend/src/soundness.rs
@@ -70,6 +70,9 @@ impl SoundnessCalculator {
     ///
     /// # Arguments
     /// * `params` - System parameters including WHIR config and LogUp parameters.
+    /// * `base_field_order` - Order `p` of the base field that `sample_bits` reduces. For BabyBear:
+    ///   `2^31 - 2^27 + 1`. Used to charge the `sample_bits` sampling bias (query bad-set argument
+    ///   and proof-of-work).
     /// * `challenge_field_bits` - Bits in the challenge field. For BabyBear4: ~124 bits.
     /// * `max_num_constraints_per_air` - Maximum constraints in any single AIR.
     /// * `num_airs` - Number of AIRs being batched.
@@ -82,6 +85,7 @@ impl SoundnessCalculator {
     #[allow(clippy::too_many_arguments)]
     pub fn calculate(
         params: &SystemParams,
+        base_field_order: f64,
         challenge_field_bits: f64,
         max_num_constraints_per_air: usize,
         num_airs: usize,
@@ -101,8 +105,12 @@ impl SoundnessCalculator {
         // log2_list_size is log2(L_{PCS}) where L_{PCS} is the list size with respect to the
         // proximity radius of the _initial_ WHIR round.
         let log2_list_size = init_prox_gap.log2_list_size;
-        let logup_bits =
-            Self::calculate_logup_soundness(params, challenge_field_bits, log2_list_size);
+        let logup_bits = Self::logup_soundness(
+            params.logup.max_interaction_count,
+            params.logup.log_max_message_length,
+            challenge_field_bits,
+            log2_list_size,
+        ) + Self::effective_pow_bits(params.logup.pow_bits, base_field_order);
 
         let gkr_sumcheck_bits =
             Self::calculate_gkr_sumcheck_soundness(challenge_field_bits, params.l_skip, n_logup);
@@ -137,6 +145,7 @@ impl SoundnessCalculator {
 
         let (whir_bits, whir_details) = Self::calculate_whir_soundness(
             params,
+            base_field_order,
             challenge_field_bits,
             num_stacked_columns,
             params.whir.proximity,
@@ -163,7 +172,7 @@ impl SoundnessCalculator {
         }
     }
 
-    /// LogUp soundness from α/β sampling.
+    /// LogUp soundness from α/β sampling (before proof-of-work grinding).
     ///
     /// - α: Random evaluation point to test whether Σ p(y)/q(y) = 0. If interactions are
     ///   unbalanced, the sum is a non-zero rational function with a bounded number of roots. By
@@ -171,23 +180,23 @@ impl SoundnessCalculator {
     /// - β: Random challenge for compressing interaction messages into field elements. Degeneracy
     ///   would allow distinct message tuples to collide.
     ///
-    /// Security = |F_ext| - log₂(2 × max_interaction_count) - log_max_message_length
-    ///            - log₂(L_PCS) + pow_bits
+    /// Security = |F_ext| - log₂(2 × max_interaction_count) - log_max_message_length - log₂(L_PCS)
+    ///
+    /// Proof-of-work grinding is an orthogonal amplification that callers add on top via
+    /// [`Self::effective_pow_bits`]. This is the single source of truth for the formula; SDK
+    /// parameter selection calibrates against it.
     ///
     /// Reference: Section 4 of docs/Soundness_of_Interactions_via_LogUp.pdf
-    fn calculate_logup_soundness(
-        params: &SystemParams,
+    pub fn logup_soundness(
+        max_interaction_count: u32,
+        log_max_message_length: u32,
         challenge_field_bits: f64,
         log2_list_size: f64,
     ) -> f64 {
-        let logup = &params.logup;
-        let max_interaction_count_bits = (2.0 * logup.max_interaction_count as f64).log2();
-
         challenge_field_bits
-            - max_interaction_count_bits
-            - logup.log_max_message_length as f64
+            - (2.0 * max_interaction_count as f64).log2()
+            - log_max_message_length as f64
             - log2_list_size
-            + logup.pow_bits as f64
     }
 
     /// Ordinary GKR sumcheck soundness (per-round).
@@ -333,6 +342,7 @@ impl SoundnessCalculator {
     /// 5. **Initial μ batching**
     fn calculate_whir_soundness(
         params: &SystemParams,
+        base_field_order: f64,
         challenge_field_bits: f64,
         num_stacked_columns: usize,
         proximity: WhirProximityStrategy,
@@ -361,7 +371,8 @@ impl SoundnessCalculator {
             params.log_blowup,
             num_stacked_columns,
         );
-        let mu_batching_bits = mu_security.log2_err + whir.mu_pow_bits as f64;
+        let mu_batching_bits =
+            mu_security.log2_err + Self::effective_pow_bits(whir.mu_pow_bits, base_field_order);
         let mut min_rbr_bits = mu_batching_bits;
 
         let mut log_inv_rate = params.log_blowup;
@@ -390,10 +401,12 @@ impl SoundnessCalculator {
                 } else {
                     log2_list_size = Some(prox_gaps.log2_list_size);
                 }
-                let prox_gaps_bits = prox_gaps.log2_err + whir.folding_pow_bits as f64;
+                let prox_gaps_bits = prox_gaps.log2_err
+                    + Self::effective_pow_bits(whir.folding_pow_bits, base_field_order);
                 min_prox_gaps_bits = min_prox_gaps_bits.min(prox_gaps_bits);
 
                 let sumcheck_bits = Self::whir_sumcheck_security(
+                    base_field_order,
                     challenge_field_bits,
                     whir.folding_pow_bits,
                     log2_list_size.unwrap(),
@@ -407,9 +420,20 @@ impl SoundnessCalculator {
             }
 
             // Query error (all rounds), protected by query_phase_pow_bits.
-            let query_bits = proximity_regime
-                .whir_query_security_bits(round_config.num_queries, log_inv_rate)
-                + whir.query_phase_pow_bits as f64;
+            //
+            // Query indices are drawn with `sample_bits(log_query_domain)` over the folded RS
+            // domain, whose log-size matches `log_rs_domain_size - k_whir` in the prover, i.e.
+            // `current_log_degree + log_inv_rate` here. `whir_query_security_biased` folds the
+            // `sample_bits` bias into the agreement-set bound.
+            let log_query_domain = current_log_degree + log_inv_rate;
+            let query_bits =
+                Self::whir_query_security_biased(
+                    proximity_regime,
+                    round_config.num_queries,
+                    log_inv_rate,
+                    log_query_domain,
+                    base_field_order,
+                ) + Self::effective_pow_bits(whir.query_phase_pow_bits, base_field_order);
             min_query_bits = min_query_bits.min(query_bits);
 
             // ε_shift and ε_out reference m_i, ℓ_{i,0} where `i = round + 1` refers to the *next*
@@ -565,6 +589,64 @@ impl SoundnessCalculator {
         -Self::log2_add(-bits_a, -bits_b)
     }
 
+    /// The bias of `sample_bits(n)`, the reduction `x mod 2^n` of a uniform `x ∈ {0, ..., p - 1}`.
+    ///
+    /// Writing `p = c·2^n + r` with `0 ≤ r < 2^n`, the `2^n` residues are not equiprobable: the
+    /// `r` "heavy" residues `0..r` occur with probability `(c+1)/p`, the `2^n - r` "light" ones
+    /// with `c/p`. Returns `(c+1)/p` (heavy), `c/p` (light), and `r` (the number of heavy
+    /// residues). `p` is the order of the field `sample_bits` reduces (the base field, BabyBear).
+    ///
+    /// Note for BabyBear `p - 1 = 2^27 · 15`, so `p ≡ 1 (mod 2^n)` and thus `r = 1` for every
+    /// `n ≤ 27` — there is a single heavy residue (the all-zero one).
+    #[inline]
+    fn sample_bits_residue_probs(num_sampled_bits: f64, base_field_order: f64) -> (f64, f64, f64) {
+        let two_pow_n = num_sampled_bits.exp2();
+        let c = (base_field_order / two_pow_n).floor();
+        let r = base_field_order - c * two_pow_n; // p mod 2^n, exact for integers < 2^53.
+        ((c + 1.0) / base_field_order, c / base_field_order, r)
+    }
+
+    /// Security bits from `num_queries` WHIR query draws of `sample_bits(log_query_domain)`,
+    /// charging the sampling bias via the agreement-set argument.
+    ///
+    /// Under ideal uniform sampling a far word evades one query with prob `≤ α` (the max
+    /// agreement). The adversary aligns its size-`g = α·N` agreement set (`N = 2^log_query_domain`)
+    /// with the heavy residues, but only `r` of those exist, so the worst-case single-query hit is
+    ///   `(g·c + min(g, r))/p = α + min(α N, r)·(1 - α)/p`   (using `Nc = p - r`).
+    /// For BabyBear `r = 1` on every query domain, so the penalty is ~`2^-31` per query
+    /// (negligible).
+    fn whir_query_security_biased(
+        proximity_regime: ProximityRegime,
+        num_queries: usize,
+        log_inv_rate: usize,
+        log_query_domain: usize,
+        base_field_order: f64,
+    ) -> f64 {
+        let alpha = proximity_regime.max_agreement(log_inv_rate);
+        let (_p_hi, _p_lo, r) =
+            Self::sample_bits_residue_probs(log_query_domain as f64, base_field_order);
+        let big_n = (log_query_domain as f64).exp2();
+        let heavy_used = (alpha * big_n).min(r);
+        // mass = α·(Nc/p) + heavy_used/p = α·(1 - r/p) + heavy_used/p.
+        let mass = (alpha * (1.0 - r / base_field_order) + heavy_used / base_field_order)
+            .clamp(f64::MIN_POSITIVE, 1.0);
+        -(num_queries as f64) * mass.log2()
+    }
+
+    /// Effective security bits of a `pow_bits` proof-of-work grind, accounting for the bias of
+    /// `sample_bits` towards its all-zero target. A random witness passes `sample_bits(pow_bits)
+    /// == 0` with probability `(c+1)/p` (residue 0 is always heavy), not `2^{-pow_bits}`, so the
+    /// grind is worth `-log2((c+1)/p)` bits — slightly under its nominal `pow_bits`.
+    #[inline]
+    fn effective_pow_bits(pow_bits: usize, base_field_order: f64) -> f64 {
+        if pow_bits == 0 {
+            // `check_witness` short-circuits to `true` without sampling, so there is no bias.
+            return 0.0;
+        }
+        let (p_hi, _p_lo, _r) = Self::sample_bits_residue_probs(pow_bits as f64, base_field_order);
+        -p_hi.log2()
+    }
+
     #[inline]
     fn bchks25_log2_a_from_log2_degrees(
         log2_d_x: f64,
@@ -706,13 +788,15 @@ impl SoundnessCalculator {
     ///
     /// Security bits = |F_ext| - log₂(d) - log2(ℓ_{i,s-1}) + folding_pow_bits
     fn whir_sumcheck_security(
+        base_field_order: f64,
         challenge_field_bits: f64,
         folding_pow_bits: usize,
         log2_list_size: f64,
     ) -> f64 {
         // For our use case, w0 has degree 1 in each variable, so d = 3.
         let sumcheck_degree: f64 = 3.0;
-        challenge_field_bits - sumcheck_degree.log2() - log2_list_size + folding_pow_bits as f64
+        challenge_field_bits - sumcheck_degree.log2() - log2_list_size
+            + Self::effective_pow_bits(folding_pow_bits, base_field_order)
     }
 
     /// Computes WHIR out-of-domain (OOD) security bits.
@@ -748,6 +832,7 @@ impl SoundnessCalculator {
 #[allow(clippy::too_many_arguments)]
 pub fn print_soundness_report(
     params: &SystemParams,
+    base_field_order: f64,
     challenge_field_bits: f64,
     max_num_constraints_per_air: usize,
     num_airs: usize,
@@ -760,6 +845,7 @@ pub fn print_soundness_report(
 ) {
     let soundness = SoundnessCalculator::calculate(
         params,
+        base_field_order,
         challenge_field_bits,
         max_num_constraints_per_air,
         num_airs,
@@ -797,6 +883,7 @@ pub fn print_soundness_report(
     println!();
     println!("Proving Context:");
     println!("  challenge_field_bits: {:.0}", challenge_field_bits);
+    println!("  base_field_order: {:.0}", base_field_order);
     println!(
         "  max_num_constraints_per_air: {}",
         max_num_constraints_per_air
@@ -895,6 +982,10 @@ mod tests {
     fn babybear_quartic_extension_bits() -> f64 {
         4.0 * (BabyBear::ORDER_U64 as f64).log2()
     }
+
+    fn babybear_base_field_order() -> f64 {
+        BabyBear::ORDER_U64 as f64
+    }
     // ==========================================================================
     // Test fixtures
     // ==========================================================================
@@ -935,6 +1026,7 @@ mod tests {
         let params = test_params();
         let soundness = SoundnessCalculator::calculate(
             &params,
+            babybear_base_field_order(),
             babybear_quartic_extension_bits(),
             1000,
             50,
@@ -973,26 +1065,32 @@ mod tests {
 
     #[test]
     fn test_logup_soundness() {
-        let params = test_params();
-        let security = SoundnessCalculator::calculate_logup_soundness(
-            &params,
+        let logup = test_params().logup;
+        let security = SoundnessCalculator::logup_soundness(
+            logup.max_interaction_count,
+            logup.log_max_message_length,
             babybear_quartic_extension_bits(),
             0.0,
+        ) + SoundnessCalculator::effective_pow_bits(
+            logup.pow_bits,
+            babybear_base_field_order(),
         );
         assert!(security > TARGET_SECURITY_BITS as f64);
     }
 
     #[test]
     fn test_logup_list_size_is_security_penalty() {
-        let params = test_params();
-        let no_list = SoundnessCalculator::calculate_logup_soundness(
-            &params,
+        let logup = test_params().logup;
+        let no_list = SoundnessCalculator::logup_soundness(
+            logup.max_interaction_count,
+            logup.log_max_message_length,
             babybear_quartic_extension_bits(),
             0.0,
         );
         let list_size_bits = 5.0;
-        let with_list = SoundnessCalculator::calculate_logup_soundness(
-            &params,
+        let with_list = SoundnessCalculator::logup_soundness(
+            logup.max_interaction_count,
+            logup.log_max_message_length,
             babybear_quartic_extension_bits(),
             list_size_bits,
         );

--- a/crates/stark-backend/src/soundness.rs
+++ b/crates/stark-backend/src/soundness.rs
@@ -8,6 +8,11 @@
 //!
 //! Each component contributes to the overall soundness error, and the total security
 //! is the minimum across all components.
+//!
+//! Components add proof-of-work grinding (`*_pow_bits`) on top of their statistical soundness.
+//! Grinding bits count hash evaluations, so the attacker's cost for `g` grinding bits is
+//! `≈ 2^g · cost(H)` for the grinding hash `H` (the transcript hash). Bit totals are thus
+//! comparable only across configs that share a grinding hash.
 
 use std::f64;
 
@@ -636,7 +641,8 @@ impl SoundnessCalculator {
     /// Effective security bits of a `pow_bits` proof-of-work grind, accounting for the bias of
     /// `sample_bits` towards its all-zero target. A random witness passes `sample_bits(pow_bits)
     /// == 0` with probability `(c+1)/p` (residue 0 is always heavy), not `2^{-pow_bits}`, so the
-    /// grind is worth `-log2((c+1)/p)` bits — slightly under its nominal `pow_bits`.
+    /// grind is worth `-log2((c+1)/p)` bits — slightly under its nominal `pow_bits`. These count
+    /// hash evaluations; see the module-level note on the grinding hash.
     #[inline]
     fn effective_pow_bits(pow_bits: usize, base_field_order: f64) -> f64 {
         if pow_bits == 0 {

--- a/crates/stark-backend/src/soundness.rs
+++ b/crates/stark-backend/src/soundness.rs
@@ -986,21 +986,11 @@ pub fn min_whir_queries(
 
 #[cfg(test)]
 mod tests {
-    use openvm_stark_sdk::config::baby_bear_poseidon2::EF;
-    use p3_baby_bear::BabyBear;
-    use p3_field::{BasedVectorSpace, PrimeField64};
+    use openvm_stark_sdk::config::{base_field_order, challenge_field_bits};
 
     use super::*;
     use crate::{config::WhirRoundConfig, interaction::LogUpSecurityParameters};
 
-    fn challenge_field_bits() -> f64 {
-        const D_EF: usize = <EF as BasedVectorSpace<BabyBear>>::DIMENSION;
-        D_EF as f64 * (BabyBear::ORDER_U64 as f64).log2()
-    }
-
-    fn base_field_order() -> f64 {
-        BabyBear::ORDER_U64 as f64
-    }
     // ==========================================================================
     // Test fixtures
     // ==========================================================================

--- a/crates/stark-backend/src/transcript/traits.rs
+++ b/crates/stark-backend/src/transcript/traits.rs
@@ -30,6 +30,19 @@ where
         SC::EF::from_basis_coefficients_fn(|_| self.sample())
     }
 
+    /// Samples and returns an integer in the range [0, 2^bits).
+    ///
+    /// # Sampling bias
+    ///
+    /// The sampling is not uniform over `[0, 2^bits)`; it works by sampling a random field element,
+    /// using its canonical embedding, and then reducing it mod 2^bits. Writing the field order as
+    /// `p = c * 2^bits + r` with `0 <= r < 2^bits`, the `r` "heavy" residues `0..r` each occur with
+    /// probability `(c + 1) / p` while the remaining `2^bits - r` "light" residues occur with
+    /// probability `c / p`. Equivalently, residues `0..r` are favored by a factor of `(c + 1) / c`.
+    /// Note residue `0` is always heavy.
+    ///
+    /// For BabyBear, `p - 1 = 2^27 * 15`, so `p ≡ 1 (mod 2^bits)` and thus `r = 1` for every
+    /// `bits <= 27`—exactly one heavy residue (the all-zero one).
     fn sample_bits(&mut self, bits: usize) -> u64 {
         assert!(bits < (u32::BITS as usize));
         assert!((1 << bits) < SC::F::ORDER_U64);

--- a/crates/stark-backend/src/transcript/traits.rs
+++ b/crates/stark-backend/src/transcript/traits.rs
@@ -51,6 +51,14 @@ where
         rand_u64 & ((1 << bits) - 1)
     }
 
+    /// Checks a proof-of-work witness: observes `witness` into the transcript and accepts iff the
+    /// next [`Self::sample_bits`] is zero (probability `≈ 2^{-bits}` for a random witness, so
+    /// [`Self::grind`] tries `≈ 2^bits` witnesses to find one).
+    ///
+    /// The work is done with the transcript hash (the `observe`/`sample_bits` sponge permutation),
+    /// so `bits` counts hash evaluations; the attacker's wall-clock cost is `≈ 2^bits · cost(H)`
+    /// for that hash `H`. Soundness targets in bits are therefore comparable only across configs
+    /// that share a grinding hash.
     #[must_use]
     fn check_witness(&mut self, bits: usize, witness: SC::F) -> bool {
         if bits == 0 {
@@ -60,6 +68,8 @@ where
         self.sample_bits(bits) == 0
     }
 
+    /// Finds a proof-of-work witness `w` such that [`Self::check_witness`]`(bits, w)` holds, by
+    /// brute force over the base field.
     #[instrument(name = "grind_pow", skip_all)]
     fn grind(&mut self, bits: usize) -> SC::F {
         assert!(bits < (u32::BITS as usize));

--- a/crates/stark-backend/tests/soundness.rs
+++ b/crates/stark-backend/tests/soundness.rs
@@ -4,13 +4,12 @@
 
 use openvm_stark_backend::{soundness::*, SystemParams};
 use openvm_stark_sdk::config::{
-    app_params_with_100_bits_security, hook_params_with_100_bits_security as hook_params,
+    app_params_with_100_bits_security, base_field_order, challenge_field_bits,
+    hook_params_with_100_bits_security as hook_params,
     internal_params_with_100_bits_security as internal_params,
     leaf_params_with_100_bits_security as leaf_params,
     root_params_with_100_bits_security as root_params, MAX_APP_LOG_STACKED_HEIGHT,
 };
-use p3_baby_bear::BabyBear;
-use p3_field::PrimeField64;
 
 // ==========================================================================
 // Circuit parameter upper bounds for soundness analysis
@@ -60,14 +59,6 @@ const RECURSION_MAX_INTERACTIONS_PER_AIR: usize = 100; // estimate, needs verifi
 
 const TARGET_SECURITY_BITS: usize = 100;
 
-fn babybear_quartic_extension_bits() -> f64 {
-    4.0 * (BabyBear::ORDER_U64 as f64).log2()
-}
-
-fn babybear_base_field_order() -> f64 {
-    BabyBear::ORDER_U64 as f64
-}
-
 fn app_params() -> SystemParams {
     app_params_with_100_bits_security(MAX_APP_LOG_STACKED_HEIGHT)
 }
@@ -83,8 +74,8 @@ fn check_soundness(
 ) -> SoundnessCalculator {
     let soundness = SoundnessCalculator::calculate(
         params,
-        babybear_base_field_order(),
-        babybear_quartic_extension_bits(),
+        base_field_order(),
+        challenge_field_bits(),
         max_constraints,
         num_airs,
         params.max_constraint_degree,

--- a/crates/stark-backend/tests/soundness.rs
+++ b/crates/stark-backend/tests/soundness.rs
@@ -64,6 +64,10 @@ fn babybear_quartic_extension_bits() -> f64 {
     4.0 * (BabyBear::ORDER_U64 as f64).log2()
 }
 
+fn babybear_base_field_order() -> f64 {
+    BabyBear::ORDER_U64 as f64
+}
+
 fn app_params() -> SystemParams {
     app_params_with_100_bits_security(MAX_APP_LOG_STACKED_HEIGHT)
 }
@@ -79,6 +83,7 @@ fn check_soundness(
 ) -> SoundnessCalculator {
     let soundness = SoundnessCalculator::calculate(
         params,
+        babybear_base_field_order(),
         babybear_quartic_extension_bits(),
         max_constraints,
         num_airs,

--- a/crates/stark-backend/tests/soundness.rs
+++ b/crates/stark-backend/tests/soundness.rs
@@ -118,7 +118,7 @@ fn check_soundness(
         soundness.zerocheck_sumcheck_bits
     );
     println!(
-        "Constraint batching: {:.1} bits",
+        "Fused boundary/batching: {:.1} bits",
         soundness.constraint_batching_bits
     );
     println!(

--- a/crates/stark-sdk/src/config/log_up_params.rs
+++ b/crates/stark-sdk/src/config/log_up_params.rs
@@ -1,6 +1,7 @@
 use openvm_stark_backend::{
     interaction::LogUpSecurityParameters,
     p3_field::{PrimeField32, PrimeField64},
+    soundness::SoundnessCalculator,
 };
 use p3_baby_bear::BabyBear;
 
@@ -19,34 +20,29 @@ pub fn log_up_security_params_baby_bear_100_bits(
         "log2_pcs_list_size must be finite and nonnegative"
     );
 
-    let mut params = LogUpSecurityParameters {
-        max_interaction_count: BabyBear::ORDER_U32,
-        log_max_message_length: 7,
-        pow_bits: 0,
-    };
-
-    // Security is linear in `pow_bits`, so the grinding needed to reach the target after the
-    // list-size penalty is exact. Floor at `MIN_BABY_BEAR_LOGUP_POW_BITS` to keep the historical
-    // baseline margin for the unique-decoding configs.
-    let security_without_pow = baby_bear_logup_security_bits(&params, log2_pcs_list_size);
-    let required_pow = (TARGET_LOGUP_SECURITY_BITS - security_without_pow)
-        .ceil()
-        .max(0.0) as usize;
-    params.pow_bits = required_pow.max(MIN_BABY_BEAR_LOGUP_POW_BITS);
-
-    assert!(
-        baby_bear_logup_security_bits(&params, log2_pcs_list_size) >= TARGET_LOGUP_SECURITY_BITS
-    );
-    params
-}
-
-/// LogUp security bits with grinding, after the PCS list-size union bound. Matches
-/// `SoundnessCalculator::calculate_logup_soundness` in the backend soundness module.
-fn baby_bear_logup_security_bits(params: &LogUpSecurityParameters, log2_pcs_list_size: f64) -> f64 {
     let challenge_field_bits = 4.0 * (BabyBear::ORDER_U64 as f64).log2();
-    challenge_field_bits
-        - (2.0 * params.max_interaction_count as f64).log2()
-        - params.log_max_message_length as f64
-        - log2_pcs_list_size
-        + params.pow_bits as f64
+    let max_interaction_count = BabyBear::ORDER_U32;
+    let log_max_message_length = 7;
+
+    // Pre-grinding LogUp security via the backend (the single source of truth). Security is linear
+    // in `pow_bits` with unit slope, so the grinding needed to reach the target is exactly the
+    // remaining gap. Floor at `MIN_BABY_BEAR_LOGUP_POW_BITS` to keep the historical baseline margin
+    // for the unique-decoding configs. The authoritative check that the resulting params clear the
+    // target is `test_all_production_configs` in the backend's soundness tests.
+    let security_without_pow = SoundnessCalculator::logup_soundness(
+        max_interaction_count,
+        log_max_message_length,
+        challenge_field_bits,
+        log2_pcs_list_size,
+    );
+    let pow_bits = ((TARGET_LOGUP_SECURITY_BITS - security_without_pow)
+        .ceil()
+        .max(0.0) as usize)
+        .max(MIN_BABY_BEAR_LOGUP_POW_BITS);
+
+    LogUpSecurityParameters {
+        max_interaction_count,
+        log_max_message_length,
+        pow_bits,
+    }
 }

--- a/crates/stark-sdk/src/config/log_up_params.rs
+++ b/crates/stark-sdk/src/config/log_up_params.rs
@@ -1,9 +1,9 @@
 use openvm_stark_backend::{
-    interaction::LogUpSecurityParameters,
-    p3_field::{PrimeField32, PrimeField64},
-    soundness::SoundnessCalculator,
+    interaction::LogUpSecurityParameters, p3_field::PrimeField32, soundness::SoundnessCalculator,
 };
 use p3_baby_bear::BabyBear;
+
+use crate::config::challenge_field_bits;
 
 const TARGET_LOGUP_SECURITY_BITS: f64 = 100.0;
 const MIN_BABY_BEAR_LOGUP_POW_BITS: usize = 18;
@@ -20,7 +20,7 @@ pub fn log_up_security_params_baby_bear_100_bits(
         "log2_pcs_list_size must be finite and nonnegative"
     );
 
-    let challenge_field_bits = 4.0 * (BabyBear::ORDER_U64 as f64).log2();
+    let challenge_field_bits = challenge_field_bits();
     let max_interaction_count = BabyBear::ORDER_U32;
     let log_max_message_length = 7;
 

--- a/crates/stark-sdk/src/config/log_up_params.rs
+++ b/crates/stark-sdk/src/config/log_up_params.rs
@@ -1,15 +1,52 @@
 use openvm_stark_backend::{
     interaction::LogUpSecurityParameters,
-    p3_field::{extension::BinomialExtensionField, PrimeField32},
+    p3_field::{PrimeField32, PrimeField64},
 };
 use p3_baby_bear::BabyBear;
 
-pub fn log_up_security_params_baby_bear_100_bits() -> LogUpSecurityParameters {
-    let params = LogUpSecurityParameters {
+const TARGET_LOGUP_SECURITY_BITS: f64 = 100.0;
+const MIN_BABY_BEAR_LOGUP_POW_BITS: usize = 18;
+
+/// Returns BabyBear LogUp parameters with at least 100 bits after the PCS list-size union bound.
+///
+/// `log2_pcs_list_size` is `log2(L_PCS)` for the initial WHIR proximity regime. It is zero for
+/// unique decoding.
+pub fn log_up_security_params_baby_bear_100_bits(
+    log2_pcs_list_size: f64,
+) -> LogUpSecurityParameters {
+    assert!(
+        log2_pcs_list_size.is_finite() && log2_pcs_list_size >= 0.0,
+        "log2_pcs_list_size must be finite and nonnegative"
+    );
+
+    let mut params = LogUpSecurityParameters {
         max_interaction_count: BabyBear::ORDER_U32,
         log_max_message_length: 7,
-        pow_bits: 18,
+        pow_bits: 0,
     };
-    assert!(params.bits_of_security::<BinomialExtensionField<BabyBear, 4>>() >= 100);
+
+    // Security is linear in `pow_bits`, so the grinding needed to reach the target after the
+    // list-size penalty is exact. Floor at `MIN_BABY_BEAR_LOGUP_POW_BITS` to keep the historical
+    // baseline margin for the unique-decoding configs.
+    let security_without_pow = baby_bear_logup_security_bits(&params, log2_pcs_list_size);
+    let required_pow = (TARGET_LOGUP_SECURITY_BITS - security_without_pow)
+        .ceil()
+        .max(0.0) as usize;
+    params.pow_bits = required_pow.max(MIN_BABY_BEAR_LOGUP_POW_BITS);
+
+    assert!(
+        baby_bear_logup_security_bits(&params, log2_pcs_list_size) >= TARGET_LOGUP_SECURITY_BITS
+    );
     params
+}
+
+/// LogUp security bits with grinding, after the PCS list-size union bound. Matches
+/// `SoundnessCalculator::calculate_logup_soundness` in the backend soundness module.
+fn baby_bear_logup_security_bits(params: &LogUpSecurityParameters, log2_pcs_list_size: f64) -> f64 {
+    let challenge_field_bits = 4.0 * (BabyBear::ORDER_U64 as f64).log2();
+    challenge_field_bits
+        - (2.0 * params.max_interaction_count as f64).log2()
+        - params.log_max_message_length as f64
+        - log2_pcs_list_size
+        + params.pow_bits as f64
 }

--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -44,18 +44,52 @@ fn babybear_quartic_extension_bits() -> f64 {
 }
 
 /// LogUp grinding sufficient for 100-bit security, accounting for the PCS list-size union bound of
-/// `params`' initial WHIR proximity regime (`log2_pcs_list_size` is 0 for unique decoding). Reads
-/// the inputs directly from `params` so they cannot diverge from the configured values.
-fn log_up_params_for_whir(params: &SystemParams) -> LogUpSecurityParameters {
+/// the initial WHIR proximity regime (`log2_pcs_list_size` is 0 for unique decoding).
+fn log_up_params_for_whir(
+    proximity: WhirProximityStrategy,
+    log_stacked_height: usize,
+    log_blowup: usize,
+    w_stack: usize,
+) -> LogUpSecurityParameters {
     let log2_pcs_list_size = SoundnessCalculator::whir_proximity_gap_security(
-        params.whir.proximity.initial_round(),
+        proximity.initial_round(),
         babybear_quartic_extension_bits(),
-        params.log_stacked_height(),
-        params.log_blowup,
-        params.w_stack,
+        log_stacked_height,
+        log_blowup,
+        w_stack,
     )
     .log2_list_size;
     log_up_security_params_baby_bear_100_bits(log2_pcs_list_size)
+}
+
+/// Builds production `SystemParams` for 100-bit security, calibrating LogUp grinding to the WHIR
+/// proximity regime's PCS list size. The LogUp params are derived up front (from the same inputs
+/// `SystemParams::new` uses to build the WHIR config) so they can be passed straight in.
+#[allow(clippy::too_many_arguments)]
+fn params_with_100_bits_security(
+    log_blowup: usize,
+    l_skip: usize,
+    n_stack: usize,
+    w_stack: usize,
+    folding_pow_bits: usize,
+    mu_pow_bits: usize,
+    proximity: WhirProximityStrategy,
+    max_constraint_degree: usize,
+) -> SystemParams {
+    let logup = log_up_params_for_whir(proximity, l_skip + n_stack, log_blowup, w_stack);
+    SystemParams::new(
+        log_blowup,
+        l_skip,
+        n_stack,
+        w_stack,
+        WHIR_MAX_LOG_FINAL_POLY_LEN,
+        folding_pow_bits,
+        mu_pow_bits,
+        proximity,
+        SECURITY_BITS_TARGET,
+        logup,
+        max_constraint_degree,
+    )
 }
 
 /// Returns `SystemParams` targeting 100 bits of proven RBR security for App VM circuits.
@@ -75,21 +109,16 @@ pub fn app_params_with_100_bits_security(log_stacked_height: usize) -> SystemPar
         log_stacked_height <= MAX_APP_LOG_STACKED_HEIGHT,
         "log_stacked_height must be <= {MAX_APP_LOG_STACKED_HEIGHT}",
     );
-    let mut params = SystemParams::new(
+    params_with_100_bits_security(
         DEFAULT_APP_LOG_BLOWUP,
         DEFAULT_APP_L_SKIP,
         log_stacked_height.saturating_sub(DEFAULT_APP_L_SKIP), // n_stack
         2048,                                                  // w_stack
-        WHIR_MAX_LOG_FINAL_POLY_LEN,
-        5,  // folding pow
-        15, // mu pow
+        5,                                                     // folding pow
+        15,                                                    // mu pow
         WhirProximityStrategy::UniqueDecoding,
-        SECURITY_BITS_TARGET,
-        log_up_security_params_baby_bear_100_bits(0.0),
         APP_MAX_CONSTRAINT_DEGREE,
-    );
-    params.logup = log_up_params_for_whir(&params);
-    params
+    )
 }
 
 /// Returns `SystemParams` targeting 100 bits of proven RBR security for leaf aggregation circuits.
@@ -108,21 +137,16 @@ pub fn app_params_with_100_bits_security(log_stacked_height: usize) -> SystemPar
 // See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
 // full soundness analysis.
 pub fn leaf_params_with_100_bits_security() -> SystemParams {
-    let mut params = SystemParams::new(
+    params_with_100_bits_security(
         DEFAULT_LEAF_LOG_BLOWUP,
         4,    // l_skip
         17,   // n_stack
         2048, // w_stack
-        WHIR_MAX_LOG_FINAL_POLY_LEN,
-        4,  // folding pow
-        13, // mu pow
+        4,    // folding pow
+        13,   // mu pow
         WhirProximityStrategy::UniqueDecoding,
-        SECURITY_BITS_TARGET,
-        log_up_security_params_baby_bear_100_bits(0.0),
         RECURSION_MAX_CONSTRAINT_DEGREE,
-    );
-    params.logup = log_up_params_for_whir(&params);
-    params
+    )
 }
 
 /// Returns `SystemParams` targeting 100 bits of proven RBR security for internal aggregation
@@ -141,21 +165,16 @@ pub fn leaf_params_with_100_bits_security() -> SystemParams {
 // See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
 // full soundness analysis.
 pub fn internal_params_with_100_bits_security() -> SystemParams {
-    let mut params = SystemParams::new(
+    params_with_100_bits_security(
         DEFAULT_INTERNAL_LOG_BLOWUP,
         2,   // l_skip
         17,  // n_stack
         512, // w_stack
-        WHIR_MAX_LOG_FINAL_POLY_LEN,
-        18, // folding pow
-        20, // mu pow
+        18,  // folding pow
+        20,  // mu pow
         WhirProximityStrategy::ListDecoding { m: 2 },
-        SECURITY_BITS_TARGET,
-        log_up_security_params_baby_bear_100_bits(0.0),
         RECURSION_MAX_CONSTRAINT_DEGREE,
-    );
-    params.logup = log_up_params_for_whir(&params);
-    params
+    )
 }
 
 /// Returns `SystemParams` targeting 100 bits of proven RBR security for root circuits.
@@ -173,21 +192,16 @@ pub fn internal_params_with_100_bits_security() -> SystemParams {
 // See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
 // full soundness analysis.
 pub fn root_params_with_100_bits_security() -> SystemParams {
-    let mut params = SystemParams::new(
+    params_with_100_bits_security(
         DEFAULT_ROOT_LOG_BLOWUP,
         2,  // l_skip
         18, // n_stack
         18, // w_stack
-        WHIR_MAX_LOG_FINAL_POLY_LEN,
         20, // folding pow
         20, // mu pow
         WhirProximityStrategy::ListDecoding { m: 1 },
-        SECURITY_BITS_TARGET,
-        log_up_security_params_baby_bear_100_bits(0.0),
         RECURSION_MAX_CONSTRAINT_DEGREE,
-    );
-    params.logup = log_up_params_for_whir(&params);
-    params
+    )
 }
 
 /// Returns `SystemParams` targeting 100 bits of proven RBR security for deferral hook circuits.
@@ -205,19 +219,14 @@ pub fn root_params_with_100_bits_security() -> SystemParams {
 // See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
 // full soundness analysis.
 pub fn hook_params_with_100_bits_security() -> SystemParams {
-    let mut params = SystemParams::new(
+    params_with_100_bits_security(
         DEFAULT_HOOK_LOG_BLOWUP,
         2,  // l_skip
         18, // n_stack
         80, // w_stack
-        WHIR_MAX_LOG_FINAL_POLY_LEN,
         12, // folding pow
         11, // mu pow
         WhirProximityStrategy::ListDecoding { m: 1 },
-        SECURITY_BITS_TARGET,
-        log_up_security_params_baby_bear_100_bits(0.0),
         RECURSION_MAX_CONSTRAINT_DEGREE,
-    );
-    params.logup = log_up_params_for_whir(&params);
-    params
+    )
 }

--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -1,4 +1,8 @@
-use openvm_stark_backend::{SystemParams, WhirProximityStrategy};
+use openvm_stark_backend::{
+    interaction::LogUpSecurityParameters, p3_field::PrimeField64, soundness::SoundnessCalculator,
+    SystemParams, WhirProximityStrategy,
+};
+use p3_baby_bear::BabyBear;
 
 use crate::config::log_up_params::log_up_security_params_baby_bear_100_bits;
 
@@ -35,6 +39,25 @@ pub const RECURSION_MAX_CONSTRAINT_DEGREE: usize = 4;
 
 pub const MAX_APP_LOG_STACKED_HEIGHT: usize = 24;
 
+fn babybear_quartic_extension_bits() -> f64 {
+    4.0 * (BabyBear::ORDER_U64 as f64).log2()
+}
+
+/// LogUp grinding sufficient for 100-bit security, accounting for the PCS list-size union bound of
+/// `params`' initial WHIR proximity regime (`log2_pcs_list_size` is 0 for unique decoding). Reads
+/// the inputs directly from `params` so they cannot diverge from the configured values.
+fn log_up_params_for_whir(params: &SystemParams) -> LogUpSecurityParameters {
+    let log2_pcs_list_size = SoundnessCalculator::whir_proximity_gap_security(
+        params.whir.proximity.initial_round(),
+        babybear_quartic_extension_bits(),
+        params.log_stacked_height(),
+        params.log_blowup,
+        params.w_stack,
+    )
+    .log2_list_size;
+    log_up_security_params_baby_bear_100_bits(log2_pcs_list_size)
+}
+
 /// Returns `SystemParams` targeting 100 bits of proven RBR security for App VM circuits.
 ///
 /// # Assumptions for 100-bit security
@@ -52,7 +75,7 @@ pub fn app_params_with_100_bits_security(log_stacked_height: usize) -> SystemPar
         log_stacked_height <= MAX_APP_LOG_STACKED_HEIGHT,
         "log_stacked_height must be <= {MAX_APP_LOG_STACKED_HEIGHT}",
     );
-    SystemParams::new(
+    let mut params = SystemParams::new(
         DEFAULT_APP_LOG_BLOWUP,
         DEFAULT_APP_L_SKIP,
         log_stacked_height.saturating_sub(DEFAULT_APP_L_SKIP), // n_stack
@@ -62,9 +85,11 @@ pub fn app_params_with_100_bits_security(log_stacked_height: usize) -> SystemPar
         15, // mu pow
         WhirProximityStrategy::UniqueDecoding,
         SECURITY_BITS_TARGET,
-        log_up_security_params_baby_bear_100_bits(),
+        log_up_security_params_baby_bear_100_bits(0.0),
         APP_MAX_CONSTRAINT_DEGREE,
-    )
+    );
+    params.logup = log_up_params_for_whir(&params);
+    params
 }
 
 /// Returns `SystemParams` targeting 100 bits of proven RBR security for leaf aggregation circuits.
@@ -83,7 +108,7 @@ pub fn app_params_with_100_bits_security(log_stacked_height: usize) -> SystemPar
 // See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
 // full soundness analysis.
 pub fn leaf_params_with_100_bits_security() -> SystemParams {
-    SystemParams::new(
+    let mut params = SystemParams::new(
         DEFAULT_LEAF_LOG_BLOWUP,
         4,    // l_skip
         17,   // n_stack
@@ -93,9 +118,11 @@ pub fn leaf_params_with_100_bits_security() -> SystemParams {
         13, // mu pow
         WhirProximityStrategy::UniqueDecoding,
         SECURITY_BITS_TARGET,
-        log_up_security_params_baby_bear_100_bits(),
+        log_up_security_params_baby_bear_100_bits(0.0),
         RECURSION_MAX_CONSTRAINT_DEGREE,
-    )
+    );
+    params.logup = log_up_params_for_whir(&params);
+    params
 }
 
 /// Returns `SystemParams` targeting 100 bits of proven RBR security for internal aggregation
@@ -114,7 +141,7 @@ pub fn leaf_params_with_100_bits_security() -> SystemParams {
 // See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
 // full soundness analysis.
 pub fn internal_params_with_100_bits_security() -> SystemParams {
-    SystemParams::new(
+    let mut params = SystemParams::new(
         DEFAULT_INTERNAL_LOG_BLOWUP,
         2,   // l_skip
         17,  // n_stack
@@ -124,9 +151,11 @@ pub fn internal_params_with_100_bits_security() -> SystemParams {
         20, // mu pow
         WhirProximityStrategy::ListDecoding { m: 2 },
         SECURITY_BITS_TARGET,
-        log_up_security_params_baby_bear_100_bits(),
+        log_up_security_params_baby_bear_100_bits(0.0),
         RECURSION_MAX_CONSTRAINT_DEGREE,
-    )
+    );
+    params.logup = log_up_params_for_whir(&params);
+    params
 }
 
 /// Returns `SystemParams` targeting 100 bits of proven RBR security for root circuits.
@@ -144,7 +173,7 @@ pub fn internal_params_with_100_bits_security() -> SystemParams {
 // See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
 // full soundness analysis.
 pub fn root_params_with_100_bits_security() -> SystemParams {
-    SystemParams::new(
+    let mut params = SystemParams::new(
         DEFAULT_ROOT_LOG_BLOWUP,
         2,  // l_skip
         18, // n_stack
@@ -154,9 +183,11 @@ pub fn root_params_with_100_bits_security() -> SystemParams {
         20, // mu pow
         WhirProximityStrategy::ListDecoding { m: 1 },
         SECURITY_BITS_TARGET,
-        log_up_security_params_baby_bear_100_bits(),
+        log_up_security_params_baby_bear_100_bits(0.0),
         RECURSION_MAX_CONSTRAINT_DEGREE,
-    )
+    );
+    params.logup = log_up_params_for_whir(&params);
+    params
 }
 
 /// Returns `SystemParams` targeting 100 bits of proven RBR security for deferral hook circuits.
@@ -174,7 +205,7 @@ pub fn root_params_with_100_bits_security() -> SystemParams {
 // See `test_all_production_configs` in `crates/stark-backend/tests/soundness.rs` for the
 // full soundness analysis.
 pub fn hook_params_with_100_bits_security() -> SystemParams {
-    SystemParams::new(
+    let mut params = SystemParams::new(
         DEFAULT_HOOK_LOG_BLOWUP,
         2,  // l_skip
         18, // n_stack
@@ -184,7 +215,9 @@ pub fn hook_params_with_100_bits_security() -> SystemParams {
         11, // mu pow
         WhirProximityStrategy::ListDecoding { m: 1 },
         SECURITY_BITS_TARGET,
-        log_up_security_params_baby_bear_100_bits(),
+        log_up_security_params_baby_bear_100_bits(0.0),
         RECURSION_MAX_CONSTRAINT_DEGREE,
-    )
+    );
+    params.logup = log_up_params_for_whir(&params);
+    params
 }

--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -1,10 +1,14 @@
 use openvm_stark_backend::{
-    interaction::LogUpSecurityParameters, p3_field::PrimeField64, soundness::SoundnessCalculator,
+    interaction::LogUpSecurityParameters,
+    p3_field::{BasedVectorSpace, PrimeField64},
+    soundness::SoundnessCalculator,
     SystemParams, WhirProximityStrategy,
 };
-use p3_baby_bear::BabyBear;
 
-use crate::config::log_up_params::log_up_security_params_baby_bear_100_bits;
+use crate::config::{
+    baby_bear_poseidon2::{EF, F},
+    log_up_params::log_up_security_params_baby_bear_100_bits,
+};
 
 /// STARK config where the base field is BabyBear, extension field is BabyBear^4, and the hasher is
 /// `Poseidon2<Bn254>`.
@@ -39,8 +43,18 @@ pub const RECURSION_MAX_CONSTRAINT_DEGREE: usize = 4;
 
 pub const MAX_APP_LOG_STACKED_HEIGHT: usize = 24;
 
-fn babybear_quartic_extension_bits() -> f64 {
-    4.0 * (BabyBear::ORDER_U64 as f64).log2()
+/// Order `p` of the configured base field.
+pub fn base_field_order() -> f64 {
+    F::ORDER_U64 as f64
+}
+
+/// Number of bits in the challenge (extension) field: `D_EF * log2(|F|)`.
+///
+/// Derived from the configured extension degree (matching `StarkProtocolConfig::D_EF`), so it
+/// tracks automatically if the extension field changes.
+pub fn challenge_field_bits() -> f64 {
+    const D_EF: usize = <EF as BasedVectorSpace<F>>::DIMENSION;
+    D_EF as f64 * base_field_order().log2()
 }
 
 /// LogUp grinding sufficient for 100-bit security, accounting for the PCS list-size union bound of
@@ -53,7 +67,7 @@ fn log_up_params_for_whir(
 ) -> LogUpSecurityParameters {
     let log2_pcs_list_size = SoundnessCalculator::whir_proximity_gap_security(
         proximity.initial_round(),
-        babybear_quartic_extension_bits(),
+        challenge_field_bits(),
         log_stacked_height,
         log_blowup,
         w_stack,


### PR DESCRIPTION
- Fuse the last LogUp-GKR input-layer challenge with ZeroCheck's
      input-point and batching challenges into
      max { max(3, n_extra) + (2^l_skip - 1) + (N_C - 1), (3|T| - 1) }.
- Apply the L_PCS list-size as a union-bound penalty (subtract
      log2(L_PCS)) in the LogUp, ZeroCheck, constraint-batching, and
      stacked-reduction terms, matching the WHIR query-phase convention;
      previously it was added.
- Derive each production config's LogUp grinding from its initial WHIR
      proximity regime so pow_bits covers the list-size penalty
      (internal: 18 -> 19; app/leaf/root unchanged).
- Account for sample bias in the calculator