### PR TITLE
fix: tighten CUDA proving memory estimates

### DIFF
--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -9,8 +9,7 @@ use crate::cuda::{
     device_info::get_sm_count,
 };
 
-/// Pure device configuration — no stream, no CUDA runtime state.
-/// Renamed from the old `GpuDevice`.
+/// Pure device configuration: no stream and no CUDA runtime state.
 #[derive(Clone, Getters, CopyGetters, MutGetters)]
 pub struct GpuDeviceConfig {
     #[getset(get = "pub")]
@@ -33,11 +32,17 @@ impl GpuProverConfig {
     pub fn proving_memory_config<SC: StarkProtocolConfig>(
         &self,
         config: &SC,
+        sm_count: u32,
     ) -> ProvingMemoryConfig {
         // Interaction memory is estimated from the CUDA fractional-GKR buffer model in
         // `openvm_stark_backend::memory_metering`. Update that estimate when changing GKR
         // input layout, work-buffer sizing, or scratch allocations.
-        ProvingMemoryConfig::from_protocol_config(config, self.cache_rs_code_matrix)
+        let mut memory_config =
+            ProvingMemoryConfig::from_protocol_config(config, self.cache_rs_code_matrix);
+        memory_config.cache_stacked_matrix = self.cache_stacked_matrix;
+        memory_config.retained_opening_memory = true;
+        memory_config.fractional_gkr_round_compute_min_blocks = sm_count as usize * 2;
+        memory_config
     }
 }
 

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -9,7 +9,8 @@ use crate::cuda::{
     device_info::get_sm_count,
 };
 
-/// Pure device configuration: no stream and no CUDA runtime state.
+/// Pure device configuration — no stream, no CUDA runtime state.
+/// Renamed from the old `GpuDevice`.
 #[derive(Clone, Getters, CopyGetters, MutGetters)]
 pub struct GpuDeviceConfig {
     #[getset(get = "pub")]
@@ -32,17 +33,9 @@ impl GpuProverConfig {
     pub fn proving_memory_config<SC: StarkProtocolConfig>(
         &self,
         config: &SC,
-        sm_count: u32,
     ) -> ProvingMemoryConfig {
-        // Interaction memory is estimated from the CUDA fractional-GKR buffer model in
-        // `openvm_stark_backend::memory_metering`. Update that estimate when changing GKR
-        // input layout, work-buffer sizing, or scratch allocations.
-        let mut memory_config =
-            ProvingMemoryConfig::from_protocol_config(config, self.cache_rs_code_matrix);
-        memory_config.cache_stacked_matrix = self.cache_stacked_matrix;
-        memory_config.retained_opening_memory = true;
-        memory_config.fractional_gkr_round_compute_min_blocks = sm_count as usize * 2;
-        memory_config
+        ProvingMemoryConfig::from_protocol_config(config, self.cache_rs_code_matrix)
+            .with_cuda_backend(self.cache_stacked_matrix)
     }
 }
 

--- a/crates/cuda-backend/src/engine.rs
+++ b/crates/cuda-backend/src/engine.rs
@@ -66,7 +66,7 @@ impl StarkEngine for GpuEngine<DefaultHashScheme> {
     fn proving_memory_config(&self) -> ProvingMemoryConfig {
         self.device
             .prover_config()
-            .proving_memory_config(self.config(), self.device.config.sm_count)
+            .proving_memory_config(self.config())
     }
 
     fn initial_transcript(&self) -> Self::TS {
@@ -103,7 +103,7 @@ impl StarkEngine for GpuEngine<BabyBearBn254Poseidon2HashScheme> {
     fn proving_memory_config(&self) -> ProvingMemoryConfig {
         self.device
             .prover_config()
-            .proving_memory_config(self.config(), self.device.config.sm_count)
+            .proving_memory_config(self.config())
     }
 
     fn initial_transcript(&self) -> Self::TS {

--- a/crates/cuda-backend/src/engine.rs
+++ b/crates/cuda-backend/src/engine.rs
@@ -66,7 +66,7 @@ impl StarkEngine for GpuEngine<DefaultHashScheme> {
     fn proving_memory_config(&self) -> ProvingMemoryConfig {
         self.device
             .prover_config()
-            .proving_memory_config(self.config())
+            .proving_memory_config(self.config(), self.device.config.sm_count)
     }
 
     fn initial_transcript(&self) -> Self::TS {
@@ -103,7 +103,7 @@ impl StarkEngine for GpuEngine<BabyBearBn254Poseidon2HashScheme> {
     fn proving_memory_config(&self) -> ProvingMemoryConfig {
         self.device
             .prover_config()
-            .proving_memory_config(self.config())
+            .proving_memory_config(self.config(), self.device.config.sm_count)
     }
 
     fn initial_transcript(&self) -> Self::TS {

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -9,7 +9,7 @@ use openvm_cuda_common::{
 use openvm_stark_backend::{
     poly_common::{eval_eq_mle, interpolate_linear_at_01, interpolate_quadratic_at_012},
     proof::GkrLayerClaims,
-    prover::fractional_sumcheck_gkr::{Frac, FracSumcheckProof},
+    prover::fractional_sumcheck_gkr::{Frac, FracSumcheckProof, FractionalGkrMemoryModel},
     FiatShamirTranscript, StarkProtocolConfig,
 };
 use p3_field::{Field, PrimeCharacteristicRing};
@@ -29,12 +29,12 @@ use crate::{
         ntt::{bit_rev_frac_ext, bit_rev_frac_ext_build_k2},
     },
     poly::SqrtEqLayers,
-    prelude::EF,
+    prelude::{D_EF, EF, F},
 };
 
 const GKR_S_DEG: usize = 3;
-const GKR_WINDOW_SIZE: usize = 3;
-const GKR_WINDOW_DEFAULT_MIN_N: usize = 22;
+const GKR_WINDOW_SIZE: usize = FractionalGkrMemoryModel::WINDOW_SIZE;
+const GKR_WINDOW_DEFAULT_MIN_N: usize = FractionalGkrMemoryModel::WINDOW_DEFAULT_MIN_N;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FractionalInputSize {
@@ -59,42 +59,10 @@ impl FractionalInputSize {
         }
     }
 
-    /// Peak work-buffer bytes (excluding the `S_frac * real_len` layer/input buffer).
-    ///
-    /// This must stay in sync with `max_work_size` in `fractional_sumcheck_gpu` and the
-    /// precompute-M EF auxiliary allocations. If the sumcheck implementation changes, this
-    /// method must be updated as well — it is the source of truth for batching budgets that
-    /// depend on the fractional-GKR peak. Also update the conservative interaction memory
-    /// estimate in `openvm_stark_backend::memory_metering`.
-    ///
-    /// ## Formula (FoldEval path, dominates for large inputs)
-    ///
-    /// ```text
-    /// work_buffer = logical_len / 4   Frac entries → S_frac * L/4 bytes
-    /// ```
-    ///
-    /// For the precompute-M path (`max_work_size` in `fractional_sumcheck_gpu`):
-    ///
-    /// ```text
-    /// work_buffer = max(L >> (1 + GKR_WINDOW_SIZE), 2^22)   Frac entries
-    /// + S_ef * (2^(2w) + max_window(m_partial) + 2^(w+1))  EF bytes
-    /// ```
-    ///
-    /// This method returns the maximum over both paths to give a conservative budget.
+    /// Peak work-buffer bytes, excluding the `S_frac * real_len` layer/input buffer.
     pub fn peak_work_buffer_bytes(&self) -> usize {
-        let s_frac = std::mem::size_of::<Frac<EF>>();
-        let fold_eval = (self.logical_len / 4) * s_frac;
-
-        let s_ef = std::mem::size_of::<EF>();
-        let w = GKR_WINDOW_SIZE;
-        let precompute_f =
-            (self.logical_len >> (1 + w)).max(1 << GKR_WINDOW_DEFAULT_MIN_N) * s_frac;
-        // Conservative estimate for M_precompute_EF: m_total + m_partial bound + eq_prefix/suffix.
-        // In practice the max_window term is ceil(2^(rem_n - w) / tail_tile) * 2^(2w) EF elems;
-        // use 2 * 2^(2w) as a safe floor (tail_tile >= 1, rem_n bounded by total_rounds).
-        let precompute_ef = ((1 << (2 * w + 1)) + (1 << (w + 1))) * s_ef;
-
-        fold_eval.max(precompute_f + precompute_ef)
+        FractionalGkrMemoryModel::new(std::mem::size_of::<F>(), D_EF)
+            .peak_work_buffer_memory_bytes(self.logical_len)
     }
 }
 
@@ -846,9 +814,9 @@ where
     // Fold-eval fallback rounds (rem_n < min_n) need at most 2^min_n elements.
     let max_work_size = if total_rounds > 2 {
         if precompute_m_env {
-            (total_leaves >> (1 + GKR_WINDOW_SIZE)).max(1 << GKR_WINDOW_DEFAULT_MIN_N)
+            FractionalGkrMemoryModel::precompute_m_work_buffer_elements(total_leaves)
         } else {
-            total_leaves >> 2
+            FractionalGkrMemoryModel::fold_eval_work_buffer_elements(total_leaves)
         }
     } else {
         0

--- a/crates/cuda-backend/src/tests.rs
+++ b/crates/cuda-backend/src/tests.rs
@@ -22,6 +22,7 @@ use openvm_stark_backend::{
 };
 use openvm_stark_backend::{
     prover::{
+        fractional_sumcheck_gkr::FractionalGkrMemoryModel,
         stacked_pcs::stacked_commit,
         stacked_reduction::{prove_stacked_opening_reduction, StackedReductionCpu},
         DeviceDataTransporter, MatrixDimensions, MultiRapProver,
@@ -54,7 +55,11 @@ use tracing::{debug, Level};
 use crate::cuda::bn254_merkle_tree::Bn254Digest;
 use crate::{
     base::DeviceMatrix,
-    cuda::{batch_ntt_small::batch_ntt_small, logup_zerocheck::frac_matrix_vertically_repeat},
+    cuda::{
+        batch_ntt_small::batch_ntt_small,
+        device_info::get_sm_count,
+        logup_zerocheck::{_frac_compute_round_temp_buffer_size, frac_matrix_vertically_repeat},
+    },
     merkle_tree::MerkleTreeGpu,
     prelude::{EF, F, SC},
     sponge::DuplexSpongeGpu,
@@ -76,6 +81,21 @@ fn test_ctx() -> GpuDeviceCtx {
 // ===========================================================================
 
 openvm_backend_tests::backend_test_suite!(Engine);
+
+#[test]
+fn fractional_gkr_round_temp_sizing_matches_cuda_ffi() {
+    let device_id = get_device().unwrap() as u32;
+    let min_blocks = get_sm_count(device_id).unwrap() as usize * 2;
+
+    for num_x in [2usize, 32, 4096, 1 << 20] {
+        let cuda_elements = unsafe { _frac_compute_round_temp_buffer_size(num_x as u32) } as usize;
+
+        assert_eq!(
+            cuda_elements,
+            FractionalGkrMemoryModel::round_temp_buffer_elements(num_x, min_blocks)
+        );
+    }
+}
 
 // ===========================================================================
 // BN254 Poseidon2 engine end-to-end test

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -87,7 +87,7 @@ pub struct ProvingMemoryEstimate {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ProvingMemoryConfig {
     /// Size of one base-field element in bytes.
-    pub base_field_size: usize,
+    pub base_field_bytes: usize,
     /// Degree of the extension field over the base field.
     pub extension_degree: usize,
     /// `-log_2` of the rate for the initial Reed-Solomon code.
@@ -109,7 +109,7 @@ pub struct ProvingMemoryConfig {
     /// Number of WHIR rounds.
     num_whir_rounds: usize,
     /// Size of one PCS digest in bytes.
-    digest_size: usize,
+    digest_bytes: usize,
 }
 
 impl ProvingMemoryConfig {
@@ -128,11 +128,11 @@ impl ProvingMemoryConfig {
     fn from_params<F>(
         params: &SystemParams,
         extension_degree: usize,
-        digest_size: usize,
+        digest_bytes: usize,
         cache_rs_code_matrix: bool,
     ) -> Self {
         Self {
-            base_field_size: size_of::<F>(),
+            base_field_bytes: size_of::<F>(),
             extension_degree,
             log_blowup: params.log_blowup,
             l_skip: params.l_skip,
@@ -143,7 +143,7 @@ impl ProvingMemoryConfig {
             log_stacked_height: params.log_stacked_height(),
             k_whir: params.k_whir(),
             num_whir_rounds: params.num_whir_rounds(),
-            digest_size,
+            digest_bytes,
         }
     }
 
@@ -157,12 +157,12 @@ impl ProvingMemoryConfig {
 
     #[inline]
     pub fn main_memory_bytes(&self, main_cells: usize) -> usize {
-        main_cells * self.base_field_size
+        main_cells * self.base_field_bytes
     }
 
     #[inline]
     pub fn rs_code_matrix_memory_bytes(&self, main_cells: usize) -> usize {
-        main_cells * (1usize << self.log_blowup) * self.base_field_size
+        main_cells * (1usize << self.log_blowup) * self.base_field_bytes
     }
 
     #[inline]
@@ -198,7 +198,7 @@ impl ProvingMemoryConfig {
     fn main_commitment_initial_digest_layer_memory_bytes(&self) -> usize {
         let log_codeword_height = self.log_stacked_height + self.log_blowup;
         let log_query_layer_height = log_codeword_height.saturating_sub(self.k_whir);
-        (1usize << log_query_layer_height) * self.digest_size
+        (1usize << log_query_layer_height) * self.digest_bytes
     }
 
     #[inline]
@@ -225,13 +225,13 @@ impl ProvingMemoryConfig {
         let height = 1usize << self.log_stacked_height;
         let ext_poly = height
             .saturating_mul(self.extension_degree)
-            .saturating_mul(self.base_field_size);
+            .saturating_mul(self.base_field_bytes);
         let first_sumcheck_tmp = height
             .div_ceil(2)
             .div_ceil(CUDA_KERNEL_DEFAULT_BLOCK_SIZE)
             .saturating_mul(WHIR_SUMCHECK_DEGREE)
             .saturating_mul(self.extension_degree)
-            .saturating_mul(self.base_field_size);
+            .saturating_mul(self.base_field_bytes);
 
         // First WHIR sumcheck round keeps f_coeffs and w_moments live while allocating folded
         // outputs. This is larger than the earlier f_ple_evals + f_coeffs conversion peak.
@@ -249,7 +249,7 @@ impl ProvingMemoryConfig {
 
     #[inline]
     fn whir_tree_memory_bytes(&self, log_codeword_height: usize) -> usize {
-        (1usize << log_codeword_height) * self.extension_degree * self.base_field_size
+        (1usize << log_codeword_height) * self.extension_degree * self.base_field_bytes
             + self.merkle_digest_layers_memory_bytes(log_codeword_height)
     }
 
@@ -257,7 +257,7 @@ impl ProvingMemoryConfig {
     fn merkle_digest_layers_memory_bytes(&self, log_codeword_height: usize) -> usize {
         let log_bottom_layer = log_codeword_height.saturating_sub(self.k_whir);
         let bottom_layer_len = 1usize << log_bottom_layer;
-        (2 * bottom_layer_len - 1) * self.digest_size
+        (2 * bottom_layer_len - 1) * self.digest_bytes
     }
 
     #[inline]
@@ -289,7 +289,7 @@ impl ProvingMemoryConfig {
         } else {
             main_cell_secondary_weight
         };
-        ceil_weighted_bytes(main_cells, self.base_field_size, weight)
+        ceil_weighted_bytes(main_cells, self.base_field_bytes, weight)
     }
 
     #[inline]
@@ -318,7 +318,7 @@ impl ProvingMemoryConfig {
 
     #[inline]
     fn fractional_gkr_memory_model(&self) -> FractionalGkrMemoryModel {
-        FractionalGkrMemoryModel::new(self.base_field_size, self.extension_degree)
+        FractionalGkrMemoryModel::new(self.base_field_bytes, self.extension_degree)
     }
 
     #[inline]
@@ -338,7 +338,7 @@ impl ProvingMemoryConfig {
             FractionalGkrMemoryModel::ROUND_COMPUTE_FALLBACK_BLOCKS,
         )
         .saturating_mul(self.extension_degree)
-        .saturating_mul(self.base_field_size)
+        .saturating_mul(self.base_field_bytes)
     }
 
     /// Interaction memory includes the fractional-GKR model plus the larger of fixed interaction
@@ -482,9 +482,9 @@ fn default_main_cell_secondary_weight(
     (1.0 + max_constraint_degree as f64 / 2.0) * extension_degree as f64 / (1usize << l_skip) as f64
 }
 
-/// `ceil(cell_count * base_field_size * weight)`
-fn ceil_weighted_bytes(cell_count: usize, base_field_size: usize, weight: f64) -> usize {
-    ((cell_count * base_field_size) as f64 * weight).ceil() as usize
+/// `ceil(cell_count * base_field_bytes * weight)`
+fn ceil_weighted_bytes(cell_count: usize, base_field_bytes: usize, weight: f64) -> usize {
+    ((cell_count * base_field_bytes) as f64 * weight).ceil() as usize
 }
 
 #[cfg(test)]
@@ -507,7 +507,7 @@ mod tests {
         main_stacked_cells: usize,
     ) -> usize {
         let cached_stacked_matrix = if config.cache_stacked_matrix {
-            main_stacked_cells * config.base_field_size
+            main_stacked_cells * config.base_field_bytes
         } else {
             0
         };
@@ -586,7 +586,7 @@ mod tests {
 
         let estimate = config.estimate(counts);
 
-        assert_eq!(estimate.main, 30 * config.base_field_size);
+        assert_eq!(estimate.main, 30 * config.base_field_bytes);
         assert_eq!(
             estimate.rs_code_matrix,
             config.rs_code_matrix_memory_bytes(64)

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -7,17 +7,28 @@ use crate::{StarkProtocolConfig, SystemParams};
 /// Fixed interaction scratch not proportional to interaction cells.
 pub const INTERACTION_MEMORY_OVERHEAD: usize = 2 << 20;
 
+// Mirrors `frac_compute_round_launch_params` and `_frac_compute_round_temp_buffer_size`
+// in the CUDA fractional-GKR kernels.
+const FRACTIONAL_GKR_SP_DEG: usize = 2;
+const FRACTIONAL_GKR_DEFAULT_BLOCK_SIZE: usize = 256;
+const FRACTIONAL_GKR_MIN_BLOCK_SIZE: usize = 64;
+const FRACTIONAL_GKR_WARP_SIZE: usize = 32;
+const FRACTIONAL_GKR_ROUND_COMPUTE_FALLBACK_BLOCKS: usize = 228;
+
 /// Cell counts for a proving memory estimate.
 ///
-/// `main_cells_*` are `Σ(padded_height * width)` in base-field cells, split by whether a trace
-/// opens next-row rotations. `interaction_cells` is the metered row-interaction slot count after
-/// power-of-two trace padding.
+/// `main_cells_*` are `Σ(padded_height * width)` in base-field cells for traces opened by the
+/// constraint and opening phases, split by whether a trace opens next-row rotations.
+/// `interaction_cells` is the metered row-interaction slot count after power-of-two trace padding.
+/// `main_stacked_cells` is the common-main stacked matrix size before Reed-Solomon blowup.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ProvingMemoryCounts {
-    /// Main trace cells for AIRs that open next-row rotations after power-of-two padding.
+    /// Opened trace cells for AIRs that open next-row rotations after power-of-two padding.
     pub main_cells_with_rot: usize,
-    /// Main trace cells for AIRs without next-row rotations after power-of-two padding.
+    /// Opened trace cells for AIRs without next-row rotations after power-of-two padding.
     pub main_cells_without_rot: usize,
+    /// Common-main stacked matrix cells before Reed-Solomon blowup.
+    pub main_stacked_cells: usize,
     /// Metered row-interaction slots after power-of-two padding.
     pub interaction_cells: usize,
 }
@@ -28,9 +39,24 @@ impl ProvingMemoryCounts {
         main_cells_without_rot: usize,
         interaction_cells: usize,
     ) -> Self {
+        Self::new_with_stacked_cells(
+            main_cells_with_rot,
+            main_cells_without_rot,
+            main_cells_with_rot + main_cells_without_rot,
+            interaction_cells,
+        )
+    }
+
+    pub const fn new_with_stacked_cells(
+        main_cells_with_rot: usize,
+        main_cells_without_rot: usize,
+        main_stacked_cells: usize,
+        interaction_cells: usize,
+    ) -> Self {
         Self {
             main_cells_with_rot,
             main_cells_without_rot,
+            main_stacked_cells,
             interaction_cells,
         }
     }
@@ -46,15 +72,17 @@ impl ProvingMemoryCounts {
 pub struct ProvingMemoryEstimate {
     /// Selected peak estimate.
     pub total: usize,
-    /// Cached main trace data.
+    /// Resident opened trace data.
     pub main: usize,
+    /// Retained common-main PCS data used by the selected secondary phase.
+    pub main_persistent: usize,
     /// Reed-Solomon code matrix for main traces.
     pub rs_code_matrix: usize,
     /// Secondary main-trace buffers after PCS opening.
     pub main_secondary: usize,
-    /// Interaction GKR buffers plus fixed interaction overhead.
+    /// Interaction GKR buffers plus fractional-GKR scratch.
     pub interaction: usize,
-    /// Peak among secondary phases, excluding cached main trace data.
+    /// Peak among secondary phases, excluding resident opened trace data.
     pub secondary_peak: usize,
 }
 
@@ -71,8 +99,22 @@ pub struct ProvingMemoryConfig {
     pub l_skip: usize,
     /// Maximum constraint degree across AIR and interaction constraints.
     pub max_constraint_degree: usize,
+    /// Whether the prover keeps the stacked matrix cached after `stacked_commit`.
+    pub cache_stacked_matrix: bool,
     /// Whether the prover keeps the Reed-Solomon code matrix cached after `stacked_commit`.
     pub cache_rs_code_matrix: bool,
+    /// Whether to include CUDA retained opening state in the estimate.
+    pub retained_opening_memory: bool,
+    /// `log_2` of the common-main stacked matrix height.
+    pub log_stacked_height: usize,
+    /// WHIR folding factor.
+    pub k_whir: usize,
+    /// Number of WHIR rounds.
+    pub num_whir_rounds: usize,
+    /// Size of one PCS digest in bytes.
+    pub digest_size: usize,
+    /// Target minimum block count for CUDA fractional-GKR round kernels.
+    pub fractional_gkr_round_compute_min_blocks: usize,
 }
 
 impl ProvingMemoryConfig {
@@ -80,12 +122,18 @@ impl ProvingMemoryConfig {
         config: &SC,
         cache_rs_code_matrix: bool,
     ) -> Self {
-        Self::from_params::<SC::F>(config.params(), SC::D_EF, cache_rs_code_matrix)
+        Self::from_params::<SC::F>(
+            config.params(),
+            SC::D_EF,
+            size_of::<SC::Digest>(),
+            cache_rs_code_matrix,
+        )
     }
 
     fn from_params<F>(
         params: &SystemParams,
         extension_degree: usize,
+        digest_size: usize,
         cache_rs_code_matrix: bool,
     ) -> Self {
         Self {
@@ -94,7 +142,14 @@ impl ProvingMemoryConfig {
             log_blowup: params.log_blowup,
             l_skip: params.l_skip,
             max_constraint_degree: params.max_constraint_degree,
+            cache_stacked_matrix: false,
             cache_rs_code_matrix,
+            retained_opening_memory: false,
+            log_stacked_height: params.log_stacked_height(),
+            k_whir: params.k_whir(),
+            num_whir_rounds: params.num_whir_rounds(),
+            digest_size,
+            fractional_gkr_round_compute_min_blocks: FRACTIONAL_GKR_ROUND_COMPUTE_FALLBACK_BLOCKS,
         }
     }
 
@@ -106,6 +161,85 @@ impl ProvingMemoryConfig {
     #[inline]
     pub fn rs_code_matrix_memory_bytes(&self, main_cells: usize) -> usize {
         main_cells * (1usize << self.log_blowup) * self.base_field_size
+    }
+
+    #[inline]
+    pub fn stacked_matrix_cells(&self, stacked_slice_cells: usize) -> usize {
+        if stacked_slice_cells == 0 {
+            return 0;
+        }
+
+        let stacked_height = 1usize << self.log_stacked_height;
+        stacked_slice_cells.div_ceil(stacked_height) * stacked_height
+    }
+
+    #[inline]
+    pub fn stacked_slice_height(&self, padded_height: usize) -> usize {
+        padded_height.max(1usize << self.l_skip)
+    }
+
+    #[inline]
+    pub fn main_persistent_memory_bytes(
+        &self,
+        main_cells: usize,
+        main_stacked_cells: usize,
+    ) -> usize {
+        if main_cells == 0 || main_stacked_cells == 0 {
+            return 0;
+        }
+
+        let common_digest_layers = if self.retained_opening_memory {
+            self.main_commitment_digest_layers_memory_bytes()
+        } else {
+            0
+        };
+        self.cached_stacked_matrix_memory_bytes(main_stacked_cells) + common_digest_layers
+    }
+
+    #[inline]
+    fn cached_stacked_matrix_memory_bytes(&self, main_stacked_cells: usize) -> usize {
+        if self.cache_stacked_matrix {
+            self.main_memory_bytes(main_stacked_cells)
+        } else {
+            0
+        }
+    }
+
+    #[inline]
+    fn main_commitment_digest_layers_memory_bytes(&self) -> usize {
+        self.merkle_digest_layers_memory_bytes(self.log_stacked_height + self.log_blowup)
+    }
+
+    #[inline]
+    fn first_whir_tree_memory_bytes(&self) -> usize {
+        (self.log_stacked_height + self.log_blowup)
+            .checked_sub(1)
+            .map_or(0, |log_codeword_height| {
+                self.whir_tree_memory_bytes(log_codeword_height)
+            })
+    }
+
+    #[inline]
+    fn second_whir_tree_memory_bytes(&self) -> usize {
+        (self.num_whir_rounds > 2)
+            .then(|| self.log_stacked_height + self.log_blowup)
+            .and_then(|log_codeword_height| log_codeword_height.checked_sub(2))
+            .map_or(0, |log_codeword_height| {
+                self.whir_tree_memory_bytes(log_codeword_height)
+            })
+    }
+
+    #[inline]
+    fn whir_tree_memory_bytes(&self, log_codeword_height: usize) -> usize {
+        (1usize << log_codeword_height) * self.extension_degree * self.base_field_size
+            + self.merkle_digest_layers_memory_bytes(log_codeword_height)
+    }
+
+    #[inline]
+    fn merkle_digest_layers_memory_bytes(&self, log_codeword_height: usize) -> usize {
+        let log_bottom_layer = log_codeword_height.saturating_sub(self.k_whir);
+        let bottom_layer_len = 1usize << log_bottom_layer;
+        (2 * bottom_layer_len - 1) * self.digest_size
     }
 
     #[inline]
@@ -156,51 +290,128 @@ impl ProvingMemoryConfig {
     }
 
     #[inline]
-    pub fn interaction_memory_bytes(&self, interaction_cells: usize) -> usize {
-        self.interaction_memory_bytes_without_overhead(interaction_cells)
-            + INTERACTION_MEMORY_OVERHEAD
+    fn fractional_gkr_logical_len(&self, interaction_cells: usize) -> usize {
+        if interaction_cells == 0 {
+            return 0;
+        }
+
+        let log_len = usize::BITS - interaction_cells.leading_zeros();
+        1usize.checked_shl(log_len).unwrap_or(usize::MAX)
     }
 
-    /// Convert main trace cells and interaction cells to memory bytes.
+    #[inline]
+    fn fractional_gkr_round_temp_buffer_memory_bytes(&self, interaction_cells: usize) -> usize {
+        let logical_len = self.fractional_gkr_logical_len(interaction_cells);
+        if logical_len <= 2 {
+            return 0;
+        }
+
+        let elements = logical_len >> 2;
+        let min_blocks = self.fractional_gkr_round_compute_min_blocks.max(1);
+        let mut block_size = FRACTIONAL_GKR_DEFAULT_BLOCK_SIZE;
+        let mut blocks_needed = elements.div_ceil(block_size);
+        if blocks_needed < min_blocks && elements >= FRACTIONAL_GKR_MIN_BLOCK_SIZE {
+            block_size = elements.div_ceil(min_blocks);
+            block_size = block_size
+                .div_ceil(FRACTIONAL_GKR_WARP_SIZE)
+                .saturating_mul(FRACTIONAL_GKR_WARP_SIZE)
+                .max(FRACTIONAL_GKR_MIN_BLOCK_SIZE);
+            blocks_needed = elements.div_ceil(block_size);
+        }
+
+        blocks_needed
+            .saturating_mul(FRACTIONAL_GKR_SP_DEG)
+            .saturating_mul(self.extension_degree)
+            .saturating_mul(self.base_field_size)
+    }
+
+    #[inline]
+    pub fn interaction_memory_bytes(&self, interaction_cells: usize) -> usize {
+        if interaction_cells == 0 {
+            return 0;
+        }
+
+        self.interaction_memory_bytes_without_overhead(interaction_cells)
+            + max(
+                INTERACTION_MEMORY_OVERHEAD,
+                self.fractional_gkr_round_temp_buffer_memory_bytes(interaction_cells),
+            )
+    }
+
+    /// Convert opened trace cells, common-main stacked cells, and interaction cells to memory
+    /// bytes.
     ///
     /// ```text
-    /// main_cells       = main_cells_with_rot + main_cells_without_rot
-    /// main             = main_cells * sizeof(F)
-    /// rs_code_matrix   = main_cells * 2^log_blowup * sizeof(F)
-    /// main_secondary   = sizeof(F) *
-    ///                    (2 * main_cell_secondary_weight() * main_cells_with_rot
-    ///                     + main_cell_secondary_weight() * main_cells_without_rot)
-    /// interaction      = sizeof(F) * interaction_cell_weight * interaction_cells
-    ///                    + INTERACTION_MEMORY_OVERHEAD
-    /// ```
+    /// main_cells         = main_cells_with_rot + main_cells_without_rot
+    /// main_stacked_cells = stacked_width * 2^log_stacked_height
+    /// main               = main_cells * sizeof(F)
+    /// cached_stacked     = main_stacked_cells * sizeof(F), when cached
+    /// common_digest      = Merkle digest layers for the common-main commitment
+    /// rs_code_matrix     = main_stacked_cells * 2^log_blowup * sizeof(F)
+    /// first_g_tree       = first WHIR folding codeword + Merkle digest layers
+    /// second_g_tree      = second WHIR folding codeword + Merkle digest layers
+    /// main_secondary     = sizeof(F) *
+    ///                      (2 * main_cell_secondary_weight() * main_cells_with_rot
+    ///                       + main_cell_secondary_weight() * main_cells_without_rot)
+    /// interaction        = sizeof(F) * interaction_cell_weight * interaction_cells
+    ///                      + max(INTERACTION_MEMORY_OVERHEAD, fractional_gkr_round_temp_buffer)
     ///
-    /// Cached RS code matrix:
-    ///
-    /// ```text
-    /// total = main + rs_code_matrix + max(main_secondary, interaction)
-    /// ```
-    ///
-    /// Dropped RS code matrix:
-    ///
-    /// ```text
-    /// total = main + max(rs_code_matrix, main_secondary, interaction)
+    /// total = main + max(
+    ///     cached_stacked + common_digest + rs_code_matrix,
+    ///     cached_stacked + common_digest + cached_rs_code_matrix + max(main_secondary, interaction),
+    ///     cached_stacked + common_digest + rs_code_matrix + first_g_tree,
+    ///     first_g_tree + second_g_tree,
+    /// )
     /// ```
     #[inline]
     pub fn estimate(&self, counts: ProvingMemoryCounts) -> ProvingMemoryEstimate {
         let main_cells = counts.main_cells();
         let main = self.main_memory_bytes(main_cells);
-        let rs_code_matrix = self.rs_code_matrix_memory_bytes(main_cells);
+        let has_common_main = counts.main_stacked_cells != 0;
+        let cached_stacked_matrix = if has_common_main {
+            self.cached_stacked_matrix_memory_bytes(counts.main_stacked_cells)
+        } else {
+            0
+        };
+        let common_digest_layers = if has_common_main && self.retained_opening_memory {
+            self.main_commitment_digest_layers_memory_bytes()
+        } else {
+            0
+        };
+        let rs_code_matrix = self.rs_code_matrix_memory_bytes(counts.main_stacked_cells);
         let main_secondary = self.main_secondary_memory_bytes(counts);
         let interaction = self.interaction_memory_bytes(counts.interaction_cells);
-        let secondary_peak = if self.cache_rs_code_matrix {
-            rs_code_matrix + max(main_secondary, interaction)
+        let first_g_tree = if has_common_main && self.retained_opening_memory {
+            self.first_whir_tree_memory_bytes()
         } else {
-            max(rs_code_matrix, max(main_secondary, interaction))
+            0
         };
+        let second_g_tree = if has_common_main && self.retained_opening_memory {
+            self.second_whir_tree_memory_bytes()
+        } else {
+            0
+        };
+        let cached_rs_code_matrix = if self.cache_rs_code_matrix {
+            rs_code_matrix
+        } else {
+            0
+        };
+        let retained_common_main = cached_stacked_matrix + common_digest_layers;
+        let commit_peak = retained_common_main + rs_code_matrix;
+        let constraint_peak =
+            retained_common_main + cached_rs_code_matrix + max(main_secondary, interaction);
+        let whir_first_round_peak = retained_common_main + rs_code_matrix + first_g_tree;
+        let whir_later_round_peak = first_g_tree + second_g_tree;
+        let secondary_peak = max(
+            max(commit_peak, constraint_peak),
+            max(whir_first_round_peak, whir_later_round_peak),
+        );
+        let main_persistent = retained_common_main;
 
         ProvingMemoryEstimate {
             total: main + secondary_peak,
             main,
+            main_persistent,
             rs_code_matrix,
             main_secondary,
             interaction,
@@ -240,41 +451,163 @@ mod tests {
     use super::*;
     use crate::test_utils::default_test_params_small;
 
+    const TEST_DIGEST_SIZE: usize = 32;
+
     fn test_memory_config() -> ProvingMemoryConfig {
         let params = default_test_params_small();
-        ProvingMemoryConfig::from_params::<u32>(&params, 4, true)
+        let mut config =
+            ProvingMemoryConfig::from_params::<u32>(&params, 4, TEST_DIGEST_SIZE, true);
+        config.retained_opening_memory = true;
+        config
+    }
+
+    fn expected_retained_common_main(
+        config: ProvingMemoryConfig,
+        main_stacked_cells: usize,
+    ) -> usize {
+        let cached_stacked_matrix = if config.cache_stacked_matrix {
+            main_stacked_cells * config.base_field_size
+        } else {
+            0
+        };
+        let common_digest_layers = if config.retained_opening_memory && main_stacked_cells != 0 {
+            config.main_commitment_digest_layers_memory_bytes()
+        } else {
+            0
+        };
+        cached_stacked_matrix + common_digest_layers
+    }
+
+    fn expected_secondary_peak(config: ProvingMemoryConfig, counts: ProvingMemoryCounts) -> usize {
+        let retained_common_main = expected_retained_common_main(config, counts.main_stacked_cells);
+        let rs_code_matrix = config.rs_code_matrix_memory_bytes(counts.main_stacked_cells);
+        let cached_rs_code_matrix = if config.cache_rs_code_matrix {
+            rs_code_matrix
+        } else {
+            0
+        };
+        let main_secondary = config.main_secondary_memory_bytes(counts);
+        let interaction = config.interaction_memory_bytes(counts.interaction_cells);
+        let has_common_main = counts.main_stacked_cells != 0 && config.retained_opening_memory;
+        let first_g_tree = if has_common_main {
+            config.first_whir_tree_memory_bytes()
+        } else {
+            0
+        };
+        let second_g_tree = if has_common_main {
+            config.second_whir_tree_memory_bytes()
+        } else {
+            0
+        };
+        let commit_peak = retained_common_main + rs_code_matrix;
+        let constraint_peak =
+            retained_common_main + cached_rs_code_matrix + max(main_secondary, interaction);
+        let whir_first_round_peak = retained_common_main + rs_code_matrix + first_g_tree;
+        let whir_later_round_peak = first_g_tree + second_g_tree;
+        max(
+            max(commit_peak, constraint_peak),
+            max(whir_first_round_peak, whir_later_round_peak),
+        )
     }
 
     #[test]
-    fn dropped_rs_code_matrix_is_phase_disjoint() {
-        let params = default_test_params_small();
-        let config = ProvingMemoryConfig::from_params::<u32>(&params, 4, false);
+    fn dropped_rs_code_matrix_uses_phase_peak() {
+        let mut config = test_memory_config();
+        config.cache_rs_code_matrix = false;
         let counts = ProvingMemoryCounts::new(10, 20, 5);
 
         let estimate = config.estimate(counts);
 
         assert_eq!(estimate.main, 30 * 4);
+        assert_eq!(
+            estimate.main_persistent,
+            expected_retained_common_main(config, counts.main_stacked_cells)
+        );
         assert_eq!(estimate.rs_code_matrix, 30 * 2 * 4);
-        assert_eq!(estimate.total, estimate.main + estimate.secondary_peak);
         assert_eq!(
             estimate.secondary_peak,
-            max(
-                estimate.rs_code_matrix,
-                max(estimate.main_secondary, estimate.interaction)
-            )
+            expected_secondary_peak(config, counts)
         );
+        assert_eq!(estimate.total, estimate.main + estimate.secondary_peak);
     }
 
     #[test]
-    fn cached_rs_code_matrix_is_additive() {
+    fn cached_rs_code_matrix_is_retained_for_constraints() {
         let config = test_memory_config();
         let counts = ProvingMemoryCounts::new(10, 20, 5);
 
         let estimate = config.estimate(counts);
 
         assert_eq!(
+            estimate.main_persistent,
+            expected_retained_common_main(config, counts.main_stacked_cells)
+        );
+        assert_eq!(
             estimate.secondary_peak,
-            estimate.rs_code_matrix + max(estimate.main_secondary, estimate.interaction)
+            expected_secondary_peak(config, counts)
+        );
+        assert_eq!(estimate.total, estimate.main + estimate.secondary_peak);
+    }
+
+    #[test]
+    fn rs_code_matrix_uses_stacked_main_cells() {
+        let mut config = test_memory_config();
+        config.cache_rs_code_matrix = false;
+        let counts = ProvingMemoryCounts::new_with_stacked_cells(10, 20, 64, 5);
+
+        let estimate = config.estimate(counts);
+
+        assert_eq!(estimate.main, 30 * config.base_field_size);
+        assert_eq!(
+            estimate.rs_code_matrix,
+            config.rs_code_matrix_memory_bytes(64)
+        );
+        assert_eq!(
+            estimate.main_secondary,
+            config.main_secondary_memory_bytes(ProvingMemoryCounts::new(10, 20, 5))
+        );
+    }
+
+    #[test]
+    fn cached_stacked_matrix_is_retained_opening_memory() {
+        let mut config = test_memory_config();
+        config.cache_stacked_matrix = true;
+        let counts = ProvingMemoryCounts::new_with_stacked_cells(10, 20, 64, 5);
+
+        let estimate = config.estimate(counts);
+
+        assert_eq!(
+            estimate.main_persistent,
+            expected_retained_common_main(config, counts.main_stacked_cells)
+        );
+    }
+
+    #[test]
+    fn generic_memory_config_has_no_persistent_main_memory() {
+        let params = default_test_params_small();
+        let estimate = ProvingMemoryConfig::from_params::<u32>(&params, 4, TEST_DIGEST_SIZE, true)
+            .estimate(ProvingMemoryCounts::new(10, 20, 5));
+
+        assert_eq!(estimate.main_persistent, 0);
+        assert_eq!(estimate.total, estimate.main + estimate.secondary_peak);
+    }
+
+    #[test]
+    fn empty_main_trace_has_no_persistent_main_memory() {
+        let estimate = test_memory_config().estimate(ProvingMemoryCounts::new(0, 0, 0));
+
+        assert_eq!(estimate.main, 0);
+        assert_eq!(estimate.main_persistent, 0);
+        assert_eq!(estimate.interaction, 0);
+    }
+
+    #[test]
+    fn persistent_main_memory_uses_retained_common_main() {
+        let config = test_memory_config();
+
+        assert_eq!(
+            config.main_persistent_memory_bytes(1, 1),
+            expected_retained_common_main(config, 1)
         );
     }
 }

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -14,6 +14,9 @@ const FRACTIONAL_GKR_DEFAULT_BLOCK_SIZE: usize = 256;
 const FRACTIONAL_GKR_MIN_BLOCK_SIZE: usize = 64;
 const FRACTIONAL_GKR_WARP_SIZE: usize = 32;
 const FRACTIONAL_GKR_ROUND_COMPUTE_FALLBACK_BLOCKS: usize = 228;
+const FRACTIONAL_INPUT_EF_ELEMENTS_PER_INTERACTION: usize = 2;
+const INTERACTION_ESTIMATE_WORK_BUFFER_RATIO: f64 = 1.0 / 16.0;
+const INTERACTION_ESTIMATE_BLOCK_SUM_RATIO: f64 = 1.0 / 256.0;
 
 /// Cell counts for a proving memory estimate.
 ///
@@ -179,24 +182,6 @@ impl ProvingMemoryConfig {
     }
 
     #[inline]
-    pub fn main_persistent_memory_bytes(
-        &self,
-        main_cells: usize,
-        main_stacked_cells: usize,
-    ) -> usize {
-        if main_cells == 0 || main_stacked_cells == 0 {
-            return 0;
-        }
-
-        let common_digest_layers = if self.retained_opening_memory {
-            self.main_commitment_digest_layers_memory_bytes()
-        } else {
-            0
-        };
-        self.cached_stacked_matrix_memory_bytes(main_stacked_cells) + common_digest_layers
-    }
-
-    #[inline]
     fn cached_stacked_matrix_memory_bytes(&self, main_stacked_cells: usize) -> usize {
         if self.cache_stacked_matrix {
             self.main_memory_bytes(main_stacked_cells)
@@ -208,6 +193,13 @@ impl ProvingMemoryConfig {
     #[inline]
     fn main_commitment_digest_layers_memory_bytes(&self) -> usize {
         self.merkle_digest_layers_memory_bytes(self.log_stacked_height + self.log_blowup)
+    }
+
+    #[inline]
+    fn main_commitment_initial_digest_layer_memory_bytes(&self) -> usize {
+        let log_codeword_height = self.log_stacked_height + self.log_blowup;
+        let log_query_layer_height = log_codeword_height.saturating_sub(self.k_whir);
+        (1usize << log_query_layer_height) * self.digest_size
     }
 
     #[inline]
@@ -346,7 +338,8 @@ impl ProvingMemoryConfig {
     /// main_stacked_cells = stacked_width * 2^log_stacked_height
     /// main               = main_cells * sizeof(F)
     /// cached_stacked     = main_stacked_cells * sizeof(F), when cached
-    /// common_digest      = Merkle digest layers for the common-main commitment
+    /// common_digest      = retained Merkle digest layers for the common-main commitment
+    /// common_first_layer = first Merkle digest layer built from the RS code matrix
     /// rs_code_matrix     = main_stacked_cells * 2^log_blowup * sizeof(F)
     /// first_g_tree       = first WHIR folding codeword + Merkle digest layers
     /// second_g_tree      = second WHIR folding codeword + Merkle digest layers
@@ -356,8 +349,14 @@ impl ProvingMemoryConfig {
     /// interaction        = sizeof(F) * interaction_cell_weight * interaction_cells
     ///                      + max(INTERACTION_MEMORY_OVERHEAD, fractional_gkr_round_temp_buffer)
     ///
+    /// commit_peak = cached_stacked + if cache_rs_code_matrix {
+    ///     rs_code_matrix + common_digest
+    /// } else {
+    ///     max(rs_code_matrix + common_first_layer, common_digest)
+    /// }
+    ///
     /// total = main + max(
-    ///     cached_stacked + common_digest + rs_code_matrix,
+    ///     commit_peak,
     ///     cached_stacked + common_digest + cached_rs_code_matrix + max(main_secondary, interaction),
     ///     cached_stacked + common_digest + rs_code_matrix + first_g_tree,
     ///     first_g_tree + second_g_tree,
@@ -379,6 +378,11 @@ impl ProvingMemoryConfig {
             0
         };
         let rs_code_matrix = self.rs_code_matrix_memory_bytes(counts.main_stacked_cells);
+        let common_initial_digest_layer = if has_common_main && self.retained_opening_memory {
+            self.main_commitment_initial_digest_layer_memory_bytes()
+        } else {
+            0
+        };
         let main_secondary = self.main_secondary_memory_bytes(counts);
         let interaction = self.interaction_memory_bytes(counts.interaction_cells);
         let first_g_tree = if has_common_main && self.retained_opening_memory {
@@ -397,7 +401,15 @@ impl ProvingMemoryConfig {
             0
         };
         let retained_common_main = cached_stacked_matrix + common_digest_layers;
-        let commit_peak = retained_common_main + rs_code_matrix;
+        let commit_peak = cached_stacked_matrix
+            + if self.cache_rs_code_matrix {
+                rs_code_matrix + common_digest_layers
+            } else {
+                max(
+                    rs_code_matrix + common_initial_digest_layer,
+                    common_digest_layers,
+                )
+            };
         let constraint_peak =
             retained_common_main + cached_rs_code_matrix + max(main_secondary, interaction);
         let whir_first_round_peak = retained_common_main + rs_code_matrix + first_g_tree;
@@ -428,17 +440,18 @@ fn default_main_cell_secondary_weight(
     (1.0 + max_constraint_degree as f64 / 2.0) * extension_degree as f64 / (1usize << l_skip) as f64
 }
 
-/// ```
-/// leaf_weight = 2 * extension_degree
+/// Conservative per-cell weight for interaction memory when the segmenter only
+/// has an aggregate row-interaction slot count.
 ///
-/// work_buffer    <= logical_len / 16
-/// tmp_block_sums ~= logical_len / 256
-/// logical_len    <= 2 * real_len
-///
-/// interaction_weight = leaf_weight * (1 + 2 * (1 / 16 + 1 / 256))
-/// ```
+/// Each row-interaction slot contributes one `Frac<EF>` input, i.e.
+/// numerator and denominator in the extension field. The two ratios reserve a
+/// proportional budget for CUDA work buffers and block sums that scale with the
+/// same slot count. Fixed fractional-GKR scratch is added separately by
+/// `interaction_memory_bytes`.
 fn default_interaction_cell_weight(extension_degree: usize) -> f64 {
-    (2 * extension_degree) as f64 * (1.0 + 2.0 * (1.0 / 16.0 + 1.0 / 256.0))
+    (FRACTIONAL_INPUT_EF_ELEMENTS_PER_INTERACTION * extension_degree) as f64
+        * (1.0
+            + 2.0 * (INTERACTION_ESTIMATE_WORK_BUFFER_RATIO + INTERACTION_ESTIMATE_BLOCK_SUM_RATIO))
 }
 
 /// `ceil(cell_count * base_field_size * weight)`
@@ -481,6 +494,12 @@ mod tests {
     fn expected_secondary_peak(config: ProvingMemoryConfig, counts: ProvingMemoryCounts) -> usize {
         let retained_common_main = expected_retained_common_main(config, counts.main_stacked_cells);
         let rs_code_matrix = config.rs_code_matrix_memory_bytes(counts.main_stacked_cells);
+        let common_initial_digest_layer =
+            if counts.main_stacked_cells != 0 && config.retained_opening_memory {
+                config.main_commitment_initial_digest_layer_memory_bytes()
+            } else {
+                0
+            };
         let cached_rs_code_matrix = if config.cache_rs_code_matrix {
             rs_code_matrix
         } else {
@@ -499,7 +518,26 @@ mod tests {
         } else {
             0
         };
-        let commit_peak = retained_common_main + rs_code_matrix;
+        let cached_stacked_matrix = if config.cache_stacked_matrix {
+            config.main_memory_bytes(counts.main_stacked_cells)
+        } else {
+            0
+        };
+        let common_digest_layers =
+            if counts.main_stacked_cells != 0 && config.retained_opening_memory {
+                config.main_commitment_digest_layers_memory_bytes()
+            } else {
+                0
+            };
+        let commit_peak = cached_stacked_matrix
+            + if config.cache_rs_code_matrix {
+                rs_code_matrix + common_digest_layers
+            } else {
+                max(
+                    rs_code_matrix + common_initial_digest_layer,
+                    common_digest_layers,
+                )
+            };
         let constraint_peak =
             retained_common_main + cached_rs_code_matrix + max(main_secondary, interaction);
         let whir_first_round_peak = retained_common_main + rs_code_matrix + first_g_tree;
@@ -604,9 +642,11 @@ mod tests {
     #[test]
     fn persistent_main_memory_uses_retained_common_main() {
         let config = test_memory_config();
+        let counts = ProvingMemoryCounts::new_with_stacked_cells(1, 0, 1, 0);
+        let estimate = config.estimate(counts);
 
         assert_eq!(
-            config.main_persistent_memory_bytes(1, 1),
+            estimate.main_persistent,
             expected_retained_common_main(config, 1)
         );
     }

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -2,21 +2,15 @@
 
 use std::{cmp::max, mem::size_of};
 
-use crate::{StarkProtocolConfig, SystemParams};
+use crate::{
+    prover::fractional_sumcheck_gkr::FractionalGkrMemoryModel, StarkProtocolConfig, SystemParams,
+};
 
 /// Fixed interaction scratch not proportional to interaction cells.
 pub const INTERACTION_MEMORY_OVERHEAD: usize = 2 << 20;
 
-// Mirrors `frac_compute_round_launch_params` and `_frac_compute_round_temp_buffer_size`
-// in the CUDA fractional-GKR kernels.
-const FRACTIONAL_GKR_SP_DEG: usize = 2;
-const FRACTIONAL_GKR_DEFAULT_BLOCK_SIZE: usize = 256;
-const FRACTIONAL_GKR_MIN_BLOCK_SIZE: usize = 64;
-const FRACTIONAL_GKR_WARP_SIZE: usize = 32;
-const FRACTIONAL_GKR_ROUND_COMPUTE_FALLBACK_BLOCKS: usize = 228;
-const FRACTIONAL_INPUT_EF_ELEMENTS_PER_INTERACTION: usize = 2;
-const INTERACTION_ESTIMATE_WORK_BUFFER_RATIO: f64 = 1.0 / 16.0;
-const INTERACTION_ESTIMATE_BLOCK_SUM_RATIO: f64 = 1.0 / 256.0;
+const WHIR_SUMCHECK_DEGREE: usize = 2;
+const CUDA_KERNEL_DEFAULT_BLOCK_SIZE: usize = 256;
 
 /// Cell counts for a proving memory estimate.
 ///
@@ -37,7 +31,7 @@ pub struct ProvingMemoryCounts {
 }
 
 impl ProvingMemoryCounts {
-    pub const fn new(
+    pub const fn new_with_unstacked_cells(
         main_cells_with_rot: usize,
         main_cells_without_rot: usize,
         interaction_cells: usize,
@@ -107,17 +101,15 @@ pub struct ProvingMemoryConfig {
     /// Whether the prover keeps the Reed-Solomon code matrix cached after `stacked_commit`.
     pub cache_rs_code_matrix: bool,
     /// Whether to include CUDA retained opening state in the estimate.
-    pub retained_opening_memory: bool,
+    retained_opening_memory: bool,
     /// `log_2` of the common-main stacked matrix height.
-    pub log_stacked_height: usize,
+    log_stacked_height: usize,
     /// WHIR folding factor.
-    pub k_whir: usize,
+    k_whir: usize,
     /// Number of WHIR rounds.
-    pub num_whir_rounds: usize,
+    num_whir_rounds: usize,
     /// Size of one PCS digest in bytes.
-    pub digest_size: usize,
-    /// Target minimum block count for CUDA fractional-GKR round kernels.
-    pub fractional_gkr_round_compute_min_blocks: usize,
+    digest_size: usize,
 }
 
 impl ProvingMemoryConfig {
@@ -152,8 +144,15 @@ impl ProvingMemoryConfig {
             k_whir: params.k_whir(),
             num_whir_rounds: params.num_whir_rounds(),
             digest_size,
-            fractional_gkr_round_compute_min_blocks: FRACTIONAL_GKR_ROUND_COMPUTE_FALLBACK_BLOCKS,
         }
+    }
+
+    /// Calibrate CUDA-only retained state estimates.
+    #[inline]
+    pub fn with_cuda_backend(mut self, cache_stacked_matrix: bool) -> Self {
+        self.cache_stacked_matrix = cache_stacked_matrix;
+        self.retained_opening_memory = true;
+        self
     }
 
     #[inline]
@@ -222,6 +221,33 @@ impl ProvingMemoryConfig {
     }
 
     #[inline]
+    fn whir_initial_workspace_memory_bytes(&self) -> usize {
+        let height = 1usize << self.log_stacked_height;
+        let ext_poly = height
+            .saturating_mul(self.extension_degree)
+            .saturating_mul(self.base_field_size);
+        let first_sumcheck_tmp = height
+            .div_ceil(2)
+            .div_ceil(CUDA_KERNEL_DEFAULT_BLOCK_SIZE)
+            .saturating_mul(WHIR_SUMCHECK_DEGREE)
+            .saturating_mul(self.extension_degree)
+            .saturating_mul(self.base_field_size);
+
+        // First WHIR sumcheck round keeps f_coeffs and w_moments live while allocating folded
+        // outputs. This is larger than the earlier f_ple_evals + f_coeffs conversion peak.
+        let first_sumcheck_peak = ext_poly
+            .saturating_mul(3)
+            .saturating_add(first_sumcheck_tmp);
+
+        // After k_whir folds, f_coeffs, w_moments, and the split base-field g_coeffs are live
+        // while building the first folded codeword tree.
+        let folded_ext_poly = ext_poly >> self.k_whir.min(usize::BITS as usize - 1);
+        let first_codeword_build_peak = folded_ext_poly.saturating_mul(3);
+
+        max(first_sumcheck_peak, first_codeword_build_peak)
+    }
+
+    #[inline]
     fn whir_tree_memory_bytes(&self, log_codeword_height: usize) -> usize {
         (1usize << log_codeword_height) * self.extension_degree * self.base_field_size
             + self.merkle_digest_layers_memory_bytes(log_codeword_height)
@@ -272,51 +298,55 @@ impl ProvingMemoryConfig {
             + self.main_secondary_memory_bytes_for_rot(counts.main_cells_without_rot, false)
     }
 
+    /// Fractional-GKR input and peak scratch, before the fixed interaction overhead.
+    ///
+    /// The input layer stores one `Frac<EF>` per real interaction cell:
+    ///
+    /// ```text
+    /// input = 2 * interaction_cells * D_EF * sizeof(F)
+    /// ```
+    ///
+    /// Work-buffer sizing is delegated to the prover-owned fractional-GKR model so CUDA batching
+    /// and metering use the same fold-eval/precompute-M peak.
     #[inline]
     pub fn interaction_memory_bytes_without_overhead(&self, interaction_cells: usize) -> usize {
-        ceil_weighted_bytes(
+        self.fractional_gkr_memory_model().peak_memory_bytes(
             interaction_cells,
-            self.base_field_size,
-            default_interaction_cell_weight(self.extension_degree),
+            Self::fractional_gkr_logical_len(interaction_cells),
         )
     }
 
     #[inline]
-    fn fractional_gkr_logical_len(&self, interaction_cells: usize) -> usize {
-        if interaction_cells == 0 {
-            return 0;
-        }
+    fn fractional_gkr_memory_model(&self) -> FractionalGkrMemoryModel {
+        FractionalGkrMemoryModel::new(self.base_field_size, self.extension_degree)
+    }
 
-        let log_len = usize::BITS - interaction_cells.leading_zeros();
-        1usize.checked_shl(log_len).unwrap_or(usize::MAX)
+    #[inline]
+    fn fractional_gkr_logical_len(interaction_cells: usize) -> usize {
+        FractionalGkrMemoryModel::logical_len(interaction_cells)
     }
 
     #[inline]
     fn fractional_gkr_round_temp_buffer_memory_bytes(&self, interaction_cells: usize) -> usize {
-        let logical_len = self.fractional_gkr_logical_len(interaction_cells);
+        let logical_len = Self::fractional_gkr_logical_len(interaction_cells);
         if logical_len <= 2 {
             return 0;
         }
 
-        let elements = logical_len >> 2;
-        let min_blocks = self.fractional_gkr_round_compute_min_blocks.max(1);
-        let mut block_size = FRACTIONAL_GKR_DEFAULT_BLOCK_SIZE;
-        let mut blocks_needed = elements.div_ceil(block_size);
-        if blocks_needed < min_blocks && elements >= FRACTIONAL_GKR_MIN_BLOCK_SIZE {
-            block_size = elements.div_ceil(min_blocks);
-            block_size = block_size
-                .div_ceil(FRACTIONAL_GKR_WARP_SIZE)
-                .saturating_mul(FRACTIONAL_GKR_WARP_SIZE)
-                .max(FRACTIONAL_GKR_MIN_BLOCK_SIZE);
-            blocks_needed = elements.div_ceil(block_size);
-        }
-
-        blocks_needed
-            .saturating_mul(FRACTIONAL_GKR_SP_DEG)
-            .saturating_mul(self.extension_degree)
-            .saturating_mul(self.base_field_size)
+        FractionalGkrMemoryModel::round_temp_buffer_elements(
+            logical_len >> 1,
+            FractionalGkrMemoryModel::ROUND_COMPUTE_FALLBACK_BLOCKS,
+        )
+        .saturating_mul(self.extension_degree)
+        .saturating_mul(self.base_field_size)
     }
 
+    /// Interaction memory includes the fractional-GKR model plus the larger of fixed interaction
+    /// scratch and CUDA round-reduction scratch:
+    ///
+    /// ```text
+    /// interaction = gkr_input_and_work + max(2 MiB, round_temp_buffer)
+    /// ```
     #[inline]
     pub fn interaction_memory_bytes(&self, interaction_cells: usize) -> usize {
         if interaction_cells == 0 {
@@ -333,20 +363,29 @@ impl ProvingMemoryConfig {
     /// Convert opened trace cells, common-main stacked cells, and interaction cells to memory
     /// bytes.
     ///
+    /// `main` is resident across the whole proving segment. `secondary_peak` is the maximum of the
+    /// secondary phases that can overlap with that resident main memory.
+    ///
     /// ```text
     /// main_cells         = main_cells_with_rot + main_cells_without_rot
     /// main_stacked_cells = stacked_width * 2^log_stacked_height
     /// main               = main_cells * sizeof(F)
+    ///
+    /// retained_common    = cached_stacked + common_digest
+    ///
     /// cached_stacked     = main_stacked_cells * sizeof(F), when cached
     /// common_digest      = retained Merkle digest layers for the common-main commitment
     /// common_first_layer = first Merkle digest layer built from the RS code matrix
     /// rs_code_matrix     = main_stacked_cells * 2^log_blowup * sizeof(F)
+    ///
     /// first_g_tree       = first WHIR folding codeword + Merkle digest layers
     /// second_g_tree      = second WHIR folding codeword + Merkle digest layers
+    /// whir_workspace     = CUDA WHIR coefficient/moment buffers and sumcheck scratch
+    ///
     /// main_secondary     = sizeof(F) *
     ///                      (2 * main_cell_secondary_weight() * main_cells_with_rot
     ///                       + main_cell_secondary_weight() * main_cells_without_rot)
-    /// interaction        = sizeof(F) * interaction_cell_weight * interaction_cells
+    /// interaction        = fractional-GKR inputs + max supported work buffer
     ///                      + max(INTERACTION_MEMORY_OVERHEAD, fractional_gkr_round_temp_buffer)
     ///
     /// commit_peak = cached_stacked + if cache_rs_code_matrix {
@@ -355,45 +394,47 @@ impl ProvingMemoryConfig {
     ///     max(rs_code_matrix + common_first_layer, common_digest)
     /// }
     ///
-    /// total = main + max(
+    /// constraint_peak       = retained_common + cached_rs_code_matrix
+    ///                         + max(main_secondary, interaction)
+    /// whir_first_round_peak = retained_common + rs_code_matrix
+    ///                         + max(whir_workspace, first_g_tree)
+    /// whir_later_round_peak = first_g_tree + second_g_tree
+    ///
+    /// secondary_peak = max(
     ///     commit_peak,
-    ///     cached_stacked + common_digest + cached_rs_code_matrix + max(main_secondary, interaction),
-    ///     cached_stacked + common_digest + rs_code_matrix + first_g_tree,
-    ///     first_g_tree + second_g_tree,
+    ///     constraint_peak,
+    ///     whir_first_round_peak,
+    ///     whir_later_round_peak,
     /// )
+    /// total = main + secondary_peak
     /// ```
     #[inline]
     pub fn estimate(&self, counts: ProvingMemoryCounts) -> ProvingMemoryEstimate {
         let main_cells = counts.main_cells();
         let main = self.main_memory_bytes(main_cells);
         let has_common_main = counts.main_stacked_cells != 0;
-        let cached_stacked_matrix = if has_common_main {
-            self.cached_stacked_matrix_memory_bytes(counts.main_stacked_cells)
-        } else {
-            0
-        };
-        let common_digest_layers = if has_common_main && self.retained_opening_memory {
-            self.main_commitment_digest_layers_memory_bytes()
-        } else {
-            0
-        };
+        let retained_opening_memory = has_common_main && self.retained_opening_memory;
+        let cached_stacked_matrix =
+            self.cached_stacked_matrix_memory_bytes(counts.main_stacked_cells);
         let rs_code_matrix = self.rs_code_matrix_memory_bytes(counts.main_stacked_cells);
-        let common_initial_digest_layer = if has_common_main && self.retained_opening_memory {
-            self.main_commitment_initial_digest_layer_memory_bytes()
-        } else {
-            0
-        };
         let main_secondary = self.main_secondary_memory_bytes(counts);
         let interaction = self.interaction_memory_bytes(counts.interaction_cells);
-        let first_g_tree = if has_common_main && self.retained_opening_memory {
-            self.first_whir_tree_memory_bytes()
+        let (
+            common_digest_layers,
+            common_initial_digest_layer,
+            first_g_tree,
+            second_g_tree,
+            whir_workspace,
+        ) = if retained_opening_memory {
+            (
+                self.main_commitment_digest_layers_memory_bytes(),
+                self.main_commitment_initial_digest_layer_memory_bytes(),
+                self.first_whir_tree_memory_bytes(),
+                self.second_whir_tree_memory_bytes(),
+                self.whir_initial_workspace_memory_bytes(),
+            )
         } else {
-            0
-        };
-        let second_g_tree = if has_common_main && self.retained_opening_memory {
-            self.second_whir_tree_memory_bytes()
-        } else {
-            0
+            (0, 0, 0, 0, 0)
         };
         let cached_rs_code_matrix = if self.cache_rs_code_matrix {
             rs_code_matrix
@@ -412,7 +453,8 @@ impl ProvingMemoryConfig {
             };
         let constraint_peak =
             retained_common_main + cached_rs_code_matrix + max(main_secondary, interaction);
-        let whir_first_round_peak = retained_common_main + rs_code_matrix + first_g_tree;
+        let whir_first_round_peak =
+            retained_common_main + rs_code_matrix + max(whir_workspace, first_g_tree);
         let whir_later_round_peak = first_g_tree + second_g_tree;
         let secondary_peak = max(
             max(commit_peak, constraint_peak),
@@ -438,20 +480,6 @@ fn default_main_cell_secondary_weight(
     max_constraint_degree: usize,
 ) -> f64 {
     (1.0 + max_constraint_degree as f64 / 2.0) * extension_degree as f64 / (1usize << l_skip) as f64
-}
-
-/// Conservative per-cell weight for interaction memory when the segmenter only
-/// has an aggregate row-interaction slot count.
-///
-/// Each row-interaction slot contributes one `Frac<EF>` input, i.e.
-/// numerator and denominator in the extension field. The two ratios reserve a
-/// proportional budget for CUDA work buffers and block sums that scale with the
-/// same slot count. Fixed fractional-GKR scratch is added separately by
-/// `interaction_memory_bytes`.
-fn default_interaction_cell_weight(extension_degree: usize) -> f64 {
-    (FRACTIONAL_INPUT_EF_ELEMENTS_PER_INTERACTION * extension_degree) as f64
-        * (1.0
-            + 2.0 * (INTERACTION_ESTIMATE_WORK_BUFFER_RATIO + INTERACTION_ESTIMATE_BLOCK_SUM_RATIO))
 }
 
 /// `ceil(cell_count * base_field_size * weight)`
@@ -491,68 +519,11 @@ mod tests {
         cached_stacked_matrix + common_digest_layers
     }
 
-    fn expected_secondary_peak(config: ProvingMemoryConfig, counts: ProvingMemoryCounts) -> usize {
-        let retained_common_main = expected_retained_common_main(config, counts.main_stacked_cells);
-        let rs_code_matrix = config.rs_code_matrix_memory_bytes(counts.main_stacked_cells);
-        let common_initial_digest_layer =
-            if counts.main_stacked_cells != 0 && config.retained_opening_memory {
-                config.main_commitment_initial_digest_layer_memory_bytes()
-            } else {
-                0
-            };
-        let cached_rs_code_matrix = if config.cache_rs_code_matrix {
-            rs_code_matrix
-        } else {
-            0
-        };
-        let main_secondary = config.main_secondary_memory_bytes(counts);
-        let interaction = config.interaction_memory_bytes(counts.interaction_cells);
-        let has_common_main = counts.main_stacked_cells != 0 && config.retained_opening_memory;
-        let first_g_tree = if has_common_main {
-            config.first_whir_tree_memory_bytes()
-        } else {
-            0
-        };
-        let second_g_tree = if has_common_main {
-            config.second_whir_tree_memory_bytes()
-        } else {
-            0
-        };
-        let cached_stacked_matrix = if config.cache_stacked_matrix {
-            config.main_memory_bytes(counts.main_stacked_cells)
-        } else {
-            0
-        };
-        let common_digest_layers =
-            if counts.main_stacked_cells != 0 && config.retained_opening_memory {
-                config.main_commitment_digest_layers_memory_bytes()
-            } else {
-                0
-            };
-        let commit_peak = cached_stacked_matrix
-            + if config.cache_rs_code_matrix {
-                rs_code_matrix + common_digest_layers
-            } else {
-                max(
-                    rs_code_matrix + common_initial_digest_layer,
-                    common_digest_layers,
-                )
-            };
-        let constraint_peak =
-            retained_common_main + cached_rs_code_matrix + max(main_secondary, interaction);
-        let whir_first_round_peak = retained_common_main + rs_code_matrix + first_g_tree;
-        let whir_later_round_peak = first_g_tree + second_g_tree;
-        max(
-            max(commit_peak, constraint_peak),
-            max(whir_first_round_peak, whir_later_round_peak),
-        )
-    }
-
     #[test]
     fn dropped_rs_code_matrix_uses_phase_peak() {
         let mut config = test_memory_config();
         config.cache_rs_code_matrix = false;
-        let counts = ProvingMemoryCounts::new(10, 20, 5);
+        let counts = ProvingMemoryCounts::new_with_unstacked_cells(10, 20, 5);
 
         let estimate = config.estimate(counts);
 
@@ -562,17 +533,35 @@ mod tests {
             expected_retained_common_main(config, counts.main_stacked_cells)
         );
         assert_eq!(estimate.rs_code_matrix, 30 * 2 * 4);
+        let commit_peak = max(
+            estimate.rs_code_matrix + config.main_commitment_initial_digest_layer_memory_bytes(),
+            estimate.main_persistent,
+        );
+        let constraint_peak =
+            estimate.main_persistent + max(estimate.main_secondary, estimate.interaction);
+        let whir_first_round_peak = estimate.main_persistent
+            + estimate.rs_code_matrix
+            + max(
+                config.whir_initial_workspace_memory_bytes(),
+                config.first_whir_tree_memory_bytes(),
+            );
+        let whir_later_round_peak =
+            config.first_whir_tree_memory_bytes() + config.second_whir_tree_memory_bytes();
         assert_eq!(
             estimate.secondary_peak,
-            expected_secondary_peak(config, counts)
+            max(
+                max(commit_peak, constraint_peak),
+                max(whir_first_round_peak, whir_later_round_peak)
+            )
         );
         assert_eq!(estimate.total, estimate.main + estimate.secondary_peak);
     }
 
     #[test]
     fn cached_rs_code_matrix_is_retained_for_constraints() {
-        let config = test_memory_config();
-        let counts = ProvingMemoryCounts::new(10, 20, 5);
+        let mut config = test_memory_config();
+        config.num_whir_rounds = 1;
+        let counts = ProvingMemoryCounts::new_with_unstacked_cells(10, 20, 5);
 
         let estimate = config.estimate(counts);
 
@@ -582,7 +571,9 @@ mod tests {
         );
         assert_eq!(
             estimate.secondary_peak,
-            expected_secondary_peak(config, counts)
+            estimate.main_persistent
+                + estimate.rs_code_matrix
+                + max(estimate.main_secondary, estimate.interaction)
         );
         assert_eq!(estimate.total, estimate.main + estimate.secondary_peak);
     }
@@ -602,7 +593,9 @@ mod tests {
         );
         assert_eq!(
             estimate.main_secondary,
-            config.main_secondary_memory_bytes(ProvingMemoryCounts::new(10, 20, 5))
+            config.main_secondary_memory_bytes(ProvingMemoryCounts::new_with_unstacked_cells(
+                10, 20, 5,
+            ))
         );
     }
 
@@ -621,10 +614,90 @@ mod tests {
     }
 
     #[test]
+    fn interaction_memory_includes_fractional_gkr_work_buffers() {
+        let config = test_memory_config();
+        let interaction_cells = 16;
+        let input = config
+            .fractional_gkr_memory_model()
+            .input_memory_bytes(interaction_cells);
+
+        assert!(config.interaction_memory_bytes_without_overhead(interaction_cells) > input);
+    }
+
+    #[test]
+    fn cuda_whir_peak_includes_initial_workspace() {
+        let config = test_memory_config();
+        let counts = ProvingMemoryCounts::new_with_stacked_cells(1, 0, 1, 0);
+        let estimate = config.estimate(counts);
+        let commit_peak = estimate.rs_code_matrix + estimate.main_persistent;
+        let constraint_peak =
+            estimate.main_persistent + estimate.rs_code_matrix + estimate.main_secondary;
+        let whir_first_round_peak = estimate.main_persistent
+            + estimate.rs_code_matrix
+            + config.whir_initial_workspace_memory_bytes();
+        let whir_later_round_peak =
+            config.first_whir_tree_memory_bytes() + config.second_whir_tree_memory_bytes();
+
+        assert_eq!(
+            estimate.secondary_peak,
+            max(
+                max(commit_peak, constraint_peak),
+                max(whir_first_round_peak, whir_later_round_peak)
+            )
+        );
+    }
+
+    #[test]
+    fn uncached_commit_peak_keeps_initial_digest_layer_only() {
+        let mut config = test_memory_config();
+        config.cache_rs_code_matrix = false;
+        config.num_whir_rounds = 1;
+        config.max_constraint_degree = 0;
+        let counts = ProvingMemoryCounts::new_with_stacked_cells(1, 0, 64, 0);
+
+        let estimate = config.estimate(counts);
+        let commit_peak = max(
+            estimate.rs_code_matrix + config.main_commitment_initial_digest_layer_memory_bytes(),
+            estimate.main_persistent,
+        );
+        let constraint_peak = estimate.main_persistent + estimate.main_secondary;
+        let whir_first_round_peak = estimate.main_persistent
+            + estimate.rs_code_matrix
+            + max(
+                config.whir_initial_workspace_memory_bytes(),
+                config.first_whir_tree_memory_bytes(),
+            );
+        let whir_later_round_peak =
+            config.first_whir_tree_memory_bytes() + config.second_whir_tree_memory_bytes();
+
+        assert_eq!(
+            estimate.secondary_peak,
+            max(
+                max(commit_peak, constraint_peak),
+                max(whir_first_round_peak, whir_later_round_peak)
+            )
+        );
+        assert_eq!(
+            estimate.main_persistent,
+            config.main_commitment_digest_layers_memory_bytes()
+        );
+    }
+
+    #[test]
+    fn cuda_backend_calibrates_derived_memory_state() {
+        let params = default_test_params_small();
+        let config = ProvingMemoryConfig::from_params::<u32>(&params, 4, TEST_DIGEST_SIZE, false)
+            .with_cuda_backend(true);
+
+        assert!(config.retained_opening_memory);
+        assert!(config.cache_stacked_matrix);
+    }
+
+    #[test]
     fn generic_memory_config_has_no_persistent_main_memory() {
         let params = default_test_params_small();
         let estimate = ProvingMemoryConfig::from_params::<u32>(&params, 4, TEST_DIGEST_SIZE, true)
-            .estimate(ProvingMemoryCounts::new(10, 20, 5));
+            .estimate(ProvingMemoryCounts::new_with_unstacked_cells(10, 20, 5));
 
         assert_eq!(estimate.main_persistent, 0);
         assert_eq!(estimate.total, estimate.main + estimate.secondary_peak);
@@ -632,7 +705,8 @@ mod tests {
 
     #[test]
     fn empty_main_trace_has_no_persistent_main_memory() {
-        let estimate = test_memory_config().estimate(ProvingMemoryCounts::new(0, 0, 0));
+        let estimate =
+            test_memory_config().estimate(ProvingMemoryCounts::new_with_unstacked_cells(0, 0, 0));
 
         assert_eq!(estimate.main, 0);
         assert_eq!(estimate.main_persistent, 0);

--- a/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
+++ b/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
@@ -43,7 +43,7 @@ const FRACTIONAL_GKR_WARP_SIZE: usize = 32;
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct FractionalGkrMemoryModel {
-    base_field_size: usize,
+    base_field_bytes: usize,
     extension_degree: usize,
 }
 
@@ -54,9 +54,9 @@ impl FractionalGkrMemoryModel {
     pub const ROUND_COMPUTE_FALLBACK_BLOCKS: usize = 228;
 
     #[inline]
-    pub const fn new(base_field_size: usize, extension_degree: usize) -> Self {
+    pub const fn new(base_field_bytes: usize, extension_degree: usize) -> Self {
         Self {
-            base_field_size,
+            base_field_bytes,
             extension_degree,
         }
     }
@@ -76,7 +76,7 @@ impl FractionalGkrMemoryModel {
         interaction_cells
             .saturating_mul(Self::INPUT_EF_ELEMENTS_PER_INTERACTION)
             .saturating_mul(self.extension_degree)
-            .saturating_mul(self.base_field_size)
+            .saturating_mul(self.base_field_bytes)
     }
 
     #[inline]
@@ -89,7 +89,7 @@ impl FractionalGkrMemoryModel {
         // The input Frac layer is counted separately by `input_memory_bytes`.
         let frac_size = Self::INPUT_EF_ELEMENTS_PER_INTERACTION
             .saturating_mul(self.extension_degree)
-            .saturating_mul(self.base_field_size);
+            .saturating_mul(self.base_field_bytes);
         let fold_eval = Self::fold_eval_work_buffer_elements(logical_len).saturating_mul(frac_size);
 
         let precompute_f =
@@ -115,7 +115,7 @@ impl FractionalGkrMemoryModel {
 
     #[inline]
     pub fn precompute_m_auxiliary_memory_bytes(&self) -> usize {
-        let ext_size = self.extension_degree.saturating_mul(self.base_field_size);
+        let ext_size = self.extension_degree.saturating_mul(self.base_field_bytes);
         let precompute_ef_elements =
             (1usize << (2 * Self::WINDOW_SIZE + 1)) + (1usize << (Self::WINDOW_SIZE + 1));
         precompute_ef_elements.saturating_mul(ext_size)

--- a/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
+++ b/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
@@ -1,4 +1,4 @@
-use std::ops::Add;
+use std::{cmp::max, ops::Add};
 
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_util::log2_strict_usize;
@@ -32,6 +32,119 @@ pub struct Frac<EF> {
     // PERF[jpw]: in the initial round, we can keep `p` in base field
     pub p: EF,
     pub q: EF,
+}
+
+const FRACTIONAL_GKR_SP_DEG: usize = 2;
+const FRACTIONAL_GKR_DEFAULT_BLOCK_SIZE: usize = 256;
+const FRACTIONAL_GKR_MIN_BLOCK_SIZE: usize = 64;
+const FRACTIONAL_GKR_WARP_SIZE: usize = 32;
+
+/// Fractional-GKR sizing model used by CUDA batching and memory metering.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FractionalGkrMemoryModel {
+    base_field_size: usize,
+    extension_degree: usize,
+}
+
+impl FractionalGkrMemoryModel {
+    const INPUT_EF_ELEMENTS_PER_INTERACTION: usize = 2;
+    pub const WINDOW_SIZE: usize = 3;
+    pub const WINDOW_DEFAULT_MIN_N: usize = 22;
+    pub const ROUND_COMPUTE_FALLBACK_BLOCKS: usize = 228;
+
+    #[inline]
+    pub const fn new(base_field_size: usize, extension_degree: usize) -> Self {
+        Self {
+            base_field_size,
+            extension_degree,
+        }
+    }
+
+    #[inline]
+    pub fn logical_len(interaction_cells: usize) -> usize {
+        if interaction_cells == 0 {
+            return 0;
+        }
+
+        let log_len = usize::BITS - interaction_cells.leading_zeros();
+        1usize.checked_shl(log_len).unwrap_or(usize::MAX)
+    }
+
+    #[inline]
+    pub fn input_memory_bytes(&self, interaction_cells: usize) -> usize {
+        interaction_cells
+            .saturating_mul(Self::INPUT_EF_ELEMENTS_PER_INTERACTION)
+            .saturating_mul(self.extension_degree)
+            .saturating_mul(self.base_field_size)
+    }
+
+    #[inline]
+    pub fn peak_work_buffer_memory_bytes(&self, logical_len: usize) -> usize {
+        if logical_len <= 2 {
+            return 0;
+        }
+
+        // Peak scratch is the larger of the fold-eval work buffer and the precompute-M path.
+        // The input Frac layer is counted separately by `input_memory_bytes`.
+        let frac_size = Self::INPUT_EF_ELEMENTS_PER_INTERACTION
+            .saturating_mul(self.extension_degree)
+            .saturating_mul(self.base_field_size);
+        let fold_eval = Self::fold_eval_work_buffer_elements(logical_len).saturating_mul(frac_size);
+
+        let precompute_f =
+            Self::precompute_m_work_buffer_elements(logical_len).saturating_mul(frac_size);
+        let precompute_ef = self.precompute_m_auxiliary_memory_bytes();
+
+        max(fold_eval, precompute_f.saturating_add(precompute_ef))
+    }
+
+    #[inline]
+    pub fn fold_eval_work_buffer_elements(logical_len: usize) -> usize {
+        logical_len / 4
+    }
+
+    #[inline]
+    pub fn precompute_m_work_buffer_elements(logical_len: usize) -> usize {
+        if logical_len <= 2 {
+            return 0;
+        }
+
+        (logical_len >> (1 + Self::WINDOW_SIZE)).max(1usize << Self::WINDOW_DEFAULT_MIN_N)
+    }
+
+    #[inline]
+    pub fn precompute_m_auxiliary_memory_bytes(&self) -> usize {
+        let ext_size = self.extension_degree.saturating_mul(self.base_field_size);
+        let precompute_ef_elements =
+            (1usize << (2 * Self::WINDOW_SIZE + 1)) + (1usize << (Self::WINDOW_SIZE + 1));
+        precompute_ef_elements.saturating_mul(ext_size)
+    }
+
+    #[inline]
+    pub fn peak_memory_bytes(&self, interaction_cells: usize, logical_len: usize) -> usize {
+        self.input_memory_bytes(interaction_cells)
+            .saturating_add(self.peak_work_buffer_memory_bytes(logical_len))
+    }
+
+    #[inline]
+    pub fn round_temp_buffer_elements(num_x: usize, min_blocks: usize) -> usize {
+        // Mirrors CUDA round-compute launch sizing for `_frac_compute_round_temp_buffer_size`.
+        let elements = num_x >> 1;
+        let min_blocks = min_blocks.max(1);
+        let mut block_size = FRACTIONAL_GKR_DEFAULT_BLOCK_SIZE;
+        let mut blocks_needed = elements.div_ceil(block_size);
+        if blocks_needed < min_blocks && elements >= FRACTIONAL_GKR_MIN_BLOCK_SIZE {
+            block_size = elements.div_ceil(min_blocks);
+            block_size = block_size
+                .div_ceil(FRACTIONAL_GKR_WARP_SIZE)
+                .saturating_mul(FRACTIONAL_GKR_WARP_SIZE)
+                .max(FRACTIONAL_GKR_MIN_BLOCK_SIZE);
+            blocks_needed = elements.div_ceil(block_size);
+        }
+
+        blocks_needed.saturating_mul(FRACTIONAL_GKR_SP_DEG)
+    }
 }
 
 impl<EF: Field> Add<Frac<EF>> for Frac<EF> {


### PR DESCRIPTION
## Summary

Tightens CUDA proving-memory estimates so metered batching accounts for retained CUDA prover state and fractional-GKR scratch instead of relying on the older interaction-cell weight.

The estimate now:

- separates opened main cells from common-main stacked cells, so RS-code and retained commitment memory use the same shape as the prover
- includes CUDA-only retained common-main commitment / WHIR opening memory when building a CUDA prover config
- shares fractional-GKR work-buffer sizing from the prover-owned GKR sizing model, so CUDA batching and memory metering use the same Rust arithmetic
- keeps generic `ProvingMemoryConfig` unchanged by default; CUDA opts in through `with_cuda_backend(cache_stacked_matrix)`

The CUDA prover workflow is not changed. The CUDA-side diff only wires the existing prover cache setting into metering and delegates batching work-buffer sizing to the shared prover-owned helper.

## Estimate Shape

Main opened trace memory is always resident for the segment:

```text
main_cells = main_cells_with_rot + main_cells_without_rot
main       = main_cells * sizeof(F)
```

CUDA retained common-main state is only enabled for CUDA configs:

```text
main_stacked_cells = stacked_width * 2^log_stacked_height
cached_stacked     = main_stacked_cells * sizeof(F), when cache_stacked_matrix
common_digest      = retained Merkle digest layers for the common-main commitment
retained_common    = cached_stacked + common_digest
```

Secondary main-trace buffers follow the existing opening/interpolation weight:

```text
mat_eval_bytes    = (padded_height / 2^l_skip) * ((1 + need_rot) * width) * sizeof(EF)
secondary_weight  = (1 + constraint_degree / 2) * D_EF / 2^l_skip
main_secondary    = sizeof(F) *
                    (2 * secondary_weight * main_cells_with_rot
                     + secondary_weight * main_cells_without_rot)
```

Interaction memory now uses the fractional-GKR sizing model:

```text
gkr_input   = 2 * interaction_cells * D_EF * sizeof(F)
gkr_work    = max(fold_eval_work_buffer, precompute_m_work_buffer)
interaction = gkr_input + gkr_work + max(2 MiB, round_temp_buffer)
```

The total estimate is `main` plus the largest secondary phase:

```text
commit_peak = cached_stacked + if cache_rs_code_matrix {
    rs_code_matrix + common_digest
} else {
    max(rs_code_matrix + common_first_layer, common_digest)
}

constraint_peak       = retained_common + cached_rs_code_matrix
                        + max(main_secondary, interaction)
whir_first_round_peak = retained_common + rs_code_matrix
                        + max(whir_workspace, first_g_tree)
whir_later_round_peak = first_g_tree + second_g_tree

secondary_peak = max(
    commit_peak,
    constraint_peak,
    whir_first_round_peak,
    whir_later_round_peak,
)
total = main + secondary_peak
```

## Validation

- `cargo +nightly fmt -- --check`
- `RUSTC_WRAPPER= cargo check -p openvm-stark-backend`
- `RUSTC_WRAPPER= cargo clippy -p openvm-stark-backend --all-targets --tests -- -D warnings`
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 cargo test -p openvm-stark-backend memory_metering`
- On `ayush-gpu` with CUDA 13.3:
  - `RUSTC_WRAPPER= cargo check -p openvm-cuda-backend`
  - `RUSTC_WRAPPER= cargo nextest run -p openvm-cuda-backend --test-threads=4` (`110 passed, 1 skipped`)
