### PR TITLE
feat(keygen): reject degenerate circuits

### DIFF
--- a/crates/stark-backend/src/keygen/mod.rs
+++ b/crates/stark-backend/src/keygen/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     air_builders::symbolic::{
         get_symbolic_builder,
         symbolic_variable::{Entry, SymbolicVariable},
-        SymbolicConstraintsDag, SymbolicExpressionNode, SymbolicRapBuilder,
+        SymbolicConstraintsDag, SymbolicExpressionNode,
     },
     hasher::MerkleHasher,
     keygen::types::{
@@ -243,11 +243,30 @@ impl<SC: StarkProtocolConfig> AirKeygenBuilder<SC> {
     ) -> Result<StarkProvingKey<SC>, KeygenError> {
         let air_name = self.air.name();
 
-        let symbolic_builder = self.get_symbolic_builder();
-        let width = symbolic_builder.width();
+        let width = self.trace_width();
+        if width.main_width() == 0 {
+            return Err(KeygenError::AirWidthZero { name: air_name });
+        }
+
+        let symbolic_builder = get_symbolic_builder(self.air.as_ref(), &width);
         let num_public_values = symbolic_builder.num_public_values();
 
         let symbolic_constraints = symbolic_builder.constraints();
+        if symbolic_constraints.constraints.is_empty()
+            && symbolic_constraints.interactions.is_empty()
+        {
+            return Err(KeygenError::AirNoConstraintsOrInteractions { name: air_name });
+        }
+        if let Some(interaction_index) = symbolic_constraints
+            .interactions
+            .iter()
+            .position(|interaction| interaction.message.is_empty())
+        {
+            return Err(KeygenError::InteractionMessageEmpty {
+                name: air_name,
+                interaction_index,
+            });
+        }
         let constraint_degree = symbolic_constraints.max_constraint_degree();
         if constraint_degree > max_constraint_degree {
             return Err(KeygenError::MaxConstraintDegreeExceeded {
@@ -294,13 +313,12 @@ impl<SC: StarkProtocolConfig> AirKeygenBuilder<SC> {
         })
     }
 
-    pub fn get_symbolic_builder(&self) -> SymbolicRapBuilder<SC::F> {
-        let width = TraceWidth {
+    fn trace_width(&self) -> TraceWidth {
+        TraceWidth {
             preprocessed: self.prep_keygen_data.width(),
             cached_mains: self.air.cached_main_widths(),
             common_main: self.air.common_main_width(),
-        };
-        get_symbolic_builder(self.air.as_ref(), &width)
+        }
     }
 }
 

--- a/crates/stark-backend/src/keygen/types.rs
+++ b/crates/stark-backend/src/keygen/types.rs
@@ -66,6 +66,15 @@ impl LinearConstraint {
 
 #[derive(Error, Debug)]
 pub enum KeygenError {
+    #[error("AIR {name} has zero main trace width")]
+    AirWidthZero { name: String },
+    #[error("AIR {name} must have at least one constraint or interaction")]
+    AirNoConstraintsOrInteractions { name: String },
+    #[error("AIR {name} interaction {interaction_index} has a zero-length message")]
+    InteractionMessageEmpty {
+        name: String,
+        interaction_index: usize,
+    },
     #[error("Max constraint degree exceeded for AIR {name}: {degree} > {max_degree}")]
     MaxConstraintDegreeExceeded {
         name: String,

--- a/crates/stark-backend/tests/keygen_validation.rs
+++ b/crates/stark-backend/tests/keygen_validation.rs
@@ -1,0 +1,76 @@
+use std::sync::Arc;
+
+use openvm_stark_backend::{
+    keygen::{
+        types::{KeygenError, MultiStarkProvingKey},
+        MultiStarkKeygenBuilder,
+    },
+    test_utils::{
+        default_test_params_small,
+        dummy_airs::interaction::dummy_interaction_air::DummyInteractionAir,
+    },
+    AirRef, PartitionedBaseAir,
+};
+use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Config;
+use p3_air::{Air, AirBuilder, BaseAir, BaseAirWithPublicValues};
+
+type SC = BabyBearPoseidon2Config;
+
+#[derive(Clone, Copy)]
+struct NoopAir {
+    width: usize,
+}
+
+impl<F> BaseAir<F> for NoopAir {
+    fn width(&self) -> usize {
+        self.width
+    }
+}
+
+impl<F> BaseAirWithPublicValues<F> for NoopAir {}
+impl<F> PartitionedBaseAir<F> for NoopAir {}
+
+impl<AB: AirBuilder> Air<AB> for NoopAir {
+    fn eval(&self, _builder: &mut AB) {}
+}
+
+fn generate_pk_for_air(air: AirRef<SC>) -> Result<MultiStarkProvingKey<SC>, KeygenError> {
+    let config = BabyBearPoseidon2Config::default_from_params(default_test_params_small());
+    let mut keygen_builder = MultiStarkKeygenBuilder::new(config);
+    keygen_builder.add_air(air);
+    keygen_builder.generate_pk()
+}
+
+fn expect_keygen_err(air: AirRef<SC>) -> KeygenError {
+    match generate_pk_for_air(air) {
+        Ok(_) => panic!("keygen unexpectedly succeeded"),
+        Err(err) => err,
+    }
+}
+
+#[test]
+fn keygen_rejects_zero_width_air() {
+    let err = expect_keygen_err(Arc::new(NoopAir { width: 0 }));
+    assert!(matches!(err, KeygenError::AirWidthZero { .. }));
+}
+
+#[test]
+fn keygen_rejects_air_without_constraints_or_interactions() {
+    let err = expect_keygen_err(Arc::new(NoopAir { width: 1 }));
+    assert!(matches!(
+        err,
+        KeygenError::AirNoConstraintsOrInteractions { .. }
+    ));
+}
+
+#[test]
+fn keygen_rejects_interaction_with_empty_message() {
+    let err = expect_keygen_err(Arc::new(DummyInteractionAir::new(0, true, 0)));
+    assert!(matches!(
+        err,
+        KeygenError::InteractionMessageEmpty {
+            interaction_index: 0,
+            ..
+        }
+    ));
+}


### PR DESCRIPTION
Require every AIR to have positive width, at least one constraint or interaction, and every interaction message to have positive length.