### PR TITLE
feat: decrease root pow bits

### DIFF
--- a/crates/stark-backend/src/config.rs
+++ b/crates/stark-backend/src/config.rs
@@ -6,8 +6,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::{hasher::MerkleHasher, interaction::LogUpSecurityParameters};
 
-pub const DEFAULT_K_WHIR: usize = 4;
-
 /// Trait that holds the associated types for the SWIRL protocol. These are the types needed by the
 /// verifier and must be independent of the prover backend.
 ///
@@ -118,10 +116,9 @@ impl SystemParams {
         security_bits: usize,
         logup: LogUpSecurityParameters,
         max_constraint_degree: usize,
+        whir_query_phase_pow_bits: usize,
+        k_whir: usize,
     ) -> SystemParams {
-        const WHIR_QUERY_PHASE_POW_BITS: usize = 20;
-
-        let k_whir = DEFAULT_K_WHIR;
         let log_stacked_height = l_skip + n_stack;
 
         SystemParams {
@@ -135,7 +132,7 @@ impl SystemParams {
                 WhirParams {
                     k: k_whir,
                     log_final_poly_len,
-                    query_phase_pow_bits: WHIR_QUERY_PHASE_POW_BITS,
+                    query_phase_pow_bits: whir_query_phase_pow_bits,
                     proximity,
                     folding_pow_bits,
                     mu_pow_bits,

--- a/crates/stark-sdk/src/config/mod.rs
+++ b/crates/stark-sdk/src/config/mod.rs
@@ -26,7 +26,9 @@ pub mod log_up_params;
 // These configurations target 100-bits of proven round-by-round (RBR) security with BabyBear as the
 // base field and BabyBear^4 as the extension field.
 
-const WHIR_MAX_LOG_FINAL_POLY_LEN: usize = 10;
+pub const DEFAULT_K_WHIR: usize = 4;
+pub const DEFAULT_WHIR_QUERY_PHASE_POW_BITS: usize = 20;
+pub const WHIR_MAX_LOG_FINAL_POLY_LEN: usize = 10;
 pub const SECURITY_BITS_TARGET: usize = 100;
 
 pub const DEFAULT_APP_L_SKIP: usize = 4;
@@ -74,7 +76,7 @@ fn log_up_params_for_whir(
 /// proximity regime's PCS list size. The LogUp params are derived up front (from the same inputs
 /// `SystemParams::new` uses to build the WHIR config) so they can be passed straight in.
 #[allow(clippy::too_many_arguments)]
-fn params_with_100_bits_security(
+pub fn params_with_100_bits_security(
     log_blowup: usize,
     l_skip: usize,
     n_stack: usize,
@@ -83,6 +85,8 @@ fn params_with_100_bits_security(
     mu_pow_bits: usize,
     proximity: WhirProximityStrategy,
     max_constraint_degree: usize,
+    whir_query_phase_pow_bits: usize,
+    k_whir: usize,
 ) -> SystemParams {
     let logup = log_up_params_for_whir(proximity, l_skip + n_stack, log_blowup, w_stack);
     SystemParams::new(
@@ -97,6 +101,8 @@ fn params_with_100_bits_security(
         SECURITY_BITS_TARGET,
         logup,
         max_constraint_degree,
+        whir_query_phase_pow_bits,
+        k_whir,
     )
 }
 
@@ -126,6 +132,8 @@ pub fn app_params_with_100_bits_security(log_stacked_height: usize) -> SystemPar
         15,                                                    // mu pow
         WhirProximityStrategy::UniqueDecoding,
         APP_MAX_CONSTRAINT_DEGREE,
+        DEFAULT_WHIR_QUERY_PHASE_POW_BITS,
+        DEFAULT_K_WHIR,
     )
 }
 
@@ -154,6 +162,8 @@ pub fn leaf_params_with_100_bits_security() -> SystemParams {
         13,   // mu pow
         WhirProximityStrategy::UniqueDecoding,
         RECURSION_MAX_CONSTRAINT_DEGREE,
+        DEFAULT_WHIR_QUERY_PHASE_POW_BITS,
+        DEFAULT_K_WHIR,
     )
 }
 
@@ -182,6 +192,8 @@ pub fn internal_params_with_100_bits_security() -> SystemParams {
         20,  // mu pow
         WhirProximityStrategy::ListDecoding { m: 2 },
         RECURSION_MAX_CONSTRAINT_DEGREE,
+        DEFAULT_WHIR_QUERY_PHASE_POW_BITS,
+        DEFAULT_K_WHIR,
     )
 }
 
@@ -205,10 +217,12 @@ pub fn root_params_with_100_bits_security() -> SystemParams {
         2,  // l_skip
         18, // n_stack
         18, // w_stack
-        20, // folding pow
-        20, // mu pow
+        15, // folding pow
+        15, // mu pow
         WhirProximityStrategy::ListDecoding { m: 1 },
         RECURSION_MAX_CONSTRAINT_DEGREE,
+        15, // whir_query_pow
+        DEFAULT_K_WHIR,
     )
 }
 
@@ -236,5 +250,7 @@ pub fn hook_params_with_100_bits_security() -> SystemParams {
         11, // mu pow
         WhirProximityStrategy::ListDecoding { m: 1 },
         RECURSION_MAX_CONSTRAINT_DEGREE,
+        DEFAULT_WHIR_QUERY_PHASE_POW_BITS,
+        DEFAULT_K_WHIR,
     )
 }


### PR DESCRIPTION
Also export more things to be public for easier testing of different params downstream in openvm.

On reth-bench new root settings lower 0.74s from 1.44s. This is because pow kernel takes a large fraction of the time.

new: https://github.com/axiom-crypto/openvm-eth/actions/runs/28200719309
orig: https://github.com/axiom-crypto/openvm-eth/actions/runs/27851015413

Resolves: INT-7945