### PR TITLE
chore: resolve some TODOs and build warnings

### DIFF
--- a/crates/cuda-backend/cuda/src/device_info.cu
+++ b/crates/cuda-backend/cuda/src/device_info.cu
@@ -3,7 +3,7 @@
 #include <cuda_runtime_api.h>
 #include <driver_types.h>
 
-extern "C" int _cuda_get_sm_count(uint32_t device_id, uint32_t *out_sm_count, cudaStream_t stream) {
+extern "C" int _cuda_get_sm_count(uint32_t device_id, uint32_t *out_sm_count) {
     int sm_count = 0;
     cudaError_t err = cudaDeviceGetAttribute(
         &sm_count, cudaDevAttrMultiProcessorCount, static_cast<int>(device_id)

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/batch_mle.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/batch_mle.cu
@@ -358,8 +358,7 @@ __global__ void logup_batch_mle_kernel(
 extern "C" size_t _zerocheck_batch_mle_intermediates_buffer_size(
     uint32_t buffer_size,
     uint32_t num_x,
-    uint32_t num_y,
-    cudaStream_t stream
+    uint32_t num_y
 ) {
     size_t height = static_cast<size_t>(num_x) * num_y;
     return height * buffer_size;
@@ -369,8 +368,7 @@ extern "C" size_t _zerocheck_batch_mle_intermediates_buffer_size(
 extern "C" size_t _logup_batch_mle_intermediates_buffer_size(
     uint32_t buffer_size,
     uint32_t num_x,
-    uint32_t num_y,
-    cudaStream_t stream
+    uint32_t num_y
 ) {
     size_t height = static_cast<size_t>(num_x) * num_y;
     return height * buffer_size;

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
@@ -1328,7 +1328,7 @@ inline std::pair<dim3, dim3> frac_compute_round_launch_params(uint32_t num_x) {
     return {dim3(blocks_needed), dim3(block_size)};
 }
 
-extern "C" uint32_t _frac_compute_round_temp_buffer_size(uint32_t num_x, cudaStream_t stream) {
+extern "C" uint32_t _frac_compute_round_temp_buffer_size(uint32_t num_x) {
     auto [grid, block] = frac_compute_round_launch_params(num_x);
     return grid.x * GKR_SP_DEG;
 }

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/logup_round0.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/logup_round0.cu
@@ -479,8 +479,7 @@ extern "C" size_t _logup_r0_temp_sums_buffer_size(
     uint32_t skip_domain,
     uint32_t num_x,
     uint32_t num_cosets,
-    size_t max_temp_bytes,
-    cudaStream_t stream
+    size_t max_temp_bytes
 ) {
     // Both modes use the same buffer size formula
     return DISPATCH_BOOL(
@@ -501,8 +500,7 @@ extern "C" size_t _logup_r0_intermediates_buffer_size(
     uint32_t skip_domain,
     uint32_t num_x,
     uint32_t num_cosets,
-    size_t max_temp_bytes,
-    cudaStream_t stream
+    size_t max_temp_bytes
 ) {
     // Both modes use the same buffer size formula
     return DISPATCH_BOOL(

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/mle.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/mle.cu
@@ -340,7 +340,7 @@ constexpr uint32_t MAX_THREADS = 128;
 
 // (Not a launcher) Utility function to calculate required size of temp sum buffer.
 // Required length of *temp_sum_buffer in FpExt elements
-extern "C" size_t _zerocheck_mle_temp_sums_buffer_size(uint32_t num_x, uint32_t num_y, cudaStream_t stream) {
+extern "C" size_t _zerocheck_mle_temp_sums_buffer_size(uint32_t num_x, uint32_t num_y) {
     return mle_rounds_config::temp_sums_buffer_size(num_x, num_y, MAX_THREADS);
 }
 
@@ -348,8 +348,7 @@ extern "C" size_t _zerocheck_mle_temp_sums_buffer_size(uint32_t num_x, uint32_t 
 extern "C" size_t _zerocheck_mle_intermediates_buffer_size(
     uint32_t buffer_size,
     uint32_t num_x,
-    uint32_t num_y,
-    cudaStream_t stream
+    uint32_t num_y
 ) {
     return mle_rounds_config::intermediates_buffer_size(
         buffer_size, num_x, num_y, ZEROCHECK_BUFFER_THRESHOLD, MAX_THREADS
@@ -407,7 +406,7 @@ extern "C" int _zerocheck_eval_mle(
 
 // (Not a launcher) Utility function to calculate required size of temp sum buffer.
 // Required length of *temp_sum_buffer in FracExt elements
-extern "C" size_t _logup_mle_temp_sums_buffer_size(uint32_t num_x, uint32_t num_y, cudaStream_t stream) {
+extern "C" size_t _logup_mle_temp_sums_buffer_size(uint32_t num_x, uint32_t num_y) {
     return mle_rounds_config::temp_sums_buffer_size(num_x, num_y, MAX_THREADS);
 }
 
@@ -415,8 +414,7 @@ extern "C" size_t _logup_mle_temp_sums_buffer_size(uint32_t num_x, uint32_t num_
 extern "C" size_t _logup_mle_intermediates_buffer_size(
     uint32_t buffer_size,
     uint32_t num_x,
-    uint32_t num_y,
-    cudaStream_t stream
+    uint32_t num_y
 ) {
     return mle_rounds_config::intermediates_buffer_size(
         buffer_size, num_x, num_y, LOGUP_BUFFER_THRESHOLD, MAX_THREADS

--- a/crates/cuda-backend/cuda/src/logup_zerocheck/zerocheck_round0.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/zerocheck_round0.cu
@@ -485,8 +485,7 @@ extern "C" size_t _zerocheck_r0_temp_sums_buffer_size(
     uint32_t skip_domain,
     uint32_t num_x,
     uint32_t num_cosets,
-    size_t max_temp_bytes,
-    cudaStream_t stream
+    size_t max_temp_bytes
 ) {
     // Both modes use the same buffer size formula
     return DISPATCH_BOOL(
@@ -507,8 +506,7 @@ extern "C" size_t _zerocheck_r0_intermediates_buffer_size(
     uint32_t skip_domain,
     uint32_t num_x,
     uint32_t num_cosets,
-    size_t max_temp_bytes,
-    cudaStream_t stream
+    size_t max_temp_bytes
 ) {
     // Both modes use the same buffer size formula
     return DISPATCH_BOOL(

--- a/crates/cuda-backend/cuda/src/stacked_reduction.cu
+++ b/crates/cuda-backend/cuda/src/stacked_reduction.cu
@@ -392,8 +392,7 @@ inline std::pair<dim3, dim3> stacked_reduction_round0_launch_params(
 extern "C" uint32_t _stacked_reduction_r0_required_temp_buffer_size(
     uint32_t trace_height,
     uint32_t trace_width,
-    uint32_t l_skip,
-    cudaStream_t stream
+    uint32_t l_skip
 ) {
     auto [grid, block] = stacked_reduction_round0_launch_params(trace_height, trace_width, l_skip);
     return ((grid.x * grid.y) << l_skip) * NUM_G;

--- a/crates/cuda-backend/cuda/src/sumcheck.cu
+++ b/crates/cuda-backend/cuda/src/sumcheck.cu
@@ -65,8 +65,9 @@ __global__ void sumcheck_mle_round_kernel(
 
     int half_height = height >> 1;
 
-    // Local accumulators for all (d, WD) pairs
-    constexpr int MAX_D = 5; // [TODO] Mark this in doc that it's max degree 4 + 1
+    // Local accumulators for all (d, WD) pairs. The maximum constraint degree this
+    // kernel supports is 4, which requires 4 + 1 evaluations.
+    constexpr int MAX_D = 5;
     FpExt local_sums[WD * MAX_D];
 
     // Initialize accumulators
@@ -300,7 +301,9 @@ extern "C" int _fold_mle(
     const uint16_t num_matrices,
     const uint32_t output_height,
     const uint32_t max_output_cells,
-    const FpExt r_val, cudaStream_t stream) {
+    const FpExt r_val,
+    cudaStream_t stream
+) {
     auto [grid, block] = fold_mle_launch_params(max_output_cells, num_matrices);
     uint8_t log_output_height = static_cast<uint8_t>(31 - __builtin_clz(output_height));
     fold_mle_kernel<<<grid, block, 0, stream>>>(
@@ -326,7 +329,9 @@ extern "C" int _batch_fold_mle(
     const uint16_t num_matrices,
     const uint8_t *log_output_heights,
     const uint32_t max_output_cells, // max(height * width)
-    const FpExt r_val, cudaStream_t stream) {
+    const FpExt r_val,
+    cudaStream_t stream
+) {
     auto [grid, block] = fold_mle_launch_params(max_output_cells, num_matrices);
     batch_fold_mle_kernel<<<grid, block, 0, stream>>>(
         input_matrices, output_matrices, widths, num_matrices, log_output_heights, r_val
@@ -340,7 +345,9 @@ extern "C" int _fold_ple_from_coeffs(
     const uint32_t num_x,
     const uint32_t width,
     const uint32_t domain_size,
-    const FpExt r_val, cudaStream_t stream) {
+    const FpExt r_val,
+    cudaStream_t stream
+) {
     int total_polys = num_x * width;
     auto [grid, block] = kernel_launch_params(total_polys);
 
@@ -356,7 +363,9 @@ extern "C" int _reduce_over_x_and_cols(
     Fp *output,
     uint32_t num_x,
     uint32_t num_cols,
-    uint32_t large_domain_size, cudaStream_t stream) {
+    uint32_t large_domain_size,
+    cudaStream_t stream
+) {
     auto [grid, block] = kernel_launch_params(large_domain_size);
     reduce_over_x_and_cols_kernel<<<grid, block, 0, stream>>>(
         input, output, num_x, num_cols, large_domain_size
@@ -372,7 +381,9 @@ extern "C" int _sumcheck_mle_round(
     const uint32_t *widths,
     const uint32_t num_matrices,
     const uint32_t height,
-    const uint32_t d, cudaStream_t stream) {
+    const uint32_t d,
+    cudaStream_t stream
+) {
     if (d == 0 || d > 5) {
         return cudaErrorInvalidValue;
     }
@@ -405,7 +416,9 @@ extern "C" int _triangular_fold_mle(
     FpExt *output,
     const FpExt *input,
     FpExt r,
-    uint32_t output_max_n, cudaStream_t stream) {
+    uint32_t output_max_n,
+    cudaStream_t stream
+) {
     auto [grid, block] = kernel_launch_params(1 << output_max_n);
     grid.y = output_max_n + 1;
 

--- a/crates/cuda-backend/cuda/src/whir.cu
+++ b/crates/cuda-backend/cuda/src/whir.cu
@@ -242,7 +242,7 @@ inline std::pair<dim3, dim3> whir_sumcheck_coeff_moments_launch_params(uint32_t 
     return kernel_launch_params(height >> 1, 256);
 }
 
-extern "C" uint32_t _whir_sumcheck_coeff_moments_required_temp_buffer_size(uint32_t height, cudaStream_t stream) {
+extern "C" uint32_t _whir_sumcheck_coeff_moments_required_temp_buffer_size(uint32_t height) {
     auto [grid, block] = whir_sumcheck_coeff_moments_launch_params(height);
     return grid.x * S_DEG;
 }

--- a/crates/cuda-backend/src/cuda/device_info.rs
+++ b/crates/cuda-backend/src/cuda/device_info.rs
@@ -1,11 +1,11 @@
-use openvm_cuda_common::{error::CudaError, stream::cudaStream_t};
+use openvm_cuda_common::error::CudaError;
 
 extern "C" {
-    fn _cuda_get_sm_count(device_id: u32, out_sm_count: *mut u32, stream: cudaStream_t) -> i32;
+    fn _cuda_get_sm_count(device_id: u32, out_sm_count: *mut u32) -> i32;
 }
 
-pub fn get_sm_count(device_id: u32, stream: cudaStream_t) -> Result<u32, CudaError> {
+pub fn get_sm_count(device_id: u32) -> Result<u32, CudaError> {
     let mut sm_count = 0u32;
-    unsafe { CudaError::from_result(_cuda_get_sm_count(device_id, &mut sm_count, stream))? };
+    unsafe { CudaError::from_result(_cuda_get_sm_count(device_id, &mut sm_count))? };
     Ok(sm_count)
 }

--- a/crates/cuda-backend/src/cuda/logup_zerocheck.rs
+++ b/crates/cuda-backend/src/cuda/logup_zerocheck.rs
@@ -149,7 +149,7 @@ extern "C" {
         stream: cudaStream_t,
     ) -> i32;
 
-    pub fn _frac_compute_round_temp_buffer_size(stride: u32, stream: cudaStream_t) -> u32;
+    pub fn _frac_compute_round_temp_buffer_size(stride: u32) -> u32;
 
     fn _frac_compute_round(
         eq_xi_low: *const EF,
@@ -347,7 +347,6 @@ extern "C" {
         num_x: u32,
         num_cosets: u32,
         max_temp_bytes: usize,
-        stream: cudaStream_t,
     ) -> usize;
 
     pub fn _logup_r0_intermediates_buffer_size(
@@ -356,7 +355,6 @@ extern "C" {
         num_x: u32,
         num_cosets: u32,
         max_temp_bytes: usize,
-        stream: cudaStream_t,
     ) -> usize;
 
     fn _logup_bary_eval_interactions_round0(
@@ -390,7 +388,6 @@ extern "C" {
         num_x: u32,
         num_cosets: u32,
         max_temp_bytes: usize,
-        stream: cudaStream_t,
     ) -> usize;
 
     pub fn _zerocheck_r0_intermediates_buffer_size(
@@ -399,7 +396,6 @@ extern "C" {
         num_x: u32,
         num_cosets: u32,
         max_temp_bytes: usize,
-        stream: cudaStream_t,
     ) -> usize;
 
     fn _zerocheck_ntt_eval_constraints(
@@ -471,14 +467,8 @@ extern "C" {
         stream: cudaStream_t,
     ) -> i32;
 
-    pub fn _logup_mle_temp_sums_buffer_size(num_x: u32, num_y: u32, stream: cudaStream_t) -> usize;
-
-    pub fn _logup_mle_intermediates_buffer_size(
-        buffer_size: u32,
-        num_x: u32,
-        num_y: u32,
-        stream: cudaStream_t,
-    ) -> usize;
+    pub fn _logup_mle_temp_sums_buffer_size(num_x: u32, num_y: u32) -> usize;
+    pub fn _logup_mle_intermediates_buffer_size(buffer_size: u32, num_x: u32, num_y: u32) -> usize;
 
     fn _logup_eval_mle(
         tmp_sums_buffer: *mut Frac<EF>,
@@ -506,14 +496,12 @@ extern "C" {
         buffer_size: u32,
         num_x: u32,
         num_y: u32,
-        stream: cudaStream_t,
     ) -> usize;
 
     pub fn _logup_batch_mle_intermediates_buffer_size(
         buffer_size: u32,
         num_x: u32,
         num_y: u32,
-        stream: cudaStream_t,
     ) -> usize;
 
     fn _zerocheck_batch_eval_mle(
@@ -693,7 +681,7 @@ pub unsafe fn frac_compute_round(
     #[cfg(debug_assertions)]
     {
         let len = tmp_block_sums.len();
-        let required = _frac_compute_round_temp_buffer_size(num_x.try_into().unwrap(), stream);
+        let required = _frac_compute_round_temp_buffer_size(num_x.try_into().unwrap());
         assert!(
             len >= required as usize,
             "tmp_block_sums len={len} < required={required}"
@@ -737,7 +725,7 @@ pub unsafe fn frac_compute_round_and_revert(
     #[cfg(debug_assertions)]
     {
         let len = tmp_block_sums.len();
-        let required = _frac_compute_round_temp_buffer_size(num_x.try_into().unwrap(), stream);
+        let required = _frac_compute_round_temp_buffer_size(num_x.try_into().unwrap());
         assert!(
             len >= required as usize,
             "tmp_block_sums len={len} < required={required}"
@@ -877,7 +865,7 @@ pub unsafe fn frac_compute_round_and_fold(
             pq_size
         );
         let len = tmp_block_sums.len();
-        let required = _frac_compute_round_temp_buffer_size(num_x as u32, stream);
+        let required = _frac_compute_round_temp_buffer_size(num_x as u32);
         assert!(
             len >= required as usize,
             "tmp_block_sums len={len} < required={required}"
@@ -940,7 +928,7 @@ pub unsafe fn frac_compute_round_and_fold_inplace(
             src_pq_size
         );
         let len = tmp_block_sums.len();
-        let required = _frac_compute_round_temp_buffer_size(num_x as u32, stream);
+        let required = _frac_compute_round_temp_buffer_size(num_x as u32);
         assert!(
             len >= required as usize,
             "tmp_block_sums len={len} < required={required}"

--- a/crates/cuda-backend/src/cuda/logup_zerocheck.rs
+++ b/crates/cuda-backend/src/cuda/logup_zerocheck.rs
@@ -433,17 +433,12 @@ extern "C" {
     ) -> i32;
 
     // mle.cu
-    pub fn _zerocheck_mle_temp_sums_buffer_size(
-        num_x: u32,
-        num_y: u32,
-        stream: cudaStream_t,
-    ) -> usize;
+    pub fn _zerocheck_mle_temp_sums_buffer_size(num_x: u32, num_y: u32) -> usize;
 
     pub fn _zerocheck_mle_intermediates_buffer_size(
         buffer_size: u32,
         num_x: u32,
         num_y: u32,
-        stream: cudaStream_t,
     ) -> usize;
 
     fn _zerocheck_eval_mle(

--- a/crates/cuda-backend/src/cuda/stacked_reduction.rs
+++ b/crates/cuda-backend/src/cuda/stacked_reduction.rs
@@ -18,7 +18,6 @@ extern "C" {
         trace_height: u32,
         trace_width: u32,
         l_skip: u32,
-        stream: cudaStream_t,
     ) -> u32;
 
     // SP_DEG=1: no z_packets needed, outputs [NUM_G * skip_domain] to be ADDed

--- a/crates/cuda-backend/src/cuda/whir.rs
+++ b/crates/cuda-backend/src/cuda/whir.rs
@@ -20,10 +20,7 @@ extern "C" {
         stream: cudaStream_t,
     ) -> i32;
 
-    pub fn _whir_sumcheck_coeff_moments_required_temp_buffer_size(
-        height: u32,
-        stream: cudaStream_t,
-    ) -> u32;
+    pub fn _whir_sumcheck_coeff_moments_required_temp_buffer_size(height: u32) -> u32;
 
     fn _whir_sumcheck_coeff_moments_round(
         f_coeffs: *const EF,
@@ -100,7 +97,7 @@ pub unsafe fn whir_sumcheck_coeff_moments_round(
     #[cfg(debug_assertions)]
     {
         let len = tmp_block_sums.len();
-        let required = _whir_sumcheck_coeff_moments_required_temp_buffer_size(height, stream);
+        let required = _whir_sumcheck_coeff_moments_required_temp_buffer_size(height);
         assert!(
             len >= required as usize,
             "tmp_block_sums len={len} < required={required}"

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -62,8 +62,7 @@ impl GpuDevice {
         };
         let id = get_device().unwrap() as u32;
         let device_ctx = GpuDeviceCtx::for_device(id)?;
-        let sm_count =
-            get_sm_count(id, device_ctx.stream.as_raw()).expect("failed to get SM count");
+        let sm_count = get_sm_count(id).expect("failed to get SM count");
         let config = GpuDeviceConfig {
             params,
             prover_config,

--- a/crates/cuda-backend/src/logup_zerocheck/batch_mle.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/batch_mle.rs
@@ -39,25 +39,17 @@ fn zerocheck_batch_mle_intermediates_buffer_bytes(
     buffer_size: u32,
     num_x: u32,
     num_y: u32,
-    device_ctx: &GpuDeviceCtx,
 ) -> usize {
-    let stream = device_ctx.stream.as_raw();
     unsafe {
-        _zerocheck_batch_mle_intermediates_buffer_size(buffer_size, num_x, num_y, stream)
+        _zerocheck_batch_mle_intermediates_buffer_size(buffer_size, num_x, num_y)
             * std::mem::size_of::<EF>()
     }
 }
 
 /// Computes logup intermediate buffer memory in bytes for a trace.
-fn logup_batch_mle_intermediates_buffer_bytes(
-    buffer_size: u32,
-    num_x: u32,
-    num_y: u32,
-    device_ctx: &GpuDeviceCtx,
-) -> usize {
-    let stream = device_ctx.stream.as_raw();
+fn logup_batch_mle_intermediates_buffer_bytes(buffer_size: u32, num_x: u32, num_y: u32) -> usize {
     unsafe {
-        _logup_batch_mle_intermediates_buffer_size(buffer_size, num_x, num_y, stream)
+        _logup_batch_mle_intermediates_buffer_size(buffer_size, num_x, num_y)
             * std::mem::size_of::<EF>()
     }
 }
@@ -173,12 +165,7 @@ impl<'a> ZerocheckMleBatchBuilder<'a> {
 
             let d_intermediates = if buffer_size > 0 {
                 let intermediates_len = unsafe {
-                    _zerocheck_batch_mle_intermediates_buffer_size(
-                        buffer_size,
-                        num_x,
-                        t.num_y,
-                        device_ctx.stream.as_raw(),
-                    )
+                    _zerocheck_batch_mle_intermediates_buffer_size(buffer_size, num_x, t.num_y)
                 };
                 let buf = DeviceBuffer::<EF>::with_capacity_on(intermediates_len, device_ctx);
                 let ptr = buf.as_mut_ptr();
@@ -317,12 +304,7 @@ impl<'a> LogupMleBatchBuilder<'a> {
 
             let d_intermediates = if buffer_size > 0 {
                 let intermediates_len = unsafe {
-                    _logup_batch_mle_intermediates_buffer_size(
-                        buffer_size,
-                        num_x,
-                        t.num_y,
-                        device_ctx.stream.as_raw(),
-                    )
+                    _logup_batch_mle_intermediates_buffer_size(buffer_size, num_x, t.num_y)
                 };
                 let buf = DeviceBuffer::<EF>::with_capacity_on(intermediates_len, device_ctx);
                 let ptr = buf.as_mut_ptr();
@@ -436,12 +418,7 @@ pub(crate) fn evaluate_zerocheck_batched<'a, HS: GpuHashScheme>(
                 .zerocheck_mle
                 .inner
                 .buffer_size;
-            let mem = zerocheck_batch_mle_intermediates_buffer_bytes(
-                buffer_size,
-                num_x,
-                t.num_y,
-                device_ctx,
-            );
+            let mem = zerocheck_batch_mle_intermediates_buffer_bytes(buffer_size, num_x, t.num_y);
             (t, mem)
         })
         .collect();
@@ -572,8 +549,7 @@ pub(crate) fn evaluate_logup_batched<HS: GpuHashScheme>(
                 .interaction_rules
                 .inner
                 .buffer_size;
-            let mem =
-                logup_batch_mle_intermediates_buffer_bytes(buffer_size, num_x, t.num_y, device_ctx);
+            let mem = logup_batch_mle_intermediates_buffer_bytes(buffer_size, num_x, t.num_y);
             (t, mem)
         })
         .collect();

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -859,8 +859,7 @@ where
         DeviceBuffer::new()
     };
     let max_tmp_buffer_capacity = if total_rounds > 1 {
-        (unsafe { _frac_compute_round_temp_buffer_size((1 << (total_rounds - 1)) as u32, stream) })
-            as usize
+        (unsafe { _frac_compute_round_temp_buffer_size((1 << (total_rounds - 1)) as u32) }) as usize
     } else {
         0
     };
@@ -898,7 +897,7 @@ where
         let lambda = transcript.sample_ext();
 
         let tmp_buffer_capacity =
-            unsafe { _frac_compute_round_temp_buffer_size((1 << round) as u32, stream) } as usize;
+            unsafe { _frac_compute_round_temp_buffer_size((1 << round) as u32) } as usize;
         if tmp_buffer_capacity > tmp_block_sums.len() {
             tmp_block_sums = DeviceBuffer::<EF>::with_capacity_on(tmp_buffer_capacity, device_ctx);
         }

--- a/crates/cuda-backend/src/logup_zerocheck/mle_round.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mle_round.rs
@@ -106,15 +106,14 @@ pub fn evaluate_mle_interactions_gpu(
     let stream = device_ctx.stream.as_raw();
     let buffer_size = rules.inner.buffer_size;
     let intermed_capacity =
-        unsafe { _logup_mle_intermediates_buffer_size(buffer_size, num_x, num_y, stream) };
+        unsafe { _logup_mle_intermediates_buffer_size(buffer_size, num_x, num_y) };
     let mut intermediates = if intermed_capacity > 0 {
         debug!("logup:intermediates_capacity={intermed_capacity}");
         DeviceBuffer::<EF>::with_capacity_on(intermed_capacity, device_ctx)
     } else {
         DeviceBuffer::<EF>::new()
     };
-    let temp_sums_buffer_capacity =
-        unsafe { _logup_mle_temp_sums_buffer_size(num_x, num_y, stream) };
+    let temp_sums_buffer_capacity = unsafe { _logup_mle_temp_sums_buffer_size(num_x, num_y) };
     debug!("logup:temp_sums_buffer_capacity={temp_sums_buffer_capacity}");
     let mut temp_sums_buffer =
         DeviceBuffer::<Frac<EF>>::with_capacity_on(temp_sums_buffer_capacity, device_ctx);

--- a/crates/cuda-backend/src/logup_zerocheck/mle_round.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mle_round.rs
@@ -45,15 +45,14 @@ pub fn evaluate_mle_constraints_gpu(
     let stream = device_ctx.stream.as_raw();
     let buffer_size = rules.inner.buffer_size;
     let intermed_capacity =
-        unsafe { _zerocheck_mle_intermediates_buffer_size(buffer_size, num_x, num_y, stream) };
+        unsafe { _zerocheck_mle_intermediates_buffer_size(buffer_size, num_x, num_y) };
     let mut intermediates = if intermed_capacity > 0 {
         debug!("zerocheck:intermediates_capacity={intermed_capacity}");
         DeviceBuffer::<EF>::with_capacity_on(intermed_capacity, device_ctx)
     } else {
         DeviceBuffer::<EF>::new()
     };
-    let temp_sums_buffer_capacity =
-        unsafe { _zerocheck_mle_temp_sums_buffer_size(num_x, num_y, stream) };
+    let temp_sums_buffer_capacity = unsafe { _zerocheck_mle_temp_sums_buffer_size(num_x, num_y) };
     debug!("zerocheck:temp_sums_buffer_capacity={temp_sums_buffer_capacity}");
     let mut temp_sums_buffer =
         DeviceBuffer::<EF>::with_capacity_on(temp_sums_buffer_capacity, device_ctx);

--- a/crates/cuda-backend/src/logup_zerocheck/round0.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/round0.rs
@@ -81,7 +81,6 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
             num_x,
             num_cosets,
             max_temp_bytes,
-            stream,
         )
     };
     let mut intermediates = if intermed_capacity > 0 {
@@ -98,7 +97,6 @@ pub fn evaluate_round0_constraints_gpu<HS: GpuHashScheme>(
             num_x,
             num_cosets,
             max_temp_bytes,
-            stream,
         )
     };
     debug!("zerocheck:temp_sums_buffer_capacity={temp_sums_buffer_capacity}");
@@ -249,7 +247,6 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
             num_x,
             num_cosets,
             max_temp_bytes,
-            stream,
         )
     };
     let mut intermediates = if intermed_capacity > 0 {
@@ -260,14 +257,7 @@ pub fn evaluate_round0_interactions_gpu<HS: GpuHashScheme>(
     };
 
     let temp_sums_buffer_capacity = unsafe {
-        _logup_r0_temp_sums_buffer_size(
-            buffer_size,
-            skip_domain,
-            num_x,
-            num_cosets,
-            max_temp_bytes,
-            stream,
-        )
+        _logup_r0_temp_sums_buffer_size(buffer_size, skip_domain, num_x, num_cosets, max_temp_bytes)
     };
     debug!("logup_r0:tmp_sums_buffer_capacity={temp_sums_buffer_capacity}");
     let mut temp_sums_buffer =

--- a/crates/cuda-backend/src/stacked_reduction.rs
+++ b/crates/cuda-backend/src/stacked_reduction.rs
@@ -533,7 +533,6 @@ impl<D: Copy + Clone + Send + Sync + 'static> StackedReductionGpu<D> {
                     trace_height as u32,
                     trace_width as u32,
                     l_skip as u32,
-                    self.device_ctx.stream.as_raw(),
                 )
             } as usize;
 

--- a/crates/cuda-backend/src/whir.rs
+++ b/crates/cuda-backend/src/whir.rs
@@ -224,12 +224,8 @@ where
             );
             debug_assert!(w_moments.len() >= f_height);
             let output_height = f_height / 2;
-            let tmp_buffer_capacity = unsafe {
-                _whir_sumcheck_coeff_moments_required_temp_buffer_size(
-                    f_height as u32,
-                    device_ctx.stream.as_raw(),
-                )
-            };
+            let tmp_buffer_capacity =
+                unsafe { _whir_sumcheck_coeff_moments_required_temp_buffer_size(f_height as u32) };
             if d_sumcheck_tmp.len() < tmp_buffer_capacity as usize {
                 d_sumcheck_tmp =
                     DeviceBuffer::<EF>::with_capacity_on(tmp_buffer_capacity as usize, device_ctx);

--- a/crates/cuda-backend/src/whir.rs
+++ b/crates/cuda-backend/src/whir.rs
@@ -573,7 +573,7 @@ mod tests {
         prover::{
             stacked_pcs::stacked_commit, CpuColMajorBackend, DeviceDataTransporter, ProvingContext,
         },
-        test_utils::{FibFixture, TestFixture},
+        test_utils::{CachedFixture11, FibFixture, TestFixture},
         verifier::whir::{verify_whir, VerifyWhirError},
         StarkEngine, StarkProtocolConfig, SystemParams, WhirConfig, WhirParams,
         WhirProximityStrategy,
@@ -694,11 +694,16 @@ mod tests {
         )
     }
 
-    fn run_whir_fib_test_gpu(params: SystemParams) -> Result<(), VerifyWhirError> {
-        let engine = BabyBearPoseidon2RefEngine::<DuplexSponge>::new(params.clone());
-        let fib = FibFixture::new(0, 1, 1 << params.log_stacked_height());
-        let (pk, _vk) = fib.keygen(&engine);
-        let ctx = fib.generate_proving_ctx();
+    fn run_whir_fixture_test_gpu<F>(
+        params: SystemParams,
+        engine: &BabyBearPoseidon2RefEngine<DuplexSponge>,
+        fx: F,
+    ) -> Result<(), VerifyWhirError>
+    where
+        F: TestFixture<SC>,
+    {
+        let (pk, _vk) = fx.keygen(engine);
+        let ctx = fx.generate_proving_ctx().into_sorted();
         run_whir_test_gpu(params, pk, ctx)
     }
 
@@ -710,6 +715,31 @@ mod tests {
             folding_pow_bits: 1,
             mu_pow_bits: 3,
             proximity: WhirProximityStrategy::UniqueDecoding,
+        }
+    }
+
+    fn whir_test_system_params(
+        n_stack: usize,
+        log_blowup: usize,
+        k_whir: usize,
+        log_final_poly_len: usize,
+    ) -> SystemParams {
+        let l_skip = 2;
+        let w_stack = 8;
+        let whir = WhirConfig::new(
+            log_blowup,
+            l_skip + n_stack,
+            whir_test_params(k_whir, log_final_poly_len),
+            10,
+        );
+        SystemParams {
+            l_skip: 2,
+            n_stack,
+            w_stack,
+            log_blowup,
+            whir,
+            logup: log_up_security_params_baby_bear_100_bits(0.0),
+            max_constraint_degree: 3,
         }
     }
 
@@ -727,25 +757,33 @@ mod tests {
     ) -> Result<(), VerifyWhirError> {
         setup_tracing_with_log_level(Level::DEBUG);
 
-        let l_skip = 2;
-        let w_stack = 8;
-        let whir = WhirConfig::new(
-            log_blowup,
-            l_skip + n_stack,
-            whir_test_params(k_whir, log_final_poly_len),
-            10,
-        );
-        let params = SystemParams {
-            l_skip: 2,
-            n_stack,
-            w_stack,
-            log_blowup,
-            whir,
-            logup: log_up_security_params_baby_bear_100_bits(0.0),
-            max_constraint_degree: 3,
-        };
-        run_whir_fib_test_gpu(params)
+        let params = whir_test_system_params(n_stack, log_blowup, k_whir, log_final_poly_len);
+        let engine = BabyBearPoseidon2RefEngine::<DuplexSponge>::new(params.clone());
+        let height = 1 << params.log_stacked_height();
+
+        run_whir_fixture_test_gpu(params, &engine, FibFixture::new(0, 1, height))
     }
 
-    // TODO: test multiple commitments with GPU prover
+    #[test_case(2, 1, 1, 2)]
+    #[test_case(2, 1, 2, 0)]
+    #[test_case(2, 1, 3, 1)]
+    #[test_case(2, 1, 4, 0)]
+    #[test_case(2, 2, 4, 0)]
+    fn test_whir_cached_gpu(
+        n_stack: usize,
+        log_blowup: usize,
+        k_whir: usize,
+        log_final_poly_len: usize,
+    ) -> Result<(), VerifyWhirError> {
+        setup_tracing_with_log_level(Level::DEBUG);
+
+        let params = whir_test_system_params(n_stack, log_blowup, k_whir, log_final_poly_len);
+        let engine = BabyBearPoseidon2RefEngine::<DuplexSponge>::new(params.clone());
+
+        run_whir_fixture_test_gpu(
+            params,
+            &engine,
+            CachedFixture11::new(engine.config().clone()),
+        )
+    }
 }


### PR DESCRIPTION
Resolves INT-8208, INT-8205. Towards INT-8370.


## Overview

This branch is a small CUDA backend cleanup and test-coverage PR on top of `develop-v2`.
It adds GPU WHIR coverage for cached/multiple-trace fixtures, documents the `sumcheck.cu`
degree bound, and removes unused `cudaStream_t` parameters from synchronous CUDA sizing
helpers and their Rust FFI call sites.

Commits:

- `2eeea275` - adds cached-trace WHIR GPU tests and factors shared WHIR test setup.
- `bdb8a6e9` - explains why `sumcheck.cu` uses `MAX_D = 5`.
- `4a270671` - removes unused stream parameters from CUDA size/query helper APIs.

## 1. WHIR GPU Test Coverage

The WHIR GPU tests in `crates/cuda-backend/src/whir.rs` are generalized from a
Fib-only helper to a fixture-based helper:

- `run_whir_fixture_test_gpu` accepts any `TestFixture<SC>`.
- `whir_test_system_params` centralizes the repeated `SystemParams` construction.
- Existing `test_whir_single_fib_gpu` cases continue to run with `FibFixture`.
- New `test_whir_cached_gpu` cases run the same WHIR parameter matrix against
  `CachedFixture11`, covering multiple cached traces/commitments.
- Proving contexts are sorted before running the GPU WHIR path via
  `generate_proving_ctx().into_sorted()`.

Reviewer focus:

- Confirm the shared helper preserves the old Fib test behavior.
- Check that the cached fixture parameter matrix covers the intended multiple-trace path.
- Confirm sorting the proving context is appropriate for both Fib and cached fixtures.

## 2. CUDA Sizing Helper ABI Cleanup

The branch removes unused `cudaStream_t` parameters from CUDA functions that only compute
sizes or query device attributes, then updates Rust FFI declarations and call sites to match.
This affects synchronous helpers in:

- `device_info`: `_cuda_get_sm_count`
- WHIR: `_whir_sumcheck_coeff_moments_required_temp_buffer_size`
- Stacked reduction: `_stacked_reduction_r0_required_temp_buffer_size`
- Fractional GKR/logup: `_frac_compute_round_temp_buffer_size`
- Logup/zerocheck round 0 buffer sizing helpers
- Logup/zerocheck MLE and batched-MLE buffer sizing helpers

These helpers do not launch kernels or perform stream-ordered work; they derive sizes from
input dimensions and launch-parameter formulas. Removing the stream argument resolves unused
parameter warnings without changing the size formulas or kernel-launch APIs.

Reviewer focus:

- Check each Rust `extern "C"` declaration still matches the corresponding `.cu` signature.
- Verify only non-launch sizing/query helpers lost the stream argument; actual kernel launch
  wrappers still take and pass `cudaStream_t`.
- Confirm memory accounting call sites still multiply element counts by the right element size
  where they return bytes.

## 3. `sumcheck.cu` Documentation and Formatting

`crates/cuda-backend/cuda/src/sumcheck.cu` now replaces the inline TODO on `MAX_D` with an
explanation: the kernel supports maximum constraint degree 4, which requires `4 + 1`
evaluations, so `MAX_D = 5`.

The rest of the changes in this file are formatting-only signature wrapping for existing
extern functions.

Reviewer focus:

- Confirm the documented maximum degree matches the protocol/config assumptions.
- Treat the remaining `sumcheck.cu` changes as formatting unless reviewing style churn.