### PR TITLE
fix: account for missing GPU allocations in proving memory estimates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,9 @@ Non-default CUDA support members (require GPU/CUDA toolchain — don't add to de
 
 Non-default benchmark workspace members:
 - **`openvm-benchmarks-fields`** (`benchmarks/fields`): CUDA field-extension and Poseidon2 benchmarks and verification tests.
-- **`openvm-benchmark-synthetic`** (`benchmarks/synthetic`): Synthetic AIR benchmark suite, including the champ-vs-candidate profile replay workflow documented in its README.
+- **`openvm-benchmark-synthetic`** (`benchmarks/synthetic`): Synthetic AIR benchmark suite, including the champ-vs-candidate profile replay workflow and the `mem_meter_runner` memory-metering validation runner documented in its README.
 
-When changing CUDA fractional-GKR buffer layout, scheduling, or scratch allocations, update the interaction memory estimate in `crates/stark-backend/src/memory_metering.rs` and the accounting in `docs/cuda-backend/gkr-prover.md`.
+When changing GPU buffer layout, scheduling, or scratch allocations in any proving phase — fractional-GKR, batch-constraint/batch-MLE, stacking/RS encoding, or WHIR opening — update the proving memory model in `crates/stark-backend/src/memory_metering.rs` (see `ProvingMemoryConfig::estimate` and the mirrored constants documented there), and validate against measured peaks with `mem_meter_runner`. For GKR changes, also update the accounting in `docs/cuda-backend/gkr-prover.md`.
 
 Plonky3 crates are exact-version crates.io dependencies pinned in the workspace `Cargo.toml`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+- Proving memory estimates (`memory_metering`) no longer under-estimate the observed peak GPU memory: the estimate now accounts for the WHIR opening working set (commitment Merkle layers, round-0 codeword and tree, scratch) that coexists with the Reed-Solomon code matrix, stacking width round-up in the RS code matrix, the fractional-GKR work-buffer floor, batch-constraint scratch (additive on `main_secondary` when `zerocheck_save_memory` is off), and the resident stacked matrix when `cache_stacked_matrix` is on.
+
+### Added
+- `tracked_memory_stats`/`reset_session_peak` in `openvm-cuda-common` for peak GPU memory measurement that survives phase-level peak resets.
+- `mem_meter_runner` benchmark binary that replays captured segment profiles on the GPU and compares the memory-metering estimate against the measured peak.
+
 ## v2.0.0 (2026-07-06)
 
 ### Added

--- a/benchmarks/synthetic/Cargo.toml
+++ b/benchmarks/synthetic/Cargo.toml
@@ -21,9 +21,13 @@ p3-matrix.workspace = true
 
 clap = { workspace = true }
 eyre = { workspace = true }
+metrics = { workspace = true }
+metrics-util = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["std", "env-filter", "fmt"] }
 
 [features]
 default = []
@@ -34,6 +38,12 @@ baby-bear-bn254-poseidon2 = ["openvm-cuda-backend?/baby-bear-bn254-poseidon2"]
 # GPU-only (imports openvm-cuda-backend unconditionally).
 [[bin]]
 name = "synthetic_runner"
+required-features = ["cuda"]
+
+# Memory-metering validation runner: replays profile segments and compares the
+# `memory_metering` estimate against the measured peak GPU memory.
+[[bin]]
+name = "mem_meter_runner"
 required-features = ["cuda"]
 
 [[bin]]

--- a/benchmarks/synthetic/README.md
+++ b/benchmarks/synthetic/README.md
@@ -6,14 +6,15 @@ a "kill column" — every constraint multiplies by it, every interaction
 count uses it). Proof validity is not exercised end-to-end; rely on
 the cuda-backend test suite for correctness.
 
-Two binaries:
+Three binaries:
 
 | Binary             | Use case                                         | Inputs                          |
 |--------------------|--------------------------------------------------|---------------------------------|
 | `synthetic_runner` | Replay a captured workload's segment shapes for champ-vs-candidate iteration on `openvm-cuda-backend` changes. | A profile JSONL from the `SHADOW_BENCH_PROFILE_PATH` probe. |
+| `mem_meter_runner` | Replay segment shapes and compare the `memory_metering` proving-memory estimate against the measured peak GPU memory, with per-phase attribution. | Same profile JSONL. |
 | `uniform_runner`   | Sweep cost dimensions with N identical AIRs.     | CLI flags (num AIRs, cols/AIR, constraints/col, etc.). |
 
-`synthetic_runner` is GPU-only (`required-features = ["cuda"]`).
+`synthetic_runner` and `mem_meter_runner` are GPU-only (`required-features = ["cuda"]`).
 `uniform_runner` runs CPU by default; build with `--features cuda` for GPU.
 
 ## What's in here
@@ -25,6 +26,7 @@ Two binaries:
 | `src/synthetic_air.rs`              | `SyntheticAir` / `SyntheticShape` — kernel-cost-faithful replay AIR.     |
 | `src/segment_profile.rs`            | Deserialization types (`SegmentProfile`, `AirShapeRecord`) for the JSONL. |
 | `src/bin/synthetic_runner.rs`       | Profile-replay runner.                                                  |
+| `src/bin/mem_meter_runner.rs`       | Memory-metering validation runner.                                      |
 | `src/bin/uniform_runner.rs`         | Uniform-shape runner.                                                   |
 
 ## `synthetic_runner` — profile replay
@@ -167,6 +169,46 @@ processes.
 is the figure of merit for champ-vs-candidate comparison.
 `skipped_segments` should be `0`; non-zero means a prove call returned
 an error and that segment's timing was excluded.
