### PR TITLE
fix: align CUDA fractional GKR memory metering

### DIFF
--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -1,5 +1,7 @@
 use getset::{CopyGetters, Getters, MutGetters};
-use openvm_cuda_common::{common::get_device, stream::GpuDeviceCtx};
+use openvm_cuda_common::{
+    common::get_device, memory_manager::vpmm_page_size_bytes, stream::GpuDeviceCtx,
+};
 use openvm_stark_backend::{
     memory_metering::ProvingMemoryConfig, StarkProtocolConfig, SystemParams,
 };
@@ -40,6 +42,10 @@ impl GpuProverConfig {
         let memory_config =
             ProvingMemoryConfig::from_protocol_config(config, self.cache_rs_code_matrix)
                 .with_cuda_backend(self.cache_stacked_matrix);
+
+        let memory_config = vpmm_page_size_bytes().map_or(memory_config, |page_size| {
+            memory_config.with_large_allocation_granularity_bytes(page_size)
+        });
 
         memory_config.with_fractional_gkr_work_buffer_strategy(
             fractional_gkr_work_buffer_metering_strategy(),

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -4,9 +4,12 @@ use openvm_stark_backend::{
     memory_metering::ProvingMemoryConfig, StarkProtocolConfig, SystemParams,
 };
 
-use crate::cuda::{
-    batch_ntt_small::{ensure_device_ntt_twiddles_initialized, validate_gpu_l_skip},
-    device_info::get_sm_count,
+use crate::{
+    cuda::{
+        batch_ntt_small::{ensure_device_ntt_twiddles_initialized, validate_gpu_l_skip},
+        device_info::get_sm_count,
+    },
+    logup_zerocheck::fractional_gkr_precompute_m_enabled,
 };
 
 /// Pure device configuration — no stream, no CUDA runtime state.
@@ -36,6 +39,7 @@ impl GpuProverConfig {
     ) -> ProvingMemoryConfig {
         ProvingMemoryConfig::from_protocol_config(config, self.cache_rs_code_matrix)
             .with_cuda_backend(self.cache_stacked_matrix)
+            .with_fractional_gkr_precompute_m(fractional_gkr_precompute_m_enabled())
     }
 }
 

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -1,6 +1,6 @@
 use getset::{CopyGetters, Getters, MutGetters};
 use openvm_cuda_common::{
-    common::get_device, memory_manager::vpmm_page_size_bytes, stream::GpuDeviceCtx,
+    common::get_device, memory_manager::vpmm_allocation_granularity_bytes, stream::GpuDeviceCtx,
 };
 use openvm_stark_backend::{
     memory_metering::ProvingMemoryConfig, StarkProtocolConfig, SystemParams,
@@ -43,9 +43,8 @@ impl GpuProverConfig {
             ProvingMemoryConfig::from_protocol_config(config, self.cache_rs_code_matrix)
                 .with_cuda_backend(self.cache_stacked_matrix);
 
-        let memory_config = vpmm_page_size_bytes().map_or(memory_config, |page_size| {
-            memory_config.with_large_allocation_granularity_bytes(page_size)
-        });
+        let memory_config = memory_config
+            .with_large_allocation_granularity_bytes(vpmm_allocation_granularity_bytes());
 
         memory_config.with_fractional_gkr_work_buffer_strategy(
             fractional_gkr_work_buffer_metering_strategy(),

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -9,7 +9,7 @@ use crate::{
         batch_ntt_small::{ensure_device_ntt_twiddles_initialized, validate_gpu_l_skip},
         device_info::get_sm_count,
     },
-    logup_zerocheck::fractional_gkr_precompute_m_enabled,
+    logup_zerocheck::fractional_gkr_precompute_m_metering_mode,
 };
 
 /// Pure device configuration — no stream, no CUDA runtime state.
@@ -37,9 +37,15 @@ impl GpuProverConfig {
         &self,
         config: &SC,
     ) -> ProvingMemoryConfig {
-        ProvingMemoryConfig::from_protocol_config(config, self.cache_rs_code_matrix)
-            .with_cuda_backend(self.cache_stacked_matrix)
-            .with_fractional_gkr_precompute_m(fractional_gkr_precompute_m_enabled())
+        let memory_config =
+            ProvingMemoryConfig::from_protocol_config(config, self.cache_rs_code_matrix)
+                .with_cuda_backend(self.cache_stacked_matrix);
+
+        if let Some(precompute_m_enabled) = fractional_gkr_precompute_m_metering_mode() {
+            memory_config.with_fractional_gkr_precompute_m(precompute_m_enabled)
+        } else {
+            memory_config
+        }
     }
 }
 

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -9,7 +9,7 @@ use crate::{
         batch_ntt_small::{ensure_device_ntt_twiddles_initialized, validate_gpu_l_skip},
         device_info::get_sm_count,
     },
-    logup_zerocheck::fractional_gkr_work_buffer_strategy,
+    logup_zerocheck::fractional_gkr_work_buffer_metering_strategy,
 };
 
 /// Pure device configuration — no stream, no CUDA runtime state.
@@ -41,8 +41,9 @@ impl GpuProverConfig {
             ProvingMemoryConfig::from_protocol_config(config, self.cache_rs_code_matrix)
                 .with_cuda_backend(self.cache_stacked_matrix);
 
-        memory_config
-            .with_fractional_gkr_work_buffer_strategy(fractional_gkr_work_buffer_strategy())
+        memory_config.with_fractional_gkr_work_buffer_strategy(
+            fractional_gkr_work_buffer_metering_strategy(),
+        )
     }
 }
 

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -9,7 +9,7 @@ use crate::{
         batch_ntt_small::{ensure_device_ntt_twiddles_initialized, validate_gpu_l_skip},
         device_info::get_sm_count,
     },
-    logup_zerocheck::fractional_gkr_precompute_m_metering_mode,
+    logup_zerocheck::fractional_gkr_work_buffer_strategy,
 };
 
 /// Pure device configuration — no stream, no CUDA runtime state.
@@ -41,11 +41,8 @@ impl GpuProverConfig {
             ProvingMemoryConfig::from_protocol_config(config, self.cache_rs_code_matrix)
                 .with_cuda_backend(self.cache_stacked_matrix);
 
-        if let Some(precompute_m_enabled) = fractional_gkr_precompute_m_metering_mode() {
-            memory_config.with_fractional_gkr_precompute_m(precompute_m_enabled)
-        } else {
-            memory_config
-        }
+        memory_config
+            .with_fractional_gkr_work_buffer_strategy(fractional_gkr_work_buffer_strategy())
     }
 }
 

--- a/crates/cuda-backend/src/engine.rs
+++ b/crates/cuda-backend/src/engine.rs
@@ -1,4 +1,5 @@
 use getset::MutGetters;
+use openvm_cuda_common::memory_manager::tracked_memory_used;
 use openvm_stark_backend::{
     memory_metering::ProvingMemoryConfig, prover::Coordinator, StarkEngine, SystemParams,
 };
