### PR TITLE
fix: cuda concurrency issues

### DIFF
--- a/crates/cuda-common/src/memory_manager/mod.rs
+++ b/crates/cuda-common/src/memory_manager/mod.rs
@@ -118,15 +118,18 @@ impl MemoryManager {
     unsafe fn d_free_under_lock(&mut self, ptr: *mut c_void) -> Result<StreamGuard, MemoryError> {
         let nn = NonNull::new(ptr).ok_or(MemoryError::NullPointer)?;
 
+        let default_stream = default_stream();
         if let Some(record) = self.allocated_ptrs.remove(&nn) {
-            if record.stream != default_stream() {
+            if record.stream != default_stream {
                 // we need to synchronize any memory allocated that is not on the default stream
                 // as work launched prior to drop might depend on this memory
-                record.stream.synchronize().map_err(MemoryError::Cuda)?;
+                default_stream
+                    .wait_on(&record.stream)
+                    .map_err(MemoryError::Cuda)?;
             }
             let size = record.size;
             self.current_size -= size;
-            check(unsafe { cudaFreeAsync(ptr, record.stream.as_raw()) }).map_err(|e| {
+            check(unsafe { cudaFreeAsync(ptr, default_stream.as_raw()) }).map_err(|e| {
                 tracing::error!("cudaFreeAsync failed: ptr={:p}: {:?}", ptr, e);
                 MemoryError::from(e)
             })?;
@@ -134,10 +137,11 @@ impl MemoryManager {
         } else {
             let (freed_size, guard) = self.pool.free_internal(ptr)?;
             self.current_size -= freed_size;
-            if guard != default_stream() {
+            if guard != default_stream {
                 // same reasoning as above, work launched on other streams depend on this memory,
                 // when reusing only the stream on which this memory is allocated on is synced.
-                guard.synchronize().map_err(MemoryError::Cuda)?;
+                default_stream.wait_on(&guard).map_err(MemoryError::Cuda)?;
+                default_stream.synchronize().map_err(MemoryError::Cuda)?;
             }
             Ok(guard)
         }

--- a/crates/cuda-common/src/memory_manager/mod.rs
+++ b/crates/cuda-common/src/memory_manager/mod.rs
@@ -10,7 +10,7 @@ use bytesize::ByteSize;
 
 use crate::{
     error::{check, MemoryError},
-    stream::{cudaStream_t, device_synchronize, StreamGuard},
+    stream::{cudaStream_t, default_stream, device_synchronize, StreamGuard},
 };
 
 mod cuda;
@@ -119,6 +119,11 @@ impl MemoryManager {
         let nn = NonNull::new(ptr).ok_or(MemoryError::NullPointer)?;
 
         if let Some(record) = self.allocated_ptrs.remove(&nn) {
+            if record.stream != default_stream() {
+                // we need to synchronize any memory allocated that is not on the default stream
+                // as work launched prior to drop might depend on this memory
+                record.stream.synchronize().map_err(MemoryError::Cuda)?;
+            }
             let size = record.size;
             self.current_size -= size;
             check(unsafe { cudaFreeAsync(ptr, record.stream.as_raw()) }).map_err(|e| {
@@ -129,6 +134,11 @@ impl MemoryManager {
         } else {
             let (freed_size, guard) = self.pool.free_internal(ptr)?;
             self.current_size -= freed_size;
+            if guard != default_stream() {
+                // same reasoning as above, work launched on other streams depend on this memory,
+                // when reusing only the stream on which this memory is allocated on is synced.
+                guard.synchronize().map_err(MemoryError::Cuda)?;
+            }
             Ok(guard)
         }
     }

--- a/crates/cuda-common/src/memory_manager/vm_pool.rs
+++ b/crates/cuda-common/src/memory_manager/vm_pool.rs
@@ -671,7 +671,7 @@ impl VirtualMemoryPool {
                 // we need to synchronize the stream with the host as remap_regions is synchronous
                 // wrt. the host; it's undefined behavior if a kernel is using an address range that
                 // gets remapped on the host
-                stream.synchronize()?;
+                region.event.synchronize()?;
             }
 
             let take = remaining.min(region.size);

--- a/crates/cuda-common/src/memory_manager/vm_pool.rs
+++ b/crates/cuda-common/src/memory_manager/vm_pool.rs
@@ -668,8 +668,10 @@ impl VirtualMemoryPool {
                 .expect("BUG: free region disappeared");
 
             if other_stream && !region.event.completed() {
-                // Make the caller's stream wait on the cross-stream event
-                stream.wait(&region.event)?;
+                // we need to synchronize the stream with the host as remap_regions is synchronous
+                // wrt. the host; it's undefined behavior if a kernel is using an address range that
+                // gets remapped on the host
+                stream.synchronize()?;
             }
 
             let take = remaining.min(region.size);

--- a/crates/cuda-common/src/stream.rs
+++ b/crates/cuda-common/src/stream.rs
@@ -76,6 +76,13 @@ impl CudaStream {
         check(unsafe { cudaStreamWaitEvent(self.stream, event.event, 0) })
     }
 
+    /// Wait for other stream to complete before continuing the present stream
+    pub fn wait_on(&self, other: &CudaStream) -> Result<(), CudaError> {
+        let event = self.host_event.lock().unwrap();
+        unsafe { event.record(other.stream) }?;
+        self.wait(&event)
+    }
+
     /// Record a per-stream event and synchronize to complete all pending D2H copies.
     /// Uses event-based sync rather than cudaStreamSynchronize because this waits
     /// only for work up to the event point, allowing future selective sync patterns

--- a/crates/cuda-common/src/stream.rs
+++ b/crates/cuda-common/src/stream.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Cow,
     ffi::c_void,
     ops::Deref,
-    sync::{Arc, Mutex},
+    sync::{Arc, LazyLock, Mutex},
 };
 
 use crate::error::{check, CudaError};
@@ -138,22 +138,38 @@ pub struct GpuDeviceCtx {
     pub stream: StreamGuard,
 }
 
+// introduce default stream so all memory
+pub(crate) static DEFAULT_STREAM: LazyLock<StreamGuard> = LazyLock::new(|| {
+    StreamGuard::new(CudaStream::new_non_blocking().expect("failed to construct default stream"))
+});
+
 impl GpuDeviceCtx {
     /// Creates a new `GpuDeviceCtx` for the given device.
     ///
     /// NOTE: This calls `set_device_by_id` as a side effect, changing the
     /// current CUDA device for the calling thread.
+    ///
+    /// Note that by default all work is launched on a per-process stream. This is fine as cuda
+    /// stream APIs are thread-safe. But for greater concurrency you can use .with_new_stream to
+    /// launch work on separate streams for each thread. Make sure that the the work is synchronized
+    /// with respect to the default stream though (with self.stream.wait(default_stream))
     pub fn for_device(device_id: u32) -> Result<Self, CudaError> {
         crate::common::set_device_by_id(device_id as i32)?;
         Ok(Self {
             device_id,
-            stream: StreamGuard::new(CudaStream::new_non_blocking()?),
+            stream: (*DEFAULT_STREAM).clone(),
         })
     }
 
     pub fn for_current_device() -> Result<Self, CudaError> {
         let device_id = crate::common::get_device()? as u32;
         Self::for_device(device_id)
+    }
+
+    /// Consumes self and returns self with new non default stream
+    pub fn with_new_stream(mut self) -> Result<Self, CudaError> {
+        self.stream = StreamGuard::new(CudaStream::new_non_blocking()?);
+        Ok(self)
     }
 }
 
@@ -164,6 +180,11 @@ impl GpuDeviceCtx {
 /// The caller must ensure that `stream` is a valid CUDA stream handle.
 pub unsafe fn sync_stream(stream: cudaStream_t) -> Result<(), CudaError> {
     check(cudaStreamSynchronize(stream))
+}
+
+/// get the per-process default stream
+pub fn default_stream() -> StreamGuard {
+    DEFAULT_STREAM.clone()
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Resolves: INT-8434

This PR fixes 2 issues, with with VPMM and one with cuda concurrency in the downstream use of the GPUEngine.

# VPMM
In the vpmm memory allocator vm_pool.rs line 672. We are defragmenting because an allocation was too big to fit in free regions. First we allocate fresh memory equal the the requested size minus the free region, then we synchronize the free regions and reuse them.

The problem I think is that the synchronization before reuse is not correct as the code calls stream.wait(&region.event) before calling vpmm apis to remap the free region address range. stream.wait makes the stream wait but is not synchronous on host, while vpmm_map is synchronous wrt. the host. So what can happen is that a kernel is not yet done executing on a free region (since it was freed asynchronously), the code calls stream.wait(...) which does not pause the execution of the host and wait for the kernel to be done, then remap_regions calls vpmm_set_access which remaps the memory address range before the kernel is actually done with it.

I think the above is undefined behavior.

# GPUEngine
What happens is that in the prover the trace gen and proving each constructs a separate GPUEngine with it's own stream. This causes two concurrency problems.

1. the work is launched in stream A in trace gen and the buffers are passed to stream B in proving, there's no explicit synchronization between them I think.
2. the trace gen buffers are allocated on stream A, the work being done on them are launched on stream B. When buffers on A are dropped using cudaFreeAsync with stream A, which does not wait for work on B to complete. This is the cause of the illegal memory access as increasing page size increases the number of allocations using cudaMallocAsync/cudaFreeAsync, which surfaces the issue on compute-sanitizer when the vpmm allocator doesn't. 

# Fix
I think a fix would be to do as pytorch does. There is a default stream that everyone launches work on, all memory allocations are allocated on the default stream, and all non default streams have to synchronize wrt. the default stream. On deallocation, if the stream that that the buffer is allocated on is not the default stream, then sync with the host because we can't be sure what work is dependent on the buffer but on a different stream.

**case 1**:
suppose bufA is allocated on stream A.
```
kernelB<<<..., defaultStream>>>(..., bufA);

drop(bufA); // kernelB could still be running on defaultStream when this is dropped. So we must make defaultStream depend on stream A and async free on the default stream. 
```
**case 2**:
suppose bufA is allocated on stream A.
```
kernelB<<<..., streamB>>>(..., bufA);
default_stream().wait_on(streamB); // this must occur as otherwise the work on streamB is independent of defaultStream and stream A, so work could still be happening as it's being dropped.
// streamA.wait_on(streamB); <- this could also work. 

drop(bufA);
```
**case 3**:
suppose buf is allocated on defaultStream.
```
kernelB<<<..., streamB>>>(..., buf);

default_stream().wait_on(streamB); // this must occur, same reasoning as above.
drop(buf);
```

The changes here protect against case 1. For cases 2,3 there's no way of protecting against race conditions in the allocator without a full device sync (sync all the streams), as any arbitrary work could be launched on a separate stream that depends on the current buffer. So it's up to the programmer to make the work dependent either on the stream the buffer is allocated on or the default stream, before any buffers the kernel launches is dropped. 