+
+## `mem_meter_runner` — memory-metering validation
+
+Replays profile segments like `synthetic_runner`, but instead of timing
+it compares the proving-memory estimate from
+`openvm_stark_backend::memory_metering` against the actual peak GPU
+memory tracked by the cuda-common memory manager. Per segment it
+replicates OpenVM's metered cell counting (`padded_height *
+total_width` split by `need_rot`, plus `padded_height *
+num_interactions`), calls `estimate()`, proves, and records the
+measured peak (via `tracked_memory_stats`/`reset_session_peak`) with
+per-phase attribution from the `gpu_mem.*` gauges that `MemTracker`
+emits.
+
+Segments whose max constraint degree exceeds the params limit are
+skipped (keygen would reject them). GPU-only.
+
+```bash
+cargo build --release -p openvm-benchmark-synthetic --features cuda --bin mem_meter_runner
+
+target/release/mem_meter_runner \
+  --profile benchmarks/synthetic/reth-block-23992138-profile.jsonl \
+  --sample-frac 0.2 --seed 7 --max-log-height 22 \
+  --out mem-report.jsonl
+```
+
+Extra knobs: `--segments 0,15,24` (explicit segment list overriding the
+sampler), `--zerocheck-save-memory <bool>` (defaults to the production
+coupling `log_blowup == 1`), `--cache-rs-code-matrix` (production
+default: off).
+
+`--out` is JSONL, written incrementally (crash-safe): one `RunHeader`
+line with the run configuration, then one line per segment containing
+the estimate breakdown (`total` / `main` / `rs_code_matrix` /
+`main_secondary` / `interaction` / cell counts), the measured
+`baseline_bytes` / `peak_bytes` / `phase_peaks`, and the
+`gap_bytes` / `peak_over_estimate` comparison. `peak_over_estimate >
+1` means the model under-estimated that segment. The console prints
+one summary line per segment plus a final count of underestimates and
+the worst ratio.
 
 ## `uniform_runner` — uniform-shape sweep
 

--- a/benchmarks/synthetic/src/bin/mem_meter_runner.rs
+++ b/benchmarks/synthetic/src/bin/mem_meter_runner.rs
@@ -6,11 +6,10 @@
 //! peak GPU memory tracked by the cuda-common memory manager.
 //!
 //! Per segment it reports:
-//! - the model estimate breakdown (main / rs_code_matrix / main_secondary /
-//!   interaction / secondary_peak / total),
-//! - the measured baseline before proving (device pk + traces), the measured
-//!   peak during proving, per-phase peaks from the `gpu_mem.*` gauges emitted
-//!   by `MemTracker`, and
+//! - the model estimate breakdown (main / rs_code_matrix / main_secondary / interaction /
+//!   secondary_peak / total),
+//! - the measured baseline before proving (device pk + traces), the measured peak during proving,
+//!   per-phase peaks from the `gpu_mem.*` gauges emitted by `MemTracker`, and
 //! - the estimate-vs-measured gap.
 //!
 //! Usage:

--- a/benchmarks/synthetic/src/bin/mem_meter_runner.rs
+++ b/benchmarks/synthetic/src/bin/mem_meter_runner.rs
@@ -1,0 +1,501 @@
+//! Memory-metering validation runner (cuda-backend / GPU).
+//!
+//! Replays captured segment profiles (same input as `synthetic_runner`) through
+//! `Coordinator::prove` on the GPU and compares the analytic proving-memory
+//! estimate from `openvm_stark_backend::memory_metering` against the actual
+//! peak GPU memory tracked by the cuda-common memory manager.
+//!
+//! Per segment it reports:
+//! - the model estimate breakdown (main / rs_code_matrix / main_secondary /
+//!   interaction / secondary_peak / total),
+//! - the measured baseline before proving (device pk + traces), the measured
+//!   peak during proving, per-phase peaks from the `gpu_mem.*` gauges emitted
+//!   by `MemTracker`, and
+//! - the estimate-vs-measured gap.
+//!
+//! Usage:
+//!     cargo run --release -p openvm-benchmark-synthetic \
+//!         --features cuda --bin mem_meter_runner -- \
+//!         --profile benchmarks/synthetic/reth-block-23992138-profile.jsonl \
+//!         --sample-frac 0.1 --seed 42 \
+//!         --max-log-height 22 \
+//!         --out benchmarks/synthetic/mem-report.json
+
+use std::{
+    collections::{BTreeMap, HashSet},
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use clap::Parser;
+use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
+use openvm_benchmark_synthetic::{
+    segment_profile::{AirShapeRecord, SegmentProfile},
+    synthetic_air::{SyntheticAir, SyntheticShape},
+};
+use openvm_cuda_backend::{DefaultHashScheme, GpuEngine};
+use openvm_cuda_common::memory_manager::{
+    device_memory_used, reset_session_peak, tracked_memory_stats,
+};
+use openvm_stark_backend::{
+    memory_metering::ProvingMemoryCounts,
+    prover::{
+        stacked_pcs::StackedLayout, AirProvingContext, ColMajorMatrix, DeviceDataTransporter,
+        ProvingContext,
+    },
+    AirRef, StarkEngine,
+};
+use openvm_stark_sdk::config::app_params_with_100_bits_security;
+use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct EstimateReport {
+    total: usize,
+    main: usize,
+    rs_code_matrix: usize,
+    main_secondary: usize,
+    interaction: usize,
+    secondary_peak: usize,
+    main_cells_with_rot: usize,
+    main_cells_without_rot: usize,
+    interaction_cells: usize,
+}
+
+#[derive(Serialize)]
+struct MeasuredReport {
+    /// Tracked bytes resident before `prove` (device pk + traces + transcript).
+    baseline_bytes: usize,
+    /// Peak tracked bytes during `prove` (absolute, includes baseline).
+    peak_bytes: usize,
+    /// Tracked bytes resident after `prove` returned.
+    after_bytes: usize,
+    /// `cudaMemGetInfo` used bytes before/after prove (whole device; catches
+    /// allocations that bypass the memory manager).
+    device_used_before: usize,
+    device_used_after: usize,
+    /// Absolute `gpu_mem.local_peak_bytes` gauge per MemTracker module label.
+    phase_peaks: BTreeMap<String, u64>,
+}
+
+#[derive(Serialize)]
+struct SegmentReport {
+    segment_idx: usize,
+    num_airs: usize,
+    clamped: bool,
+    /// Sum of `height * width` over the traces actually transported (bytes = cells * 4).
+    trace_bytes: usize,
+    /// Stacked-matrix layout of the common-main commit: `2^(l_skip+n_stack)` height and the
+    /// number of stacked columns actually used.
+    stacked_height: usize,
+    stacked_width: usize,
+    prove_ms: u128,
+    estimate: EstimateReport,
+    measured: MeasuredReport,
+    /// `measured.peak_bytes - estimate.total` (positive = model underestimates).
+    gap_bytes: i64,
+    /// `measured.peak_bytes / estimate.total`.
+    peak_over_estimate: f64,
+}
+
+#[derive(Serialize)]
+struct RunHeader {
+    profile_path: String,
+    max_log_height: usize,
+    zerocheck_save_memory: bool,
+    cache_rs_code_matrix: bool,
+    vpmm_page_size: Option<String>,
+    log_blowup: usize,
+    l_skip: usize,
+    n_stack: usize,
+    k_whir: usize,
+    max_constraint_degree: usize,
+}
+
+#[derive(Parser)]
+#[command(about = "Memory-metering validation runner (cuda-backend / GPU)")]
+struct Args {
+    /// Path to the profile JSONL.
+    #[arg(long)]
+    profile: PathBuf,
+
+    /// Comma-separated segment indices to run. Overrides sampling if set.
+    #[arg(long)]
+    segments: Option<String>,
+
+    /// Fraction of segments to sample (0 < frac <= 1).
+    #[arg(long, default_value_t = 0.1)]
+    sample_frac: f64,
+
+    /// RNG seed for the segment sampler.
+    #[arg(long, default_value_t = 42)]
+    seed: u64,
+
+    /// Per-AIR `log_height` clamp. Anything above is clipped.
+    #[arg(long, default_value_t = 22)]
+    max_log_height: usize,
+
+    /// Value for `GpuProverConfig::zerocheck_save_memory`. Defaults to the
+    /// production setting for the params (`log_blowup == 1`).
+    #[arg(long)]
+    zerocheck_save_memory: Option<bool>,
+
+    /// Enable `GpuProverConfig::cache_rs_code_matrix` (production default: off).
+    #[arg(long, default_value_t = false)]
+    cache_rs_code_matrix: bool,
+
+    /// If set, write the report here as JSONL (one header line, then one line
+    /// per segment, flushed incrementally). Otherwise print to stdout.
+    #[arg(long)]
+    out: Option<PathBuf>,
+}
+
+fn read_profile(path: &Path) -> eyre::Result<Vec<SegmentProfile>> {
+    let f = std::fs::File::open(path)?;
+    let mut out = Vec::new();
+    for line in BufReader::new(f).lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let segment: SegmentProfile = serde_json::from_str(&line)?;
+        out.push(segment);
+    }
+    Ok(out)
+}
+
+fn shape_from_record(rec: &AirShapeRecord, max_log_height: usize) -> SyntheticShape {
+    let buses_set: HashSet<_> = rec.buses.iter().copied().collect();
+    let log_height = rec.log_height.min(max_log_height);
+    SyntheticShape {
+        air_name: rec.air_name.clone(),
+        log_height,
+        preprocessed_width: rec.width.preprocessed.unwrap_or(0),
+        cached_main_widths: rec.width.cached_mains.clone(),
+        common_main_width: rec.width.common_main,
+        after_challenge_widths: rec.width.after_challenge.clone(),
+        num_constraints: rec.num_constraints,
+        num_interactions: rec.num_interactions,
+        num_distinct_buses: buses_set.len(),
+        max_constraint_degree: rec.max_constraint_degree,
+        interaction_message_lens: rec.interaction_message_lens.clone(),
+        interaction_count_weights: rec.interaction_count_weights.clone(),
+        occurrences: 1,
+    }
+}
+
+/// Extract the absolute `gpu_mem.local_peak_bytes` gauge per module label from a
+/// metrics snapshot.
+fn phase_peaks_from_snapshot(snapshotter: &Snapshotter) -> BTreeMap<String, u64> {
+    let mut out = BTreeMap::new();
+    for (ckey, _, _, value) in snapshotter.snapshot().into_vec() {
+        let (_kind, key) = ckey.into_parts();
+        if key.name() != "gpu_mem.local_peak_bytes" {
+            continue;
+        }
+        let module = key
+            .labels()
+            .find(|l| l.key() == "module")
+            .map(|l| l.value().to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+        if let DebugValue::Gauge(v) = value {
+            out.insert(module, v.into_inner() as u64);
+        }
+    }
+    out
+}
+
+fn main() -> eyre::Result<()> {
+    let args = Args::parse();
+    eyre::ensure!(
+        args.sample_frac.is_finite() && args.sample_frac > 0.0 && args.sample_frac <= 1.0,
+        "--sample-frac must be in (0, 1], got {}",
+        args.sample_frac
+    );
+
+    // Install a debugging recorder to capture the `gpu_mem.*` gauges emitted by
+    // `MemTracker::emit_metrics` inside the prover phases.
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+    metrics::set_global_recorder(recorder).expect("failed to install metrics recorder");
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .init();
+
+    let segments = read_profile(&args.profile)?;
+    println!(
+        "loaded {} segments from {}",
+        segments.len(),
+        args.profile.display()
+    );
+
+    let sample_idxs_sorted: Vec<usize> = if let Some(list) = &args.segments {
+        let mut idxs = list
+            .split(',')
+            .map(|s| s.trim().parse::<usize>())
+            .collect::<Result<Vec<_>, _>>()?;
+        idxs.sort_unstable();
+        idxs.dedup();
+        for &i in &idxs {
+            eyre::ensure!(i < segments.len(), "segment index {i} out of range");
+        }
+        idxs
+    } else {
+        let mut rng = StdRng::seed_from_u64(args.seed);
+        let total = segments.len();
+        let n = ((total as f64) * args.sample_frac).ceil() as usize;
+        let n = n.min(total).max(1);
+        let mut idxs: Vec<usize> = (0..total).collect();
+        idxs.shuffle(&mut rng);
+        let mut sample = idxs[..n].to_vec();
+        sample.sort_unstable();
+        sample
+    };
+    println!(
+        "running {}/{} segments (max_log_h={})",
+        sample_idxs_sorted.len(),
+        segments.len(),
+        args.max_log_height
+    );
+
+    let params = app_params_with_100_bits_security(args.max_log_height);
+    let mut engine = GpuEngine::<DefaultHashScheme>::new(params.clone());
+    let zerocheck_save_memory = args.zerocheck_save_memory.unwrap_or(params.log_blowup == 1);
+    engine
+        .device_mut()
+        .prover_config_mut()
+        .zerocheck_save_memory = zerocheck_save_memory;
+    engine.device_mut().prover_config_mut().cache_rs_code_matrix = args.cache_rs_code_matrix;
+
+    let header = RunHeader {
+        profile_path: args.profile.display().to_string(),
+        max_log_height: args.max_log_height,
+        zerocheck_save_memory,
+        cache_rs_code_matrix: args.cache_rs_code_matrix,
+        vpmm_page_size: std::env::var("VPMM_PAGE_SIZE").ok(),
+        log_blowup: params.log_blowup,
+        l_skip: params.l_skip,
+        n_stack: params.n_stack,
+        k_whir: params.k_whir(),
+        max_constraint_degree: params.max_constraint_degree,
+    };
+    let mut out_file = args
+        .out
+        .as_ref()
+        .map(|p| std::fs::File::create(p).expect("failed to create --out file"));
+    let emit = |line: &str, out_file: &mut Option<std::fs::File>| {
+        if let Some(f) = out_file {
+            use std::io::Write;
+            writeln!(f, "{line}").expect("failed to write report line");
+            f.flush().expect("failed to flush report");
+        } else {
+            println!("{line}");
+        }
+    };
+    emit(&serde_json::to_string(&header)?, &mut out_file);
+
+    let mut reports = Vec::new();
+    for (i, &seg_idx) in sample_idxs_sorted.iter().enumerate() {
+        let segment = &segments[seg_idx];
+        // Keygen rejects AIRs whose constraint degree exceeds the params limit.
+        let max_degree = segment
+            .airs
+            .iter()
+            .map(|r| r.max_constraint_degree)
+            .max()
+            .unwrap_or(0);
+        if max_degree > params.max_constraint_degree {
+            println!(
+                "[{:>3}/{:>3}] seg {:>3} SKIPPED (constraint degree {} > {})",
+                i + 1,
+                sample_idxs_sorted.len(),
+                seg_idx,
+                max_degree,
+                params.max_constraint_degree
+            );
+            continue;
+        }
+        let shapes: Vec<SyntheticShape> = segment
+            .airs
+            .iter()
+            .map(|r| {
+                let mut s = shape_from_record(r, args.max_log_height);
+                // SyntheticAir reads `local` and `next` rows in eval, so
+                // the trace must have height >= 2.
+                s.log_height = s.log_height.max(1);
+                s
+            })
+            .collect();
+        let clamped = segment
+            .airs
+            .iter()
+            .any(|r| r.log_height > args.max_log_height);
+
+        let synths: Vec<Arc<SyntheticAir>> = shapes
+            .iter()
+            .map(|s| Arc::new(SyntheticAir::from_shape(s)))
+            .collect();
+        let airs: Vec<AirRef<_>> = synths.iter().map(|a| a.clone() as AirRef<_>).collect();
+
+        let (pk, _vk) = engine.keygen(&airs);
+
+        // Replicate OpenVM's metered-execution cell counting
+        // (`SegmentationCtx::calculate_cell_counts`): per AIR,
+        // `padded_height * total_width` split by `need_rot`, plus
+        // `padded_height * num_interactions`.
+        let mut main_cells_with_rot = 0usize;
+        let mut main_cells_without_rot = 0usize;
+        let mut interaction_cells = 0usize;
+        for (shape, air_pk) in shapes.iter().zip(pk.per_air.iter()) {
+            let padded_height = 1usize << shape.log_height;
+            let width = air_pk.vk.params.width.total_width();
+            if air_pk.vk.params.need_rot {
+                main_cells_with_rot += padded_height * width;
+            } else {
+                main_cells_without_rot += padded_height * width;
+            }
+            interaction_cells += padded_height * air_pk.vk.symbolic_constraints.interactions.len();
+        }
+        let counts = ProvingMemoryCounts::new(
+            main_cells_with_rot,
+            main_cells_without_rot,
+            interaction_cells,
+        );
+        let memory_config = engine.proving_memory_config();
+        let estimate = memory_config.estimate(counts);
+
+        // Stacked layout of the common-main commit (all synthetic traces are
+        // common-main only), for offline model fitting.
+        let stacked_layout = {
+            let mut sorted_meta = shapes
+                .iter()
+                .zip(synths.iter())
+                .map(|(s, synth)| (synth.width(), s.log_height))
+                .collect::<Vec<_>>();
+            sorted_meta.sort_by(|a, b| b.1.cmp(&a.1));
+            StackedLayout::new(params.l_skip, params.l_skip + params.n_stack, sorted_meta)
+                .expect("stacked layout")
+        };
+
+        let device = engine.device();
+        let d_pk = <_ as DeviceDataTransporter<
+            <GpuEngine<DefaultHashScheme> as StarkEngine>::SC,
+            <GpuEngine<DefaultHashScheme> as StarkEngine>::PB,
+        >>::transport_pk_to_device(device, &pk);
+
+        let mut trace_bytes = 0usize;
+        let mut per_trace = Vec::new();
+        for (air_id, (s, synth)) in shapes.iter().zip(synths.iter()).enumerate() {
+            let row_trace = synth.generate_trace::<_>(s.log_height);
+            trace_bytes += (1usize << s.log_height) * synth.width() * size_of::<u32>();
+            let d_trace = <_ as DeviceDataTransporter<
+                <GpuEngine<DefaultHashScheme> as StarkEngine>::SC,
+                <GpuEngine<DefaultHashScheme> as StarkEngine>::PB,
+            >>::transport_matrix_to_device(
+                device, &ColMajorMatrix::from_row_major(&row_trace)
+            );
+            per_trace.push((air_id, AirProvingContext::simple_no_pis(d_trace)));
+        }
+        let ctx = ProvingContext::new(per_trace);
+
+        let device_used_before = device_memory_used();
+        let baseline = tracked_memory_stats().current;
+        reset_session_peak();
+
+        let pv_start = std::time::Instant::now();
+        let prove_res = engine.prove(&d_pk, ctx);
+        let prove_ms = pv_start.elapsed().as_millis();
+
+        let stats = tracked_memory_stats();
+        let device_used_after = device_memory_used();
+        let phase_peaks = phase_peaks_from_snapshot(&snapshotter);
+
+        if let Err(e) = prove_res {
+            eprintln!(
+                "[{}/{}] segment {} prove FAILED: {:?}",
+                i + 1,
+                sample_idxs_sorted.len(),
+                seg_idx,
+                e
+            );
+            continue;
+        }
+
+        let gap_bytes = stats.session_peak as i64 - estimate.total as i64;
+        let peak_over_estimate = stats.session_peak as f64 / estimate.total as f64;
+
+        let peak_phase = phase_peaks
+            .iter()
+            .max_by_key(|(_, &v)| v)
+            .map(|(k, _)| k.as_str())
+            .unwrap_or("?");
+        println!(
+            "[{:>3}/{:>3}] seg {:>3} | {:>2} airs | est {:>6} MiB | peak {:>6} MiB | ratio {:.3} | base {:>5} MiB | peak@{} | {:>6} ms{}",
+            i + 1,
+            sample_idxs_sorted.len(),
+            seg_idx,
+            segment.airs.len(),
+            estimate.total >> 20,
+            stats.session_peak >> 20,
+            peak_over_estimate,
+            baseline >> 20,
+            peak_phase,
+            prove_ms,
+            if clamped { " (clamped)" } else { "" },
+        );
+
+        let report = SegmentReport {
+            segment_idx: seg_idx,
+            num_airs: segment.airs.len(),
+            clamped,
+            trace_bytes,
+            stacked_height: stacked_layout.height(),
+            stacked_width: stacked_layout.width(),
+            prove_ms,
+            estimate: EstimateReport {
+                total: estimate.total,
+                main: estimate.main,
+                rs_code_matrix: estimate.rs_code_matrix,
+                main_secondary: estimate.main_secondary,
+                interaction: estimate.interaction,
+                secondary_peak: estimate.secondary_peak,
+                main_cells_with_rot,
+                main_cells_without_rot,
+                interaction_cells,
+            },
+            measured: MeasuredReport {
+                baseline_bytes: baseline,
+                peak_bytes: stats.session_peak,
+                after_bytes: stats.current,
+                device_used_before,
+                device_used_after,
+                phase_peaks,
+            },
+            gap_bytes,
+            peak_over_estimate,
+        };
+        emit(&serde_json::to_string(&report)?, &mut out_file);
+        reports.push(report);
+    }
+
+    let underestimates = reports.iter().filter(|r| r.gap_bytes > 0).count();
+    let max_ratio = reports
+        .iter()
+        .map(|r| r.peak_over_estimate)
+        .fold(f64::NEG_INFINITY, f64::max);
+    println!(
+        "\nsummary: {} segments, {} underestimated by the model, worst peak/estimate = {:.3}",
+        reports.len(),
+        underestimates,
+        max_ratio
+    );
+    if let Some(out) = &args.out {
+        println!("wrote report to {}", out.display());
+    }
+    Ok(())
+}

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -37,7 +37,11 @@ impl GpuProverConfig {
         // Interaction memory is estimated from the CUDA fractional-GKR buffer model in
         // `openvm_stark_backend::memory_metering`. Update that estimate when changing GKR
         // input layout, work-buffer sizing, or scratch allocations.
-        ProvingMemoryConfig::from_protocol_config(config, self.cache_rs_code_matrix)
+        let mut memory_config =
+            ProvingMemoryConfig::from_protocol_config(config, self.cache_rs_code_matrix);
+        memory_config.cache_stacked_matrix = self.cache_stacked_matrix;
+        memory_config.zerocheck_save_memory = self.zerocheck_save_memory;
+        memory_config
     }
 }
 

--- a/crates/cuda-common/src/memory_manager/mod.rs
+++ b/crates/cuda-common/src/memory_manager/mod.rs
@@ -53,6 +53,10 @@ pub struct MemoryManager {
     allocated_ptrs: HashMap<NonNull<c_void>, AllocRecord>,
     current_size: usize,
     max_used_size: usize,
+    /// Peak of `current_size` since the last [`reset_session_peak`] call. Unlike
+    /// `max_used_size`, this is never reset by [`MemTracker::reset_peak`], so it survives
+    /// the phase-level peak resets inside the prover.
+    session_peak: usize,
 }
 
 /// # Safety
@@ -71,6 +75,7 @@ impl MemoryManager {
             allocated_ptrs: HashMap::new(),
             current_size: 0,
             max_used_size: 0,
+            session_peak: 0,
         }
     }
 
@@ -104,6 +109,9 @@ impl MemoryManager {
         self.current_size += tracked_size;
         if self.current_size > self.max_used_size {
             self.max_used_size = self.current_size;
+        }
+        if self.current_size > self.session_peak {
+            self.session_peak = self.current_size;
         }
         Ok(ptr)
     }
@@ -157,6 +165,35 @@ pub fn d_malloc_on(size: usize, stream: &StreamGuard) -> Result<*mut c_void, Mem
     let manager = MEMORY_MANAGER.get().unwrap();
     let mut manager = manager.lock().map_err(|_| MemoryError::LockError)?;
     manager.d_malloc_on(size, stream)
+}
+
+/// Snapshot of the memory manager's tracked allocation counters, in bytes.
+///
+/// `current` is the sum of live allocations as tracked by the manager (pool allocations are
+/// page-rounded). `session_peak` is the maximum of `current` since the last
+/// [`reset_session_peak`] call; it is not affected by [`MemTracker::reset_peak`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TrackedMemoryStats {
+    pub current: usize,
+    pub session_peak: usize,
+}
+
+pub fn tracked_memory_stats() -> TrackedMemoryStats {
+    MEMORY_MANAGER
+        .get()
+        .and_then(|m| m.lock().ok())
+        .map(|m| TrackedMemoryStats {
+            current: m.current_size,
+            session_peak: m.session_peak,
+        })
+        .unwrap_or_default()
+}
+
+/// Resets the session peak to the current tracked allocation size. See [`tracked_memory_stats`].
+pub fn reset_session_peak() {
+    if let Some(mut manager) = MEMORY_MANAGER.get().and_then(|m| m.lock().ok()) {
+        manager.session_peak = manager.current_size;
+    }
 }
 
 /// # Safety

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -4,8 +4,32 @@ use std::{cmp::max, mem::size_of};
 
 use crate::{StarkProtocolConfig, SystemParams};
 
-/// Fixed interaction scratch not proportional to interaction cells.
-pub const INTERACTION_MEMORY_OVERHEAD: usize = 2 << 20;
+/// Fixed interaction scratch not proportional to interaction cells: challenge/metadata
+/// buffers, per-bus tables, and allocator page rounding across the live GKR buffers.
+pub const INTERACTION_MEMORY_OVERHEAD: usize = 64 << 20;
+
+/// Minimum fractional-GKR work-buffer length in `Frac<EF>` entries. Mirrors
+/// `GKR_WINDOW_DEFAULT_MIN_N` in the CUDA fractional sumcheck: the work buffer never
+/// shrinks below `2^22` entries, which dominates the `logical_len / 16` sizing for
+/// small interaction counts.
+pub const GKR_MIN_WORK_BUFFER_LEN: usize = 1 << 22;
+
+/// Fixed WHIR opening scratch not proportional to the stacked height: folded sumcheck
+/// buffers, query-opening staging, proof-of-work grinding, and allocator page rounding
+/// across the many live buffers at the round-0 query step.
+pub const WHIR_MEMORY_OVERHEAD: usize = 64 << 20;
+
+/// Fixed batch-constraint scratch on top of the modeled `mat_eval`/interpolation buffers:
+/// eq segment trees, folded selector columns, logup monomial combination tables, and
+/// allocator page rounding. Calibrated against measured batch-phase peaks (~90 MiB at
+/// 2^22 stacked height on the reth profile).
+pub const BATCH_CONSTRAINT_MEMORY_OVERHEAD: usize = 192 << 20;
+
+/// Minimum batch-MLE scratch budget when `zerocheck_save_memory` is off. Mirrors
+/// `BATCH_MLE_DEFAULT_MEMORY_FLOOR` in `openvm-cuda-backend`: without the save-memory
+/// subtraction, evaluation scratch is greedily packed up to
+/// `max(gkr_peak, BATCH_MLE_MEMORY_FLOOR)` *in addition to* the `mat_eval` buffers.
+pub const BATCH_MLE_MEMORY_FLOOR: usize = 6 << 30;
 
 /// Cell counts for a proving memory estimate.
 ///
@@ -50,7 +74,10 @@ pub struct ProvingMemoryEstimate {
     pub main: usize,
     /// Reed-Solomon code matrix for main traces.
     pub rs_code_matrix: usize,
-    /// Secondary main-trace buffers after PCS opening.
+    /// WHIR opening working set that coexists with the RS code matrix at the round-0
+    /// query step (commitment Merkle layers, round-0 codeword and its tree, scratch).
+    pub whir_overhead: usize,
+    /// Batch-constraint `mat_eval` and interpolation buffers derived from the main traces.
     pub main_secondary: usize,
     /// Interaction GKR buffers plus fixed interaction overhead.
     pub interaction: usize,
@@ -65,14 +92,27 @@ pub struct ProvingMemoryConfig {
     pub base_field_size: usize,
     /// Degree of the extension field over the base field.
     pub extension_degree: usize,
+    /// Size of one commitment digest in bytes.
+    pub digest_size: usize,
     /// `-log_2` of the rate for the initial Reed-Solomon code.
     pub log_blowup: usize,
     /// `log_2` of the univariate skip domain.
     pub l_skip: usize,
+    /// `log_2` of the stacked matrix height (`l_skip + n_stack`).
+    pub log_stacked_height: usize,
+    /// `log_2` of the number of codeword rows per WHIR Merkle-tree leaf.
+    pub k_whir: usize,
     /// Maximum constraint degree across AIR and interaction constraints.
     pub max_constraint_degree: usize,
     /// Whether the prover keeps the Reed-Solomon code matrix cached after `stacked_commit`.
     pub cache_rs_code_matrix: bool,
+    /// Whether the prover keeps the stacked matrix cached after `stacked_commit`
+    /// (`GpuProverConfig::cache_stacked_matrix`).
+    pub cache_stacked_matrix: bool,
+    /// Whether the batch-MLE scratch budget is reduced by the resident `mat_eval` buffers
+    /// (`GpuProverConfig::zerocheck_save_memory`). When off, evaluation scratch up to
+    /// `max(gkr_peak, BATCH_MLE_MEMORY_FLOOR)` is additive on `main_secondary`.
+    pub zerocheck_save_memory: bool,
 }
 
 impl ProvingMemoryConfig {
@@ -80,10 +120,10 @@ impl ProvingMemoryConfig {
         config: &SC,
         cache_rs_code_matrix: bool,
     ) -> Self {
-        Self::from_params::<SC::F>(config.params(), SC::D_EF, cache_rs_code_matrix)
+        Self::from_params::<SC::F, SC::Digest>(config.params(), SC::D_EF, cache_rs_code_matrix)
     }
 
-    fn from_params<F>(
+    fn from_params<F, Digest>(
         params: &SystemParams,
         extension_degree: usize,
         cache_rs_code_matrix: bool,
@@ -91,10 +131,17 @@ impl ProvingMemoryConfig {
         Self {
             base_field_size: size_of::<F>(),
             extension_degree,
+            digest_size: size_of::<Digest>(),
             log_blowup: params.log_blowup,
             l_skip: params.l_skip,
+            log_stacked_height: params.l_skip + params.n_stack,
+            k_whir: params.k_whir(),
             max_constraint_degree: params.max_constraint_degree,
             cache_rs_code_matrix,
+            cache_stacked_matrix: false,
+            // Default coupling used by `GpuDevice::new`; override with the actual prover
+            // config flag when available.
+            zerocheck_save_memory: params.log_blowup == 1,
         }
     }
 
@@ -103,9 +150,40 @@ impl ProvingMemoryConfig {
         main_cells * self.base_field_size
     }
 
+    /// Bytes of the Reed-Solomon code matrix of the stacked traces.
+    ///
+    /// Stacking pads the used width up to whole columns of height `2^log_stacked_height`,
+    /// so the codeword can cover up to one stacked column beyond the raw cell count.
     #[inline]
     pub fn rs_code_matrix_memory_bytes(&self, main_cells: usize) -> usize {
-        main_cells * (1usize << self.log_blowup) * self.base_field_size
+        (main_cells + self.stacked_height()) * (1usize << self.log_blowup) * self.base_field_size
+    }
+
+    #[inline]
+    pub fn stacked_height(&self) -> usize {
+        1usize << self.log_stacked_height
+    }
+
+    /// Peak WHIR opening working set that coexists with the resident main traces and the
+    /// (cached or recomputed) RS code matrix at the round-0 query step:
+    ///
+    /// ```text
+    /// codeword_height = 2^(log_stacked_height + log_blowup)
+    /// commit_tree     = 2 * digest_size * codeword_height / 2^k_whir
+    /// g_codeword      = D_EF * base_field_size * codeword_height / 2
+    /// g_tree          = 2 * digest_size * codeword_height / 2^(k_whir + 1)
+    /// whir_overhead   = commit_tree + g_codeword + g_tree + WHIR_MEMORY_OVERHEAD
+    /// ```
+    ///
+    /// `commit_tree` is the digest layers of the commitment Merkle tree (still open for
+    /// query proofs), `g_codeword`/`g_tree` are the round-0 folded codeword and its tree.
+    #[inline]
+    pub fn whir_overhead_memory_bytes(&self) -> usize {
+        let codeword_height = self.stacked_height() << self.log_blowup;
+        let commit_tree = 2 * self.digest_size * (codeword_height >> self.k_whir);
+        let g_codeword = self.extension_degree * self.base_field_size * (codeword_height >> 1);
+        let g_tree = 2 * self.digest_size * (codeword_height >> (self.k_whir + 1));
+        commit_tree + g_codeword + g_tree + WHIR_MEMORY_OVERHEAD
     }
 
     #[inline]