@@ -67,6 +68,7 @@ impl StarkEngine for GpuEngine<DefaultHashScheme> {
         self.device
             .prover_config()
             .proving_memory_config(self.config())
+            .with_retained_backend_memory_bytes(tracked_memory_used())
     }
 
     fn initial_transcript(&self) -> Self::TS {
@@ -104,6 +106,7 @@ impl StarkEngine for GpuEngine<BabyBearBn254Poseidon2HashScheme> {
         self.device
             .prover_config()
             .proving_memory_config(self.config())
+            .with_retained_backend_memory_bytes(tracked_memory_used())
     }
 
     fn initial_transcript(&self) -> Self::TS {

--- a/crates/cuda-backend/src/engine.rs
+++ b/crates/cuda-backend/src/engine.rs
@@ -1,5 +1,4 @@
 use getset::MutGetters;
-use openvm_cuda_common::memory_manager::tracked_memory_used;
 use openvm_stark_backend::{
     memory_metering::ProvingMemoryConfig, prover::Coordinator, StarkEngine, SystemParams,
 };
@@ -68,7 +67,6 @@ impl StarkEngine for GpuEngine<DefaultHashScheme> {
         self.device
             .prover_config()
             .proving_memory_config(self.config())
-            .with_retained_backend_memory_bytes(tracked_memory_used())
     }
 
     fn initial_transcript(&self) -> Self::TS {
@@ -106,7 +104,6 @@ impl StarkEngine for GpuEngine<BabyBearBn254Poseidon2HashScheme> {
         self.device
             .prover_config()
             .proving_memory_config(self.config())
-            .with_retained_backend_memory_bytes(tracked_memory_used())
     }
 
     fn initial_transcript(&self) -> Self::TS {

--- a/crates/cuda-backend/src/gpu_backend.rs
+++ b/crates/cuda-backend/src/gpu_backend.rs
@@ -1,14 +1,13 @@
-use std::marker::PhantomData;
+use std::{marker::PhantomData, mem::size_of};
 
 use itertools::Itertools;
 use openvm_cuda_common::{d_buffer::DeviceBuffer, memory_manager::MemTracker};
 use openvm_stark_backend::{
-    memory_metering::ProvingMemoryConfig,
     poly_common::Squarable,
     proof::*,
     prover::{
-        CommittedTraceData, DeviceMultiStarkProvingKey, MultiRapProver, OpeningProver,
-        ProverBackend, ProverDevice, ProvingContext, TraceCommitter,
+        DeviceMultiStarkProvingKey, MultiRapProver, OpeningProver, ProverBackend, ProverDevice,
+        ProvingContext, TraceCommitter,
     },
 };
 use tracing::instrument;
@@ -57,129 +56,99 @@ impl<HS: GpuHashScheme> ProverBackend for GenericGpuBackend<HS> {
     type PcsData = StackedPcsDataGpu<F, HS::Digest>;
     type OtherAirData = AirDataGpu;
 
-    fn retained_proving_key_memory_bytes(
-        mpk: &DeviceMultiStarkProvingKey<Self>,
-        config: &ProvingMemoryConfig,
-    ) -> usize {
-        sum_memory(mpk.per_air.iter().map(|air| {
-            option_memory_bytes(air.preprocessed_data.as_ref(), |data| {
-                committed_trace_memory_bytes::<HS>(data, config)
-            })
-            .saturating_add(air_data_memory_bytes(&air.other_data, config))
-        }))
+    fn retained_proving_key_allocation_bytes(mpk: &DeviceMultiStarkProvingKey<Self>) -> Vec<usize> {
+        let mut allocations = Vec::new();
+        for air in &mpk.per_air {
+            if let Some(data) = &air.preprocessed_data {
+                push_pcs_data_allocations(&mut allocations, data.data.as_ref());
+            }
+            push_air_data_allocations(&mut allocations, &air.other_data);
+        }
+        allocations
     }
 }
 
-fn sum_memory(bytes: impl IntoIterator<Item = usize>) -> usize {
-    bytes
-        .into_iter()
-        .fold(0usize, |total, bytes| total.saturating_add(bytes))
-}
-
-fn option_memory_bytes<T>(value: Option<&T>, memory_bytes: impl FnOnce(&T) -> usize) -> usize {
-    value.map_or(0, memory_bytes)
-}
-
-fn buffer_memory_bytes<T>(buffer: &DeviceBuffer<T>, config: &ProvingMemoryConfig) -> usize {
-    if buffer.is_empty() {
-        return 0;
+fn push_buffer_allocation<T>(allocations: &mut Vec<usize>, buffer: &DeviceBuffer<T>) {
+    if !buffer.is_empty() {
+        allocations.push(buffer.len().saturating_mul(size_of::<T>()));
     }
-    config.tracked_allocation_bytes(buffer.len().saturating_mul(size_of::<T>()))
 }
 
-fn matrix_memory_bytes<T>(matrix: &DeviceMatrix<T>, config: &ProvingMemoryConfig) -> usize {
-    buffer_memory_bytes(matrix.buffer(), config)
+fn push_matrix_allocations<T>(allocations: &mut Vec<usize>, matrix: &DeviceMatrix<T>) {
+    push_buffer_allocation(allocations, matrix.buffer());
 }
 
-fn ple_matrix_memory_bytes(matrix: &PleMatrix<F>, config: &ProvingMemoryConfig) -> usize {
-    buffer_memory_bytes(matrix.mixed(), config)
+fn push_ple_matrix_allocations(allocations: &mut Vec<usize>, matrix: &PleMatrix<F>) {
+    push_buffer_allocation(allocations, matrix.mixed());
 }
 
-fn committed_trace_memory_bytes<HS: GpuHashScheme>(
-    trace_data: &CommittedTraceData<GenericGpuBackend<HS>>,
-    config: &ProvingMemoryConfig,
-) -> usize {
-    matrix_memory_bytes(&trace_data.trace, config)
-        .saturating_add(pcs_data_memory_bytes(trace_data.data.as_ref(), config))
+fn push_pcs_data_allocations<D>(allocations: &mut Vec<usize>, pcs_data: &StackedPcsDataGpu<F, D>) {
+    if let Some(matrix) = &pcs_data.matrix {
+        push_ple_matrix_allocations(allocations, matrix);
+    }
+    push_merkle_tree_allocations(allocations, &pcs_data.tree);
 }
 
-fn pcs_data_memory_bytes<D>(
-    pcs_data: &StackedPcsDataGpu<F, D>,
-    config: &ProvingMemoryConfig,
-) -> usize {
-    option_memory_bytes(pcs_data.matrix.as_ref(), |matrix| {
-        ple_matrix_memory_bytes(matrix, config)
-    })
-    .saturating_add(merkle_tree_memory_bytes(&pcs_data.tree, config))
+fn push_merkle_tree_allocations<D>(allocations: &mut Vec<usize>, tree: &MerkleTreeGpu<F, D>) {
+    if let Some(matrix) = &tree.backing_matrix {
+        push_matrix_allocations(allocations, matrix);
+    }
+    for layer in &tree.digest_layers {
+        push_buffer_allocation(allocations, layer);
+    }
 }
 
-fn merkle_tree_memory_bytes<D>(tree: &MerkleTreeGpu<F, D>, config: &ProvingMemoryConfig) -> usize {
-    option_memory_bytes(tree.backing_matrix.as_ref(), |matrix| {
-        matrix_memory_bytes(matrix, config)
-    })
-    .saturating_add(sum_memory(
-        tree.digest_layers
-            .iter()
-            .map(|layer| buffer_memory_bytes(layer, config)),
-    ))
+fn push_air_data_allocations(allocations: &mut Vec<usize>, data: &AirDataGpu) {
+    push_interaction_eval_rules_allocations(allocations, &data.interaction_rules);
+    push_constraint_rules_allocations(allocations, &data.zerocheck_round0);
+    push_constraint_rules_allocations(allocations, &data.zerocheck_mle);
+    if let Some(monomials) = &data.zerocheck_monomials {
+        push_zerocheck_monomial_allocations(allocations, monomials);
+    }
+    if let Some(monomials) = &data.interaction_monomials {
+        push_interaction_monomial_allocations(allocations, monomials);
+    }
 }
 
-fn air_data_memory_bytes(data: &AirDataGpu, config: &ProvingMemoryConfig) -> usize {
-    interaction_eval_rules_memory_bytes(&data.interaction_rules, config)
-        .saturating_add(constraint_rules_memory_bytes(
-            &data.zerocheck_round0,
-            config,
-        ))
-        .saturating_add(constraint_rules_memory_bytes(&data.zerocheck_mle, config))
-        .saturating_add(option_memory_bytes(
-            data.zerocheck_monomials.as_ref(),
-            |monomials| zerocheck_monomials_memory_bytes(monomials, config),
-        ))
-        .saturating_add(option_memory_bytes(
-            data.interaction_monomials.as_ref(),
-            |monomials| interaction_monomials_memory_bytes(monomials, config),
-        ))
+fn push_eval_rules_allocations(allocations: &mut Vec<usize>, rules: &EvalRules) {
+    push_buffer_allocation(allocations, &rules.d_rules);
+    push_buffer_allocation(allocations, &rules.d_used_nodes);
 }
 
-fn eval_rules_memory_bytes(rules: &EvalRules, config: &ProvingMemoryConfig) -> usize {
-    buffer_memory_bytes(&rules.d_rules, config)
-        .saturating_add(buffer_memory_bytes(&rules.d_used_nodes, config))
-}
-
-fn interaction_eval_rules_memory_bytes(
+fn push_interaction_eval_rules_allocations(
+    allocations: &mut Vec<usize>,
     rules: &InteractionEvalRules,
-    config: &ProvingMemoryConfig,
-) -> usize {
-    eval_rules_memory_bytes(&rules.inner, config)
-        .saturating_add(buffer_memory_bytes(&rules.d_pair_idxs, config))
+) {
+    push_eval_rules_allocations(allocations, &rules.inner);
+    push_buffer_allocation(allocations, &rules.d_pair_idxs);
 }
 
-fn constraint_rules_memory_bytes<const BUFFER_VARS: bool>(
+fn push_constraint_rules_allocations<const BUFFER_VARS: bool>(
+    allocations: &mut Vec<usize>,
     rules: &ConstraintOnlyRules<BUFFER_VARS>,
-    config: &ProvingMemoryConfig,
-) -> usize {
-    eval_rules_memory_bytes(&rules.inner, config)
+) {
+    push_eval_rules_allocations(allocations, &rules.inner);
 }
 
-fn zerocheck_monomials_memory_bytes(
+fn push_zerocheck_monomial_allocations(
+    allocations: &mut Vec<usize>,
     monomials: &ZerocheckMonomials,
-    config: &ProvingMemoryConfig,
-) -> usize {
-    buffer_memory_bytes(&monomials.d_headers, config)
-        .saturating_add(buffer_memory_bytes(&monomials.d_variables, config))
-        .saturating_add(buffer_memory_bytes(&monomials.d_lambda_terms, config))
+) {
+    push_buffer_allocation(allocations, &monomials.d_headers);
+    push_buffer_allocation(allocations, &monomials.d_variables);
+    push_buffer_allocation(allocations, &monomials.d_lambda_terms);
 }
 
-fn interaction_monomials_memory_bytes(
+fn push_interaction_monomial_allocations(
+    allocations: &mut Vec<usize>,
     monomials: &InteractionMonomials,
-    config: &ProvingMemoryConfig,
-) -> usize {
-    buffer_memory_bytes(&monomials.d_numer_headers, config)
-        .saturating_add(buffer_memory_bytes(&monomials.d_numer_variables, config))
-        .saturating_add(buffer_memory_bytes(&monomials.d_numer_terms, config))
-        .saturating_add(buffer_memory_bytes(&monomials.d_denom_headers, config))
-        .saturating_add(buffer_memory_bytes(&monomials.d_denom_variables, config))
-        .saturating_add(buffer_memory_bytes(&monomials.d_denom_terms, config))
+) {
+    push_buffer_allocation(allocations, &monomials.d_numer_headers);
+    push_buffer_allocation(allocations, &monomials.d_numer_variables);
+    push_buffer_allocation(allocations, &monomials.d_numer_terms);
+    push_buffer_allocation(allocations, &monomials.d_denom_headers);
+    push_buffer_allocation(allocations, &monomials.d_denom_variables);
+    push_buffer_allocation(allocations, &monomials.d_denom_terms);
 }
 
 impl<HS: GpuHashScheme> TraceCommitter<GenericGpuBackend<HS>> for GpuDevice

--- a/crates/cuda-backend/src/gpu_backend.rs
+++ b/crates/cuda-backend/src/gpu_backend.rs
@@ -1,13 +1,14 @@
 use std::marker::PhantomData;
 
 use itertools::Itertools;
-use openvm_cuda_common::memory_manager::MemTracker;
+use openvm_cuda_common::{d_buffer::DeviceBuffer, memory_manager::MemTracker};
 use openvm_stark_backend::{
+    memory_metering::ProvingMemoryConfig,
     poly_common::Squarable,
     proof::*,
     prover::{
-        DeviceMultiStarkProvingKey, MultiRapProver, OpeningProver, ProverBackend, ProverDevice,
-        ProvingContext, TraceCommitter,
+        CommittedTraceData, DeviceMultiStarkProvingKey, MultiRapProver, OpeningProver,
+        ProverBackend, ProverDevice, ProvingContext, TraceCommitter,
     },
 };
 use tracing::instrument;
@@ -16,13 +17,18 @@ use crate::{
     base::DeviceMatrix,
     hash_scheme::{DefaultHashScheme, GpuHashScheme},
     logup_zerocheck::prove_zerocheck_and_logup_gpu,
-    merkle_tree::{MerkleProofQueryDigest, MerkleTreeConstructor},
+    merkle_tree::{MerkleProofQueryDigest, MerkleTreeConstructor, MerkleTreeGpu},
+    pkey::{
+        AirDataGpu, ConstraintOnlyRules, EvalRules, InteractionEvalRules, InteractionMonomials,
+        ZerocheckMonomials,
+    },
+    poly::PleMatrix,
     prelude::{D_EF, EF, F},
     sponge::GpuFiatShamirTranscript,
     stacked_pcs::{stacked_commit, StackedPcsDataGpu},
     stacked_reduction::prove_stacked_opening_reduction_gpu,
     whir::prove_whir_opening_gpu,
-    AirDataGpu, GpuDevice, ProverError,
+    GpuDevice, ProverError,
 };
 
 /// Generic GPU prover backend parameterised by a hash scheme `HS`.
@@ -50,6 +56,130 @@ impl<HS: GpuHashScheme> ProverBackend for GenericGpuBackend<HS> {
     type Matrix = DeviceMatrix<F>;
     type PcsData = StackedPcsDataGpu<F, HS::Digest>;
     type OtherAirData = AirDataGpu;
+
+    fn retained_proving_key_memory_bytes(
+        mpk: &DeviceMultiStarkProvingKey<Self>,
+        config: &ProvingMemoryConfig,
+    ) -> usize {
+        sum_memory(mpk.per_air.iter().map(|air| {
+            option_memory_bytes(air.preprocessed_data.as_ref(), |data| {
+                committed_trace_memory_bytes::<HS>(data, config)
+            })
+            .saturating_add(air_data_memory_bytes(&air.other_data, config))
+        }))
+    }
+}
+
+fn sum_memory(bytes: impl IntoIterator<Item = usize>) -> usize {
+    bytes
+        .into_iter()
+        .fold(0usize, |total, bytes| total.saturating_add(bytes))
+}
+
+fn option_memory_bytes<T>(value: Option<&T>, memory_bytes: impl FnOnce(&T) -> usize) -> usize {
+    value.map_or(0, memory_bytes)
+}
+
+fn buffer_memory_bytes<T>(buffer: &DeviceBuffer<T>, config: &ProvingMemoryConfig) -> usize {
+    if buffer.is_empty() {
+        return 0;
+    }
+    config.tracked_allocation_bytes(buffer.len().saturating_mul(size_of::<T>()))
+}
+
+fn matrix_memory_bytes<T>(matrix: &DeviceMatrix<T>, config: &ProvingMemoryConfig) -> usize {
+    buffer_memory_bytes(matrix.buffer(), config)
+}
+
+fn ple_matrix_memory_bytes(matrix: &PleMatrix<F>, config: &ProvingMemoryConfig) -> usize {
+    buffer_memory_bytes(matrix.mixed(), config)
+}
+
+fn committed_trace_memory_bytes<HS: GpuHashScheme>(
+    trace_data: &CommittedTraceData<GenericGpuBackend<HS>>,
+    config: &ProvingMemoryConfig,
+) -> usize {
+    matrix_memory_bytes(&trace_data.trace, config)
+        .saturating_add(pcs_data_memory_bytes(trace_data.data.as_ref(), config))
+}
+
+fn pcs_data_memory_bytes<D>(
+    pcs_data: &StackedPcsDataGpu<F, D>,
+    config: &ProvingMemoryConfig,
+) -> usize {
+    option_memory_bytes(pcs_data.matrix.as_ref(), |matrix| {
+        ple_matrix_memory_bytes(matrix, config)
+    })
+    .saturating_add(merkle_tree_memory_bytes(&pcs_data.tree, config))
+}
+
+fn merkle_tree_memory_bytes<D>(tree: &MerkleTreeGpu<F, D>, config: &ProvingMemoryConfig) -> usize {
+    option_memory_bytes(tree.backing_matrix.as_ref(), |matrix| {
+        matrix_memory_bytes(matrix, config)
+    })
+    .saturating_add(sum_memory(
+        tree.digest_layers
+            .iter()
+            .map(|layer| buffer_memory_bytes(layer, config)),
+    ))
+}
+
+fn air_data_memory_bytes(data: &AirDataGpu, config: &ProvingMemoryConfig) -> usize {
+    interaction_eval_rules_memory_bytes(&data.interaction_rules, config)
+        .saturating_add(constraint_rules_memory_bytes(
+            &data.zerocheck_round0,
+            config,
+        ))
+        .saturating_add(constraint_rules_memory_bytes(&data.zerocheck_mle, config))
+        .saturating_add(option_memory_bytes(
+            data.zerocheck_monomials.as_ref(),
+            |monomials| zerocheck_monomials_memory_bytes(monomials, config),
+        ))
+        .saturating_add(option_memory_bytes(
+            data.interaction_monomials.as_ref(),
+            |monomials| interaction_monomials_memory_bytes(monomials, config),
+        ))
+}
+
+fn eval_rules_memory_bytes(rules: &EvalRules, config: &ProvingMemoryConfig) -> usize {
+    buffer_memory_bytes(&rules.d_rules, config)
+        .saturating_add(buffer_memory_bytes(&rules.d_used_nodes, config))
+}
+
+fn interaction_eval_rules_memory_bytes(
+    rules: &InteractionEvalRules,
+    config: &ProvingMemoryConfig,
+) -> usize {
+    eval_rules_memory_bytes(&rules.inner, config)
+        .saturating_add(buffer_memory_bytes(&rules.d_pair_idxs, config))
+}
+
+fn constraint_rules_memory_bytes<const BUFFER_VARS: bool>(
+    rules: &ConstraintOnlyRules<BUFFER_VARS>,
+    config: &ProvingMemoryConfig,
+) -> usize {
+    eval_rules_memory_bytes(&rules.inner, config)
+}
+
+fn zerocheck_monomials_memory_bytes(
+    monomials: &ZerocheckMonomials,
+    config: &ProvingMemoryConfig,
+) -> usize {
+    buffer_memory_bytes(&monomials.d_headers, config)
+        .saturating_add(buffer_memory_bytes(&monomials.d_variables, config))
+        .saturating_add(buffer_memory_bytes(&monomials.d_lambda_terms, config))
+}
+
+fn interaction_monomials_memory_bytes(
+    monomials: &InteractionMonomials,
+    config: &ProvingMemoryConfig,
+) -> usize {
+    buffer_memory_bytes(&monomials.d_numer_headers, config)
+        .saturating_add(buffer_memory_bytes(&monomials.d_numer_variables, config))
+        .saturating_add(buffer_memory_bytes(&monomials.d_numer_terms, config))
+        .saturating_add(buffer_memory_bytes(&monomials.d_denom_headers, config))
+        .saturating_add(buffer_memory_bytes(&monomials.d_denom_variables, config))
+        .saturating_add(buffer_memory_bytes(&monomials.d_denom_terms, config))
 }
 
 impl<HS: GpuHashScheme> TraceCommitter<GenericGpuBackend<HS>> for GpuDevice

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -9,7 +9,9 @@ use openvm_cuda_common::{
 use openvm_stark_backend::{
     poly_common::{eval_eq_mle, interpolate_linear_at_01, interpolate_quadratic_at_012},
     proof::GkrLayerClaims,
-    prover::fractional_sumcheck_gkr::{Frac, FracSumcheckProof, FractionalGkrMemoryModel},
+    prover::fractional_sumcheck_gkr::{
+        Frac, FracSumcheckProof, FractionalGkrMemoryModel, FractionalGkrWorkBufferStrategy,
+    },
     FiatShamirTranscript, StarkProtocolConfig,
 };
 use p3_field::{Field, PrimeCharacteristicRing};
@@ -74,14 +76,10 @@ impl FractionalInputSize {
     /// Peak work-buffer bytes, excluding the `S_frac * real_len` layer/input buffer.
     pub fn peak_work_buffer_bytes(&self) -> usize {
         let model = FractionalGkrMemoryModel::new(std::mem::size_of::<F>(), D_EF);
-        if let Some(precompute_m_enabled) = precompute_m_metering_mode() {
-            model.peak_work_buffer_memory_bytes_with_precompute_m(
-                self.logical_len,
-                precompute_m_enabled,
-            )
-        } else {
-            model.peak_work_buffer_memory_bytes(self.logical_len)
-        }
+        model.peak_work_buffer_memory_bytes_with_strategy(
+            self.logical_len,
+            precompute_m_work_buffer_strategy(),
+        )
     }
 }
 
@@ -193,16 +191,16 @@ fn precompute_m_enabled() -> bool {
     )
 }
 
-pub(super) fn precompute_m_metering_mode() -> Option<bool> {
+pub(crate) fn precompute_m_work_buffer_strategy() -> FractionalGkrWorkBufferStrategy {
     if !precompute_m_enabled() {
-        Some(false)
+        FractionalGkrWorkBufferStrategy::FoldEval
     } else if PRECOMPUTE_M_TUNING_ENV_VARS
         .iter()
         .all(|key| env::var_os(key).is_none())
     {
-        Some(true)
+        FractionalGkrWorkBufferStrategy::PrecomputeM
     } else {
-        None
+        FractionalGkrWorkBufferStrategy::Conservative
     }
 }
 
@@ -840,10 +838,13 @@ where
     // input pq_size = total_leaves, output pq_size = total_leaves >> (1 + w).
     // Fold-eval fallback rounds (rem_n < min_n) need at most 2^min_n elements.
     let max_work_size = if total_rounds > 2 {
-        if precompute_m_env {
-            FractionalGkrMemoryModel::precompute_m_work_buffer_elements(total_leaves)
-        } else {
-            FractionalGkrMemoryModel::fold_eval_work_buffer_elements(total_leaves)
+        let fold_eval = FractionalGkrMemoryModel::fold_eval_work_buffer_elements(total_leaves);
+        let precompute_m =
+            FractionalGkrMemoryModel::precompute_m_work_buffer_elements(total_leaves);
+        match precompute_m_work_buffer_strategy() {
+            FractionalGkrWorkBufferStrategy::Conservative => fold_eval.max(precompute_m),
+            FractionalGkrWorkBufferStrategy::FoldEval => fold_eval,
+            FractionalGkrWorkBufferStrategy::PrecomputeM => precompute_m,
         }
     } else {
         0

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -62,7 +62,10 @@ impl FractionalInputSize {
     /// Peak work-buffer bytes, excluding the `S_frac * real_len` layer/input buffer.
     pub fn peak_work_buffer_bytes(&self) -> usize {
         FractionalGkrMemoryModel::new(std::mem::size_of::<F>(), D_EF)
-            .peak_work_buffer_memory_bytes(self.logical_len)
+            .peak_work_buffer_memory_bytes_with_precompute_m(
+                self.logical_len,
+                precompute_m_enabled(),
+            )
     }
 }
 
@@ -172,7 +175,7 @@ impl BufferScheduler {
     }
 }
 
-fn precompute_m_enabled() -> bool {
+pub(crate) fn precompute_m_enabled() -> bool {
     !matches!(
         env::var("SWIRL_CUDA_GKR_PRECOMPUTE_M"),
         Ok(val) if matches!(val.as_str(), "0" | "false" | "FALSE" | "no" | "NO")

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -35,6 +35,18 @@ use crate::{
 const GKR_S_DEG: usize = 3;
 const GKR_WINDOW_SIZE: usize = FractionalGkrMemoryModel::WINDOW_SIZE;
 const GKR_WINDOW_DEFAULT_MIN_N: usize = FractionalGkrMemoryModel::WINDOW_DEFAULT_MIN_N;
+const PRECOMPUTE_M_MIN_TAIL_TILE: usize = FractionalGkrMemoryModel::PRECOMPUTE_M_MIN_TAIL_TILE;
+const PRECOMPUTE_M_TAIL_TILE: usize = FractionalGkrMemoryModel::PRECOMPUTE_M_DEFAULT_TAIL_TILE;
+const PRECOMPUTE_M_DEFAULT_MIN_BLOCKS: usize =
+    FractionalGkrMemoryModel::PRECOMPUTE_M_DEFAULT_MIN_BLOCKS;
+const PRECOMPUTE_M_DEFAULT_TARGET_BLOCKS: usize =
+    FractionalGkrMemoryModel::PRECOMPUTE_M_DEFAULT_TARGET_BLOCKS;
+const PRECOMPUTE_M_TUNING_ENV_VARS: [&str; 4] = [
+    "SWIRL_CUDA_GKR_PRECOMPUTE_M_MIN_BLOCKS",
+    "SWIRL_CUDA_GKR_PRECOMPUTE_M_TARGET_BLOCKS",
+    "SWIRL_CUDA_GKR_PRECOMPUTE_M_TAIL_TILE",
+    "SWIRL_CUDA_GKR_PRECOMPUTE_M_MIN_N",
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FractionalInputSize {
@@ -61,11 +73,15 @@ impl FractionalInputSize {
 
     /// Peak work-buffer bytes, excluding the `S_frac * real_len` layer/input buffer.
     pub fn peak_work_buffer_bytes(&self) -> usize {
-        FractionalGkrMemoryModel::new(std::mem::size_of::<F>(), D_EF)
-            .peak_work_buffer_memory_bytes_with_precompute_m(
+        let model = FractionalGkrMemoryModel::new(std::mem::size_of::<F>(), D_EF);
+        if let Some(precompute_m_enabled) = precompute_m_metering_mode() {
+            model.peak_work_buffer_memory_bytes_with_precompute_m(
                 self.logical_len,
-                precompute_m_enabled(),
+                precompute_m_enabled,
             )
+        } else {
+            model.peak_work_buffer_memory_bytes(self.logical_len)
+        }
     }
 }
 
@@ -98,11 +114,6 @@ enum GkrRoundStrategy {
     FoldEval,
     PrecomputeM,
 }
-
-const PRECOMPUTE_M_TAIL_TILE: usize = 4096;
-const PRECOMPUTE_M_MIN_TAIL_TILE: usize = 256;
-const PRECOMPUTE_M_DEFAULT_MIN_BLOCKS: usize = 64;
-const PRECOMPUTE_M_DEFAULT_TARGET_BLOCKS: usize = 1024;
 
 impl BufferScheduler {
     /// Creates a new scheduler with data initially in layer buffer.
@@ -175,11 +186,24 @@ impl BufferScheduler {
     }
 }
 
-pub(crate) fn precompute_m_enabled() -> bool {
+fn precompute_m_enabled() -> bool {
     !matches!(
         env::var("SWIRL_CUDA_GKR_PRECOMPUTE_M"),
         Ok(val) if matches!(val.as_str(), "0" | "false" | "FALSE" | "no" | "NO")
     )
+}
+
+pub(super) fn precompute_m_metering_mode() -> Option<bool> {
+    if !precompute_m_enabled() {
+        Some(false)
+    } else if PRECOMPUTE_M_TUNING_ENV_VARS
+        .iter()
+        .all(|key| env::var_os(key).is_none())
+    {
+        Some(true)
+    } else {
+        None
+    }
 }
 
 fn precompute_m_min_blocks_threshold() -> usize {

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -194,14 +194,17 @@ fn precompute_m_enabled() -> bool {
 pub(crate) fn precompute_m_work_buffer_strategy() -> FractionalGkrWorkBufferStrategy {
     if !precompute_m_enabled() {
         FractionalGkrWorkBufferStrategy::FoldEval
-    } else if PRECOMPUTE_M_TUNING_ENV_VARS
-        .iter()
-        .all(|key| env::var_os(key).is_none())
-    {
-        FractionalGkrWorkBufferStrategy::PrecomputeM
-    } else {
+    } else if precompute_m_tuning_env_vars_present() {
         FractionalGkrWorkBufferStrategy::Conservative
+    } else {
+        FractionalGkrWorkBufferStrategy::PrecomputeM
     }
+}
+
+fn precompute_m_tuning_env_vars_present() -> bool {
+    PRECOMPUTE_M_TUNING_ENV_VARS
+        .iter()
+        .any(|key| env::var_os(key).is_some())
 }
 
 fn precompute_m_min_blocks_threshold() -> usize {
@@ -836,7 +839,8 @@ where
     // When precompute-M is active, the first multifold folds w+1 variables at once
     // (pending r_prev + w window challenges). The largest case is the last outer round:
     // input pq_size = total_leaves, output pq_size = total_leaves >> (1 + w).
-    // Fold-eval fallback rounds (rem_n < min_n) need at most 2^min_n elements.
+    // Non-default precompute-M tuning can force non-last rounds onto the fold-eval path, so
+    // tuned configs reserve enough capacity for either selected path.
     let max_work_size = if total_rounds > 2 {
         let fold_eval = FractionalGkrMemoryModel::fold_eval_work_buffer_elements(total_leaves);
         let precompute_m =

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -75,11 +75,8 @@ impl FractionalInputSize {
 
     /// Peak work-buffer bytes, excluding the `S_frac * real_len` layer/input buffer.
     pub fn peak_work_buffer_bytes(&self) -> usize {
-        let model = FractionalGkrMemoryModel::new(std::mem::size_of::<F>(), D_EF);
-        model.peak_work_buffer_memory_bytes_with_strategy(
-            self.logical_len,
-            precompute_m_work_buffer_strategy(),
-        )
+        FractionalGkrMemoryModel::new(std::mem::size_of::<F>(), D_EF)
+            .peak_work_buffer_memory_bytes(self.logical_len)
     }
 }
 
@@ -839,16 +836,12 @@ where
     // When precompute-M is active, the first multifold folds w+1 variables at once
     // (pending r_prev + w window challenges). The largest case is the last outer round:
     // input pq_size = total_leaves, output pq_size = total_leaves >> (1 + w).
-    // Non-default precompute-M tuning can force non-last rounds onto the fold-eval path, so
-    // tuned configs reserve enough capacity for either selected path.
+    // Fold-eval fallback rounds (rem_n < min_n) need at most 2^min_n elements.
     let max_work_size = if total_rounds > 2 {
-        let fold_eval = FractionalGkrMemoryModel::fold_eval_work_buffer_elements(total_leaves);
-        let precompute_m =
-            FractionalGkrMemoryModel::precompute_m_work_buffer_elements(total_leaves);
-        match precompute_m_work_buffer_strategy() {
-            FractionalGkrWorkBufferStrategy::Conservative => fold_eval.max(precompute_m),
-            FractionalGkrWorkBufferStrategy::FoldEval => fold_eval,
-            FractionalGkrWorkBufferStrategy::PrecomputeM => precompute_m,
+        if precompute_m_env {
+            FractionalGkrMemoryModel::precompute_m_work_buffer_elements(total_leaves)
+        } else {
+            FractionalGkrMemoryModel::fold_eval_work_buffer_elements(total_leaves)
         }
     } else {
         0

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -77,10 +77,6 @@ mod mle_round;
 mod round0;
 pub(crate) mod rules;
 
-pub(crate) fn fractional_gkr_precompute_m_metering_mode() -> Option<bool> {
-    fractional::precompute_m_metering_mode()
-}
-
 use batch_mle::{evaluate_logup_batched, TraceCtx};
 use batch_mle_monomial::{
     compute_lambda_combinations, compute_logup_combinations, get_num_monomials,
@@ -88,6 +84,7 @@ use batch_mle_monomial::{
     ZerocheckMonomialBatch, ZerocheckMonomialParYBatch,
 };
 pub use errors::*;
+pub(crate) use fractional::precompute_m_work_buffer_strategy as fractional_gkr_work_buffer_strategy;
 pub use fractional::{fractional_sumcheck_gpu, make_synthetic_leaves, FractionalInputSize};
 use gkr_input::{collect_trace_interactions, log_gkr_input_evals};
 use round0::evaluate_round0_constraints_gpu;

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -84,7 +84,7 @@ use batch_mle_monomial::{
     ZerocheckMonomialBatch, ZerocheckMonomialParYBatch,
 };
 pub use errors::*;
-pub(crate) use fractional::precompute_m_work_buffer_strategy as fractional_gkr_work_buffer_strategy;
+pub(crate) use fractional::precompute_m_work_buffer_strategy as fractional_gkr_work_buffer_metering_strategy;
 pub use fractional::{fractional_sumcheck_gpu, make_synthetic_leaves, FractionalInputSize};
 use gkr_input::{collect_trace_interactions, log_gkr_input_evals};
 use round0::evaluate_round0_constraints_gpu;

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -71,12 +71,15 @@ mod errors;
 pub(crate) mod fold_ple;
 /// Fraction sumcheck via GKR
 mod fractional;
-pub(crate) use fractional::precompute_m_enabled as fractional_gkr_precompute_m_enabled;
 /// Logup interaction evaluations for GKR input
 mod gkr_input;
 mod mle_round;
 mod round0;
 pub(crate) mod rules;
+
+pub(crate) fn fractional_gkr_precompute_m_metering_mode() -> Option<bool> {
+    fractional::precompute_m_metering_mode()
+}
 
 use batch_mle::{evaluate_logup_batched, TraceCtx};
 use batch_mle_monomial::{

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -71,6 +71,7 @@ mod errors;
 pub(crate) mod fold_ple;
 /// Fraction sumcheck via GKR
 mod fractional;
+pub(crate) use fractional::precompute_m_enabled as fractional_gkr_precompute_m_enabled;
 /// Logup interaction evaluations for GKR input
 mod gkr_input;
 mod mle_round;

--- a/crates/cuda-common/src/memory_manager/mod.rs
+++ b/crates/cuda-common/src/memory_manager/mod.rs
@@ -36,6 +36,18 @@ pub fn device_memory_used() -> usize {
     total - free
 }
 
+pub fn vpmm_page_size_bytes() -> Option<usize> {
+    let manager = MEMORY_MANAGER.get().and_then(|m| m.lock().ok())?;
+    (manager.pool.page_size != usize::MAX).then_some(manager.pool.page_size)
+}
+
+pub fn tracked_memory_used() -> usize {
+    MEMORY_MANAGER
+        .get()
+        .and_then(|m| m.lock().ok())
+        .map_or(0, |manager| manager.current_size)
+}
+
 #[ctor::ctor]
 fn init() {
     let _ = MEMORY_MANAGER.set(Mutex::new(MemoryManager::new()));
@@ -229,16 +241,22 @@ impl MemTracker {
         let peak = manager.max_used_size;
         let used = current as isize - self.current as isize;
         let sign = if used >= 0 { "+" } else { "-" };
+        let used_abs = used.unsigned_abs();
         let pool_usage = manager.pool.memory_usage();
         tracing::info!(
-            "GPU mem: used={}{}, current={}, peak={}, in pool={} ({})",
+            "GPU mem: used={}{}, current={}, peak={}, in pool={} ({}) | bytes used={}{} current={} peak={} pool={}",
             sign,
-            ByteSize::b(used.unsigned_abs() as u64),
+            ByteSize::b(used_abs as u64),
             ByteSize::b(current as u64),
             ByteSize::b(peak as u64),
             ByteSize::b(pool_usage as u64),
             msg.into()
-                .map_or(self.label.to_string(), |m| format!("{}:{}", self.label, m))
+                .map_or(self.label.to_string(), |m| format!("{}:{}", self.label, m)),
+            sign,
+            used_abs,
+            current,
+            peak,
+            pool_usage,
         );
     }
 

--- a/crates/cuda-common/src/memory_manager/mod.rs
+++ b/crates/cuda-common/src/memory_manager/mod.rs
@@ -36,16 +36,14 @@ pub fn device_memory_used() -> usize {
     total - free
 }
 
-pub fn vpmm_page_size_bytes() -> Option<usize> {
-    let manager = MEMORY_MANAGER.get().and_then(|m| m.lock().ok())?;
-    (manager.pool.page_size != usize::MAX).then_some(manager.pool.page_size)
-}
+pub const DEFAULT_VPMM_PAGE_SIZE_BYTES: usize = 2 << 20;
 
-pub fn tracked_memory_used() -> usize {
-    MEMORY_MANAGER
-        .get()
-        .and_then(|m| m.lock().ok())
-        .map_or(0, |manager| manager.current_size)
+pub fn vpmm_allocation_granularity_bytes() -> usize {
+    std::env::var("VPMM_PAGE_SIZE").map_or(DEFAULT_VPMM_PAGE_SIZE_BYTES, |val| {
+        let size: usize = val.parse().expect("VPMM_PAGE_SIZE must be a valid number");
+        assert!(size > 0, "VPMM_PAGE_SIZE must be > 0");
+        size
+    })
 }
 
 #[ctor::ctor]

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -2,6 +2,8 @@
 
 use std::{cmp::max, mem::size_of};
 
+use serde::{Deserialize, Serialize};
+
 use crate::{
     prover::fractional_sumcheck_gkr::{FractionalGkrMemoryModel, FractionalGkrWorkBufferStrategy},
     StarkProtocolConfig, SystemParams,
@@ -85,7 +87,7 @@ pub struct ProvingMemoryEstimate {
 }
 
 /// Configuration for proving memory estimates.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ProvingMemoryConfig {
     /// Size of one base-field element in bytes.
     pub base_field_bytes: usize,

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -17,6 +17,12 @@ pub const INTERACTION_MEMORY_OVERHEAD: usize = 2 << 20;
 
 const WHIR_SUMCHECK_DEGREE: usize = 2;
 const CUDA_KERNEL_DEFAULT_BLOCK_SIZE: usize = 256;
+const CUDA_MEMORY_CHUNK_CELLS: usize = 8;
+const CUDA_MEMORY_BLOCK_CELLS: usize = 4;
+const CUDA_BOUNDARY_RECORD_BYTES: usize =
+    (2 + CUDA_MEMORY_CHUNK_CELLS / CUDA_MEMORY_BLOCK_CELLS + CUDA_MEMORY_CHUNK_CELLS)
+        * size_of::<u32>();
+const CUDA_MERKLE_RECORD_BYTES: usize = (3 + CUDA_MEMORY_CHUNK_CELLS) * size_of::<u32>();
 
 /// Cell counts for a proving memory estimate.
 ///
@@ -242,6 +248,20 @@ impl ProvingMemoryConfig {
             Some(granularity) if bytes >= granularity => bytes.next_multiple_of(granularity),
             _ => bytes,
         }
+    }
+
+    /// CUDA memory-boundary records are retained until the segment trace is generated.
+    ///
+    /// `boundary_records` is the final boundary AIR record count. The CUDA pre-merge input can
+    /// contain at most two four-cell records for each output record.
+    #[inline]
+    pub fn retained_boundary_memory_bytes(&self, boundary_records: usize) -> usize {
+        if boundary_records == 0 {
+            return 0;
+        }
+
+        self.tracked_allocation_bytes(2 * boundary_records * CUDA_BOUNDARY_RECORD_BYTES)
+            + self.tracked_allocation_bytes(boundary_records * CUDA_MERKLE_RECORD_BYTES)
     }
 
     #[inline]

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -21,6 +21,8 @@ const CUDA_KERNEL_DEFAULT_BLOCK_SIZE: usize = 256;
 /// constraint and opening phases, split by whether a trace opens next-row rotations.
 /// `interaction_cells` is the metered row-interaction slot count after power-of-two trace padding.
 /// `main_stacked_cells` is the common-main stacked matrix size before Reed-Solomon blowup.
+/// `main_memory_bytes`, when set, is the resident allocation size for opened trace matrices.
+/// `retained_auxiliary_bytes` is extra caller-owned memory retained during proving.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ProvingMemoryCounts {
     /// Opened trace cells for AIRs that open next-row rotations after power-of-two padding.
@@ -31,6 +33,10 @@ pub struct ProvingMemoryCounts {
     pub main_stacked_cells: usize,
     /// Metered row-interaction slots after power-of-two padding.
     pub interaction_cells: usize,
+    /// Resident opened-trace allocation bytes, if different from `main_cells * sizeof(F)`.
+    pub main_memory_bytes: Option<usize>,
+    /// Additional resident caller-owned bytes live during secondary proving phases.
+    pub retained_auxiliary_bytes: usize,
 }
 
 impl ProvingMemoryCounts {
@@ -58,12 +64,26 @@ impl ProvingMemoryCounts {
             main_cells_without_rot,
             main_stacked_cells,
             interaction_cells,
+            main_memory_bytes: None,
+            retained_auxiliary_bytes: 0,
         }
     }
 
     #[inline]
     pub const fn main_cells(&self) -> usize {
         self.main_cells_with_rot + self.main_cells_without_rot
+    }
+
+    #[inline]
+    pub const fn with_main_memory_bytes(mut self, main_memory_bytes: usize) -> Self {
+        self.main_memory_bytes = Some(main_memory_bytes);
+        self
+    }
+
+    #[inline]
+    pub const fn with_retained_auxiliary_bytes(mut self, retained_auxiliary_bytes: usize) -> Self {
+        self.retained_auxiliary_bytes = retained_auxiliary_bytes;
+        self
     }
 }
 
@@ -74,15 +94,17 @@ pub struct ProvingMemoryEstimate {
     pub total: usize,
     /// Resident opened trace data.
     pub main: usize,
-    /// Retained common-main PCS data used by the selected secondary phase.
+    /// Retained common-main PCS data used by secondary phases.
     pub main_persistent: usize,
+    /// Caller/backend-owned auxiliary memory retained during secondary proving phases.
+    pub retained_auxiliary: usize,
     /// Reed-Solomon code matrix for main traces.
     pub rs_code_matrix: usize,
     /// Secondary main-trace buffers after PCS opening.
     pub main_secondary: usize,
     /// Interaction GKR buffers plus fractional-GKR scratch.
     pub interaction: usize,
-    /// Peak among secondary phases, excluding resident opened trace data.
+    /// Peak among secondary phases, excluding resident main and retained auxiliary bytes.
     pub secondary_peak: usize,
 }
 
@@ -116,6 +138,11 @@ pub struct ProvingMemoryConfig {
     num_whir_rounds: usize,
     /// Size of one PCS digest in bytes.
     digest_bytes: usize,
+    /// Backend-owned resident memory not represented by per-segment trace/protocol counts.
+    retained_backend_memory_bytes: usize,
+    /// CUDA VPMM page size for large allocation accounting.
+    #[serde(default)]
+    large_allocation_granularity_bytes: Option<usize>,
 }
 
 impl ProvingMemoryConfig {
@@ -151,6 +178,8 @@ impl ProvingMemoryConfig {
             k_whir: params.k_whir(),
             num_whir_rounds: params.num_whir_rounds(),
             digest_bytes,
+            retained_backend_memory_bytes: 0,
+            large_allocation_granularity_bytes: None,
         }
     }
 
@@ -159,6 +188,28 @@ impl ProvingMemoryConfig {
     pub fn with_cuda_backend(mut self, cache_stacked_matrix: bool) -> Self {
         self.cache_stacked_matrix = cache_stacked_matrix;
         self.retained_opening_memory = true;
+        self
+    }
+
+    /// Calibrate CUDA allocation accounting.
+    #[inline]
+    #[doc(hidden)]
+    pub fn with_large_allocation_granularity_bytes(
+        mut self,
+        allocation_granularity: usize,
+    ) -> Self {
+        assert!(allocation_granularity > 0);
+        self.large_allocation_granularity_bytes = Some(allocation_granularity);
+        self
+    }
+
+    #[inline]
+    #[doc(hidden)]
+    pub const fn with_retained_backend_memory_bytes(
+        mut self,
+        retained_backend_memory: usize,
+    ) -> Self {
+        self.retained_backend_memory_bytes = retained_backend_memory;
         self
     }
 
@@ -175,6 +226,15 @@ impl ProvingMemoryConfig {
     #[inline]
     pub fn main_memory_bytes(&self, main_cells: usize) -> usize {
         main_cells * self.base_field_bytes
+    }
+
+    /// Bytes tracked by the CUDA memory manager for one allocation of `bytes`.
+    #[inline]
+    pub fn tracked_allocation_bytes(&self, bytes: usize) -> usize {
+        match self.large_allocation_granularity_bytes {
+            Some(granularity) if bytes >= granularity => bytes.next_multiple_of(granularity),
+            _ => bytes,
+        }
     }
 
     #[inline]
@@ -343,10 +403,11 @@ impl ProvingMemoryConfig {
     pub fn interaction_memory_bytes_without_overhead(&self, interaction_cells: usize) -> usize {
         let logical_len = Self::fractional_gkr_logical_len(interaction_cells);
         let model = self.fractional_gkr_memory_model();
-        model.peak_memory_bytes_with_strategy(
+        model.peak_memory_bytes_with_allocator(
             interaction_cells,
             logical_len,
             self.fractional_gkr_work_buffer_strategy,
+            |bytes| self.tracked_allocation_bytes(bytes),
         )
     }
 
@@ -367,12 +428,13 @@ impl ProvingMemoryConfig {
             return 0;
         }
 
-        FractionalGkrMemoryModel::round_temp_buffer_elements(
+        let bytes = FractionalGkrMemoryModel::round_temp_buffer_elements(
             logical_len >> 1,
             FractionalGkrMemoryModel::ROUND_COMPUTE_FALLBACK_BLOCKS,
         )
         .saturating_mul(self.extension_degree)
-        .saturating_mul(self.base_field_bytes)
+        .saturating_mul(self.base_field_bytes);
+        self.tracked_allocation_bytes(bytes)
     }
 
     /// Interaction memory includes the fractional-GKR model plus the larger of fixed interaction
@@ -397,13 +459,15 @@ impl ProvingMemoryConfig {
     /// Convert opened trace cells, common-main stacked cells, and interaction cells to memory
     /// bytes.
     ///
-    /// `main` is resident across the whole proving segment. `secondary_peak` is the maximum of the
-    /// secondary phases that can overlap with that resident main memory.
+    /// `main` is resident across the whole proving segment. `retained_auxiliary` is caller/backend
+    /// memory that remains live while proving. `secondary_peak` is the maximum of the secondary
+    /// phases that can overlap with both resident components.
     ///
     /// ```text
     /// main_cells         = main_cells_with_rot + main_cells_without_rot
     /// main_stacked_cells = stacked_width * 2^log_stacked_height
-    /// main               = main_cells * sizeof(F)
+    /// main               = main_memory_bytes, or main_cells * sizeof(F)
+    /// retained_auxiliary = caller/backend retained allocation bytes
     ///
     /// retained_common    = cached_stacked + common_digest
     ///
@@ -445,12 +509,17 @@ impl ProvingMemoryConfig {
     ///     whir_first_round_peak,
     ///     whir_later_round_peak,
     /// )
-    /// total = main + secondary_peak
+    /// total = main + retained_auxiliary + secondary_peak
     /// ```
     #[inline]
     pub fn estimate(&self, counts: ProvingMemoryCounts) -> ProvingMemoryEstimate {
         let main_cells = counts.main_cells();
-        let main = self.main_memory_bytes(main_cells);
+        let main = counts
+            .main_memory_bytes
+            .unwrap_or_else(|| self.main_memory_bytes(main_cells));
+        let retained_auxiliary = counts
+            .retained_auxiliary_bytes
+            .saturating_add(self.retained_backend_memory_bytes);
         let has_common_main = counts.main_stacked_cells != 0;
         let retained_opening_memory = has_common_main && self.retained_opening_memory;
         let cached_stacked_matrix =
@@ -508,9 +577,10 @@ impl ProvingMemoryConfig {
         let main_persistent = retained_common_main;
 
         ProvingMemoryEstimate {
-            total: main + secondary_peak,
+            total: main + retained_auxiliary + secondary_peak,
             main,
             main_persistent,
+            retained_auxiliary,
             rs_code_matrix,
             main_secondary,
             interaction,
@@ -643,6 +713,80 @@ mod tests {
                 10, 20, 5,
             ))
         );
+    }
+
+    #[test]
+    fn main_memory_can_use_caller_allocation_sum() {
+        let mut config = test_memory_config();
+        config.large_allocation_granularity_bytes = Some(16);
+        let main_memory_bytes = config.tracked_allocation_bytes(17)
+            + config.tracked_allocation_bytes(17)
+            + config.tracked_allocation_bytes(15);
+        let counts = ProvingMemoryCounts::new_with_unstacked_cells(10, 20, 5)
+            .with_main_memory_bytes(main_memory_bytes);
+
+        let estimate = config.estimate(counts);
+
+        assert_eq!(main_memory_bytes, 32 + 32 + 15);
+        assert_ne!(
+            main_memory_bytes,
+            config.tracked_allocation_bytes(17 + 17 + 15)
+        );
+        assert_eq!(estimate.main, main_memory_bytes);
+        assert_eq!(estimate.total, main_memory_bytes + estimate.secondary_peak);
+    }
+
+    #[test]
+    fn retained_auxiliary_memory_is_resident() {
+        let config = test_memory_config();
+        let base_counts = ProvingMemoryCounts::new_with_unstacked_cells(10, 20, 5);
+        let with_aux = base_counts.with_retained_auxiliary_bytes(123);
+
+        let base = config.estimate(base_counts);
+        let estimate = config.estimate(with_aux);
+
+        assert_eq!(estimate.secondary_peak, base.secondary_peak);
+        assert_eq!(estimate.retained_auxiliary, 123);
+        assert_eq!(estimate.main_persistent, base.main_persistent);
+        assert_eq!(estimate.total, base.total + 123);
+    }
+
+    #[test]
+    fn retained_backend_memory_is_resident() {
+        let config = test_memory_config().with_retained_backend_memory_bytes(456);
+        let counts = ProvingMemoryCounts::new_with_unstacked_cells(10, 20, 5);
+
+        let estimate = config.estimate(counts);
+
+        assert_eq!(estimate.retained_auxiliary, 456);
+        assert_eq!(
+            estimate.total,
+            estimate.main + estimate.secondary_peak + estimate.retained_auxiliary
+        );
+    }
+
+    #[test]
+    fn tracked_allocation_bytes_uses_cuda_granularity() {
+        let mut config = test_memory_config();
+        config.large_allocation_granularity_bytes = Some(16);
+
+        assert_eq!(config.tracked_allocation_bytes(0), 0);
+        assert_eq!(config.tracked_allocation_bytes(15), 15);
+        assert_eq!(config.tracked_allocation_bytes(16), 16);
+        assert_eq!(config.tracked_allocation_bytes(17), 32);
+    }
+
+    #[test]
+    fn interaction_memory_uses_cuda_allocation_granularity() {
+        let interaction_cells = (1 << 24) + 1;
+        let raw = test_memory_config()
+            .with_fractional_gkr_work_buffer_strategy(FractionalGkrWorkBufferStrategy::PrecomputeM)
+            .interaction_memory_bytes_without_overhead(interaction_cells);
+        let mut rounded = test_memory_config()
+            .with_fractional_gkr_work_buffer_strategy(FractionalGkrWorkBufferStrategy::PrecomputeM);
+        rounded.large_allocation_granularity_bytes = Some(1 << 27);
+
+        assert!(rounded.interaction_memory_bytes_without_overhead(interaction_cells) > raw);
     }
 
     #[test]

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -102,6 +102,9 @@ pub struct ProvingMemoryConfig {
     pub cache_rs_code_matrix: bool,
     /// Whether to include CUDA retained opening state in the estimate.
     retained_opening_memory: bool,
+    /// CUDA fractional-GKR work-buffer allocation, when metering is configured by the CUDA
+    /// backend.
+    fractional_gkr_precompute_m: Option<bool>,
     /// `log_2` of the common-main stacked matrix height.
     log_stacked_height: usize,
     /// WHIR folding factor.
@@ -140,6 +143,7 @@ impl ProvingMemoryConfig {
             cache_stacked_matrix: false,
             cache_rs_code_matrix,
             retained_opening_memory: false,
+            fractional_gkr_precompute_m: None,
             log_stacked_height: params.log_stacked_height(),
             k_whir: params.k_whir(),
             num_whir_rounds: params.num_whir_rounds(),
@@ -152,6 +156,13 @@ impl ProvingMemoryConfig {
     pub fn with_cuda_backend(mut self, cache_stacked_matrix: bool) -> Self {
         self.cache_stacked_matrix = cache_stacked_matrix;
         self.retained_opening_memory = true;
+        self
+    }
+
+    /// Match the CUDA fractional-GKR work-buffer allocation selected by the backend.
+    #[inline]
+    pub fn with_fractional_gkr_precompute_m(mut self, enabled: bool) -> Self {
+        self.fractional_gkr_precompute_m = Some(enabled);
         self
     }
 
@@ -221,7 +232,7 @@ impl ProvingMemoryConfig {
     }
 
     #[inline]
-    fn whir_initial_workspace_memory_bytes(&self) -> usize {
+    fn whir_first_sumcheck_memory_bytes(&self) -> usize {
         let height = 1usize << self.log_stacked_height;
         let ext_poly = height
             .saturating_mul(self.extension_degree)
@@ -235,16 +246,30 @@ impl ProvingMemoryConfig {
 
         // First WHIR sumcheck round keeps f_coeffs and w_moments live while allocating folded
         // outputs. This is larger than the earlier f_ple_evals + f_coeffs conversion peak.
-        let first_sumcheck_peak = ext_poly
+        ext_poly
             .saturating_mul(3)
-            .saturating_add(first_sumcheck_tmp);
+            .saturating_add(first_sumcheck_tmp)
+    }
+
+    #[inline]
+    fn whir_folded_state_memory_bytes(&self) -> usize {
+        let height = 1usize << self.log_stacked_height;
+        let ext_poly = height
+            .saturating_mul(self.extension_degree)
+            .saturating_mul(self.base_field_bytes);
+        let first_sumcheck_tmp = height
+            .div_ceil(2)
+            .div_ceil(CUDA_KERNEL_DEFAULT_BLOCK_SIZE)
+            .saturating_mul(WHIR_SUMCHECK_DEGREE)
+            .saturating_mul(self.extension_degree)
+            .saturating_mul(self.base_field_bytes);
 
         // After k_whir folds, f_coeffs, w_moments, and the split base-field g_coeffs are live
         // while building the first folded codeword tree.
         let folded_ext_poly = ext_poly >> self.k_whir.min(usize::BITS as usize - 1);
-        let first_codeword_build_peak = folded_ext_poly.saturating_mul(3);
-
-        max(first_sumcheck_peak, first_codeword_build_peak)
+        folded_ext_poly
+            .saturating_mul(3)
+            .saturating_add(first_sumcheck_tmp)
     }
 
     #[inline]
@@ -307,13 +332,20 @@ impl ProvingMemoryConfig {
     /// ```
     ///
     /// Work-buffer sizing is delegated to the prover-owned fractional-GKR model so CUDA batching
-    /// and metering use the same fold-eval/precompute-M peak.
+    /// and metering use the same selected fold-eval/precompute-M strategy.
     #[inline]
     pub fn interaction_memory_bytes_without_overhead(&self, interaction_cells: usize) -> usize {
-        self.fractional_gkr_memory_model().peak_memory_bytes(
-            interaction_cells,
-            Self::fractional_gkr_logical_len(interaction_cells),
-        )
+        let logical_len = Self::fractional_gkr_logical_len(interaction_cells);
+        let model = self.fractional_gkr_memory_model();
+        if let Some(precompute_m_enabled) = self.fractional_gkr_precompute_m {
+            model.peak_memory_bytes_with_precompute_m(
+                interaction_cells,
+                logical_len,
+                precompute_m_enabled,
+            )
+        } else {
+            model.peak_memory_bytes(interaction_cells, logical_len)
+        }
     }
 
     #[inline]
@@ -380,7 +412,9 @@ impl ProvingMemoryConfig {
     ///
     /// first_g_tree       = first WHIR folding codeword + Merkle digest layers
     /// second_g_tree      = second WHIR folding codeword + Merkle digest layers
-    /// whir_workspace     = CUDA WHIR coefficient/moment buffers and sumcheck scratch
+    /// first_sumcheck     = full-height f/w sumcheck buffers and first-round sumcheck scratch
+    /// folded_state       = folded f/w/g buffers plus retained sumcheck scratch while opening the
+    ///                      first folded tree
     ///
     /// main_secondary     = sizeof(F) *
     ///                      (2 * main_cell_secondary_weight() * main_cells_with_rot
@@ -396,8 +430,11 @@ impl ProvingMemoryConfig {
     ///
     /// constraint_peak       = retained_common + cached_rs_code_matrix
     ///                         + max(main_secondary, interaction)
-    /// whir_first_round_peak = retained_common + rs_code_matrix
-    ///                         + max(whir_workspace, first_g_tree)
+    /// whir_first_round_peak = retained_common + if cache_rs_code_matrix {
+    ///     rs_code_matrix + max(first_sumcheck, first_g_tree + folded_state)
+    /// } else {
+    ///     max(first_sumcheck, rs_code_matrix + first_g_tree + folded_state)
+    /// }
     /// whir_later_round_peak = first_g_tree + second_g_tree
     ///
     /// secondary_peak = max(
@@ -424,17 +461,19 @@ impl ProvingMemoryConfig {
             common_initial_digest_layer,
             first_g_tree,
             second_g_tree,
-            whir_workspace,
+            first_sumcheck,
+            folded_state,
         ) = if retained_opening_memory {
             (
                 self.main_commitment_digest_layers_memory_bytes(),
                 self.main_commitment_initial_digest_layer_memory_bytes(),
                 self.first_whir_tree_memory_bytes(),
                 self.second_whir_tree_memory_bytes(),
-                self.whir_initial_workspace_memory_bytes(),
+                self.whir_first_sumcheck_memory_bytes(),
+                self.whir_folded_state_memory_bytes(),
             )
         } else {
-            (0, 0, 0, 0, 0)
+            (0, 0, 0, 0, 0, 0)
         };
         let cached_rs_code_matrix = if self.cache_rs_code_matrix {
             rs_code_matrix
@@ -453,8 +492,12 @@ impl ProvingMemoryConfig {
             };
         let constraint_peak =
             retained_common_main + cached_rs_code_matrix + max(main_secondary, interaction);
-        let whir_first_round_peak =
-            retained_common_main + rs_code_matrix + max(whir_workspace, first_g_tree);
+        let whir_first_round_peak = retained_common_main
+            + if self.cache_rs_code_matrix {
+                rs_code_matrix + max(first_sumcheck, first_g_tree + folded_state)
+            } else {
+                max(first_sumcheck, rs_code_matrix + first_g_tree + folded_state)
+            };
         let whir_later_round_peak = first_g_tree + second_g_tree;
         let secondary_peak = max(
             max(commit_peak, constraint_peak),
@@ -540,10 +583,11 @@ mod tests {
         let constraint_peak =
             estimate.main_persistent + max(estimate.main_secondary, estimate.interaction);
         let whir_first_round_peak = estimate.main_persistent
-            + estimate.rs_code_matrix
             + max(
-                config.whir_initial_workspace_memory_bytes(),
-                config.first_whir_tree_memory_bytes(),
+                config.whir_first_sumcheck_memory_bytes(),
+                estimate.rs_code_matrix
+                    + config.first_whir_tree_memory_bytes()
+                    + config.whir_folded_state_memory_bytes(),
             );
         let whir_later_round_peak =
             config.first_whir_tree_memory_bytes() + config.second_whir_tree_memory_bytes();
@@ -625,6 +669,18 @@ mod tests {
     }
 
     #[test]
+    fn fractional_gkr_strategy_changes_interaction_peak() {
+        let interaction_cells = 1 << 24;
+        let precompute_m = test_memory_config().with_fractional_gkr_precompute_m(true);
+        let fold_eval = test_memory_config().with_fractional_gkr_precompute_m(false);
+
+        assert!(
+            fold_eval.interaction_memory_bytes_without_overhead(interaction_cells)
+                > precompute_m.interaction_memory_bytes_without_overhead(interaction_cells)
+        );
+    }
+
+    #[test]
     fn cuda_whir_peak_includes_initial_workspace() {
         let config = test_memory_config();
         let counts = ProvingMemoryCounts::new_with_stacked_cells(1, 0, 1, 0);
@@ -634,7 +690,10 @@ mod tests {
             estimate.main_persistent + estimate.rs_code_matrix + estimate.main_secondary;
         let whir_first_round_peak = estimate.main_persistent
             + estimate.rs_code_matrix
-            + config.whir_initial_workspace_memory_bytes();
+            + max(
+                config.whir_first_sumcheck_memory_bytes(),
+                config.first_whir_tree_memory_bytes() + config.whir_folded_state_memory_bytes(),
+            );
         let whir_later_round_peak =
             config.first_whir_tree_memory_bytes() + config.second_whir_tree_memory_bytes();
 
@@ -662,10 +721,11 @@ mod tests {
         );
         let constraint_peak = estimate.main_persistent + estimate.main_secondary;
         let whir_first_round_peak = estimate.main_persistent
-            + estimate.rs_code_matrix
             + max(
-                config.whir_initial_workspace_memory_bytes(),
-                config.first_whir_tree_memory_bytes(),
+                config.whir_first_sumcheck_memory_bytes(),
+                estimate.rs_code_matrix
+                    + config.first_whir_tree_memory_bytes()
+                    + config.whir_folded_state_memory_bytes(),
             );
         let whir_later_round_peak =
             config.first_whir_tree_memory_bytes() + config.second_whir_tree_memory_bytes();

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -105,7 +105,8 @@ pub struct ProvingMemoryConfig {
     pub cache_rs_code_matrix: bool,
     /// Whether to include CUDA retained opening state in the estimate.
     retained_opening_memory: bool,
-    /// CUDA fractional-GKR work-buffer allocation strategy.
+    /// CUDA fractional-GKR work-buffer strategy.
+    #[serde(default)]
     fractional_gkr_work_buffer_strategy: FractionalGkrWorkBufferStrategy,
     /// `log_2` of the common-main stacked matrix height.
     log_stacked_height: usize,
@@ -337,7 +338,7 @@ impl ProvingMemoryConfig {
     /// ```
     ///
     /// Work-buffer sizing is delegated to the prover-owned fractional-GKR model so CUDA batching
-    /// and metering use the same selected fold-eval/precompute-M strategy.
+    /// and metering use the same budget model for the selected fold-eval/precompute-M mode.
     #[inline]
     pub fn interaction_memory_bytes_without_overhead(&self, interaction_cells: usize) -> usize {
         let logical_len = Self::fractional_gkr_logical_len(interaction_cells);
@@ -420,7 +421,7 @@ impl ProvingMemoryConfig {
     /// main_secondary     = sizeof(F) *
     ///                      (2 * main_cell_secondary_weight() * main_cells_with_rot
     ///                       + main_cell_secondary_weight() * main_cells_without_rot)
-    /// interaction        = fractional-GKR inputs + max supported work buffer
+    /// interaction        = fractional-GKR inputs + selected work-buffer/auxiliary budget
     ///                      + max(INTERACTION_MEMORY_OVERHEAD, fractional_gkr_round_temp_buffer)
     ///
     /// commit_peak = cached_stacked + if cache_rs_code_matrix {

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -160,6 +160,7 @@ impl ProvingMemoryConfig {
     }
 
     #[inline]
+    #[doc(hidden)]
     pub fn with_fractional_gkr_work_buffer_strategy(
         mut self,
         strategy: FractionalGkrWorkBufferStrategy,
@@ -677,11 +678,14 @@ mod tests {
         // precompute aux:
         //   m_buffer + prefix/suffix = (4^3 + 2 * 2^3) EF
         //   m_partial_buffer         = 1024 * 4^3 EF
+        // conservative tuned aux:
+        //   m_partial_buffer         = ceil(2^20 / 256) * 4^3 EF
         // common aux:
         //   SqrtEqLayers for 23 challenges = (2^12 - 1) + (2^13 - 2) EF
         //   d_sum_evals + copy_scratch     = 4 EF
         let precompute_expected = 672_335_120;
         let fold_eval_expected = 805_502_992;
+        let conservative_expected = 809_698_576;
         let precompute_m = test_memory_config()
             .with_fractional_gkr_work_buffer_strategy(FractionalGkrWorkBufferStrategy::PrecomputeM);
         let fold_eval = test_memory_config()
@@ -698,7 +702,7 @@ mod tests {
         );
         assert_eq!(
             conservative.interaction_memory_bytes_without_overhead(interaction_cells),
-            fold_eval_expected
+            conservative_expected
         );
     }
 

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -3,7 +3,8 @@
 use std::{cmp::max, mem::size_of};
 
 use crate::{
-    prover::fractional_sumcheck_gkr::FractionalGkrMemoryModel, StarkProtocolConfig, SystemParams,
+    prover::fractional_sumcheck_gkr::{FractionalGkrMemoryModel, FractionalGkrWorkBufferStrategy},
+    StarkProtocolConfig, SystemParams,
 };
 
 /// Fixed interaction scratch not proportional to interaction cells.
@@ -102,9 +103,8 @@ pub struct ProvingMemoryConfig {
     pub cache_rs_code_matrix: bool,
     /// Whether to include CUDA retained opening state in the estimate.
     retained_opening_memory: bool,
-    /// CUDA fractional-GKR work-buffer allocation, when metering is configured by the CUDA
-    /// backend.
-    fractional_gkr_precompute_m: Option<bool>,
+    /// CUDA fractional-GKR work-buffer allocation strategy.
+    fractional_gkr_work_buffer_strategy: FractionalGkrWorkBufferStrategy,
     /// `log_2` of the common-main stacked matrix height.
     log_stacked_height: usize,
     /// WHIR folding factor.
@@ -143,7 +143,7 @@ impl ProvingMemoryConfig {
             cache_stacked_matrix: false,
             cache_rs_code_matrix,
             retained_opening_memory: false,
-            fractional_gkr_precompute_m: None,
+            fractional_gkr_work_buffer_strategy: FractionalGkrWorkBufferStrategy::Conservative,
             log_stacked_height: params.log_stacked_height(),
             k_whir: params.k_whir(),
             num_whir_rounds: params.num_whir_rounds(),
@@ -159,10 +159,12 @@ impl ProvingMemoryConfig {
         self
     }
 
-    /// Match the CUDA fractional-GKR work-buffer allocation selected by the backend.
     #[inline]
-    pub fn with_fractional_gkr_precompute_m(mut self, enabled: bool) -> Self {
-        self.fractional_gkr_precompute_m = Some(enabled);
+    pub fn with_fractional_gkr_work_buffer_strategy(
+        mut self,
+        strategy: FractionalGkrWorkBufferStrategy,
+    ) -> Self {
+        self.fractional_gkr_work_buffer_strategy = strategy;
         self
     }
 
@@ -337,15 +339,11 @@ impl ProvingMemoryConfig {
     pub fn interaction_memory_bytes_without_overhead(&self, interaction_cells: usize) -> usize {
         let logical_len = Self::fractional_gkr_logical_len(interaction_cells);
         let model = self.fractional_gkr_memory_model();
-        if let Some(precompute_m_enabled) = self.fractional_gkr_precompute_m {
-            model.peak_memory_bytes_with_precompute_m(
-                interaction_cells,
-                logical_len,
-                precompute_m_enabled,
-            )
-        } else {
-            model.peak_memory_bytes(interaction_cells, logical_len)
-        }
+        model.peak_memory_bytes_with_strategy(
+            interaction_cells,
+            logical_len,
+            self.fractional_gkr_work_buffer_strategy,
+        )
     }
 
     #[inline]
@@ -669,14 +667,38 @@ mod tests {
     }
 
     #[test]
-    fn fractional_gkr_strategy_changes_interaction_peak() {
+    fn fractional_gkr_strategy_selects_default_cuda_peak() {
         let interaction_cells = 1 << 24;
-        let precompute_m = test_memory_config().with_fractional_gkr_precompute_m(true);
-        let fold_eval = test_memory_config().with_fractional_gkr_precompute_m(false);
+        // logical_len = 2^25, sizeof(Frac<EF>) = 32, sizeof(EF) = 16.
+        //
+        // input         = 2^24 * 32
+        // fold_eval     = 2^23 * 32
+        // precompute-M  = 2^22 * 32
+        // precompute aux:
+        //   m_buffer + prefix/suffix = (4^3 + 2 * 2^3) EF
+        //   m_partial_buffer         = 1024 * 4^3 EF
+        // common aux:
+        //   SqrtEqLayers for 23 challenges = (2^12 - 1) + (2^13 - 2) EF
+        //   d_sum_evals + copy_scratch     = 4 EF
+        let precompute_expected = 672_335_120;
+        let fold_eval_expected = 805_502_992;
+        let precompute_m = test_memory_config()
+            .with_fractional_gkr_work_buffer_strategy(FractionalGkrWorkBufferStrategy::PrecomputeM);
+        let fold_eval = test_memory_config()
+            .with_fractional_gkr_work_buffer_strategy(FractionalGkrWorkBufferStrategy::FoldEval);
+        let conservative = test_memory_config();
 
-        assert!(
-            fold_eval.interaction_memory_bytes_without_overhead(interaction_cells)
-                > precompute_m.interaction_memory_bytes_without_overhead(interaction_cells)
+        assert_eq!(
+            precompute_m.interaction_memory_bytes_without_overhead(interaction_cells),
+            precompute_expected
+        );
+        assert_eq!(
+            fold_eval.interaction_memory_bytes_without_overhead(interaction_cells),
+            fold_eval_expected
+        );
+        assert_eq!(
+            conservative.interaction_memory_bytes_without_overhead(interaction_cells),
+            fold_eval_expected
         );
     }
 

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -337,8 +337,8 @@ impl ProvingMemoryConfig {
     /// input = 2 * interaction_cells * D_EF * sizeof(F)
     /// ```
     ///
-    /// Work-buffer sizing is delegated to the prover-owned fractional-GKR model so CUDA batching
-    /// and metering use the same budget model for the selected fold-eval/precompute-M mode.
+    /// Work-buffer sizing is delegated to the prover-owned fractional-GKR model so metering follows
+    /// the selected fold-eval/precompute-M mode without duplicating the CUDA sizing formulas.
     #[inline]
     pub fn interaction_memory_bytes_without_overhead(&self, interaction_cells: usize) -> usize {
         let logical_len = Self::fractional_gkr_logical_len(interaction_cells);

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -5,7 +5,10 @@ use std::{cmp::max, mem::size_of};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    prover::fractional_sumcheck_gkr::{FractionalGkrMemoryModel, FractionalGkrWorkBufferStrategy},
+    prover::{
+        fractional_sumcheck_gkr::{FractionalGkrMemoryModel, FractionalGkrWorkBufferStrategy},
+        DeviceMultiStarkProvingKey, ProverBackend,
+    },
     StarkProtocolConfig, SystemParams,
 };
 
@@ -205,11 +208,15 @@ impl ProvingMemoryConfig {
 
     #[inline]
     #[doc(hidden)]
-    pub const fn with_retained_backend_memory_bytes(
+    pub fn with_retained_proving_key_allocations<PB: ProverBackend>(
         mut self,
-        retained_backend_memory: usize,
+        mpk: &DeviceMultiStarkProvingKey<PB>,
     ) -> Self {
-        self.retained_backend_memory_bytes = retained_backend_memory;
+        self.retained_backend_memory_bytes = PB::retained_proving_key_allocation_bytes(mpk)
+            .into_iter()
+            .fold(0usize, |total, bytes| {
+                total.saturating_add(self.tracked_allocation_bytes(bytes))
+            });
         self
     }
 
@@ -749,20 +756,6 @@ mod tests {
         assert_eq!(estimate.retained_auxiliary, 123);
         assert_eq!(estimate.main_persistent, base.main_persistent);
         assert_eq!(estimate.total, base.total + 123);
-    }
-
-    #[test]
-    fn retained_backend_memory_is_resident() {
-        let config = test_memory_config().with_retained_backend_memory_bytes(456);
-        let counts = ProvingMemoryCounts::new_with_unstacked_cells(10, 20, 5);
-
-        let estimate = config.estimate(counts);
-
-        assert_eq!(estimate.retained_auxiliary, 456);
-        assert_eq!(
-            estimate.total,
-            estimate.main + estimate.secondary_peak + estimate.retained_auxiliary
-        );
     }
 
     #[test]

--- a/crates/stark-backend/src/prover/hal.rs
+++ b/crates/stark-backend/src/prover/hal.rs
@@ -4,6 +4,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
     keygen::types::MultiStarkProvingKey,
+    memory_metering::ProvingMemoryConfig,
     prover::{
         stacked_pcs::StackedPcsData, AirProvingContext, ColMajorMatrix, CommittedTraceData,
         CpuColMajorBackend, DeviceMultiStarkProvingKey, ProvingContext,
@@ -48,6 +49,17 @@ pub trait ProverBackend {
     /// For example, multiple buffers for LDE matrices, their trace domain sizes, and pointer to
     /// mixed merkle tree.
     type PcsData: Send + Sync;
+
+    /// Backend-owned proving-key memory retained while proving a segment.
+    fn retained_proving_key_memory_bytes(
+        _mpk: &DeviceMultiStarkProvingKey<Self>,
+        _config: &ProvingMemoryConfig,
+    ) -> usize
+    where
+        Self: Sized,
+    {
+        0
+    }
 }
 
 pub trait ProverDevice<PB: ProverBackend, TS>:

--- a/crates/stark-backend/src/prover/hal.rs
+++ b/crates/stark-backend/src/prover/hal.rs
@@ -4,7 +4,6 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
     keygen::types::MultiStarkProvingKey,
-    memory_metering::ProvingMemoryConfig,
     prover::{
         stacked_pcs::StackedPcsData, AirProvingContext, ColMajorMatrix, CommittedTraceData,
         CpuColMajorBackend, DeviceMultiStarkProvingKey, ProvingContext,
@@ -50,15 +49,12 @@ pub trait ProverBackend {
     /// mixed merkle tree.
     type PcsData: Send + Sync;
 
-    /// Backend-owned proving-key memory retained while proving a segment.
-    fn retained_proving_key_memory_bytes(
-        _mpk: &DeviceMultiStarkProvingKey<Self>,
-        _config: &ProvingMemoryConfig,
-    ) -> usize
+    /// Backend-owned proving-key allocations retained while proving a segment.
+    fn retained_proving_key_allocation_bytes(_mpk: &DeviceMultiStarkProvingKey<Self>) -> Vec<usize>
     where
         Self: Sized,
     {
-        0
+        Vec::new()
     }
 }
 

--- a/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
+++ b/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
@@ -2,6 +2,7 @@ use std::{cmp::max, ops::Add};
 
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_util::log2_strict_usize;
+use serde::{Deserialize, Serialize};
 use tracing::{debug, instrument};
 
 use crate::{
@@ -58,7 +59,7 @@ struct WorkBufferMemoryCandidates {
 
 /// Fractional-GKR work-buffer strategy selected by the CUDA backend.
 #[doc(hidden)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FractionalGkrWorkBufferStrategy {
     /// Use the larger of the fold-eval and default precompute-M allocations.
     #[default]

--- a/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
+++ b/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
@@ -120,20 +120,49 @@ impl FractionalGkrMemoryModel {
         logical_len: usize,
         strategy: FractionalGkrWorkBufferStrategy,
     ) -> usize {
+        self.peak_work_buffer_memory_bytes_with_allocator(logical_len, strategy, |bytes| bytes)
+    }
+
+    #[inline]
+    pub(crate) fn peak_work_buffer_memory_bytes_with_allocator(
+        &self,
+        logical_len: usize,
+        strategy: FractionalGkrWorkBufferStrategy,
+        mut allocation_bytes: impl FnMut(usize) -> usize,
+    ) -> usize {
         let candidates = self.work_buffer_memory_candidates(logical_len);
         match strategy {
-            FractionalGkrWorkBufferStrategy::Conservative => candidates
-                .common_aux
-                .saturating_add(max(candidates.fold_eval, candidates.precompute_m))
-                .saturating_add(candidates.max_tuned_precompute_aux),
-            FractionalGkrWorkBufferStrategy::FoldEval => {
-                candidates.common_aux.saturating_add(candidates.fold_eval)
+            FractionalGkrWorkBufferStrategy::Conservative => {
+                allocation_bytes(candidates.common_aux)
+                    .saturating_add(allocation_bytes(max(
+                        candidates.fold_eval,
+                        candidates.precompute_m,
+                    )))
+                    .saturating_add(allocation_bytes(candidates.max_tuned_precompute_aux))
             }
-            FractionalGkrWorkBufferStrategy::PrecomputeM => candidates
-                .common_aux
-                .saturating_add(candidates.precompute_m)
-                .saturating_add(candidates.default_precompute_aux),
+            FractionalGkrWorkBufferStrategy::FoldEval => allocation_bytes(candidates.common_aux)
+                .saturating_add(allocation_bytes(candidates.fold_eval)),
+            FractionalGkrWorkBufferStrategy::PrecomputeM => allocation_bytes(candidates.common_aux)
+                .saturating_add(allocation_bytes(candidates.precompute_m))
+                .saturating_add(allocation_bytes(candidates.default_precompute_aux)),
         }
+    }
+
+    #[inline]
+    pub(crate) fn peak_memory_bytes_with_allocator(
+        &self,
+        interaction_cells: usize,
+        logical_len: usize,
+        strategy: FractionalGkrWorkBufferStrategy,
+        mut allocation_bytes: impl FnMut(usize) -> usize,
+    ) -> usize {
+        allocation_bytes(self.input_memory_bytes(interaction_cells)).saturating_add(
+            self.peak_work_buffer_memory_bytes_with_allocator(
+                logical_len,
+                strategy,
+                allocation_bytes,
+            ),
+        )
     }
 
     #[inline]
@@ -311,17 +340,6 @@ impl FractionalGkrMemoryModel {
     fn log2_len(logical_len: usize) -> Option<usize> {
         (logical_len > 2 && logical_len.is_power_of_two())
             .then_some(logical_len.trailing_zeros() as usize)
-    }
-
-    #[inline]
-    pub(crate) fn peak_memory_bytes_with_strategy(
-        &self,
-        interaction_cells: usize,
-        logical_len: usize,
-        strategy: FractionalGkrWorkBufferStrategy,
-    ) -> usize {
-        self.input_memory_bytes(interaction_cells)
-            .saturating_add(self.peak_work_buffer_memory_bytes_with_strategy(logical_len, strategy))
     }
 
     #[inline]

--- a/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
+++ b/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
@@ -61,7 +61,7 @@ struct WorkBufferMemoryCandidates {
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FractionalGkrWorkBufferStrategy {
-    /// Use the larger of the fold-eval and default precompute-M allocations.
+    /// Non-default CUDA tuning can select either work-buffer shape, so reserve and meter both.
     #[default]
     Conservative,
     /// Precompute-M is disabled, so CUDA allocates the fold-eval work buffer.

--- a/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
+++ b/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
@@ -98,8 +98,10 @@ impl FractionalGkrMemoryModel {
 
     #[inline]
     pub fn peak_work_buffer_memory_bytes(&self, logical_len: usize) -> usize {
-        let (fold_eval, precompute_m) = self.work_buffer_memory_candidates(logical_len);
-        max(fold_eval, precompute_m)
+        self.peak_work_buffer_memory_bytes_with_strategy(
+            logical_len,
+            FractionalGkrWorkBufferStrategy::Conservative,
+        )
     }
 
     #[inline]
@@ -108,18 +110,26 @@ impl FractionalGkrMemoryModel {
         logical_len: usize,
         strategy: FractionalGkrWorkBufferStrategy,
     ) -> usize {
-        let (fold_eval, precompute_m) = self.work_buffer_memory_candidates(logical_len);
+        let (fold_eval, precompute_m, default_precompute_aux, max_tuned_precompute_aux, common_aux) =
+            self.work_buffer_memory_candidates(logical_len);
         match strategy {
-            FractionalGkrWorkBufferStrategy::Conservative => max(fold_eval, precompute_m),
-            FractionalGkrWorkBufferStrategy::FoldEval => fold_eval,
-            FractionalGkrWorkBufferStrategy::PrecomputeM => precompute_m,
+            FractionalGkrWorkBufferStrategy::Conservative => common_aux
+                .saturating_add(max(fold_eval, precompute_m))
+                .saturating_add(max_tuned_precompute_aux),
+            FractionalGkrWorkBufferStrategy::FoldEval => common_aux.saturating_add(fold_eval),
+            FractionalGkrWorkBufferStrategy::PrecomputeM => common_aux
+                .saturating_add(precompute_m)
+                .saturating_add(default_precompute_aux),
         }
     }
 
     #[inline]
-    fn work_buffer_memory_candidates(&self, logical_len: usize) -> (usize, usize) {
+    fn work_buffer_memory_candidates(
+        &self,
+        logical_len: usize,
+    ) -> (usize, usize, usize, usize, usize) {
         if logical_len <= 2 {
-            return (0, 0);
+            return (0, 0, 0, 0, 0);
         }
 
         // The input Frac layer is counted separately by `input_memory_bytes`.
@@ -127,14 +137,18 @@ impl FractionalGkrMemoryModel {
             .saturating_mul(self.extension_degree)
             .saturating_mul(self.base_field_bytes);
         let fold_eval = Self::fold_eval_work_buffer_elements(logical_len).saturating_mul(frac_size);
-        let precompute_m = Self::precompute_m_work_buffer_elements(logical_len)
-            .saturating_mul(frac_size)
-            .saturating_add(self.precompute_m_auxiliary_memory_bytes(logical_len));
-
+        let precompute_m =
+            Self::precompute_m_work_buffer_elements(logical_len).saturating_mul(frac_size);
+        let default_precompute_aux = self.precompute_m_auxiliary_memory_bytes(logical_len);
+        let max_tuned_precompute_aux =
+            self.max_tuned_precompute_m_auxiliary_memory_bytes(logical_len);
         let common_aux = self.common_auxiliary_memory_bytes(logical_len);
         (
-            fold_eval.saturating_add(common_aux),
-            precompute_m.saturating_add(common_aux),
+            fold_eval,
+            precompute_m,
+            default_precompute_aux,
+            max_tuned_precompute_aux,
+            common_aux,
         )
     }
 
@@ -213,6 +227,50 @@ impl FractionalGkrMemoryModel {
                 continue;
             }
 
+            let m_len = 1usize << (2 * Self::WINDOW_SIZE);
+            max_partial_len = max(max_partial_len, num_blocks.saturating_mul(m_len));
+        }
+
+        max_partial_len
+    }
+
+    #[inline]
+    fn max_tuned_precompute_m_auxiliary_memory_bytes(&self, logical_len: usize) -> usize {
+        let ext_size = self.extension_degree.saturating_mul(self.base_field_bytes);
+        let max_partial_len = Self::max_tuned_precompute_m_partial_buffer_elements(logical_len);
+        if max_partial_len == 0 {
+            return 0;
+        }
+
+        let precompute_ef_elements =
+            (1usize << (2 * Self::WINDOW_SIZE)) + (1usize << (Self::WINDOW_SIZE + 1));
+        precompute_ef_elements
+            .saturating_add(max_partial_len)
+            .saturating_mul(ext_size)
+    }
+
+    #[inline]
+    fn max_tuned_precompute_m_partial_buffer_elements(logical_len: usize) -> usize {
+        let Some(total_rounds) = Self::log2_len(logical_len) else {
+            return 0;
+        };
+
+        let mut max_partial_len = 0usize;
+        for round in 1..total_rounds {
+            let stop = round.div_ceil(2);
+            if stop <= 1 {
+                continue;
+            }
+
+            let rem_n = round - 1;
+            let rounds_left = stop - 1;
+            if rem_n < Self::WINDOW_SIZE || rounds_left < Self::WINDOW_SIZE {
+                continue;
+            }
+
+            let tail_n = rem_n - Self::WINDOW_SIZE;
+            let tail_points = 1usize << tail_n;
+            let num_blocks = tail_points.div_ceil(Self::PRECOMPUTE_M_MIN_TAIL_TILE);
             let m_len = 1usize << (2 * Self::WINDOW_SIZE);
             max_partial_len = max(max_partial_len, num_blocks.saturating_mul(m_len));
         }

--- a/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
+++ b/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
@@ -81,22 +81,40 @@ impl FractionalGkrMemoryModel {
 
     #[inline]
     pub fn peak_work_buffer_memory_bytes(&self, logical_len: usize) -> usize {
+        let (fold_eval, precompute_m) = self.work_buffer_memory_candidates(logical_len);
+        max(fold_eval, precompute_m)
+    }
+
+    #[inline]
+    pub fn peak_work_buffer_memory_bytes_with_precompute_m(
+        &self,
+        logical_len: usize,
+        precompute_m_enabled: bool,
+    ) -> usize {
+        let (fold_eval, precompute_m) = self.work_buffer_memory_candidates(logical_len);
+        if precompute_m_enabled {
+            precompute_m
+        } else {
+            fold_eval
+        }
+    }
+
+    #[inline]
+    fn work_buffer_memory_candidates(&self, logical_len: usize) -> (usize, usize) {
         if logical_len <= 2 {
-            return 0;
+            return (0, 0);
         }
 
-        // Peak scratch is the larger of the fold-eval work buffer and the precompute-M path.
         // The input Frac layer is counted separately by `input_memory_bytes`.
         let frac_size = Self::INPUT_EF_ELEMENTS_PER_INTERACTION
             .saturating_mul(self.extension_degree)
             .saturating_mul(self.base_field_bytes);
         let fold_eval = Self::fold_eval_work_buffer_elements(logical_len).saturating_mul(frac_size);
+        let precompute_m = Self::precompute_m_work_buffer_elements(logical_len)
+            .saturating_mul(frac_size)
+            .saturating_add(self.precompute_m_auxiliary_memory_bytes());
 
-        let precompute_f =
-            Self::precompute_m_work_buffer_elements(logical_len).saturating_mul(frac_size);
-        let precompute_ef = self.precompute_m_auxiliary_memory_bytes();
-
-        max(fold_eval, precompute_f.saturating_add(precompute_ef))
+        (fold_eval, precompute_m)
     }
 
     #[inline]
@@ -125,6 +143,18 @@ impl FractionalGkrMemoryModel {
     pub fn peak_memory_bytes(&self, interaction_cells: usize, logical_len: usize) -> usize {
         self.input_memory_bytes(interaction_cells)
             .saturating_add(self.peak_work_buffer_memory_bytes(logical_len))
+    }
+
+    #[inline]
+    pub fn peak_memory_bytes_with_precompute_m(
+        &self,
+        interaction_cells: usize,
+        logical_len: usize,
+        precompute_m_enabled: bool,
+    ) -> usize {
+        self.input_memory_bytes(interaction_cells).saturating_add(
+            self.peak_work_buffer_memory_bytes_with_precompute_m(logical_len, precompute_m_enabled),
+        )
     }
 
     #[inline]

--- a/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
+++ b/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
@@ -47,6 +47,19 @@ pub struct FractionalGkrMemoryModel {
     extension_degree: usize,
 }
 
+/// Fractional-GKR work-buffer strategy selected by the CUDA backend.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FractionalGkrWorkBufferStrategy {
+    /// Use the larger of the fold-eval and default precompute-M allocations.
+    #[default]
+    Conservative,
+    /// Precompute-M is disabled, so CUDA allocates the fold-eval work buffer.
+    FoldEval,
+    /// Precompute-M is enabled with default tuning.
+    PrecomputeM,
+}
+
 impl FractionalGkrMemoryModel {
     const INPUT_EF_ELEMENTS_PER_INTERACTION: usize = 2;
     pub const WINDOW_SIZE: usize = 3;
@@ -66,7 +79,7 @@ impl FractionalGkrMemoryModel {
     }
 
     #[inline]
-    pub fn logical_len(interaction_cells: usize) -> usize {
+    pub(crate) fn logical_len(interaction_cells: usize) -> usize {
         if interaction_cells == 0 {
             return 0;
         }
@@ -76,7 +89,7 @@ impl FractionalGkrMemoryModel {
     }
 
     #[inline]
-    pub fn input_memory_bytes(&self, interaction_cells: usize) -> usize {
+    pub(crate) fn input_memory_bytes(&self, interaction_cells: usize) -> usize {
         interaction_cells
             .saturating_mul(Self::INPUT_EF_ELEMENTS_PER_INTERACTION)
             .saturating_mul(self.extension_degree)
@@ -90,16 +103,16 @@ impl FractionalGkrMemoryModel {
     }
 
     #[inline]
-    pub fn peak_work_buffer_memory_bytes_with_precompute_m(
+    pub fn peak_work_buffer_memory_bytes_with_strategy(
         &self,
         logical_len: usize,
-        precompute_m_enabled: bool,
+        strategy: FractionalGkrWorkBufferStrategy,
     ) -> usize {
         let (fold_eval, precompute_m) = self.work_buffer_memory_candidates(logical_len);
-        if precompute_m_enabled {
-            precompute_m
-        } else {
-            fold_eval
+        match strategy {
+            FractionalGkrWorkBufferStrategy::Conservative => max(fold_eval, precompute_m),
+            FractionalGkrWorkBufferStrategy::FoldEval => fold_eval,
+            FractionalGkrWorkBufferStrategy::PrecomputeM => precompute_m,
         }
     }
 
@@ -127,12 +140,16 @@ impl FractionalGkrMemoryModel {
 
     #[inline]
     pub fn fold_eval_work_buffer_elements(logical_len: usize) -> usize {
+        if logical_len <= 4 {
+            return 0;
+        }
+
         logical_len / 4
     }
 
     #[inline]
     pub fn precompute_m_work_buffer_elements(logical_len: usize) -> usize {
-        if logical_len <= 2 {
+        if logical_len <= 4 {
             return 0;
         }
 
@@ -140,8 +157,12 @@ impl FractionalGkrMemoryModel {
     }
 
     #[inline]
-    pub fn precompute_m_auxiliary_memory_bytes(&self, logical_len: usize) -> usize {
+    fn precompute_m_auxiliary_memory_bytes(&self, logical_len: usize) -> usize {
         let ext_size = self.extension_degree.saturating_mul(self.base_field_bytes);
+        if !Self::has_default_precompute_m_window(logical_len) {
+            return 0;
+        }
+
         // m_buffer has 4^w EF entries; prefix/suffix buffers each have 2^w EF entries.
         // m_partial_buffer is retained across rounds and uses the same default tail tiling as CUDA.
         let precompute_ef_elements =
@@ -200,6 +221,11 @@ impl FractionalGkrMemoryModel {
     }
 
     #[inline]
+    fn has_default_precompute_m_window(logical_len: usize) -> bool {
+        Self::precompute_m_partial_buffer_elements(logical_len) != 0
+    }
+
+    #[inline]
     fn sqrt_eq_layers_elements(logical_len: usize) -> usize {
         let Some(total_rounds) = Self::log2_len(logical_len) else {
             return 0;
@@ -220,21 +246,14 @@ impl FractionalGkrMemoryModel {
     }
 
     #[inline]
-    pub fn peak_memory_bytes(&self, interaction_cells: usize, logical_len: usize) -> usize {
-        self.input_memory_bytes(interaction_cells)
-            .saturating_add(self.peak_work_buffer_memory_bytes(logical_len))
-    }
-
-    #[inline]
-    pub fn peak_memory_bytes_with_precompute_m(
+    pub(crate) fn peak_memory_bytes_with_strategy(
         &self,
         interaction_cells: usize,
         logical_len: usize,
-        precompute_m_enabled: bool,
+        strategy: FractionalGkrWorkBufferStrategy,
     ) -> usize {
-        self.input_memory_bytes(interaction_cells).saturating_add(
-            self.peak_work_buffer_memory_bytes_with_precompute_m(logical_len, precompute_m_enabled),
-        )
+        self.input_memory_bytes(interaction_cells)
+            .saturating_add(self.peak_work_buffer_memory_bytes_with_strategy(logical_len, strategy))
     }
 
     #[inline]

--- a/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
+++ b/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
@@ -47,6 +47,15 @@ pub struct FractionalGkrMemoryModel {
     extension_degree: usize,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct WorkBufferMemoryCandidates {
+    fold_eval: usize,
+    precompute_m: usize,
+    default_precompute_aux: usize,
+    max_tuned_precompute_aux: usize,
+    common_aux: usize,
+}
+
 /// Fractional-GKR work-buffer strategy selected by the CUDA backend.
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -110,26 +119,26 @@ impl FractionalGkrMemoryModel {
         logical_len: usize,
         strategy: FractionalGkrWorkBufferStrategy,
     ) -> usize {
-        let (fold_eval, precompute_m, default_precompute_aux, max_tuned_precompute_aux, common_aux) =
-            self.work_buffer_memory_candidates(logical_len);
+        let candidates = self.work_buffer_memory_candidates(logical_len);
         match strategy {
-            FractionalGkrWorkBufferStrategy::Conservative => common_aux
-                .saturating_add(max(fold_eval, precompute_m))
-                .saturating_add(max_tuned_precompute_aux),
-            FractionalGkrWorkBufferStrategy::FoldEval => common_aux.saturating_add(fold_eval),
-            FractionalGkrWorkBufferStrategy::PrecomputeM => common_aux
-                .saturating_add(precompute_m)
-                .saturating_add(default_precompute_aux),
+            FractionalGkrWorkBufferStrategy::Conservative => candidates
+                .common_aux
+                .saturating_add(max(candidates.fold_eval, candidates.precompute_m))
+                .saturating_add(candidates.max_tuned_precompute_aux),
+            FractionalGkrWorkBufferStrategy::FoldEval => {
+                candidates.common_aux.saturating_add(candidates.fold_eval)
+            }
+            FractionalGkrWorkBufferStrategy::PrecomputeM => candidates
+                .common_aux
+                .saturating_add(candidates.precompute_m)
+                .saturating_add(candidates.default_precompute_aux),
         }
     }
 
     #[inline]
-    fn work_buffer_memory_candidates(
-        &self,
-        logical_len: usize,
-    ) -> (usize, usize, usize, usize, usize) {
+    fn work_buffer_memory_candidates(&self, logical_len: usize) -> WorkBufferMemoryCandidates {
         if logical_len <= 2 {
-            return (0, 0, 0, 0, 0);
+            return WorkBufferMemoryCandidates::default();
         }
 
         // The input Frac layer is counted separately by `input_memory_bytes`.
@@ -143,13 +152,13 @@ impl FractionalGkrMemoryModel {
         let max_tuned_precompute_aux =
             self.max_tuned_precompute_m_auxiliary_memory_bytes(logical_len);
         let common_aux = self.common_auxiliary_memory_bytes(logical_len);
-        (
+        WorkBufferMemoryCandidates {
             fold_eval,
             precompute_m,
             default_precompute_aux,
             max_tuned_precompute_aux,
             common_aux,
-        )
+        }
     }
 
     #[inline]

--- a/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
+++ b/crates/stark-backend/src/prover/logup_zerocheck/fractional_sumcheck_gkr.rs
@@ -51,6 +51,10 @@ impl FractionalGkrMemoryModel {
     const INPUT_EF_ELEMENTS_PER_INTERACTION: usize = 2;
     pub const WINDOW_SIZE: usize = 3;
     pub const WINDOW_DEFAULT_MIN_N: usize = 22;
+    pub const PRECOMPUTE_M_MIN_TAIL_TILE: usize = 256;
+    pub const PRECOMPUTE_M_DEFAULT_TAIL_TILE: usize = 4096;
+    pub const PRECOMPUTE_M_DEFAULT_MIN_BLOCKS: usize = 64;
+    pub const PRECOMPUTE_M_DEFAULT_TARGET_BLOCKS: usize = 1024;
     pub const ROUND_COMPUTE_FALLBACK_BLOCKS: usize = 228;
 
     #[inline]
@@ -112,9 +116,13 @@ impl FractionalGkrMemoryModel {
         let fold_eval = Self::fold_eval_work_buffer_elements(logical_len).saturating_mul(frac_size);
         let precompute_m = Self::precompute_m_work_buffer_elements(logical_len)
             .saturating_mul(frac_size)
-            .saturating_add(self.precompute_m_auxiliary_memory_bytes());
+            .saturating_add(self.precompute_m_auxiliary_memory_bytes(logical_len));
 
-        (fold_eval, precompute_m)
+        let common_aux = self.common_auxiliary_memory_bytes(logical_len);
+        (
+            fold_eval.saturating_add(common_aux),
+            precompute_m.saturating_add(common_aux),
+        )
     }
 
     #[inline]
@@ -132,11 +140,83 @@ impl FractionalGkrMemoryModel {
     }
 
     #[inline]
-    pub fn precompute_m_auxiliary_memory_bytes(&self) -> usize {
+    pub fn precompute_m_auxiliary_memory_bytes(&self, logical_len: usize) -> usize {
         let ext_size = self.extension_degree.saturating_mul(self.base_field_bytes);
+        // m_buffer has 4^w EF entries; prefix/suffix buffers each have 2^w EF entries.
+        // m_partial_buffer is retained across rounds and uses the same default tail tiling as CUDA.
         let precompute_ef_elements =
-            (1usize << (2 * Self::WINDOW_SIZE + 1)) + (1usize << (Self::WINDOW_SIZE + 1));
-        precompute_ef_elements.saturating_mul(ext_size)
+            (1usize << (2 * Self::WINDOW_SIZE)) + (1usize << (Self::WINDOW_SIZE + 1));
+        precompute_ef_elements
+            .saturating_add(Self::precompute_m_partial_buffer_elements(logical_len))
+            .saturating_mul(ext_size)
+    }
+
+    #[inline]
+    fn common_auxiliary_memory_bytes(&self, logical_len: usize) -> usize {
+        let ext_size = self.extension_degree.saturating_mul(self.base_field_bytes);
+        // SqrtEqLayers and the tiny d_sum_evals/copy_scratch buffers are live with both strategies.
+        Self::sqrt_eq_layers_elements(logical_len)
+            .saturating_add(4)
+            .saturating_mul(ext_size)
+    }
+
+    #[inline]
+    fn precompute_m_partial_buffer_elements(logical_len: usize) -> usize {
+        let Some(total_rounds) = Self::log2_len(logical_len) else {
+            return 0;
+        };
+
+        let mut max_partial_len = 0usize;
+        for round in 1..total_rounds {
+            let stop = round.div_ceil(2);
+            if stop <= 1 {
+                continue;
+            }
+
+            let rem_n = round - 1;
+            let rounds_left = stop - 1;
+            if rem_n < Self::WINDOW_DEFAULT_MIN_N || rounds_left < Self::WINDOW_SIZE {
+                continue;
+            }
+
+            let tail_n = rem_n - Self::WINDOW_SIZE;
+            let tail_points = 1usize << tail_n;
+            let target_blocks =
+                Self::PRECOMPUTE_M_DEFAULT_TARGET_BLOCKS.max(Self::PRECOMPUTE_M_DEFAULT_MIN_BLOCKS);
+            let tail_tile = tail_points.div_ceil(target_blocks).max(1).clamp(
+                Self::PRECOMPUTE_M_MIN_TAIL_TILE,
+                Self::PRECOMPUTE_M_DEFAULT_TAIL_TILE,
+            );
+            let num_blocks = tail_points.div_ceil(tail_tile);
+            if num_blocks < Self::PRECOMPUTE_M_DEFAULT_MIN_BLOCKS {
+                continue;
+            }
+
+            let m_len = 1usize << (2 * Self::WINDOW_SIZE);
+            max_partial_len = max(max_partial_len, num_blocks.saturating_mul(m_len));
+        }
+
+        max_partial_len
+    }
+
+    #[inline]
+    fn sqrt_eq_layers_elements(logical_len: usize) -> usize {
+        let Some(total_rounds) = Self::log2_len(logical_len) else {
+            return 0;
+        };
+
+        // In outer round `r`, CUDA builds layers for `xi_prev[1..]`, length `r - 1`.
+        // EqEvalLayers keeps every layer 1, 2, ..., 2^n; the shared length-1 seed is counted once.
+        let n = total_rounds - 2;
+        let low_n = n / 2;
+        let high_n = n - low_n;
+        ((1usize << (low_n + 1)) - 1).saturating_add((1usize << (high_n + 1)) - 2)
+    }
+
+    #[inline]
+    fn log2_len(logical_len: usize) -> Option<usize> {
+        (logical_len > 2 && logical_len.is_power_of_two())
+            .then_some(logical_len.trailing_zeros() as usize)
     }
 
     #[inline]

--- a/docs/cuda-backend/gkr-prover.md
+++ b/docs/cuda-backend/gkr-prover.md
@@ -345,7 +345,7 @@ Total GPU memory required (workspace + input leaves `2^n * |Frac| = 2^(n+1) * |E
   - `n = 29`: `< 16.63 GiB`
   - `n = 30`: `< 33.25 GiB`
 
-If precompute-M is disabled, `work_buffer = 2^(n-2) * |Frac|`. If hidden precompute-M
+If precompute-M is disabled, `work_buffer = 2^(n-2) * |Frac|`. If non-default precompute-M
 tuning env vars are set, batching uses the larger of the fold-eval and default precompute-M work
 buffer estimates, plus a worst-case precompute-M auxiliary buffer using the minimum clamped
 `tail_tile = 256`.

--- a/docs/cuda-backend/gkr-prover.md
+++ b/docs/cuda-backend/gkr-prover.md
@@ -346,8 +346,8 @@ Total GPU memory required (workspace + input leaves `2^n * |Frac| = 2^(n+1) * |E
   - `n = 30`: `< 33.25 GiB`
 
 If precompute-M is disabled, `work_buffer = 2^(n-2) * |Frac|`. If non-default precompute-M
-tuning env vars are set, CUDA reserves the larger of the fold-eval and default precompute-M work
-buffers because tuned thresholds can make non-last rounds fall back to fold-eval. Metering also
-adds a worst-case precompute-M auxiliary buffer using the minimum clamped `tail_tile = 256`.
+tuning env vars are set, metering uses the larger of the fold-eval and default precompute-M work
+buffers because tuned thresholds can make non-last rounds fall back to fold-eval. It also adds a
+worst-case precompute-M auxiliary buffer using the minimum clamped `tail_tile = 256`.
 
 Dominant term is the input leaves (`2^(n+1) * |EF|`). With default precompute-M, workspace overhead is ~3%.

--- a/docs/cuda-backend/gkr-prover.md
+++ b/docs/cuda-backend/gkr-prover.md
@@ -318,29 +318,36 @@ Let:
 - `w = GKR_WINDOW_SIZE` (default `w = 3`)
 - `|EF| = sizeof(EF)` bytes
 - `|Frac| = sizeof(Frac<EF>) = 2 * |EF|`
-- Assume `n` is large
-- Assume precompute-M is active
+- Assume `n` is large and default precompute-M tuning is active
 
 Buffers used at peak (workspace only; excludes input `layer`/leaves):
 - `work_buffer`: `2^(n-w-2) * |Frac|` (precompute-M defers `w+1` folds before first write)
 - `copy_scratch`: `1 * |Frac|`
 - `d_sum_evals`: `2 * |EF|`
-- `tmp_block_sums`: `< 2^(n-7) * |EF|`
 - `eq_buffer` (`SqrtEqLayers`): `(2^floor(n/2) + 2^ceil(n/2) - 2) * |EF|`
 - `m_buffer`: `4^w * |EF|` (default `w=3` gives `64 * |EF|`)
 - `m_partial_buffer`: `num_blocks * 4^w * |EF|`, with `num_blocks <= 2^(n-w-10)` for large `n`, so `< 2^(n+w-10) * |EF|`
 - `eq_r_prefix_buffer` + `eq_suffix_buffer`: `2^(w+1) * |EF|` (default `w=3` gives `16 * |EF|`)
 
 Workspace upper bound (sum of the buffers above), using `|Frac| = 2 * |EF|`:
-- `W < (2^(n-w-1) + 2^(n-7) + 2^(n+w-10) + 2^floor(n/2) + 2^ceil(n/2) + 4^w + 2^(w+1) + 2) * |EF|`
+- `W < (2^(n-w-1) + 2^(n+w-10) + 2^floor(n/2) + 2^ceil(n/2) + 4^w + 2^(w+1) + 2) * |EF|`
+
+The metering code adds the round-reduction scratch separately:
+- `round_temp_buffer = _frac_compute_round_temp_buffer_size(2^(n-1)) * |EF|`
+- `interaction_overhead = max(2 MiB, round_temp_buffer)`
 
 Total GPU memory required (workspace + input leaves `2^n * |Frac| = 2^(n+1) * |EF|`):
-- `M_total < (2^(n+1) + 2^(n-w-1) + 2^(n-7) + 2^(n+w-10) + 2^floor(n/2) + 2^ceil(n/2) + 4^w + 2^(w+1) + 2) * |EF|`
+- `M_total < 2^(n+1) * |EF| + W + interaction_overhead`
 - With default `w = 3` and `|EF| = 16` bytes:
-  - `M_total < (2^(n+1) + 2^(n-4) + 2^(n-6) + 2^floor(n/2) + 2^ceil(n/2) + 82) / 2^26 GiB`
+  - excluding `interaction_overhead`, `2^(n+1) * |EF| + W < (2^(n+1) + 2^(n-4) + 2^(n-7) + 2^floor(n/2) + 2^ceil(n/2) + 82) / 2^26 GiB`
   - `n = 27`: `M_total < 4.16 GiB`
   - `n = 28`: `M_total < 8.31 GiB`
   - `n = 29`: `M_total < 16.63 GiB`
   - `n = 30`: `M_total < 33.25 GiB`
 
-Dominant term is the input leaves (`2^(n+1) * |EF|`). Workspace overhead is ~4%.
+If precompute-M is disabled, `work_buffer = 2^(n-2) * |Frac|`. If hidden precompute-M
+tuning env vars are set, batching uses the larger of the fold-eval and default precompute-M work
+buffer estimates, plus a worst-case precompute-M auxiliary buffer using the minimum clamped
+`tail_tile = 256`.
+
+Dominant term is the input leaves (`2^(n+1) * |EF|`). With default precompute-M, workspace overhead is ~3%.

--- a/docs/cuda-backend/gkr-prover.md
+++ b/docs/cuda-backend/gkr-prover.md
@@ -346,8 +346,8 @@ Total GPU memory required (workspace + input leaves `2^n * |Frac| = 2^(n+1) * |E
   - `n = 30`: `< 33.25 GiB`
 
 If precompute-M is disabled, `work_buffer = 2^(n-2) * |Frac|`. If non-default precompute-M
-tuning env vars are set, batching uses the larger of the fold-eval and default precompute-M work
-buffer estimates, plus a worst-case precompute-M auxiliary buffer using the minimum clamped
-`tail_tile = 256`.
+tuning env vars are set, CUDA reserves the larger of the fold-eval and default precompute-M work
+buffers because tuned thresholds can make non-last rounds fall back to fold-eval. Metering also
+adds a worst-case precompute-M auxiliary buffer using the minimum clamped `tail_tile = 256`.
 
 Dominant term is the input leaves (`2^(n+1) * |EF|`). With default precompute-M, workspace overhead is ~3%.

--- a/docs/cuda-backend/gkr-prover.md
+++ b/docs/cuda-backend/gkr-prover.md
@@ -340,10 +340,10 @@ Total GPU memory required (workspace + input leaves `2^n * |Frac| = 2^(n+1) * |E
 - `M_total < 2^(n+1) * |EF| + W + interaction_overhead`
 - With default `w = 3` and `|EF| = 16` bytes:
   - excluding `interaction_overhead`, `2^(n+1) * |EF| + W < (2^(n+1) + 2^(n-4) + 2^(n-7) + 2^floor(n/2) + 2^ceil(n/2) + 82) / 2^26 GiB`
-  - `n = 27`: `M_total < 4.16 GiB`
-  - `n = 28`: `M_total < 8.31 GiB`
-  - `n = 29`: `M_total < 16.63 GiB`
-  - `n = 30`: `M_total < 33.25 GiB`
+  - `n = 27`: `< 4.16 GiB`
+  - `n = 28`: `< 8.31 GiB`
+  - `n = 29`: `< 16.63 GiB`
+  - `n = 30`: `< 33.25 GiB`
 
 If precompute-M is disabled, `work_buffer = 2^(n-2) * |Frac|`. If hidden precompute-M
 tuning env vars are set, batching uses the larger of the fold-eval and default precompute-M work


### PR DESCRIPTION
## Summary

Follow-up to #367. That PR made CUDA proving memory estimates more faithful, but the fractional-GKR interaction estimate still overcharged default CUDA runs by treating two mutually exclusive work-buffer paths as if the larger path always applied:

- fold-eval work buffer: `logical_len / 4` `Frac` elements
- precompute-M work buffer: `max(logical_len >> (1 + GKR_WINDOW_SIZE), 2^GKR_WINDOW_DEFAULT_MIN_N)` `Frac` elements, plus EF auxiliary buffers

CUDA defaults to precompute-M through `SWIRL_CUDA_GKR_PRECOMPUTE_M`, so default proving should meter the precompute-M budget instead of the fold-eval budget. This PR wires the CUDA-selected fractional-GKR strategy into `ProvingMemoryConfig` and keeps the generic `openvm-stark-backend` default conservative.

This is a metering change. The CUDA prover's batching budget, fractional-GKR work-buffer allocation, kernels, transcript/proof logic, and GKR scheduling stay on their existing paths. The selected CUDA strategy is only passed into `ProvingMemoryConfig`.

For non-default precompute-M tuning env vars, metering stays conservative because tuned thresholds can make non-last rounds fall back to fold-eval while precompute-M is globally enabled. That conservative tuned-env estimate does not change the prover allocation path.

The PR also keeps the more precise WHIR first-opening overlap model in `memory_metering.rs`, and adds serde compatibility for the new private metering field.

To cover CUDA resident memory that is not represented by per-segment trace/protocol counts, the CUDA backend now reports raw retained proving-key allocation sizes. `ProvingMemoryConfig` applies CUDA allocation rounding and incorporates the retained total into the segment estimate. This keeps the dependency direction as metering depending on backend allocation shape, not the prover depending on memory-metering config. The retained allocation walk counts retained PCS/tree/rule buffers and does not count the preprocessed trace buffer separately, since opened trace memory is already represented by the segment main-memory estimate.

## Validation

Local:

- `cargo +nightly fmt -- --check`
- `git diff --check`
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 cargo check -p openvm-stark-backend`
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 cargo test -p openvm-stark-backend memory_metering --features test-utils`
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 cargo clippy -p openvm-stark-backend --all-targets --tests -- -D warnings`

CUDA backend:

- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 cargo check -p openvm-cuda-backend`
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 cargo clippy -p openvm-cuda-backend --all-targets --tests -- -D warnings`

OpenVM integration check with the matching metering call-site:

- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 cargo check -p openvm-circuit`
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 cargo clippy -p openvm-circuit --all-targets --tests -- -D warnings`

openvm-eth, `execute-metered`, block `23992138`:

- CUDA backend enabled: yes
- completed: yes
- segments: `88`
- memory utilization over 88 segments: min `61.65%`, avg `78.25%`, max `97.87%`

openvm-eth, `prove-app`, `--segment-max-memory 16106127360`, with the matching OpenVM metering integration:

| Block | Segments | Max metered segment | Max CUDA-tracked peak | Peak minus max segment |
|---|---:|---:|---:|---:|
| `23992138` | `88` | `16,106,105,376` bytes | `15,391,912,044` bytes | `-714,193,332` bytes |
| `25399321` | `163` | `16,102,877,728` bytes | `15,822,868,764` bytes | `-280,008,964` bytes |

The maximum metered segment remains at or below the configured 15 GiB cap. The observed CUDA-tracked prover peak is below the corresponding segment estimate for both the default representative block and the heavier block.

The peak in both prove runs occurs during `prover.logup_zerocheck_prover:after_fractional_sumcheck_gkr`, so the remaining high-water mark is from the expected fractional-GKR proving phase plus resident main/proving-key state, not from metered execution allocating GPU buffers.

This recovers the reported regression from about `115` segments back to `88` for the representative default block while preserving the safer retained-memory accounting from #367.

### Benchmark runs

[block 23992138](https://github.com/axiom-crypto/openvm-eth/actions/runs/28465393386)
[block 25399321](https://github.com/axiom-crypto/openvm-eth/actions/runs/28465411633)