@@ -146,13 +224,26 @@ impl ProvingMemoryConfig {
             + self.main_secondary_memory_bytes_for_rot(counts.main_cells_without_rot, false)
     }
 
+    /// Peak fractional-GKR buffer bytes for `interaction_cells` metered interaction slots.
+    ///
+    /// Mirrors the CUDA fractional sumcheck (see `FractionalInputSize` in
+    /// `openvm-cuda-backend`), with `logical_len = next_power_of_two(real_len) <= 2 * real_len`
+    /// and one `Frac<EF>` (two extension-field elements) per slot:
+    ///
+    /// ```text
+    /// leaf_bytes     = 2 * extension_degree * base_field_size
+    /// leaves         = interaction_cells * leaf_bytes
+    /// work_buffer    = max(logical_len / 16, GKR_MIN_WORK_BUFFER_LEN) * leaf_bytes
+    /// tmp_block_sums = logical_len / 256 * leaf_bytes
+    /// ```
     #[inline]
     pub fn interaction_memory_bytes_without_overhead(&self, interaction_cells: usize) -> usize {
-        ceil_weighted_bytes(
-            interaction_cells,
-            self.base_field_size,
-            default_interaction_cell_weight(self.extension_degree),
-        )
+        let leaf_bytes = 2 * self.extension_degree * self.base_field_size;
+        let logical_len_bound = 2 * interaction_cells;
+        let leaves = interaction_cells * leaf_bytes;
+        let work_buffer = max(logical_len_bound / 16, GKR_MIN_WORK_BUFFER_LEN) * leaf_bytes;
+        let tmp_block_sums = logical_len_bound / 256 * leaf_bytes;
+        leaves + work_buffer + tmp_block_sums
     }
 
     #[inline]
@@ -166,42 +257,69 @@ impl ProvingMemoryConfig {
     /// ```text
     /// main_cells       = main_cells_with_rot + main_cells_without_rot
     /// main             = main_cells * sizeof(F)
-    /// rs_code_matrix   = main_cells * 2^log_blowup * sizeof(F)
+    /// rs_code_matrix   = (main_cells + 2^log_stacked_height) * 2^log_blowup * sizeof(F)
+    /// whir_overhead    = whir_overhead_memory_bytes()
     /// main_secondary   = sizeof(F) *
     ///                    (2 * main_cell_secondary_weight() * main_cells_with_rot
     ///                     + main_cell_secondary_weight() * main_cells_without_rot)
-    /// interaction      = sizeof(F) * interaction_cell_weight * interaction_cells
+    /// interaction      = interaction_memory_bytes_without_overhead(interaction_cells)
     ///                    + INTERACTION_MEMORY_OVERHEAD
     /// ```
+    ///
+    /// The main traces stay resident through all proving phases, so `total` is `main` plus
+    /// the peak among the phases that follow (plus the resident stacked matrix when
+    /// `cache_stacked_matrix` is on). The opening phase holds the RS code matrix
+    /// (recomputed if not cached) together with the WHIR round-0 working set, which is why
+    /// `whir_overhead` is added on top of `rs_code_matrix` rather than maxed with it.
+    ///
+    /// The batch-constraint phase costs `main_secondary` plus fixed scratch; with
+    /// `zerocheck_save_memory` the evaluation scratch is budgeted inside the GKR peak
+    /// (`batch = max(main_secondary, interaction) + overhead`), without it the scratch is
+    /// additive (`batch = main_secondary + max(gkr, BATCH_MLE_MEMORY_FLOOR) + overhead`).
     ///
     /// Cached RS code matrix:
     ///
     /// ```text
-    /// total = main + rs_code_matrix + max(main_secondary, interaction)
+    /// total = main + stacked + rs_code_matrix + max(whir_overhead, batch, interaction)
     /// ```
     ///
     /// Dropped RS code matrix:
     ///
     /// ```text
-    /// total = main + max(rs_code_matrix, main_secondary, interaction)
+    /// total = main + stacked + max(rs_code_matrix + whir_overhead, batch, interaction)
     /// ```
     #[inline]
     pub fn estimate(&self, counts: ProvingMemoryCounts) -> ProvingMemoryEstimate {
         let main_cells = counts.main_cells();
         let main = self.main_memory_bytes(main_cells);
         let rs_code_matrix = self.rs_code_matrix_memory_bytes(main_cells);
+        let whir_overhead = self.whir_overhead_memory_bytes();
         let main_secondary = self.main_secondary_memory_bytes(counts);
-        let interaction = self.interaction_memory_bytes(counts.interaction_cells);
-        let secondary_peak = if self.cache_rs_code_matrix {
-            rs_code_matrix + max(main_secondary, interaction)
+        let gkr = self.interaction_memory_bytes_without_overhead(counts.interaction_cells);
+        let interaction = gkr + INTERACTION_MEMORY_OVERHEAD;
+        let batch_secondary = if self.zerocheck_save_memory {
+            max(main_secondary, gkr) + BATCH_CONSTRAINT_MEMORY_OVERHEAD
         } else {
-            max(rs_code_matrix, max(main_secondary, interaction))
+            main_secondary + max(gkr, BATCH_MLE_MEMORY_FLOOR) + BATCH_CONSTRAINT_MEMORY_OVERHEAD
+        };
+        // Kept stacked matrix is resident through all phases, like `main`.
+        let stacked_matrix = if self.cache_stacked_matrix {
+            (main_cells + self.stacked_height()) * self.base_field_size
+        } else {
+            0
+        };
+        let secondary_phases = max(batch_secondary, interaction);
+        let secondary_peak = if self.cache_rs_code_matrix {
+            rs_code_matrix + max(whir_overhead, secondary_phases)
+        } else {
+            max(rs_code_matrix + whir_overhead, secondary_phases)
         };
 
         ProvingMemoryEstimate {
-            total: main + secondary_peak,
+            total: main + stacked_matrix + secondary_peak,
             main,
             rs_code_matrix,
+            whir_overhead,
             main_secondary,
             interaction,
             secondary_peak,
@@ -217,19 +335,6 @@ fn default_main_cell_secondary_weight(
     (1.0 + max_constraint_degree as f64 / 2.0) * extension_degree as f64 / (1usize << l_skip) as f64
 }
 
-/// ```
-/// leaf_weight = 2 * extension_degree
-///
-/// work_buffer    <= logical_len / 16
-/// tmp_block_sums ~= logical_len / 256
-/// logical_len    <= 2 * real_len
-///
-/// interaction_weight = leaf_weight * (1 + 2 * (1 / 16 + 1 / 256))
-/// ```
-fn default_interaction_cell_weight(extension_degree: usize) -> f64 {
-    (2 * extension_degree) as f64 * (1.0 + 2.0 * (1.0 / 16.0 + 1.0 / 256.0))
-}
-
 /// `ceil(cell_count * base_field_size * weight)`
 fn ceil_weighted_bytes(cell_count: usize, base_field_size: usize, weight: f64) -> usize {
     ((cell_count * base_field_size) as f64 * weight).ceil() as usize
@@ -242,25 +347,39 @@ mod tests {
 
     fn test_memory_config() -> ProvingMemoryConfig {
         let params = default_test_params_small();
-        ProvingMemoryConfig::from_params::<u32>(&params, 4, true)
+        ProvingMemoryConfig::from_params::<u32, [u32; 8]>(&params, 4, true)
+    }
+
+    fn batch_secondary(config: &ProvingMemoryConfig, counts: ProvingMemoryCounts) -> usize {
+        let gkr = config.interaction_memory_bytes_without_overhead(counts.interaction_cells);
+        if config.zerocheck_save_memory {
+            max(config.main_secondary_memory_bytes(counts), gkr) + BATCH_CONSTRAINT_MEMORY_OVERHEAD
+        } else {
+            config.main_secondary_memory_bytes(counts)
+                + max(gkr, BATCH_MLE_MEMORY_FLOOR)
+                + BATCH_CONSTRAINT_MEMORY_OVERHEAD
+        }
     }
 
     #[test]
     fn dropped_rs_code_matrix_is_phase_disjoint() {
         let params = default_test_params_small();
-        let config = ProvingMemoryConfig::from_params::<u32>(&params, 4, false);
+        let config = ProvingMemoryConfig::from_params::<u32, [u32; 8]>(&params, 4, false);
         let counts = ProvingMemoryCounts::new(10, 20, 5);
 
         let estimate = config.estimate(counts);
 
         assert_eq!(estimate.main, 30 * 4);
-        assert_eq!(estimate.rs_code_matrix, 30 * 2 * 4);
+        assert_eq!(
+            estimate.rs_code_matrix,
+            (30 + config.stacked_height()) * (1 << params.log_blowup) * 4
+        );
         assert_eq!(estimate.total, estimate.main + estimate.secondary_peak);
         assert_eq!(
             estimate.secondary_peak,
             max(
-                estimate.rs_code_matrix,
-                max(estimate.main_secondary, estimate.interaction)
+                estimate.rs_code_matrix + estimate.whir_overhead,
+                max(batch_secondary(&config, counts), estimate.interaction)
             )
         );
     }
@@ -274,7 +393,62 @@ mod tests {
 
         assert_eq!(
             estimate.secondary_peak,
-            estimate.rs_code_matrix + max(estimate.main_secondary, estimate.interaction)
+            estimate.rs_code_matrix
+                + max(
+                    estimate.whir_overhead,
+                    max(batch_secondary(&config, counts), estimate.interaction)
+                )
+        );
+    }
+
+    #[test]
+    fn no_save_memory_batch_scratch_is_additive() {
+        let params = default_test_params_small();
+        let mut config = ProvingMemoryConfig::from_params::<u32, [u32; 8]>(&params, 4, false);
+        let counts = ProvingMemoryCounts::new(10, 20, 5);
+
+        config.zerocheck_save_memory = true;
+        let saved = config.estimate(counts);
+        config.zerocheck_save_memory = false;
+        let unsaved = config.estimate(counts);
+
+        assert!(unsaved.total > saved.total);
+        assert_eq!(
+            unsaved.secondary_peak,
+            max(
+                unsaved.rs_code_matrix + unsaved.whir_overhead,
+                max(batch_secondary(&config, counts), unsaved.interaction)
+            )
+        );
+    }
+
+    #[test]
+    fn cached_stacked_matrix_is_resident() {
+        let params = default_test_params_small();
+        let mut config = ProvingMemoryConfig::from_params::<u32, [u32; 8]>(&params, 4, false);
+        let counts = ProvingMemoryCounts::new(10, 20, 5);
+
+        let without = config.estimate(counts);
+        config.cache_stacked_matrix = true;
+        let with = config.estimate(counts);
+
+        assert_eq!(
+            with.total - without.total,
+            (counts.main_cells() + config.stacked_height()) * config.base_field_size
+        );
+    }
+
+    #[test]
+    fn whir_overhead_component_formulas() {
+        let config = test_memory_config();
+        let codeword_height = config.stacked_height() << config.log_blowup;
+
+        let commit_tree = 2 * config.digest_size * (codeword_height >> config.k_whir);
+        let g_codeword = config.extension_degree * config.base_field_size * (codeword_height >> 1);
+        let g_tree = 2 * config.digest_size * (codeword_height >> (config.k_whir + 1));
+        assert_eq!(
+            config.whir_overhead_memory_bytes(),
+            commit_tree + g_codeword + g_tree + WHIR_MEMORY_OVERHEAD
         );
     }
 }

--- a/docs/cuda-backend/gkr-prover.md
+++ b/docs/cuda-backend/gkr-prover.md
@@ -334,6 +334,17 @@ Buffers used at peak (workspace only; excludes input `layer`/leaves):
 Workspace upper bound (sum of the buffers above), using `|Frac| = 2 * |EF|`:
 - `W < (2^(n-w-1) + 2^(n-7) + 2^(n+w-10) + 2^floor(n/2) + 2^ceil(n/2) + 4^w + 2^(w+1) + 2) * |EF|`
 
+For small `n` the budgeted work buffer does not shrink below `2^22` `Frac` entries
+(`GKR_WINDOW_DEFAULT_MIN_N` in `FractionalInputSize::peak_work_buffer_bytes`), so the
+work-buffer term is effectively `max(2^(n-w-2), 2^21) * |Frac|`.
+
+The conservative interaction memory estimate in
+`openvm_stark_backend::memory_metering::ProvingMemoryConfig::interaction_memory_bytes_without_overhead`
+mirrors this accounting with `logical_len = 2^n <= 2 * real_len`: leaves
+`real_len * |Frac|`, work buffer `max(logical_len / 16, 2^22) * |Frac|`, block sums
+`logical_len / 256 * |Frac|`, plus a fixed `INTERACTION_MEMORY_OVERHEAD` for the
+challenge/metadata buffers. Keep the two in sync when changing buffer sizing here.
+
 Total GPU memory required (workspace + input leaves `2^n * |Frac| = 2^(n+1) * |EF|`):
 - `M_total < (2^(n+1) + 2^(n-w-1) + 2^(n-7) + 2^(n+w-10) + 2^floor(n/2) + 2^ceil(n/2) + 4^w + 2^(w+1) + 2) * |EF|`
 - With default `w = 3` and `|EF| = 16` bytes:

--- a/docs/vpmm_spec.md
+++ b/docs/vpmm_spec.md
@@ -233,6 +233,15 @@ Additional rules:
 * **Pending unmap (zombies):** `sum(pool.zombie_regions.iter().map(|z| z.size))`
 * `Debug` output prints the metrics above plus every region in ascending VA order.
 
+The outer `MemoryManager` additionally exposes a public snapshot API:
+
+* `tracked_memory_stats() -> TrackedMemoryStats { current, session_peak }` — `current` is the
+  sum of live tracked allocations (pool allocations page-rounded); `session_peak` is the peak
+  of `current` since the last `reset_session_peak()` call. Unlike `max_used_size` (surfaced
+  through `MemTracker` and reset by phase-level `MemTracker::reset_peak` calls inside the
+  prover), `session_peak` survives those resets, so callers can measure a whole-proof peak.
+* `reset_session_peak()` — resets `session_peak` to the current tracked size.
+
 ## Asynchrony & Streams
 
 * VPMM supports **multi-stream workloads** using `cudaStreamPerThread`.


### PR DESCRIPTION
# Fix GPU proving memory estimates underestimating observed peaks (INT-8600)

## Overview

The metered-execution memory estimate (`memory_metering.rs`) was sometimes **below** the actual peak GPU memory observed during proving — up to **+3.2%** measured on the captured reth-block profile (e.g. estimate 5008 MiB vs measured peak 5167 MiB). On a tightly budgeted GPU this is an OOM risk: OpenVM uses `estimate().total` against `segmentation_max_memory` to decide segment boundaries.

Root cause (validated empirically on an RTX Pro 6000 and by a per-phase allocation audit of the CUDA prover): the true proving peak lands at the **WHIR round-0 query step**, where the prover *recomputes the full RS code matrix* (production runs with `cache_rs_code_matrix = false`) while the traces, the commitment Merkle digest layers, and the round-0 folded codeword + its tree are all still resident (`whir.rs:396-466`). The model priced that phase as bare `max(rs_code_matrix, …)`. Several smaller buffers were also unpriced.

There are no AIR or constraint changes in this PR; it only touches the host-side memory model, memory-manager instrumentation, and adds a validation benchmark.

## `crates/stark-backend` — memory model fix (reviewable on its own)

`estimate()` changes from

```text
total = main + max(rs_code_matrix, main_secondary, interaction)
```

to

```text
total = main + stacked_matrix_if_cached
      + max( rs_code_matrix + whir_overhead,   # opening phase: RS + WHIR working set coexist
             batch_secondary,                  # batch-constraint phase, explicit scratch
             interaction )                     # fractional-GKR phase
```

Term by term:

- **`whir_overhead_memory_bytes()`** (new): commitment-tree digest layers (`2·digest·C/2^k_whir`, still open for query proofs), round-0 folded codeword (`D_EF·F·C/2`), its tree, plus a fixed 64 MiB scratch term (`C = 2^(log_stacked_height + log_blowup)`). Added **on top of** `rs_code_matrix`, not maxed — measured at a stable ~140 MiB at 2^22 stacked height.
- **`rs_code_matrix_memory_bytes()`**: allows one extra stacked column, since stacking rounds the used width up to whole columns of height `2^(l_skip+n_stack)`.
- **`interaction_memory_bytes_without_overhead()`**: now mirrors the actual fractional-GKR work-buffer sizing, including its **2^22-entry floor** (`GKR_WINDOW_DEFAULT_MIN_N` in `fractional.rs`) which the old `logical_len/16` weight missed for small interaction counts (~90 MiB); fixed overhead raised 2 MiB → 64 MiB.
- **Batch-constraint term** (new): with `zerocheck_save_memory` the batch-MLE scratch is budgeted inside the GKR peak, so `max(main_secondary, gkr) + 192 MiB` (the constant covers eq segment trees, folded selectors, logup monomial tables — measured ~90 MiB). Without it (`log_blowup > 1`), the code greedily packs scratch up to `max(gkr_peak, 6 GiB)` **in addition to** `mat_evals` (no subtraction in that path), so the term becomes `main_secondary + max(gkr, BATCH_MLE_MEMORY_FLOOR) + 192 MiB`.
- **`cache_stacked_matrix`**: keeps a resident stacked-matrix copy for the whole proof; now added to `total`.

`ProvingMemoryConfig` gains `log_stacked_height`, `k_whir`, `digest_size`, `cache_stacked_matrix`, `zerocheck_save_memory` (defaults preserve the production coupling `zerocheck_save_memory = (log_blowup == 1)`). `ProvingMemoryEstimate` gains a `whir_overhead` component field. Constants that mirror CUDA-side sizing are documented as such (`GKR_MIN_WORK_BUFFER_LEN`, `BATCH_MLE_MEMORY_FLOOR`).

## `crates/cuda-backend` — config plumbing (2 lines)

`GpuProverConfig::proving_memory_config()` forwards the actual `cache_stacked_matrix` / `zerocheck_save_memory` flags into `ProvingMemoryConfig` so the estimate matches the prover configuration in use.

## `crates/cuda-common` — peak instrumentation

The prover's phase-level `MemTracker::reset_peak()` calls clobber `max_used_size`, so a whole-proof peak could not be read externally. Adds a `session_peak` counter that only `reset_session_peak()` resets, exposed via `tracked_memory_stats()`. No change to allocation behavior (two integer compares under the existing lock).

## `benchmarks/synthetic` — validation harness

New `mem_meter_runner` binary: replays captured segment profiles through `Coordinator::prove` on the GPU, replicates OpenVM's metered cell counting (`padded_height·total_width` split by `need_rot`, `padded_height·num_interactions`), and reports estimate-vs-measured peak with per-phase attribution from the `gpu_mem.*` gauges. Skips segments whose constraint degree exceeds the params limit; streams results as JSONL.

## Validation (RTX Pro 6000, reth-block profile, `app_params_with_100_bits_security(22)`)

| Configuration | Segments | Underestimates | Worst peak/estimate |
|---|---|---|---|
| **Before** (default flags) | 30 | 11 | **1.032** |
| After — default, full profile | 149 | 0 | 0.994 |
| After — `cache_rs_code_matrix = true` | 22 | 0 | 0.990 |
| After — `zerocheck_save_memory = false` | 44 | 0 | 0.994 |
| After — stacked height 2^20 | 48 | 0 | 0.992 |

Worst-case remaining headroom is 0.6%; conservatism is bounded at ~5–7% in the production metering regime. Estimates in that regime grow by ~200–400 MiB (~3–6%).
