### PR TITLE
feat(cuda-common): static GPU memory planner with allocation tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+- (CUDA common) Static memory planner ([spec](./docs/static_alloc_spec.md)): declare allocations and their lifetimes up front via `AllocBuilder`/`DeviceBufFake` RAII handles, pack them into a single fixed workspace with an interference-graph packing pass, and serve fixed-offset buffers through `StaticAllocator::get` with run-time detection of use-after-lifetime. Includes allocation tracing (`VPMM_TRACE`), offline plan analysis tools, and a record-and-replay mode (`VPMM_REPLAY`) that serves a recorded workload's large allocations from a statically planned workspace with no prover code changes.
+
 ## v2.0.0 (2026-07-06)
 
 ### Added

--- a/crates/cuda-common/Cargo.toml
+++ b/crates/cuda-common/Cargo.toml
@@ -30,3 +30,15 @@ touchemall = []
 # operations (fill_zero, etc.) use the same stream. Useful for catching
 # accidental cross-stream misuse during development.
 debug-cuda-stream = []
+
+[[bench]]
+name = "static_alloc"
+harness = false
+
+[[bench]]
+name = "trace_replay"
+harness = false
+
+[[bench]]
+name = "trace_phases"
+harness = false

--- a/crates/cuda-common/benches/static_alloc.rs
+++ b/crates/cuda-common/benches/static_alloc.rs
@@ -1,0 +1,444 @@
+//! Static vs dynamic allocation benchmark.
+//!
+//! Replays a STARK-prover-like allocation schedule (skewed sizes, phase
+//! structure: commit -> perm -> quotient -> opening/FRI) twice:
+//!   1. dynamically, through `DeviceBuffer::with_capacity`/drop (VPMM pool);
+//!   2. statically, planning the same schedule with `AllocBuilder` and then serving every buffer
+//!      from the packed workspace.
+//!
+//! Reports peak GPU memory, wall time per round, and cumulative CPU time
+//! spent inside alloc/free (resp. get/drop) calls.
+//!
+//! Env knobs: `BENCH_NUM_AIRS` (default 40), `BENCH_LOG_MAX` (max log trace
+//! height, default 19), `BENCH_ROUNDS` (measured rounds, default 3),
+//! `BENCH_TOUCH` (memset every acquired buffer, default 1).
+//!
+//! Run: `cargo bench -p openvm-cuda-common --bench static_alloc`
+
+use std::time::{Duration, Instant};
+
+use bytesize::ByteSize;
+use openvm_cuda_common::{
+    d_buffer::DeviceBuffer,
+    memory_manager::{memory_stats, MemTracker},
+    static_alloc::{AllocBuilder, AllocIdx, StaticAllocator, StaticDeviceBuffer},
+    stream::GpuDeviceCtx,
+};
+
+// ============================================================================
+// Schedule: an abstract allocation trace with slot identities
+// ============================================================================
+
+enum Op {
+    /// Allocate `len` u32 elements into `slot`.
+    Alloc {
+        slot: usize,
+        len: usize,
+        label: String,
+    },
+    /// Release `slot`.
+    Free { slot: usize },
+    /// Touch `slot` (async memset), standing in for kernel work.
+    Touch { slot: usize },
+}
+
+struct Schedule {
+    ops: Vec<Op>,
+    num_slots: usize,
+}
+
+struct ScheduleBuilder {
+    ops: Vec<Op>,
+    next_slot: usize,
+    touch: bool,
+}
+
+impl ScheduleBuilder {
+    fn alloc(&mut self, len: usize, label: String) -> usize {
+        let slot = self.next_slot;
+        self.next_slot += 1;
+        self.ops.push(Op::Alloc { slot, len, label });
+        if self.touch {
+            self.ops.push(Op::Touch { slot });
+        }
+        slot
+    }
+
+    fn free(&mut self, slot: usize) {
+        self.ops.push(Op::Free { slot });
+    }
+}
+
+/// xorshift64* — deterministic sizes without external deps.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 >> 12;
+        self.0 ^= self.0 << 25;
+        self.0 ^= self.0 >> 27;
+        self.0 = self.0.wrapping_mul(0x2545F4914F6CDD1D);
+        self.0
+    }
+
+    fn range(&mut self, lo: u64, hi: u64) -> u64 {
+        lo + self.next() % (hi - lo + 1)
+    }
+}
+
+/// Builds a prover-like schedule. Sizes are in u32 elements (4 bytes); the
+/// extension-field factor (EF = 4 x F) is folded into element counts.
+/// Lifetimes mirror the real pipeline: LDEs and digests live from commit
+/// until the end of opening; per-phase temps die within their phase; the
+/// quotient phase is serialized per AIR on purpose (as in the real prover).
+fn build_schedule(num_airs: usize, log_max: u32, touch: bool) -> Schedule {
+    let mut rng = Rng(0x5EED_5EED_5EED_5EED);
+    let mut sb = ScheduleBuilder {
+        ops: Vec::new(),
+        next_slot: 0,
+        touch,
+    };
+
+    // Skewed AIR shapes: mostly small, a few huge (heights 2^8..2^log_max).
+    let mut airs: Vec<(u32, usize, usize)> = (0..num_airs) // (log_h, width, qd)
+        .map(|_| {
+            let p = rng.range(0, 99);
+            let log_h = if p < 70 {
+                rng.range(8, 13) as u32
+            } else if p < 95 {
+                rng.range(14, log_max as u64 - 2) as u32
+            } else {
+                rng.range(log_max as u64 - 1, log_max as u64) as u32
+            };
+            // Wide traces occur on small heights; cap width for huge ones.
+            let width = if log_h >= 18 {
+                rng.range(16, 128) as usize
+            } else {
+                rng.range(8, 400) as usize
+            };
+            let qd = 1usize << rng.range(0, 2);
+            (log_h, width, qd)
+        })
+        .collect();
+    airs.sort_by_key(|&(log_h, ..)| std::cmp::Reverse(log_h));
+
+    const BLOWUP: usize = 2;
+    let mut retained: Vec<usize> = Vec::new(); // slots that live until the end
+
+    // Phase 1: commit — per AIR: trace (temp) -> LDE + digests (retained).
+    for (i, &(log_h, width, _)) in airs.iter().enumerate() {
+        let h = 1usize << log_h;
+        let trace = sb.alloc(h * width, format!("trace{i}"));
+        let lde = sb.alloc(BLOWUP * h * width, format!("lde{i}"));
+        let digest = sb.alloc(2 * BLOWUP * h * 8, format!("digest{i}"));
+        sb.free(trace);
+        retained.push(lde);
+        retained.push(digest);
+    }
+
+    // Phase 2: perm — every other AIR gets a perm trace, committed together.
+    for (i, &(log_h, ..)) in airs.iter().enumerate().filter(|(i, _)| i % 2 == 0) {
+        let h = 1usize << log_h;
+        let perm_width = 4 * rng.range(2, 8) as usize;
+        let cumsum = sb.alloc(h * 4, format!("cumsum{i}"));
+        let perm_lde = sb.alloc(BLOWUP * h * perm_width, format!("perm_lde{i}"));
+        sb.free(cumsum);
+        retained.push(perm_lde);
+    }
+
+    // Phase 3: quotient — per AIR serialized temps, retained chunk LDEs.
+    for (i, &(log_h, _, qd)) in airs.iter().enumerate() {
+        let h = 1usize << log_h;
+        let qsize = h * qd;
+        let acc = sb.alloc(qsize * 4, format!("q_acc{i}"));
+        let selectors = sb.alloc(4 * qsize, format!("q_sel{i}"));
+        let chunks_lde = sb.alloc(BLOWUP * h * 4 * qd, format!("q_lde{i}"));
+        sb.free(selectors);
+        sb.free(acc);
+        retained.push(chunks_lde);
+    }
+
+    // Phase 4: opening — inv denominators + reduced openings per distinct
+    // height, then the FRI fold ladder from the max LDE height down.
+    let mut heights: Vec<u32> = airs.iter().map(|&(log_h, ..)| log_h).collect();
+    heights.dedup();
+    let mut opening_temps = Vec::new();
+    for &log_h in &heights {
+        let lde_h = 1usize << (log_h + 1);
+        let inv_denom = sb.alloc(lde_h * 4, format!("inv_denom{log_h}"));
+        let reduced = sb.alloc(lde_h * 4, format!("reduced{log_h}"));
+        opening_temps.push(inv_denom);
+        opening_temps.push(reduced);
+    }
+    let max_lde = 1usize << (heights[0] + 1);
+    let mut len = max_lde;
+    let mut layer = 0;
+    while len > 32 {
+        let folded = sb.alloc(len / 2 * 8, format!("fri_folded{layer}"));
+        let g_inv = sb.alloc(len / 2, format!("fri_ginv{layer}"));
+        let d_result = sb.alloc(len / 2 * 4, format!("fri_dres{layer}"));
+        sb.free(g_inv);
+        sb.free(d_result);
+        retained.push(folded);
+        len /= 2;
+        layer += 1;
+    }
+    for slot in opening_temps {
+        sb.free(slot);
+    }
+
+    // Proof done: everything device-side is dropped.
+    for slot in retained {
+        sb.free(slot);
+    }
+
+    Schedule {
+        num_slots: sb.next_slot,
+        ops: sb.ops,
+    }
+}
+
+// ============================================================================
+// Runners
+// ============================================================================
+
+struct RunStats {
+    wall: Duration,
+    alloc_cpu: Duration,
+    free_cpu: Duration,
+}
+
+fn run_dynamic(schedule: &Schedule, ctx: &GpuDeviceCtx) -> RunStats {
+    let mut slots: Vec<Option<DeviceBuffer<u32>>> = (0..schedule.num_slots).map(|_| None).collect();
+    let mut alloc_cpu = Duration::ZERO;
+    let mut free_cpu = Duration::ZERO;
+    ctx.stream.synchronize().unwrap();
+    let start = Instant::now();
+    for op in &schedule.ops {
+        match op {
+            Op::Alloc { slot, len, .. } => {
+                let t = Instant::now();
+                slots[*slot] = Some(DeviceBuffer::with_capacity_on(*len, ctx));
+                alloc_cpu += t.elapsed();
+            }
+            Op::Free { slot } => {
+                let t = Instant::now();
+                slots[*slot] = None;
+                free_cpu += t.elapsed();
+            }
+            Op::Touch { slot } => {
+                slots[*slot].as_ref().unwrap().fill_zero_on(ctx).unwrap();
+            }
+        }
+    }
+    ctx.stream.synchronize().unwrap();
+    RunStats {
+        wall: start.elapsed(),
+        alloc_cpu,
+        free_cpu,
+    }
+}
+
+fn plan_static(
+    schedule: &Schedule,
+    ctx: &GpuDeviceCtx,
+) -> (StaticAllocator, Vec<AllocIdx<u32>>, Duration) {
+    let start = Instant::now();
+    let builder = AllocBuilder::new();
+    let mut fakes: Vec<Option<openvm_cuda_common::static_alloc::DeviceBufFake<u32>>> =
+        (0..schedule.num_slots).map(|_| None).collect();
+    let mut idxs: Vec<Option<AllocIdx<u32>>> = vec![None; schedule.num_slots];
+    for op in &schedule.ops {
+        match op {
+            Op::Alloc { slot, len, label } => {
+                let fake = builder.alloc_fake_labeled::<u32>(*len, label);
+                idxs[*slot] = Some(fake.idx());
+                fakes[*slot] = Some(fake);
+            }
+            Op::Free { slot } => {
+                fakes[*slot] = None;
+            }
+            Op::Touch { .. } => {}
+        }
+    }
+    drop(fakes);
+    let alloc = builder.build_on(ctx).unwrap();
+    let elapsed = start.elapsed();
+    (
+        alloc,
+        idxs.into_iter().map(Option::unwrap).collect(),
+        elapsed,
+    )
+}
+
+fn run_static(
+    schedule: &Schedule,
+    alloc: &StaticAllocator,
+    idxs: &[AllocIdx<u32>],
+    ctx: &GpuDeviceCtx,
+) -> RunStats {
+    let mut slots: Vec<Option<StaticDeviceBuffer<u32>>> =
+        (0..schedule.num_slots).map(|_| None).collect();
+    let mut alloc_cpu = Duration::ZERO;
+    let mut free_cpu = Duration::ZERO;
+    ctx.stream.synchronize().unwrap();
+    let start = Instant::now();
+    for op in &schedule.ops {
+        match op {
+            Op::Alloc { slot, .. } => {
+                let t = Instant::now();
+                slots[*slot] = Some(alloc.get(&idxs[*slot]).unwrap());
+                alloc_cpu += t.elapsed();
+            }
+            Op::Free { slot } => {
+                let t = Instant::now();
+                slots[*slot] = None;
+                free_cpu += t.elapsed();
+            }
+            Op::Touch { slot } => {
+                slots[*slot].as_ref().unwrap().fill_zero_on(ctx).unwrap();
+            }
+        }
+    }
+    ctx.stream.synchronize().unwrap();
+    RunStats {
+        wall: start.elapsed(),
+        alloc_cpu,
+        free_cpu,
+    }
+}
+
+// ============================================================================
+// Micro-benchmark: raw alloc/free vs get/drop cost
+// ============================================================================
+
+fn micro_alloc_overhead(iters: usize, ctx: &GpuDeviceCtx) {
+    let len = 1usize << 20; // 4 MB
+    let t = Instant::now();
+    for _ in 0..iters {
+        let buf = DeviceBuffer::<u32>::with_capacity_on(len, ctx);
+        std::hint::black_box(buf.as_ptr());
+    }
+    let dynamic = t.elapsed();
+
+    let builder = AllocBuilder::new();
+    let idx = builder.alloc_fake_labeled::<u32>(len, "micro").idx();
+    let alloc = builder.build_on(ctx).unwrap();
+    let t = Instant::now();
+    for _ in 0..iters {
+        let buf = alloc.get(&idx).unwrap();
+        std::hint::black_box(buf.as_ptr());
+    }
+    let static_ = t.elapsed();
+
+    println!(
+        "micro ({iters} iters of 4 MB alloc+free): dynamic {:?}/op, static {:?}/op",
+        dynamic / iters as u32,
+        static_ / iters as u32
+    );
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn main() {
+    let num_airs = env_usize("BENCH_NUM_AIRS", 40);
+    assert!(num_airs >= 1, "BENCH_NUM_AIRS must be >= 1");
+    let log_max = env_usize("BENCH_LOG_MAX", 19) as u32;
+    assert!(
+        (17..=26).contains(&log_max),
+        "BENCH_LOG_MAX must be in 17..=26"
+    );
+    let rounds = env_usize("BENCH_ROUNDS", 3);
+    assert!(rounds >= 1, "BENCH_ROUNDS must be >= 1");
+    let touch = env_usize("BENCH_TOUCH", 1) != 0;
+
+    let ctx = GpuDeviceCtx::for_current_device().unwrap();
+    let schedule = build_schedule(num_airs, log_max, touch);
+    let num_allocs = schedule
+        .ops
+        .iter()
+        .filter(|op| matches!(op, Op::Alloc { .. }))
+        .count();
+    println!(
+        "schedule: {num_airs} AIRs, max height 2^{log_max}, {num_allocs} allocations, touch={touch}"
+    );
+
+    // --- Dynamic ---
+    let mut tracker = MemTracker::start("bench-dynamic");
+    tracker.reset_peak();
+    let (_, base_peak) = memory_stats();
+    let mut dyn_stats = Vec::new();
+    for round in 0..=rounds {
+        let stats = run_dynamic(&schedule, &ctx);
+        if round > 0 {
+            dyn_stats.push(stats); // round 0 = warm-up
+        }
+    }
+    let (_, dyn_peak) = memory_stats();
+    let dyn_peak = dyn_peak - base_peak.min(dyn_peak);
+
+    // --- Static ---
+    let (alloc, idxs, plan_time) = plan_static(&schedule, &ctx);
+    println!(
+        "static plan: workspace {} (peak live {}), planned in {:?}",
+        ByteSize::b(alloc.workspace_size() as u64),
+        ByteSize::b(alloc.peak_live_size() as u64),
+        plan_time
+    );
+    let mut static_stats = Vec::new();
+    for round in 0..=rounds {
+        let stats = run_static(&schedule, &alloc, &idxs, &ctx);
+        if round > 0 {
+            static_stats.push(stats);
+        }
+    }
+
+    // --- Report ---
+    let avg = |stats: &[RunStats]| {
+        let n = stats.len() as u32;
+        (
+            stats.iter().map(|s| s.wall).sum::<Duration>() / n,
+            stats.iter().map(|s| s.alloc_cpu).sum::<Duration>() / n,
+            stats.iter().map(|s| s.free_cpu).sum::<Duration>() / n,
+        )
+    };
+    let (d_wall, d_alloc, d_free) = avg(&dyn_stats);
+    let (s_wall, s_alloc, s_free) = avg(&static_stats);
+
+    println!("\n=== results (avg over {rounds} rounds) ===");
+    println!(
+        "dynamic: wall {:?}, alloc cpu {:?}, free cpu {:?}, peak mem {}",
+        d_wall,
+        d_alloc,
+        d_free,
+        ByteSize::b(dyn_peak as u64)
+    );
+    println!(
+        "static : wall {:?}, get cpu {:?}, drop cpu {:?}, workspace {}",
+        s_wall,
+        s_alloc,
+        s_free,
+        ByteSize::b(alloc.workspace_size() as u64)
+    );
+    if dyn_peak > 0 {
+        println!(
+            "workspace vs dynamic peak: {:.1}%",
+            100.0 * alloc.workspace_size() as f64 / dyn_peak as f64
+        );
+    }
+    println!(
+        "packing efficiency (workspace / peak-live lower bound): {:.3}",
+        alloc.workspace_size() as f64 / alloc.peak_live_size() as f64
+    );
+
+    micro_alloc_overhead(1000, &ctx);
+}

--- a/crates/cuda-common/benches/trace_phases.rs
+++ b/crates/cuda-common/benches/trace_phases.rs
@@ -1,0 +1,385 @@
+//! Per-phase static-vs-dynamic analysis of a `VPMM_TRACE` allocation trace.
+//!
+//! Produces three tables:
+//!   1. totals — dynamic allocator vs a whole-trace static plan;
+//!   2. per-phase (`MemTracker` scope label) — dynamic stats per proving phase: allocation
+//!      counts/bytes, measured allocator CPU time, peak memory while the phase was open;
+//!   3. per-stage — proofs are delimited by `UNIT_LABEL` scope starts and classified into stages by
+//!      ordinal (`STAGE_COUNTS`); each proof window gets its own static packing pass, mimicking a
+//!      per-proof plan.
+//!
+//! Usage:
+//!   TRACE=trace.csv [PAGE=4194304] [MIN_SIZE=16777216] \
+//!   [UNIT_LABEL=prover.stack_traces] [STAGE_COUNTS=app:150,leaf:150,internal:76,root:1] \
+//!     cargo bench -p openvm-cuda-common --bench trace_phases
+
+use std::collections::HashMap;
+
+use bytesize::ByteSize;
+use openvm_cuda_common::static_alloc::{AllocBuilder, DeviceBufFake};
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+#[derive(Clone, Copy)]
+enum Ev {
+    /// (alloc id, requested size)
+    Alloc(u32, usize),
+    /// (alloc id)
+    Free(u32),
+    /// (label id) — scope start
+    Start(u32),
+    /// (label id) — scope end
+    End(u32),
+}
+
+#[derive(Default, Clone)]
+struct PhaseStat {
+    instances: usize,
+    allocs: usize,
+    frees: usize,
+    alloc_bytes: u128,
+    alloc_ns: u128,
+    free_ns: u128,
+    /// max over instances of (max dynamic tracked bytes while the scope was open)
+    peak_dyn: usize,
+    /// max over instances of (max raw live bytes while the scope was open)
+    peak_live: usize,
+}
+
+fn gib(x: impl TryInto<u64>) -> String {
+    ByteSize::b(x.try_into().unwrap_or(0)).to_string()
+}
+
+fn ms(ns: u128) -> String {
+    format!("{:.1}ms", ns as f64 / 1e6)
+}
+
+fn main() {
+    let path = std::env::var("TRACE").expect("set TRACE=<trace.csv>");
+    let page = env_usize("PAGE", 4 << 20);
+    let min_size = env_usize("MIN_SIZE", 16 << 20);
+    let unit_label = std::env::var("UNIT_LABEL").unwrap_or_else(|_| "prover.stack_traces".into());
+    let stage_counts: Vec<(String, usize)> = std::env::var("STAGE_COUNTS")
+        .unwrap_or_default()
+        .split(',')
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            let (name, n) = s.split_once(':').expect("STAGE_COUNTS=name:count,...");
+            (name.to_string(), n.parse().expect("bad stage count"))
+        })
+        .collect();
+    let data = std::fs::read_to_string(&path).expect("cannot read trace");
+
+    // ---- Pass 1: parse into a compact event stream ------------------------
+    let mut events: Vec<Ev> = Vec::new();
+    let mut labels: Vec<String> = Vec::new();
+    let mut label_ids: HashMap<String, u32> = HashMap::new();
+    // alloc id -> (size, birth event idx, death event idx or MAX)
+    let mut allocs: Vec<(usize, usize, usize)> = Vec::new();
+    let mut live_ptr: HashMap<u64, u32> = HashMap::new();
+    // parallel per-event alloc/free durations (ns), 0 for markers
+    let mut durs: Vec<u64> = Vec::new();
+
+    for line in data.lines() {
+        let mut f = line.split(',');
+        let (op, a, b, _stream, _t, dur) = (
+            f.next().unwrap_or(""),
+            f.next().unwrap_or(""),
+            f.next().unwrap_or(""),
+            f.next().unwrap_or(""),
+            f.next().unwrap_or(""),
+            f.next().unwrap_or(""),
+        );
+        match op {
+            "A" => {
+                let ptr = u64::from_str_radix(a.trim_start_matches("0x"), 16).unwrap();
+                let size: usize = b.parse().unwrap();
+                let id = allocs.len() as u32;
+                allocs.push((size, events.len(), usize::MAX));
+                live_ptr.insert(ptr, id);
+                durs.push(dur.parse().unwrap_or(0));
+                events.push(Ev::Alloc(id, size));
+            }
+            "F" => {
+                let ptr = u64::from_str_radix(a.trim_start_matches("0x"), 16).unwrap();
+                if let Some(id) = live_ptr.remove(&ptr) {
+                    allocs[id as usize].2 = events.len();
+                    durs.push(dur.parse().unwrap_or(0));
+                    events.push(Ev::Free(id));
+                }
+            }
+            "M" => {
+                let (edge, label) = a.split_once(':').unwrap_or(("", a));
+                if edge != "start" && edge != "end" {
+                    continue; // "mark" intermediate points not used here
+                }
+                let id = *label_ids.entry(label.to_string()).or_insert_with(|| {
+                    labels.push(label.to_string());
+                    labels.len() as u32 - 1
+                });
+                durs.push(0);
+                events.push(if edge == "start" {
+                    Ev::Start(id)
+                } else {
+                    Ev::End(id)
+                });
+            }
+            _ => {}
+        }
+    }
+
+    // ---- Pass 2: walk events, accumulate per-phase + per-stage stats ------
+    let tracked = |size: usize| {
+        if size < page {
+            size
+        } else {
+            size.next_multiple_of(page)
+        }
+    };
+    let mut stats: Vec<PhaseStat> = vec![PhaseStat::default(); labels.len()];
+    // open scope stack: (label id, peak_dyn so far, peak_live so far)
+    let mut open: Vec<(u32, usize, usize)> = Vec::new();
+    let mut dyn_cur = 0usize;
+    let mut live_cur = 0usize;
+    let (mut dyn_peak, mut live_peak) = (0usize, 0usize);
+    let (mut total_alloc_ns, mut total_free_ns) = (0u128, 0u128);
+
+    // proof-unit windows (event index ranges)
+    let unit_id = label_ids.get(unit_label.as_str()).copied();
+    let mut unit_starts: Vec<usize> = Vec::new();
+
+    for (i, ev) in events.iter().enumerate() {
+        match *ev {
+            Ev::Alloc(_, size) => {
+                dyn_cur += tracked(size);
+                live_cur += size;
+                dyn_peak = dyn_peak.max(dyn_cur);
+                live_peak = live_peak.max(live_cur);
+                total_alloc_ns += durs[i] as u128;
+                if let Some(&mut (top, ..)) = open.last_mut() {
+                    let s = &mut stats[top as usize];
+                    s.allocs += 1;
+                    s.alloc_bytes += size as u128;
+                    s.alloc_ns += durs[i] as u128;
+                }
+                for o in open.iter_mut() {
+                    o.1 = o.1.max(dyn_cur);
+                    o.2 = o.2.max(live_cur);
+                }
+            }
+            Ev::Free(id) => {
+                let size = allocs[id as usize].0;
+                dyn_cur -= tracked(size);
+                live_cur -= size;
+                total_free_ns += durs[i] as u128;
+                if let Some(&mut (top, ..)) = open.last_mut() {
+                    let s = &mut stats[top as usize];
+                    s.frees += 1;
+                    s.free_ns += durs[i] as u128;
+                }
+            }
+            Ev::Start(l) => {
+                if Some(l) == unit_id {
+                    unit_starts.push(i);
+                }
+                open.push((l, dyn_cur, live_cur));
+            }
+            Ev::End(l) => {
+                // scopes may close out of order: pop the most recent match
+                if let Some(pos) = open.iter().rposition(|&(ol, ..)| ol == l) {
+                    let (_, pd, pl) = open.remove(pos);
+                    let s = &mut stats[l as usize];
+                    s.instances += 1;
+                    s.peak_dyn = s.peak_dyn.max(pd);
+                    s.peak_live = s.peak_live.max(pl);
+                }
+            }
+        }
+    }
+
+    // ---- Whole-trace static plan ------------------------------------------
+    let global_plan = plan_window(&allocs, &events, 0, events.len(), min_size);
+
+    println!(
+        "trace: {path}  ({} events, {} allocs)",
+        events.len(),
+        allocs.len()
+    );
+    println!("\n=== totals: dynamic default vs static plan ===");
+    println!(
+        "  dynamic: peak tracked {} (page {}), raw peak-live {}",
+        gib(dyn_peak),
+        gib(page),
+        gib(live_peak)
+    );
+    println!(
+        "  dynamic: allocator CPU {} alloc + {} free over {} allocs",
+        ms(total_alloc_ns),
+        ms(total_free_ns),
+        allocs.len()
+    );
+    println!(
+        "  static : workspace {} = {:.1}% of dynamic peak (plan over {} allocs >= {}; efficiency {:.3})",
+        gib(global_plan.0),
+        100.0 * global_plan.0 as f64 / dyn_peak.max(1) as f64,
+        global_plan.2,
+        gib(min_size),
+        global_plan.0 as f64 / global_plan.1.max(1) as f64,
+    );
+
+    // ---- Per-phase table ----------------------------------------------------
+    println!("\n=== per-phase (MemTracker scopes; events attributed to innermost open scope) ===");
+    println!(
+        "{:<38} {:>5} {:>8} {:>10} {:>10} {:>10} {:>11} {:>11}",
+        "phase", "inst", "allocs", "allocGiB", "alloc cpu", "free cpu", "peak dyn", "peak live"
+    );
+    let mut order: Vec<usize> = (0..labels.len()).collect();
+    order.sort_by_key(|&i| std::cmp::Reverse(stats[i].alloc_bytes));
+    for i in order {
+        let s = &stats[i];
+        if s.instances == 0 && s.allocs == 0 {
+            continue;
+        }
+        println!(
+            "{:<38} {:>5} {:>8} {:>10.2} {:>10} {:>10} {:>11} {:>11}",
+            labels[i],
+            s.instances,
+            s.allocs,
+            s.alloc_bytes as f64 / (1u64 << 30) as f64,
+            ms(s.alloc_ns),
+            ms(s.free_ns),
+            gib(s.peak_dyn),
+            gib(s.peak_live),
+        );
+    }
+
+    // ---- Per-stage windows --------------------------------------------------
+    if !unit_starts.is_empty() && !stage_counts.is_empty() {
+        println!(
+            "\n=== per-stage (windows of '{}' scopes; per-proof static plan) ===",
+            unit_label
+        );
+        println!(
+            "{:<10} {:>6} {:>10} {:>12} {:>12} {:>12} {:>10}",
+            "stage", "proofs", "allocs", "alloc cpu", "max dyn", "max static", "ws/dyn"
+        );
+        let mut idx = 0usize;
+        for (stage, count) in &stage_counts {
+            let lo = idx.min(unit_starts.len());
+            let hi = (idx + count).min(unit_starts.len());
+            idx += count;
+            if lo >= hi {
+                continue;
+            }
+            let mut st_allocs = 0usize;
+            let mut st_ns = 0u128;
+            let (mut st_dyn, mut st_ws) = (0usize, 0usize);
+            for w in lo..hi {
+                let s = unit_starts[w];
+                let e = if w + 1 < unit_starts.len() {
+                    unit_starts[w + 1]
+                } else {
+                    events.len()
+                };
+                let mut dcur = live_at_tracked(&allocs, s, page);
+                let mut dmax = dcur;
+                for i in s..e {
+                    match events[i] {
+                        Ev::Alloc(_, size) => {
+                            dcur += tracked(size);
+                            dmax = dmax.max(dcur);
+                            st_allocs += 1;
+                            st_ns += durs[i] as u128;
+                        }
+                        Ev::Free(id) => dcur -= tracked(allocs[id as usize].0),
+                        _ => {}
+                    }
+                }
+                st_dyn = st_dyn.max(dmax);
+                let (ws, ..) = plan_window(&allocs, &events, s, e, min_size);
+                st_ws = st_ws.max(ws);
+            }
+            println!(
+                "{:<10} {:>6} {:>10} {:>12} {:>12} {:>12} {:>9.1}%",
+                stage,
+                hi - lo,
+                st_allocs,
+                ms(st_ns),
+                gib(st_dyn),
+                gib(st_ws),
+                100.0 * st_ws as f64 / st_dyn.max(1) as f64,
+            );
+        }
+        if idx < unit_starts.len() {
+            println!(
+                "  (warning: {} proof windows beyond STAGE_COUNTS)",
+                unit_starts.len() - idx
+            );
+        }
+    } else {
+        println!(
+            "\n(per-stage table skipped: UNIT_LABEL '{}' seen {} times, STAGE_COUNTS {:?})",
+            unit_label,
+            unit_starts.len(),
+            stage_counts
+        );
+    }
+}
+
+/// Tracked bytes of allocations alive at event index `s` (born before, not yet freed).
+fn live_at_tracked(allocs: &[(usize, usize, usize)], s: usize, page: usize) -> usize {
+    allocs
+        .iter()
+        .filter(|&&(_, b, d)| b < s && d >= s)
+        .map(|&(size, ..)| {
+            if size < page {
+                size
+            } else {
+                size.next_multiple_of(page)
+            }
+        })
+        .sum()
+}
+
+/// Packs the window `[s, e)` as its own static plan: carried-over live buffers
+/// become window-start allocations, buffers still live at the end stay
+/// immortal. Returns (workspace, peak_live, planned alloc count).
+fn plan_window(
+    allocs: &[(usize, usize, usize)],
+    events: &[Ev],
+    s: usize,
+    e: usize,
+    min_size: usize,
+) -> (usize, usize, usize) {
+    let builder = AllocBuilder::new();
+    let mut fakes: HashMap<u32, DeviceBufFake<u8>> = HashMap::new();
+    // Carried-over buffers first: all alive together at window start.
+    for (id, &(size, b, d)) in allocs.iter().enumerate() {
+        if size >= min_size && b < s && d >= s {
+            fakes.insert(id as u32, builder.alloc_fake::<u8>(size));
+        }
+    }
+    for ev in &events[s..e] {
+        match *ev {
+            Ev::Alloc(id, size) => {
+                if size >= min_size {
+                    fakes.insert(id, builder.alloc_fake::<u8>(size));
+                }
+            }
+            Ev::Free(id) => {
+                fakes.remove(&id);
+            }
+            _ => {}
+        }
+    }
+    // Buffers still live at the window end die here, after every in-window
+    // birth — equivalent to immortal for interference purposes.
+    drop(fakes);
+    let stats = builder.plan_stats();
+    (stats.workspace_size, stats.peak_live_size, stats.num_allocs)
+}

--- a/crates/cuda-common/benches/trace_replay.rs
+++ b/crates/cuda-common/benches/trace_replay.rs
@@ -1,0 +1,127 @@
+//! Replays a `VPMM_TRACE` allocation trace against the static allocator's
+//! packing pass and reports the workspace a static plan would need for the
+//! same workload, next to what the dynamic allocator actually consumed.
+//!
+//! Usage:
+//!   TRACE=trace.csv [MIN_SIZE=2097152] [PAGE=4194304] \
+//!     cargo bench -p openvm-cuda-common --bench trace_replay
+//!
+//! - `TRACE`: CSV produced by running any workload with `VPMM_TRACE=<path>`.
+//! - `MIN_SIZE` (default 2 MiB): allocations smaller than this are excluded from the packing pass
+//!   (they take the `cudaMallocAsync` path in the dynamic allocator and are not the static
+//!   planner's target), but they are still counted in the reported dynamic peaks.
+//! - `PAGE` (default 4 MiB): page size used to reproduce the dynamic allocator's size rounding for
+//!   allocations >= `MIN_SIZE`.
+//!
+//! Requires a CUDA device only because the crate initializes its memory
+//! manager at program start; the replay itself never touches the GPU.
+
+use std::collections::HashMap;
+
+use bytesize::ByteSize;
+use openvm_cuda_common::static_alloc::{AllocBuilder, DeviceBufFake};
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn main() {
+    let path = std::env::var("TRACE").expect("set TRACE=<trace.csv>");
+    let min_size = env_usize("MIN_SIZE", 2 << 20);
+    let page = env_usize("PAGE", 4 << 20);
+    let data = std::fs::read_to_string(&path).expect("cannot read trace");
+
+    let builder = AllocBuilder::new();
+    // ptr -> (fake handle or None if below MIN_SIZE, tracked size)
+    let mut live: HashMap<u64, (Option<DeviceBufFake<u8>>, usize)> = HashMap::new();
+    let (mut n_alloc, mut n_small, mut n_unmatched_free) = (0usize, 0usize, 0usize);
+    // Dynamic-allocator accounting: sizes rounded exactly as the memory
+    // manager tracks them (page multiples for pool-path allocations).
+    let (mut dyn_cur, mut dyn_peak) = (0usize, 0usize);
+    let mut streams: Vec<u64> = Vec::new();
+
+    for (lineno, line) in data.lines().enumerate() {
+        let mut fields = line.split(',');
+        let (op, ptr, size, stream) = (
+            fields.next().unwrap_or(""),
+            fields.next().unwrap_or(""),
+            fields.next().unwrap_or(""),
+            fields.next().unwrap_or(""),
+        );
+        if op != "A" && op != "F" {
+            continue; // phase markers etc.
+        }
+        let ptr = u64::from_str_radix(ptr.trim_start_matches("0x"), 16)
+            .unwrap_or_else(|_| panic!("bad ptr at line {lineno}"));
+        match op {
+            "A" => {
+                let size: usize = size
+                    .parse()
+                    .unwrap_or_else(|_| panic!("bad size @{lineno}"));
+                let stream: u64 = stream.parse().unwrap_or(0);
+                if !streams.contains(&stream) {
+                    streams.push(stream);
+                }
+                n_alloc += 1;
+                let tracked = if size < page {
+                    size
+                } else {
+                    size.next_multiple_of(page)
+                };
+                dyn_cur += tracked;
+                dyn_peak = dyn_peak.max(dyn_cur);
+                let fake = if size >= min_size {
+                    Some(builder.alloc_fake_on_stream::<u8>(size, &format!("l{lineno}"), stream))
+                } else {
+                    n_small += 1;
+                    None
+                };
+                // A ptr can only be live once; VPMM may reuse addresses after
+                // a free, which removes the old entry below.
+                live.insert(ptr, (fake, tracked));
+            }
+            "F" => match live.remove(&ptr) {
+                Some((fake, tracked)) => {
+                    dyn_cur -= tracked;
+                    drop(fake); // ends the declared lifetime
+                }
+                None => n_unmatched_free += 1,
+            },
+            _ => {}
+        }
+    }
+    let leaked = live.len();
+    drop(live); // still-live allocations stay immortal in the plan
+
+    let stats = builder.plan_stats();
+    println!("trace: {path}");
+    println!(
+        "  events: {n_alloc} allocs ({n_small} below {} excluded from plan), \
+         {n_unmatched_free} unmatched frees, {leaked} never freed, {} stream(s)",
+        ByteSize::b(min_size as u64),
+        streams.len(),
+    );
+    println!(
+        "  dynamic (page {}): peak tracked {}",
+        ByteSize::b(page as u64),
+        ByteSize::b(dyn_peak as u64)
+    );
+    println!(
+        "  static plan over {} allocs: workspace {}, peak live {}, sum of sizes {}",
+        stats.num_allocs,
+        ByteSize::b(stats.workspace_size as u64),
+        ByteSize::b(stats.peak_live_size as u64),
+        ByteSize::b(stats.sum_of_sizes as u64)
+    );
+    println!(
+        "  packing efficiency (workspace / peak-live): {:.3}",
+        stats.workspace_size as f64 / stats.peak_live_size.max(1) as f64
+    );
+    println!(
+        "  static workspace vs dynamic peak: {:.1}%",
+        100.0 * stats.workspace_size as f64 / dyn_peak.max(1) as f64
+    );
+}

--- a/crates/cuda-common/src/lib.rs
+++ b/crates/cuda-common/src/lib.rs
@@ -4,4 +4,5 @@ pub mod d_buffer;
 pub mod error;
 pub mod memory_manager;
 pub mod pinned;
+pub mod static_alloc;
 pub mod stream;

--- a/crates/cuda-common/src/memory_manager/mod.rs
+++ b/crates/cuda-common/src/memory_manager/mod.rs
@@ -14,7 +14,11 @@ use crate::{
 };
 
 mod cuda;
+mod replay;
+mod trace;
 mod vm_pool;
+use replay::ReplayAllocator;
+use trace::AllocTracer;
 use vm_pool::VirtualMemoryPool;
 
 #[cfg(test)]
@@ -53,6 +57,8 @@ pub struct MemoryManager {
     allocated_ptrs: HashMap<NonNull<c_void>, AllocRecord>,
     current_size: usize,
     max_used_size: usize,
+    tracer: Option<AllocTracer>,
+    replay: Option<ReplayAllocator>,
 }
 
 /// # Safety
@@ -71,6 +77,8 @@ impl MemoryManager {
             allocated_ptrs: HashMap::new(),
             current_size: 0,
             max_used_size: 0,
+            tracer: AllocTracer::from_env(),
+            replay: ReplayAllocator::from_env(),
         }
     }
 
@@ -80,6 +88,30 @@ impl MemoryManager {
         stream: &StreamGuard,
     ) -> Result<*mut c_void, MemoryError> {
         assert!(size != 0, "Requested size must be non-zero");
+
+        if self.replay.as_ref().is_some_and(|r| size >= r.min_size)
+            && self.pool.page_size != usize::MAX
+        {
+            // Lazily allocate the replay workspace through the pool so it is
+            // tracked like any other allocation (counted once, not per serve).
+            if self.replay.as_ref().unwrap().workspace.is_none() {
+                let total = self
+                    .replay
+                    .as_ref()
+                    .unwrap()
+                    .total_size
+                    .next_multiple_of(self.pool.page_size);
+                let ws = self.pool.malloc_internal(total, stream)?;
+                self.current_size += total;
+                self.max_used_size = self.max_used_size.max(self.current_size);
+                self.replay.as_mut().unwrap().workspace = Some(ws);
+                tracing::warn!("VPMM_REPLAY: workspace of {} bytes allocated", total);
+            }
+            let key = stream.as_raw() as u64;
+            if let Some(ptr) = self.replay.as_mut().unwrap().try_alloc(size, key) {
+                return Ok(ptr);
+            }
+        }
 
         let mut tracked_size = size;
         let ptr = if size < self.pool.page_size {
@@ -115,8 +147,24 @@ impl MemoryManager {
     /// - The pointer `ptr` must be a valid, previously allocated device pointer.
     /// - The caller must ensure that `ptr` is not used after this function is called.
     /// - The caller must hold the `MEMORY_MANAGER` lock before calling this method.
-    unsafe fn d_free_under_lock(&mut self, ptr: *mut c_void) -> Result<StreamGuard, MemoryError> {
+    unsafe fn d_free_under_lock(
+        &mut self,
+        ptr: *mut c_void,
+    ) -> Result<Option<StreamGuard>, MemoryError> {
         let nn = NonNull::new(ptr).ok_or(MemoryError::NullPointer)?;
+
+        if let Some(replay) = &mut self.replay {
+            if replay.try_free(ptr) {
+                return Ok(None);
+            }
+            // The workspace base is also a live pool record covering the whole
+            // replay workspace: it must never reach `pool.free_internal`, or a
+            // caller double-free of the offset-0 served pointer would silently
+            // release the entire workspace while served buffers live inside it.
+            if replay.workspace == Some(ptr) {
+                return Err(MemoryError::InvalidPointer);
+            }
+        }
 
         if let Some(record) = self.allocated_ptrs.remove(&nn) {
             let size = record.size;
@@ -125,11 +173,11 @@ impl MemoryManager {
                 tracing::error!("cudaFreeAsync failed: ptr={:p}: {:?}", ptr, e);
                 MemoryError::from(e)
             })?;
-            Ok(record.stream)
+            Ok(Some(record.stream))
         } else {
             let (freed_size, guard) = self.pool.free_internal(ptr)?;
             self.current_size -= freed_size;
-            Ok(guard)
+            Ok(Some(guard))
         }
     }
 }
@@ -154,21 +202,41 @@ impl Default for MemoryManager {
 }
 
 pub fn d_malloc_on(size: usize, stream: &StreamGuard) -> Result<*mut c_void, MemoryError> {
+    let t0 = std::time::Instant::now();
     let manager = MEMORY_MANAGER.get().unwrap();
     let mut manager = manager.lock().map_err(|_| MemoryError::LockError)?;
-    manager.d_malloc_on(size, stream)
+    let ptr = manager.d_malloc_on(size, stream)?;
+    if let Some(tracer) = &mut manager.tracer {
+        tracer.record_alloc(ptr, size, stream.as_raw() as u64, t0.elapsed().as_nanos());
+    }
+    Ok(ptr)
 }
 
 /// # Safety
 /// The pointer `ptr` must be a valid, previously allocated device pointer.
 /// The caller must ensure that `ptr` is not used after this function is called.
 pub unsafe fn d_free(ptr: *mut c_void) -> Result<(), MemoryError> {
+    let t0 = std::time::Instant::now();
     let manager = MEMORY_MANAGER.get().unwrap();
     let mut manager = manager.lock().map_err(|_| MemoryError::LockError)?;
     let guard = manager.d_free_under_lock(ptr)?;
+    if let Some(tracer) = &mut manager.tracer {
+        let key = guard.as_ref().map(|g| g.as_raw() as u64).unwrap_or(0);
+        tracer.record_free(ptr, key, t0.elapsed().as_nanos());
+    }
     drop(manager);
     drop(guard);
     Ok(())
+}
+
+/// Returns `(current, peak)` GPU memory tracked by the global memory manager,
+/// in bytes. Returns zeros if the manager is unavailable.
+pub fn memory_stats() -> (usize, usize) {
+    MEMORY_MANAGER
+        .get()
+        .and_then(|m| m.lock().ok())
+        .map(|m| (m.current_size, m.max_used_size))
+        .unwrap_or((0, 0))
 }
 
 #[derive(Debug, Clone)]
@@ -182,7 +250,12 @@ impl MemTracker {
         let current = MEMORY_MANAGER
             .get()
             .and_then(|m| m.lock().ok())
-            .map(|m| m.current_size)
+            .map(|mut m| {
+                if let Some(tracer) = &mut m.tracer {
+                    tracer.record_marker("start", label);
+                }
+                m.current_size
+            })
             .unwrap_or_default();
 
         Self { current, label }
@@ -221,10 +294,17 @@ impl MemTracker {
 
     #[inline]
     pub fn tracing_info(&self, msg: impl Into<Option<&'static str>>) {
-        let Some(manager) = MEMORY_MANAGER.get().and_then(|m| m.lock().ok()) else {
+        let Some(mut manager) = MEMORY_MANAGER.get().and_then(|m| m.lock().ok()) else {
             tracing::error!("Memory manager not available");
             return;
         };
+        let msg = msg.into();
+        if let Some(tracer) = &mut manager.tracer {
+            match msg {
+                None => tracer.record_marker("end", self.label),
+                Some(m) => tracer.record_marker("mark", &format!("{}:{}", self.label, m)),
+            }
+        }
         let current = manager.current_size;
         let peak = manager.max_used_size;
         let used = current as isize - self.current as isize;
@@ -237,8 +317,7 @@ impl MemTracker {
             ByteSize::b(current as u64),
             ByteSize::b(peak as u64),
             ByteSize::b(pool_usage as u64),
-            msg.into()
-                .map_or(self.label.to_string(), |m| format!("{}:{}", self.label, m))
+            msg.map_or(self.label.to_string(), |m| format!("{}:{}", self.label, m))
         );
     }
 

--- a/crates/cuda-common/src/memory_manager/replay.rs
+++ b/crates/cuda-common/src/memory_manager/replay.rs
@@ -1,0 +1,386 @@
+//! Record-and-replay static allocation.
+//!
+//! When `VPMM_REPLAY` points at a `VPMM_TRACE` file recorded from an earlier
+//! run of the same workload, the memory manager pre-plans all allocations of
+//! at least `VPMM_REPLAY_MIN` bytes (default 16 MiB): a greedy packing pass
+//! assigns each traced allocation a fixed offset in one workspace so that no
+//! two allocations with overlapping traced lifetimes share memory. At run
+//! time the k-th matching allocation is served at its planned offset — pointer
+//! arithmetic instead of pool work — and frees of served pointers are pure
+//! bookkeeping (no CUDA calls).
+//!
+//! Correctness does not depend on the run replaying the trace exactly:
+//! - an allocation is served only if its size matches the next planned event AND its planned range
+//!   overlaps no currently-live served allocation; otherwise it silently falls back to the dynamic
+//!   allocator;
+//! - replay assumes single-stream ordering (the recorded workloads run everything on one stream):
+//!   if a second stream is observed, replay disables itself permanently and everything falls back.
+//!
+//! Divergence counters are logged when the plan is exhausted and on drop.
+
+use std::collections::{BTreeMap, HashMap};
+
+/// Minimum alignment for planned offsets; matches `cudaMalloc`'s guarantee.
+const MIN_ALIGN: usize = 256;
+
+struct PlannedEvent {
+    size: usize,
+    offset: usize,
+}
+
+pub(super) struct ReplayAllocator {
+    /// Planned allocation events in traced order.
+    seq: Vec<PlannedEvent>,
+    next: usize,
+    pub(super) min_size: usize,
+    /// Total workspace bytes required by the plan.
+    pub(super) total_size: usize,
+    /// Base pointer of the workspace once allocated (lazily, on first serve).
+    pub(super) workspace: Option<*mut std::ffi::c_void>,
+    /// Live served allocations: ptr -> (offset, size).
+    live: HashMap<usize, (usize, usize)>,
+    /// Live planned intervals: offset -> end (for the aliasing safety check).
+    live_intervals: BTreeMap<usize, usize>,
+    /// The single stream replay is bound to (raw handle), set on first serve.
+    stream: Option<u64>,
+    disabled: bool,
+    served: u64,
+    fallback: u64,
+    reported: bool,
+}
+
+impl ReplayAllocator {
+    /// Builds the plan from `VPMM_REPLAY` if set. Panics on unreadable input:
+    /// a silently absent plan would invalidate a replay benchmark.
+    pub(super) fn from_env() -> Option<Self> {
+        let path = std::env::var("VPMM_REPLAY").ok()?;
+        let min_size = std::env::var("VPMM_REPLAY_MIN")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(16 << 20);
+        let data = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("VPMM_REPLAY: cannot read {path}: {e}"));
+        Self::from_trace(&data, min_size, &path)
+    }
+
+    fn from_trace(data: &str, min_size: usize, path: &str) -> Option<Self> {
+        // Parse plannable events: sizes + lifetime intervals in event order.
+        let mut sizes: Vec<usize> = Vec::new();
+        let mut births: Vec<u64> = Vec::new();
+        let mut deaths: Vec<u64> = Vec::new();
+        let mut live_ptr: HashMap<u64, usize> = HashMap::new();
+        let mut clock: u64 = 0;
+        for line in data.lines() {
+            let mut f = line.split(',');
+            let (op, ptr, size) = (
+                f.next().unwrap_or(""),
+                f.next().unwrap_or(""),
+                f.next().unwrap_or(""),
+            );
+            match op {
+                "A" => {
+                    let ptr = u64::from_str_radix(ptr.trim_start_matches("0x"), 16)
+                        .expect("VPMM_REPLAY: bad ptr");
+                    let size: usize = size.parse().expect("VPMM_REPLAY: bad size");
+                    if size >= min_size {
+                        live_ptr.insert(ptr, sizes.len());
+                        sizes.push(size);
+                        births.push(clock);
+                        deaths.push(u64::MAX);
+                        clock += 1;
+                    }
+                }
+                "F" => {
+                    let ptr = u64::from_str_radix(ptr.trim_start_matches("0x"), 16)
+                        .expect("VPMM_REPLAY: bad ptr");
+                    if let Some(idx) = live_ptr.remove(&ptr) {
+                        deaths[idx] = clock;
+                        clock += 1;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let (offsets, total_size) = plan_offsets(&sizes, &births, &deaths);
+        if sizes.is_empty() || total_size == 0 {
+            tracing::warn!(
+                "VPMM_REPLAY: no allocations >= {min_size} bytes in {path}; replay disabled"
+            );
+            return None;
+        }
+        let seq = sizes
+            .iter()
+            .zip(&offsets)
+            .map(|(&size, &offset)| PlannedEvent { size, offset })
+            .collect::<Vec<_>>();
+        tracing::info!(
+            "VPMM_REPLAY: planned {} allocations (>= {} bytes) from {path} into a {} byte workspace",
+            seq.len(),
+            min_size,
+            total_size,
+        );
+        Some(Self {
+            seq,
+            next: 0,
+            min_size,
+            total_size,
+            workspace: None,
+            live: HashMap::new(),
+            live_intervals: BTreeMap::new(),
+            stream: None,
+            disabled: false,
+            served: 0,
+            fallback: 0,
+            reported: false,
+        })
+    }
+
+    /// Tries to serve an allocation from the plan. `None` means the caller
+    /// must fall back to the dynamic allocator. The workspace must already be
+    /// allocated by the caller.
+    pub(super) fn try_alloc(&mut self, size: usize, stream: u64) -> Option<*mut std::ffi::c_void> {
+        debug_assert!(size >= self.min_size);
+        if self.disabled {
+            return None;
+        }
+        match self.stream {
+            None => self.stream = Some(stream),
+            Some(s) if s != stream => {
+                tracing::error!(
+                    "VPMM_REPLAY: second stream observed; disabling replay (single-stream only)"
+                );
+                self.disabled = true;
+                return None;
+            }
+            _ => {}
+        }
+        let base = self.workspace?;
+        let ev = self.seq.get(self.next)?;
+        if ev.size != size {
+            self.note_fallback(size);
+            return None;
+        }
+        let (offset, end) = (ev.offset, ev.offset + ev.size);
+        // Aliasing safety: the planned range must not overlap any live served
+        // allocation. Overlap here means the run diverged from the trace.
+        if let Some((&o, &e)) = self.live_intervals.range(..end).next_back() {
+            if e > offset && o < end {
+                self.note_fallback(size);
+                return None;
+            }
+        }
+        self.next += 1;
+        self.served += 1;
+        let ptr = unsafe { base.byte_add(offset) };
+        self.live.insert(ptr as usize, (offset, size));
+        self.live_intervals.insert(offset, end);
+        if self.next == self.seq.len() && !self.reported {
+            self.reported = true;
+            tracing::warn!(
+                "VPMM_REPLAY: plan exhausted: served {} allocations, {} fell back to dynamic",
+                self.served,
+                self.fallback,
+            );
+        }
+        Some(ptr)
+    }
+
+    /// Returns true if `ptr` was served from the workspace (bookkeeping-only free).
+    pub(super) fn try_free(&mut self, ptr: *mut std::ffi::c_void) -> bool {
+        if let Some((offset, _size)) = self.live.remove(&(ptr as usize)) {
+            self.live_intervals.remove(&offset);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn note_fallback(&mut self, size: usize) {
+        self.fallback += 1;
+        if self.fallback <= 10 {
+            tracing::warn!(
+                "VPMM_REPLAY: sequence divergence at planned event {} (requested {} bytes); \
+                 serving dynamically",
+                self.next,
+                size,
+            );
+        }
+    }
+}
+
+impl Drop for ReplayAllocator {
+    fn drop(&mut self) {
+        tracing::info!(
+            "VPMM_REPLAY: final stats: served {}, fell back {}, plan position {}/{}",
+            self.served,
+            self.fallback,
+            self.next,
+            self.seq.len(),
+        );
+    }
+}
+
+/// Greedy best-fit-decreasing packing over the interval interference graph
+/// (same heuristic as the static allocator's planner: place in decreasing
+/// size order at the lowest 256-byte-aligned offset that does not overlap any
+/// already-placed allocation with an overlapping lifetime).
+fn plan_offsets(sizes: &[usize], births: &[u64], deaths: &[u64]) -> (Vec<usize>, usize) {
+    let n = sizes.len();
+    let mut order: Vec<usize> = (0..n).collect();
+    order.sort_by_key(|&i| (std::cmp::Reverse(sizes[i]), births[i], i));
+
+    let align_up = |x: usize| (x + MIN_ALIGN - 1) & !(MIN_ALIGN - 1);
+    let mut offsets = vec![0usize; n];
+    let mut placed: Vec<usize> = Vec::with_capacity(n);
+    let mut total = 0usize;
+    for &i in &order {
+        let mut occupied: Vec<(usize, usize)> = placed
+            .iter()
+            .filter(|&&j| births[i] < deaths[j] && births[j] < deaths[i])
+            .map(|&j| (offsets[j], offsets[j] + sizes[j]))
+            .collect();
+        occupied.sort_unstable();
+        let mut cursor = 0usize;
+        for (start, end) in occupied {
+            if cursor + sizes[i] <= start {
+                break;
+            }
+            cursor = cursor.max(align_up(end));
+        }
+        offsets[i] = cursor;
+        placed.push(i);
+        total = total.max(cursor + sizes[i]);
+    }
+    (offsets, total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MI: usize = 1 << 20;
+
+    /// A dummy device base pointer: replay only does pointer arithmetic on it.
+    fn base() -> *mut std::ffi::c_void {
+        0x1000_0000usize as *mut std::ffi::c_void
+    }
+
+    fn trace(events: &[(char, u64, usize)]) -> String {
+        events
+            .iter()
+            .map(|&(op, ptr, size)| {
+                if op == 'A' {
+                    format!("A,{ptr:#x},{size},7,0,0\n")
+                } else {
+                    format!("F,{ptr:#x},,7,0,0\n")
+                }
+            })
+            .collect()
+    }
+
+    fn replay_from(events: &[(char, u64, usize)]) -> ReplayAllocator {
+        let mut r = ReplayAllocator::from_trace(&trace(events), 16 * MI, "test").unwrap();
+        r.workspace = Some(base());
+        r
+    }
+
+    #[test]
+    fn test_convergent_run_serves_everything() {
+        // A and B live concurrently, C reuses after both die.
+        let ev = [
+            ('A', 1, 32 * MI),
+            ('A', 2, 32 * MI),
+            ('F', 1, 0),
+            ('F', 2, 0),
+            ('A', 3, 32 * MI),
+            ('F', 3, 0),
+        ];
+        let mut r = replay_from(&ev);
+        assert_eq!(r.total_size, 64 * MI);
+
+        let a = r.try_alloc(32 * MI, 7).unwrap();
+        let b = r.try_alloc(32 * MI, 7).unwrap();
+        assert_ne!(a, b, "concurrently live buffers must not alias");
+        assert!(r.try_free(a));
+        assert!(r.try_free(b));
+        let c = r.try_alloc(32 * MI, 7).unwrap();
+        assert!(r.try_free(c));
+        assert_eq!(r.served, 3);
+        assert_eq!(r.fallback, 0);
+    }
+
+    #[test]
+    fn test_size_mismatch_falls_back_then_recovers() {
+        let ev = [
+            ('A', 1, 32 * MI),
+            ('F', 1, 0),
+            ('A', 2, 64 * MI),
+            ('F', 2, 0),
+        ];
+        let mut r = replay_from(&ev);
+
+        // Unexpected size: not served, cursor stays.
+        assert!(r.try_alloc(48 * MI, 7).is_none());
+        assert_eq!(r.fallback, 1);
+        // The expected sequence still replays afterwards.
+        let a = r.try_alloc(32 * MI, 7).unwrap();
+        assert!(r.try_free(a));
+        assert!(r.try_alloc(64 * MI, 7).is_some());
+        assert_eq!(r.served, 2);
+    }
+
+    #[test]
+    fn test_overlap_with_live_buffer_falls_back() {
+        // In the trace, B reuses A's space after A dies. At run time A is
+        // still held when B arrives: serving B would alias A, so it must
+        // fall back even though the size matches.
+        let ev = [
+            ('A', 1, 32 * MI),
+            ('F', 1, 0),
+            ('A', 2, 32 * MI),
+            ('F', 2, 0),
+        ];
+        let mut r = replay_from(&ev);
+        assert_eq!(r.total_size, 32 * MI, "plan should reuse A's space for B");
+
+        let a = r.try_alloc(32 * MI, 7).unwrap();
+        assert!(r.try_alloc(32 * MI, 7).is_none(), "B would alias live A");
+        assert_eq!(r.fallback, 1);
+        assert!(r.try_free(a));
+    }
+
+    #[test]
+    fn test_second_stream_disables_replay() {
+        let ev = [
+            ('A', 1, 32 * MI),
+            ('F', 1, 0),
+            ('A', 2, 32 * MI),
+            ('F', 2, 0),
+        ];
+        let mut r = replay_from(&ev);
+        assert!(r.try_alloc(32 * MI, 7).is_some());
+        assert!(
+            r.try_alloc(32 * MI, 8).is_none(),
+            "other stream must not be served"
+        );
+        assert!(r.disabled);
+        assert!(r.try_alloc(32 * MI, 7).is_none(), "replay stays disabled");
+    }
+
+    #[test]
+    fn test_empty_plan_is_rejected() {
+        assert!(ReplayAllocator::from_trace(&trace(&[('A', 1, MI)]), 16 * MI, "test").is_none());
+        assert!(ReplayAllocator::from_trace("", 16 * MI, "test").is_none());
+    }
+
+    #[test]
+    fn test_free_of_unknown_pointer_is_not_claimed() {
+        let ev = [('A', 1, 32 * MI), ('F', 1, 0)];
+        let mut r = replay_from(&ev);
+        assert!(!r.try_free(base()), "never-served pointer is not replay's");
+        let a = r.try_alloc(32 * MI, 7).unwrap();
+        assert!(r.try_free(a));
+        assert!(!r.try_free(a), "double free is not claimed twice");
+    }
+}

--- a/crates/cuda-common/src/memory_manager/trace.rs
+++ b/crates/cuda-common/src/memory_manager/trace.rs
@@ -1,0 +1,97 @@
+//! Optional allocation-event tracing for offline memory-planning analysis.
+//!
+//! When the `VPMM_TRACE` environment variable is set to a file path, every
+//! `d_malloc`/`d_free` through the global memory manager appends one CSV line,
+//! and every [`MemTracker`](super::MemTracker) scope appends phase markers:
+//!
+//! ```text
+//! A,<ptr hex>,<requested size bytes>,<stream key>,<micros since start>,<call duration ns>
+//! F,<ptr hex>,,<stream key>,<micros since start>,<call duration ns>
+//! M,<start|end>:<label>,,,<micros since start>,
+//! ```
+//!
+//! Sizes are the *requested* sizes (before page rounding). The call duration
+//! covers lock acquisition plus the allocator work, i.e. what the calling
+//! thread actually paid. Records are written under the memory-manager mutex,
+//! so line order is the global allocation order. Traces are replayed against
+//! the static allocator's packing pass (`benches/trace_replay.rs`,
+//! `benches/trace_phases.rs`).
+
+use std::{
+    fs::File,
+    io::{BufWriter, Write},
+    time::Instant,
+};
+
+pub(super) struct AllocTracer {
+    out: BufWriter<File>,
+    start: Instant,
+    /// Flush every N records so a crash or (ctor-static) missing drop loses
+    /// at most one batch.
+    pending: u32,
+}
+
+const FLUSH_EVERY: u32 = 64;
+
+impl AllocTracer {
+    /// Creates a tracer if `VPMM_TRACE` is set. Panics if the file cannot be
+    /// created — a silently missing trace is worse than a loud failure.
+    pub(super) fn from_env() -> Option<Self> {
+        let path = std::env::var("VPMM_TRACE").ok()?;
+        let file =
+            File::create(&path).unwrap_or_else(|e| panic!("VPMM_TRACE: cannot create {path}: {e}"));
+        tracing::info!("VPMM_TRACE: recording allocation trace to {path}");
+        Some(Self {
+            out: BufWriter::new(file),
+            start: Instant::now(),
+            pending: 0,
+        })
+    }
+
+    pub(super) fn record_alloc(
+        &mut self,
+        ptr: *mut std::ffi::c_void,
+        size: usize,
+        stream: u64,
+        dur_ns: u128,
+    ) {
+        let t_us = self.start.elapsed().as_micros();
+        self.write_line(format_args!(
+            "A,{:#x},{size},{stream},{t_us},{dur_ns}",
+            ptr as usize
+        ));
+    }
+
+    pub(super) fn record_free(&mut self, ptr: *mut std::ffi::c_void, stream: u64, dur_ns: u128) {
+        let t_us = self.start.elapsed().as_micros();
+        self.write_line(format_args!(
+            "F,{:#x},,{stream},{t_us},{dur_ns}",
+            ptr as usize
+        ));
+    }
+
+    /// Phase marker; `edge` is "start" or "end".
+    pub(super) fn record_marker(&mut self, edge: &str, label: &str) {
+        let t_us = self.start.elapsed().as_micros();
+        // Commas in labels would corrupt the CSV.
+        let label = label.replace(',', ";");
+        self.write_line(format_args!("M,{edge}:{label},,,{t_us},"));
+    }
+
+    fn write_line(&mut self, args: std::fmt::Arguments<'_>) {
+        if writeln!(self.out, "{args}").is_err() {
+            return;
+        }
+        self.pending += 1;
+        if self.pending >= FLUSH_EVERY {
+            let _ = self.out.flush();
+            self.pending = 0;
+        }
+    }
+}
+
+impl Drop for AllocTracer {
+    fn drop(&mut self) {
+        let _ = self.out.flush();
+    }
+}

--- a/crates/cuda-common/src/pinned.rs
+++ b/crates/cuda-common/src/pinned.rs
@@ -83,7 +83,6 @@ fn cleaner() -> &'static Mutex<mpsc::Sender<ReturnedBuffer>> {
         std::thread::Builder::new()
             .name("pinned-cleaner".into())
             .spawn(move || {
-                let mut batch_idx = 0usize;
                 while let Ok(first) = rx.recv() {
                     // Coalesce the burst of buffer returns behind one device sync.
                     let mut batch = vec![first];
@@ -96,10 +95,7 @@ fn cleaner() -> &'static Mutex<mpsc::Sender<ReturnedBuffer>> {
                     // The H2D copies reading these buffers were enqueued
                     // before the owners gave them back; wait for them (and
                     // anything else in flight) before touching contents.
-                    let _span =
-                        tracing::info_span!("pinned_cleaner_batch", batch = batch_idx.to_string())
-                            .entered();
-                    batch_idx += 1;
+                    let _span = tracing::info_span!("pinned_cleaner_batch").entered();
                     if let Err(e) = device_synchronize() {
                         tracing::debug!(
                             "cudaDeviceSynchronize failed: {e}; dropping {} pooled buffers",

--- a/crates/cuda-common/src/static_alloc/mod.rs
+++ b/crates/cuda-common/src/static_alloc/mod.rs
@@ -1,0 +1,797 @@
+//! Static GPU memory planning.
+//!
+//! For provers with very large, heavily skewed allocation sizes we want GPU
+//! memory laid out statically: all allocations and their lifetimes are
+//! declared up front, a packing pass assigns each one a fixed offset inside a
+//! single workspace, and the compute code then acquires buffers at those
+//! fixed offsets. This avoids fragmentation and non-deterministic allocator
+//! behavior entirely (same plan → same pointers, which is also what CUDA
+//! graph replay needs), and it makes peak memory a compile-time-style
+//! artifact of the plan instead of an emergent property of allocator state.
+//!
+//! Usage happens in two stages (see `docs/static_alloc_spec.md`):
+//!
+//! 1. **Setup**: each phase of the computation declares its allocations through an
+//!    [`AllocBuilder`], receiving RAII [`DeviceBufFake`] handles. A fake buffer owns no memory —
+//!    its Rust lifetime *is* the declared lifetime of the future allocation, and the builder's
+//!    logical clock records the birth/death interval of every handle. Keep the handle alive exactly
+//!    as long as the real buffer must stay valid, then drop it. [`DeviceBufFake::idx`] yields a
+//!    small, copyable [`AllocIdx`] used to retrieve the real buffer later.
+//! 2. **Run**: [`AllocBuilder::build_on`] packs the declared allocations into a minimal workspace
+//!    (one big device allocation) and returns a [`StaticAllocator`]. Compute code calls
+//!    [`StaticAllocator::get`] with an [`AllocIdx`] to receive a [`StaticDeviceBuffer`] — a RAII
+//!    view of the planned region that derefs to [`DeviceBuffer`], so kernels and device-to-host
+//!    copies work unchanged; host-to-device copies go through [`StaticDeviceBuffer::copy_from`].
+//!    Pointers are stable across acquire/release cycles.
+//!
+//! The allocator also *checks* the plan at run time: while a planned buffer
+//! is acquired, acquiring another buffer whose planned region overlaps is a
+//! lifetime-contract violation. Depending on [`ViolationPolicy`] this either
+//! fails with [`StaticAllocError::LifetimeViolation`] or logs a warning and
+//! serves the request from a fresh dynamic allocation.
+//!
+//! # Declaring lifetimes correctly
+//!
+//! The planner only knows what the fake handles tell it. In particular,
+//! `builder.alloc_fake::<F>(n).idx()` creates *and immediately drops* the
+//! fake handle, declaring a buffer that is live for a single tick and whose
+//! space is instantly reusable. Buffers that are used simultaneously in the
+//! run stage must be declared by handles that are alive simultaneously in the
+//! setup stage:
+//!
+//! ```no_run
+//! use openvm_cuda_common::static_alloc::{
+//!     AllocBuilder, AllocIdx, DeviceBufFake, StaticAllocator,
+//! };
+//!
+//! struct QuotientPhase {
+//!     accumulator: AllocIdx<u32>, // temp, internal to this phase
+//!     selectors: AllocIdx<u32>,   // temp, internal to this phase
+//!     chunks: AllocIdx<u32>,      // output, used downstream
+//! }
+//!
+//! impl QuotientPhase {
+//!     fn setup(builder: &AllocBuilder, quotient_size: usize) -> (Self, DeviceBufFake<u32>) {
+//!         // Bind every fake to a local so all three are alive together —
+//!         // they are used together in `run`.
+//!         let accumulator = builder.alloc_fake::<u32>(4 * quotient_size);
+//!         let selectors = builder.alloc_fake::<u32>(4 * quotient_size);
+//!         let chunks = builder.alloc_fake::<u32>(4 * quotient_size);
+//!         let this = Self {
+//!             accumulator: accumulator.idx(),
+//!             selectors: selectors.idx(),
+//!             chunks: chunks.idx(),
+//!         };
+//!         // `accumulator` and `selectors` fakes die here: their space is
+//!         // free for later phases. `chunks` is used downstream, so its fake
+//!         // is returned — the CALLER ends its lifetime by dropping it.
+//!         (this, chunks)
+//!     }
+//!
+//!     fn run(&self, alloc: &StaticAllocator) {
+//!         let accumulator = alloc.get(&self.accumulator).unwrap();
+//!         let selectors = alloc.get(&self.selectors).unwrap();
+//!         let chunks = alloc.get(&self.chunks).unwrap();
+//!         // ... launch kernels on the buffers; all three deref to
+//!         // &DeviceBuffer<u32> ...
+//!         let _ = (accumulator.as_ptr(), selectors.as_ptr(), chunks.as_ptr());
+//!     }
+//! }
+//! ```
+//!
+//! # Streams
+//!
+//! A [`StaticAllocator`] is bound to the [`GpuDeviceCtx`] it was built with
+//! ([`AllocBuilder::build_on`]): the workspace lives on that stream, fallback
+//! allocations use it, and planned memory reuse is safe because work on a
+//! single stream executes in issue order — the run stage must therefore issue
+//! work against the buffers in declared-lifetime order on that stream, the
+//! same discipline every explicitly-allocated [`DeviceBuffer`] already
+//! follows. Memory is never shared between different declared stream keys
+//! ([`AllocBuilder::alloc_fake_on_stream`]): cross-stream reuse would need
+//! event synchronization the planner does not insert, and using a planned
+//! buffer on a foreign stream requires the caller to synchronize, exactly as
+//! with any other device buffer.
+
+use std::{
+    fmt,
+    marker::PhantomData,
+    mem::ManuallyDrop,
+    ops::Deref,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex, PoisonError,
+    },
+};
+
+use bytesize::ByteSize;
+use thiserror::Error;
+
+use crate::{
+    copy::MemCopyH2D,
+    d_buffer::DeviceBuffer,
+    error::{CudaError, MemCopyError, MemoryError},
+    memory_manager::d_malloc_on,
+    stream::GpuDeviceCtx,
+};
+
+mod planner;
+#[cfg(test)]
+mod tests;
+
+pub use planner::MIN_ALIGN;
+use planner::{plan_offsets, PlannedAlloc, Tick, IMMORTAL};
+
+/// Stream key used by [`AllocBuilder::alloc_fake`]: the single logical stream
+/// of a program that runs everything on the per-thread default stream.
+pub const DEFAULT_STREAM_KEY: u64 = 0;
+
+static NEXT_PLAN_ID: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Error, Debug)]
+pub enum StaticAllocError {
+    #[error(transparent)]
+    Cuda(#[from] CudaError),
+
+    #[error(transparent)]
+    Memory(#[from] MemoryError),
+
+    #[error(
+        "allocation index belongs to a different plan (expected plan {expected}, got {actual})"
+    )]
+    PlanMismatch { expected: u64, actual: u64 },
+
+    #[error("allocation '{label}' is already acquired")]
+    AlreadyAcquired { label: String },
+
+    #[error(
+        "planned space of '{requested}' is still held by {holders:?}: \
+         a buffer is being used beyond its declared lifetime"
+    )]
+    LifetimeViolation {
+        requested: String,
+        holders: Vec<String>,
+    },
+
+    #[error("workspace base pointer is not aligned to {required} bytes")]
+    MisalignedWorkspace { required: usize },
+
+    #[error("failed to acquire static allocator lock")]
+    LockError,
+}
+
+/// Result of a dry-run packing pass ([`AllocBuilder::plan_stats`]).
+#[derive(Debug, Clone, Copy)]
+pub struct PlanStats {
+    /// Total workspace the plan would allocate, in bytes.
+    pub workspace_size: usize,
+    /// Peak of concurrently live declared bytes (lower bound for any layout).
+    pub peak_live_size: usize,
+    /// Sum of all declared allocation sizes, in bytes.
+    pub sum_of_sizes: usize,
+    pub num_allocs: usize,
+}
+
+/// What [`StaticAllocator::get`] does when the requested buffer's planned
+/// space is still occupied by a buffer that outlived its declared lifetime.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ViolationPolicy {
+    /// Fail with [`StaticAllocError::LifetimeViolation`].
+    #[default]
+    Error,
+    /// Log a warning and serve the request from a fresh dynamic allocation.
+    ///
+    /// This is a diagnostic/recovery mode, not a steady state: the pointer is
+    /// NOT the planned one (replay-stability is lost for that buffer) and
+    /// data written through the fallback is freed with it — it never reaches
+    /// the planned region, so it does NOT survive into a later acquisition of
+    /// the same index (the next planned acquisition warns about this).
+    WarnAndAllocate,
+}
+
+// ============================================================================
+// Setup stage: AllocBuilder + DeviceBufFake
+// ============================================================================
+
+struct BuilderState {
+    clock: Tick,
+    allocs: Vec<PlannedAlloc>,
+    /// Element counts parallel to `allocs` (sizes there are in bytes).
+    elem_lens: Vec<usize>,
+    /// Set by `build_on`: later fake drops must no longer mutate the plan.
+    sealed: bool,
+}
+
+/// Records allocations and their lifetimes during the setup stage.
+///
+/// Create one, let every phase declare its allocations with
+/// [`alloc_fake`](Self::alloc_fake), then call [`build_on`](Self::build_on) to pack
+/// the plan and allocate the workspace.
+pub struct AllocBuilder {
+    plan_id: u64,
+    state: Arc<Mutex<BuilderState>>,
+}
+
+impl AllocBuilder {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            plan_id: NEXT_PLAN_ID.fetch_add(1, Ordering::Relaxed),
+            state: Arc::new(Mutex::new(BuilderState {
+                clock: 0,
+                allocs: Vec::new(),
+                elem_lens: Vec::new(),
+                sealed: false,
+            })),
+        }
+    }
+
+    /// Declares an allocation of `len` elements of `T` on the default stream
+    /// key. The returned RAII handle's lifetime declares the real buffer's
+    /// lifetime: drop it at the point where the buffer may be reused.
+    pub fn alloc_fake<T>(&self, len: usize) -> DeviceBufFake<T> {
+        self.alloc_fake_impl(len, DEFAULT_STREAM_KEY, None)
+    }
+
+    /// Same as [`alloc_fake`](Self::alloc_fake) with a label used in
+    /// diagnostics and lifetime-violation errors.
+    pub fn alloc_fake_labeled<T>(&self, len: usize, label: &str) -> DeviceBufFake<T> {
+        self.alloc_fake_impl(len, DEFAULT_STREAM_KEY, Some(label.to_string()))
+    }
+
+    /// Same as [`alloc_fake_labeled`](Self::alloc_fake_labeled) for work
+    /// issued on a different stream. Allocations never share memory across
+    /// stream keys.
+    pub fn alloc_fake_on_stream<T>(
+        &self,
+        len: usize,
+        label: &str,
+        stream: u64,
+    ) -> DeviceBufFake<T> {
+        self.alloc_fake_impl(len, stream, Some(label.to_string()))
+    }
+
+    fn alloc_fake_impl<T>(
+        &self,
+        len: usize,
+        stream: u64,
+        label: Option<String>,
+    ) -> DeviceBufFake<T> {
+        assert_ne!(len, 0, "Zero capacity request is wrong");
+        let size = std::mem::size_of::<T>()
+            .checked_mul(len)
+            .expect("allocation size overflows usize");
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        assert!(!state.sealed, "BUG: alloc_fake after build");
+        let id = state.allocs.len() as u32;
+        let label =
+            label.unwrap_or_else(|| format!("alloc{}: {}x{}", id, std::any::type_name::<T>(), len));
+        let birth = state.clock;
+        state.clock += 1;
+        state.allocs.push(PlannedAlloc {
+            size,
+            align: std::mem::align_of::<T>().max(MIN_ALIGN),
+            birth,
+            death: IMMORTAL,
+            stream,
+            label,
+        });
+        state.elem_lens.push(len);
+        DeviceBufFake {
+            id,
+            plan_id: self.plan_id,
+            len,
+            state: Arc::clone(&self.state),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Runs the packing pass WITHOUT allocating device memory and returns the
+    /// resulting sizes. Non-consuming: fakes still alive are treated as live
+    /// until the end of the plan, and more allocations can be declared (or
+    /// [`build_on`](Self::build_on) called) afterwards.
+    ///
+    /// Useful for offline analysis, e.g. replaying a recorded allocation
+    /// trace to see what workspace a static plan would need.
+    pub fn plan_stats(&self) -> PlanStats {
+        let allocs = {
+            let state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            state.allocs.clone()
+        };
+        let layout = plan_offsets(&allocs);
+        PlanStats {
+            workspace_size: layout.total_size,
+            peak_live_size: layout.peak_live_size,
+            sum_of_sizes: allocs.iter().map(|a| a.size).sum(),
+            num_allocs: allocs.len(),
+        }
+    }
+
+    /// Packs all declared allocations and allocates the workspace on the
+    /// given stream.
+    ///
+    /// The returned allocator is bound to `ctx`: fallback allocations and
+    /// diagnostics use it, and planned memory reuse relies on work being
+    /// issued in declared-lifetime order on that stream. Fake handles still
+    /// alive are treated as live until the end of the plan; dropping them
+    /// afterwards has no effect. Uses the default [`ViolationPolicy::Error`].
+    pub fn build_on(self, ctx: &GpuDeviceCtx) -> Result<StaticAllocator, StaticAllocError> {
+        self.build_with_policy_on(ctx, ViolationPolicy::default())
+    }
+
+    pub fn build_with_policy_on(
+        self,
+        ctx: &GpuDeviceCtx,
+        policy: ViolationPolicy,
+    ) -> Result<StaticAllocator, StaticAllocError> {
+        let (allocs, elem_lens) = {
+            let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            state.sealed = true;
+            (state.allocs.clone(), state.elem_lens.clone())
+        };
+
+        let layout = plan_offsets(&allocs);
+        let workspace = if layout.total_size == 0 {
+            DeviceBuffer::new()
+        } else {
+            let ptr = d_malloc_on(layout.total_size, &ctx.stream)?;
+            // SAFETY: `ptr` was just returned by `d_malloc_on` for
+            // `layout.total_size` bytes, so the buffer owns it and its drop
+            // (`d_free`) is the matching deallocation.
+            unsafe { DeviceBuffer::from_raw_parts(ptr as *mut u8, layout.total_size) }
+        };
+        #[cfg(feature = "touchemall")]
+        if !workspace.is_empty() {
+            // Poison so reads of never-written planned bytes are detectable.
+            unsafe {
+                crate::d_buffer::cudaMemsetAsync(
+                    workspace.as_mut_raw_ptr(),
+                    0xff,
+                    layout.total_size,
+                    ctx.stream.as_raw(),
+                );
+            }
+        }
+
+        let max_align = allocs
+            .iter()
+            .map(|a| a.align.max(MIN_ALIGN))
+            .max()
+            .unwrap_or(MIN_ALIGN);
+        if !workspace.is_empty() && !(workspace.as_ptr() as usize).is_multiple_of(max_align) {
+            return Err(StaticAllocError::MisalignedWorkspace {
+                required: max_align,
+            });
+        }
+
+        let sum_of_sizes: usize = allocs.iter().map(|a| a.size).sum();
+        tracing::info!(
+            "StaticAllocator: {} allocations packed into {} (peak live {}, sum of sizes {})",
+            allocs.len(),
+            ByteSize::b(layout.total_size as u64),
+            ByteSize::b(layout.peak_live_size as u64),
+            ByteSize::b(sum_of_sizes as u64),
+        );
+
+        let entries = allocs
+            .into_iter()
+            .zip(layout.offsets)
+            .zip(elem_lens)
+            .map(|((alloc, offset), elem_len)| PlanEntry {
+                offset,
+                elem_len,
+                alloc,
+            })
+            .collect::<Vec<_>>();
+        let live = (0..entries.len())
+            .map(|_| EntryRuntime {
+                state: LiveState::Free,
+                contents_lost: false,
+            })
+            .collect();
+
+        Ok(StaticAllocator {
+            inner: Arc::new(AllocatorInner {
+                ctx: ctx.clone(),
+                workspace,
+                entries,
+                live: Mutex::new(live),
+                plan_id: self.plan_id,
+                policy,
+                total_size: layout.total_size,
+                peak_live_size: layout.peak_live_size,
+            }),
+        })
+    }
+}
+
+/// RAII stand-in for a future allocation, created during the setup stage.
+///
+/// Owns no device memory. Its Rust lifetime declares the lifetime of the real
+/// buffer: the allocation is considered live from the `alloc_fake` call until
+/// the handle is dropped, and the packer only reuses its space for
+/// allocations whose declared lifetimes do not overlap it.
+pub struct DeviceBufFake<T> {
+    id: u32,
+    plan_id: u64,
+    len: usize,
+    state: Arc<Mutex<BuilderState>>,
+    _marker: PhantomData<fn() -> T>,
+}
+
+impl<T> DeviceBufFake<T> {
+    /// Returns the persistent handle used to acquire the real buffer from the
+    /// [`StaticAllocator`] in the run stage.
+    pub fn idx(&self) -> AllocIdx<T> {
+        AllocIdx {
+            id: self.id,
+            plan_id: self.plan_id,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Alias for [`idx`](Self::idx).
+    pub fn get_idx(&self) -> AllocIdx<T> {
+        self.idx()
+    }
+
+    /// Number of `T` elements declared.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+impl<T> Drop for DeviceBufFake<T> {
+    fn drop(&mut self) {
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        if !state.sealed {
+            let death = state.clock;
+            state.clock += 1;
+            state.allocs[self.id as usize].death = death;
+        }
+    }
+}
+
+impl<T> fmt::Debug for DeviceBufFake<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DeviceBufFake(id={}, len={})", self.id, self.len)
+    }
+}
+
+/// Copyable handle to a planned allocation. Obtained from
+/// [`DeviceBufFake::idx`] during setup; redeemed with
+/// [`StaticAllocator::get`] during the run stage.
+pub struct AllocIdx<T> {
+    id: u32,
+    plan_id: u64,
+    _marker: PhantomData<fn() -> T>,
+}
+
+impl<T> Clone for AllocIdx<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<T> Copy for AllocIdx<T> {}
+
+impl<T> fmt::Debug for AllocIdx<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "AllocIdx(plan={}, id={})", self.plan_id, self.id)
+    }
+}
+
+// ============================================================================
+// Run stage: StaticAllocator + StaticDeviceBuffer
+// ============================================================================
+
+#[derive(Debug)]
+struct PlanEntry {
+    offset: usize,
+    elem_len: usize,
+    alloc: PlannedAlloc,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LiveState {
+    Free,
+    /// Acquired and occupying its planned region of the workspace.
+    Planned,
+    /// Acquired but served from a fresh dynamic allocation
+    /// ([`ViolationPolicy::WarnAndAllocate`] fallback).
+    Fallback,
+}
+
+/// Per-allocation runtime state, guarded by the allocator mutex.
+struct EntryRuntime {
+    state: LiveState,
+    /// The last acquisition was served off-plan
+    /// ([`ViolationPolicy::WarnAndAllocate`]), so anything written through it
+    /// never reached the planned region. The next planned acquisition warns
+    /// and clears this.
+    contents_lost: bool,
+}
+
+struct AllocatorInner {
+    /// The stream this allocator is bound to: the workspace is allocated on
+    /// it, fallback allocations use it, and all planned reuse relies on its
+    /// issue order.
+    ctx: GpuDeviceCtx,
+    workspace: DeviceBuffer<u8>,
+    entries: Vec<PlanEntry>,
+    live: Mutex<Vec<EntryRuntime>>,
+    plan_id: u64,
+    policy: ViolationPolicy,
+    total_size: usize,
+    peak_live_size: usize,
+}
+
+/// Serves planned buffers at fixed offsets inside one workspace allocation.
+///
+/// Cheap to clone (shared handle). Buffers acquired through [`get`](Self::get)
+/// release their planned region when dropped; the same [`AllocIdx`] can be
+/// acquired again afterwards and returns the same device pointer.
+#[derive(Clone)]
+pub struct StaticAllocator {
+    inner: Arc<AllocatorInner>,
+}
+
+impl StaticAllocator {
+    /// Acquires the planned buffer for `idx`.
+    ///
+    /// Errors if `idx` belongs to another plan, is already acquired, or —
+    /// under [`ViolationPolicy::Error`] — if its planned space is still held
+    /// by a buffer that outlived its declared lifetime. Under
+    /// [`ViolationPolicy::WarnAndAllocate`] the latter case logs a warning
+    /// and serves a fresh dynamic allocation instead; the space conflict
+    /// resolves once the offending buffer is dropped.
+    pub fn get<T>(&self, idx: &AllocIdx<T>) -> Result<StaticDeviceBuffer<T>, StaticAllocError> {
+        let inner = &self.inner;
+        if idx.plan_id != inner.plan_id {
+            return Err(StaticAllocError::PlanMismatch {
+                expected: inner.plan_id,
+                actual: idx.plan_id,
+            });
+        }
+        let entry = &inner.entries[idx.id as usize];
+        debug_assert_eq!(entry.alloc.size, entry.elem_len * std::mem::size_of::<T>());
+        let range = entry.offset..entry.offset + entry.alloc.size;
+        let overlaps = |other: &PlanEntry| {
+            other.offset < range.end && range.start < other.offset + other.alloc.size
+        };
+
+        let mut live = inner.live.lock().map_err(|_| StaticAllocError::LockError)?;
+        if live[idx.id as usize].state != LiveState::Free {
+            return Err(StaticAllocError::AlreadyAcquired {
+                label: entry.alloc.label.clone(),
+            });
+        }
+
+        let holders: Vec<String> = inner
+            .entries
+            .iter()
+            .enumerate()
+            .filter(|&(j, other)| live[j].state == LiveState::Planned && overlaps(other))
+            .map(|(_, other)| other.alloc.label.clone())
+            .collect();
+
+        if holders.is_empty() {
+            // Diagnostics: a live fallback buffer whose planned range
+            // overlaps is a declared-lifetime violation too (its holder was
+            // served off-plan), even though it does not physically occupy
+            // this space. Report it so violations don't disappear just
+            // because an earlier one was absorbed by the fallback policy.
+            for (j, other) in inner.entries.iter().enumerate() {
+                if live[j].state == LiveState::Fallback && overlaps(other) {
+                    tracing::warn!(
+                        "StaticAllocator: granting '{}' while '{}' (overlapping plan) \
+                         is still live off-plan — a buffer outlived its declared lifetime",
+                        entry.alloc.label,
+                        other.alloc.label
+                    );
+                }
+            }
+            if live[idx.id as usize].contents_lost {
+                live[idx.id as usize].contents_lost = false;
+                tracing::warn!(
+                    "StaticAllocator: '{}' was previously served off-plan; data written \
+                     during that acquisition was not preserved in its planned region",
+                    entry.alloc.label
+                );
+            }
+            live[idx.id as usize].state = LiveState::Planned;
+            // SAFETY: the planned region lies inside the workspace allocation
+            // (offset + size <= total_size by construction), is aligned for T
+            // (offset is MIN_ALIGN-aligned, base checked at build), and the
+            // returned buffer is wrapped in ManuallyDrop so it never frees.
+            let buf = unsafe {
+                DeviceBuffer::from_raw_parts(
+                    inner.workspace.as_mut_ptr().add(entry.offset) as *mut T,
+                    entry.elem_len,
+                )
+            };
+            // Poison each acquisition so reads of stale bytes from a
+            // previous occupant of this region are detectable, mirroring
+            // `with_capacity_on` semantics under this feature.
+            #[cfg(feature = "touchemall")]
+            unsafe {
+                crate::d_buffer::cudaMemsetAsync(
+                    buf.as_mut_raw_ptr(),
+                    0xff,
+                    entry.alloc.size,
+                    inner.ctx.stream.as_raw(),
+                );
+            }
+            return Ok(StaticDeviceBuffer {
+                buf: ManuallyDrop::new(buf),
+                id: idx.id,
+                kind: LiveState::Planned,
+                alloc: Arc::clone(inner),
+            });
+        }
+
+        match inner.policy {
+            ViolationPolicy::Error => Err(StaticAllocError::LifetimeViolation {
+                requested: entry.alloc.label.clone(),
+                holders,
+            }),
+            ViolationPolicy::WarnAndAllocate => {
+                tracing::warn!(
+                    "StaticAllocator: planned space of '{}' still held by {:?}; \
+                     serving a fresh dynamic allocation instead",
+                    entry.alloc.label,
+                    holders
+                );
+                // Allocate with the lock released: `with_capacity_on` panics
+                // on OOM and must not poison the live set.
+                drop(live);
+                let buf = DeviceBuffer::<T>::with_capacity_on(entry.elem_len, &inner.ctx);
+                let mut live = inner.live.lock().map_err(|_| StaticAllocError::LockError)?;
+                if live[idx.id as usize].state != LiveState::Free {
+                    // A racing `get` acquired this idx while the lock was
+                    // released; `buf` is dropped and freed normally.
+                    return Err(StaticAllocError::AlreadyAcquired {
+                        label: entry.alloc.label.clone(),
+                    });
+                }
+                live[idx.id as usize].state = LiveState::Fallback;
+                // Data written through this guard lands in the fallback
+                // allocation and is freed with it — the planned region never
+                // sees it. Remember that so the next planned acquisition can
+                // warn about the persistence break.
+                live[idx.id as usize].contents_lost = true;
+                Ok(StaticDeviceBuffer {
+                    buf: ManuallyDrop::new(buf),
+                    id: idx.id,
+                    kind: LiveState::Fallback,
+                    alloc: Arc::clone(inner),
+                })
+            }
+        }
+    }
+
+    /// Total workspace size in bytes.
+    pub fn workspace_size(&self) -> usize {
+        self.inner.total_size
+    }
+
+    /// Peak of concurrently live declared bytes — the lower bound the packer
+    /// was aiming for.
+    pub fn peak_live_size(&self) -> usize {
+        self.inner.peak_live_size
+    }
+
+    /// Number of planned allocations.
+    pub fn num_allocs(&self) -> usize {
+        self.inner.entries.len()
+    }
+
+    /// Human-readable table of the plan, ordered by offset.
+    pub fn describe(&self) -> String {
+        let mut order: Vec<usize> = (0..self.inner.entries.len()).collect();
+        order.sort_by_key(|&i| {
+            (
+                self.inner.entries[i].offset,
+                self.inner.entries[i].alloc.birth,
+            )
+        });
+        let mut out = format!(
+            "StaticAllocator plan {}: workspace {} (peak live {})\n",
+            self.inner.plan_id,
+            ByteSize::b(self.inner.total_size as u64),
+            ByteSize::b(self.inner.peak_live_size as u64),
+        );
+        for i in order {
+            let e = &self.inner.entries[i];
+            let death = if e.alloc.death == IMMORTAL {
+                "end".to_string()
+            } else {
+                e.alloc.death.to_string()
+            };
+            out.push_str(&format!(
+                "  [{:#012x}..{:#012x}) {:>10} life=[{},{}) stream={} '{}'\n",
+                e.offset,
+                e.offset + e.alloc.size,
+                ByteSize::b(e.alloc.size as u64).to_string(),
+                e.alloc.birth,
+                death,
+                e.alloc.stream,
+                e.alloc.label,
+            ));
+        }
+        out
+    }
+}
+
+impl fmt::Debug for StaticAllocator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.describe())
+    }
+}
+
+/// RAII view of a planned region of the workspace (or of a fallback dynamic
+/// allocation under [`ViolationPolicy::WarnAndAllocate`]).
+///
+/// Derefs to [`DeviceBuffer`] (shared access), so kernels and the
+/// device-to-host copy traits work unchanged; host-to-device copies go
+/// through [`copy_from`](Self::copy_from). Dropping it releases the planned
+/// region for the allocations that reuse the same space; it does NOT free the
+/// workspace memory.
+pub struct StaticDeviceBuffer<T> {
+    buf: ManuallyDrop<DeviceBuffer<T>>,
+    id: u32,
+    kind: LiveState,
+    alloc: Arc<AllocatorInner>,
+}
+
+impl<T> StaticDeviceBuffer<T> {
+    /// Copies `src` from the host into this buffer on the given stream.
+    ///
+    /// This is an inherent method rather than `DerefMut` +
+    /// [`MemCopyH2D::copy_to_on`]: handing out `&mut DeviceBuffer<T>` would
+    /// let safe code move the non-owning view out of the guard (e.g. with
+    /// `mem::replace`) and `d_free` workspace-interior memory on its drop.
+    pub fn copy_from(&mut self, src: &[T], ctx: &GpuDeviceCtx) -> Result<(), MemCopyError> {
+        src.copy_to_on(&mut self.buf, ctx)
+    }
+}
+
+impl<T> Deref for StaticDeviceBuffer<T> {
+    type Target = DeviceBuffer<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.buf
+    }
+}
+
+impl<T> Drop for StaticDeviceBuffer<T> {
+    fn drop(&mut self) {
+        let mut live = self
+            .alloc
+            .live
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let rt = &mut live[self.id as usize];
+        if self.kind == LiveState::Fallback {
+            // SAFETY: dropped exactly once, here; the buffer owns a real
+            // dynamic allocation made in `get`.
+            unsafe { ManuallyDrop::drop(&mut self.buf) };
+        }
+        rt.state = LiveState::Free;
+    }
+}
+
+impl<T> fmt::Debug for StaticDeviceBuffer<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "StaticDeviceBuffer(id={}, len={}, ptr={:p})",
+            self.id,
+            self.buf.len(),
+            self.buf.as_ptr()
+        )
+    }
+}

--- a/crates/cuda-common/src/static_alloc/planner.rs
+++ b/crates/cuda-common/src/static_alloc/planner.rs
@@ -1,0 +1,335 @@
+//! Offline offset planning for the static allocator.
+//!
+//! Pure CPU logic with no CUDA dependencies: given the set of declared
+//! allocations with their logical lifetime intervals, assign a byte offset
+//! inside a single workspace to each allocation so that no two allocations
+//! with interfering lifetimes overlap in memory, while keeping the total
+//! workspace size close to the peak of concurrently live bytes.
+
+use std::cmp::Reverse;
+
+/// Minimum alignment (bytes) applied to every planned allocation. Matches the
+/// 256-byte alignment guarantee of `cudaMalloc`, so kernel assumptions that
+/// hold for individually `cudaMalloc`-ed buffers keep holding for planned
+/// sub-buffers of the workspace.
+pub const MIN_ALIGN: usize = 256;
+
+/// Logical timestamp assigned by the [`AllocBuilder`](super::AllocBuilder)
+/// clock. Each allocation and each drop gets a distinct tick.
+pub(super) type Tick = u64;
+
+/// A tick larger than any real event: the death of allocations still alive
+/// when the plan is built.
+pub(super) const IMMORTAL: Tick = Tick::MAX;
+
+/// One declared allocation with its lifetime interval `[birth, death)`.
+#[derive(Debug, Clone)]
+pub(super) struct PlannedAlloc {
+    /// Size in bytes (non-zero).
+    pub size: usize,
+    /// Required alignment in bytes (power of two); raised to [`MIN_ALIGN`]
+    /// during placement.
+    pub align: usize,
+    pub birth: Tick,
+    /// Exclusive end of the lifetime; [`IMMORTAL`] if alive at build time.
+    pub death: Tick,
+    /// Logical stream key. Allocations on different streams always interfere
+    /// because reusing memory across streams would require extra
+    /// synchronization that the planner does not insert.
+    pub stream: u64,
+    /// Human-readable name used in diagnostics.
+    pub label: String,
+}
+
+impl PlannedAlloc {
+    /// Whether two allocations may NOT share memory.
+    pub(super) fn interferes(&self, other: &Self) -> bool {
+        if self.stream != other.stream {
+            return true;
+        }
+        self.birth < other.death && other.birth < self.death
+    }
+}
+
+/// Result of packing: byte offsets parallel to the input allocations.
+#[derive(Debug)]
+pub(super) struct PlanLayout {
+    pub offsets: Vec<usize>,
+    /// Total workspace size in bytes.
+    pub total_size: usize,
+    /// Peak of concurrently live bytes over time — a lower bound for the
+    /// workspace size of ANY layout (ignoring alignment and cross-stream
+    /// constraints, so multi-stream plans may not be able to reach it).
+    pub peak_live_size: usize,
+}
+
+#[inline]
+fn align_up(x: usize, align: usize) -> usize {
+    debug_assert!(align.is_power_of_two());
+    (x + align - 1) & !(align - 1)
+}
+
+/// Greedy best-fit-decreasing packing over the interference graph.
+///
+/// Allocations are placed in order of decreasing size (ties broken by birth
+/// tick, then declaration order, so the result is fully deterministic). Each
+/// allocation takes the lowest aligned offset that does not overlap any
+/// already-placed allocation it interferes with. This is the classic
+/// "greedy by size" heuristic for offline dynamic storage allocation; it is
+/// not optimal (the problem is NP-hard) but stays close to the peak-live
+/// lower bound on realistic skewed workloads.
+pub(super) fn plan_offsets(allocs: &[PlannedAlloc]) -> PlanLayout {
+    let mut order: Vec<usize> = (0..allocs.len()).collect();
+    order.sort_by_key(|&i| (Reverse(allocs[i].size), allocs[i].birth, i));
+
+    let mut offsets = vec![0usize; allocs.len()];
+    let mut placed: Vec<usize> = Vec::with_capacity(allocs.len());
+    let mut total_size = 0usize;
+
+    for &i in &order {
+        let alloc = &allocs[i];
+        debug_assert_ne!(alloc.size, 0, "zero-size planned allocation");
+
+        // Occupied ranges of already-placed interfering allocations.
+        let mut occupied: Vec<(usize, usize)> = placed
+            .iter()
+            .filter(|&&j| alloc.interferes(&allocs[j]))
+            .map(|&j| (offsets[j], offsets[j] + allocs[j].size))
+            .collect();
+        occupied.sort_unstable();
+
+        // First fit: sweep the sorted ranges for the lowest aligned gap.
+        let align = alloc.align.max(MIN_ALIGN);
+        let mut cursor = 0usize;
+        for (start, end) in occupied {
+            if cursor + alloc.size <= start {
+                break;
+            }
+            cursor = cursor.max(align_up(end, align));
+        }
+
+        offsets[i] = cursor;
+        placed.push(i);
+        total_size = total_size.max(cursor + alloc.size);
+    }
+
+    PlanLayout {
+        offsets,
+        total_size,
+        peak_live_size: peak_live_size(allocs),
+    }
+}
+
+/// Maximum over time of the sum of sizes of live allocations.
+fn peak_live_size(allocs: &[PlannedAlloc]) -> usize {
+    // (tick, delta); births and deaths have distinct ticks by construction.
+    let mut events: Vec<(Tick, isize)> = Vec::with_capacity(allocs.len() * 2);
+    for alloc in allocs {
+        events.push((alloc.birth, alloc.size as isize));
+        if alloc.death != IMMORTAL {
+            events.push((alloc.death, -(alloc.size as isize)));
+        }
+    }
+    events.sort_unstable();
+
+    let mut live = 0isize;
+    let mut peak = 0isize;
+    for (_, delta) in events {
+        live += delta;
+        peak = peak.max(live);
+    }
+    peak as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn alloc(size: usize, birth: Tick, death: Tick) -> PlannedAlloc {
+        alloc_on_stream(size, birth, death, 0)
+    }
+
+    fn alloc_on_stream(size: usize, birth: Tick, death: Tick, stream: u64) -> PlannedAlloc {
+        PlannedAlloc {
+            size,
+            align: MIN_ALIGN,
+            birth,
+            death,
+            stream,
+            label: format!("[{birth},{death})x{size}"),
+        }
+    }
+
+    /// Checks that no two interfering allocations overlap in the layout and
+    /// that all offsets are aligned.
+    fn validate(allocs: &[PlannedAlloc], layout: &PlanLayout) {
+        for (i, a) in allocs.iter().enumerate() {
+            let a_range = layout.offsets[i]..layout.offsets[i] + a.size;
+            assert_eq!(
+                layout.offsets[i] % a.align.max(MIN_ALIGN),
+                0,
+                "misaligned offset for {}",
+                a.label
+            );
+            assert!(a_range.end <= layout.total_size);
+            for (j, b) in allocs.iter().enumerate().skip(i + 1) {
+                if a.interferes(b) {
+                    let b_range = layout.offsets[j]..layout.offsets[j] + b.size;
+                    assert!(
+                        a_range.end <= b_range.start || b_range.end <= a_range.start,
+                        "interfering allocations '{}' and '{}' overlap: {:?} vs {:?}",
+                        a.label,
+                        b.label,
+                        a_range,
+                        b_range
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_empty_plan() {
+        let layout = plan_offsets(&[]);
+        assert_eq!(layout.total_size, 0);
+        assert_eq!(layout.peak_live_size, 0);
+    }
+
+    #[test]
+    fn test_disjoint_lifetimes_share_space() {
+        // A: [0,1), B: [2,3) — same stream, disjoint — must share offset 0.
+        let allocs = vec![alloc(1 << 20, 0, 1), alloc(1 << 20, 2, 3)];
+        let layout = plan_offsets(&allocs);
+        validate(&allocs, &layout);
+        assert_eq!(layout.offsets[0], layout.offsets[1]);
+        assert_eq!(layout.total_size, 1 << 20);
+    }
+
+    #[test]
+    fn test_overlapping_lifetimes_disjoint_space() {
+        let allocs = vec![alloc(1 << 20, 0, 3), alloc(1 << 20, 1, 4)];
+        let layout = plan_offsets(&allocs);
+        validate(&allocs, &layout);
+        assert_eq!(layout.total_size, 2 << 20);
+    }
+
+    #[test]
+    fn test_cross_stream_always_interferes() {
+        // Disjoint lifetimes but different streams — may not share memory.
+        let allocs = vec![
+            alloc_on_stream(1 << 20, 0, 1, 0),
+            alloc_on_stream(1 << 20, 2, 3, 1),
+        ];
+        let layout = plan_offsets(&allocs);
+        validate(&allocs, &layout);
+        assert_ne!(layout.offsets[0], layout.offsets[1]);
+        assert_eq!(layout.total_size, 2 << 20);
+    }
+
+    #[test]
+    fn test_immortal_allocations_never_reused() {
+        let allocs = vec![
+            alloc(1 << 20, 0, IMMORTAL),
+            alloc(1 << 20, 1, 2),
+            alloc(1 << 20, 3, 4),
+        ];
+        let layout = plan_offsets(&allocs);
+        validate(&allocs, &layout);
+        // The two temps share space; the immortal buffer is separate.
+        assert_eq!(layout.offsets[1], layout.offsets[2]);
+        assert_ne!(layout.offsets[0], layout.offsets[1]);
+        assert_eq!(layout.total_size, 2 << 20);
+    }
+
+    #[test]
+    fn test_offsets_are_aligned_for_odd_sizes() {
+        // Odd sizes force gaps: every offset must still be MIN_ALIGN-aligned.
+        let allocs = vec![alloc(1000, 0, 5), alloc(999, 1, 5), alloc(1001, 2, 5)];
+        let layout = plan_offsets(&allocs);
+        validate(&allocs, &layout);
+    }
+
+    #[test]
+    fn test_larger_alignment_respected() {
+        let mut a = alloc(100, 0, 3);
+        a.align = 1024;
+        let allocs = vec![alloc(300, 0, 3), a];
+        let layout = plan_offsets(&allocs);
+        validate(&allocs, &layout);
+        assert_eq!(layout.offsets[1] % 1024, 0);
+    }
+
+    #[test]
+    fn test_deterministic() {
+        let allocs: Vec<_> = (0u64..50)
+            .map(|i| {
+                alloc(
+                    (((i * 7919) % 1000 + 1) << 10) as usize,
+                    i,
+                    i + ((i * 13) % 17) + 1,
+                )
+            })
+            .collect();
+        let l1 = plan_offsets(&allocs);
+        let l2 = plan_offsets(&allocs);
+        assert_eq!(l1.offsets, l2.offsets);
+        assert_eq!(l1.total_size, l2.total_size);
+    }
+
+    #[test]
+    fn test_phase_structured_reuse_hits_lower_bound() {
+        // Two phases of equal-size temps + one long-lived output: the packer
+        // should reach exactly the peak-live lower bound.
+        let allocs = vec![
+            alloc(4 << 20, 0, 4),        // phase 1 temp
+            alloc(2 << 20, 1, 4),        // phase 1 temp
+            alloc(1 << 20, 2, IMMORTAL), // output
+            alloc(4 << 20, 5, 9),        // phase 2 temp (reuses phase 1 space)
+            alloc(2 << 20, 6, 9),        // phase 2 temp
+        ];
+        let layout = plan_offsets(&allocs);
+        validate(&allocs, &layout);
+        assert_eq!(layout.total_size, layout.peak_live_size);
+    }
+
+    /// Deterministic pseudo-random stress: heavily skewed sizes, phase
+    /// structure with interleaved lifetimes.
+    #[test]
+    fn test_fuzz_skewed_sizes() {
+        // xorshift64* PRNG — deterministic, no external deps.
+        let mut state = 0x9E3779B97F4A7C15u64;
+        let mut rng = move || {
+            state ^= state >> 12;
+            state ^= state << 25;
+            state ^= state >> 27;
+            state = state.wrapping_mul(0x2545F4914F6CDD1D);
+            state
+        };
+
+        for _round in 0..20 {
+            let n = (rng() % 60 + 2) as usize;
+            let mut clock: Tick = 0;
+            let mut allocs = Vec::with_capacity(n);
+            let mut live: Vec<usize> = Vec::new();
+            for _ in 0..n {
+                // Sizes skewed across 5 orders of magnitude.
+                let size = 1usize << (rng() % 18 + 4);
+                allocs.push(alloc(size, clock, IMMORTAL));
+                live.push(allocs.len() - 1);
+                clock += 1;
+                // Randomly kill some live allocations.
+                while !live.is_empty() && rng() % 3 == 0 {
+                    let k = (rng() % live.len() as u64) as usize;
+                    let idx = live.swap_remove(k);
+                    allocs[idx].death = clock;
+                    clock += 1;
+                }
+            }
+            let layout = plan_offsets(&allocs);
+            validate(&allocs, &layout);
+            let sum: usize = allocs.iter().map(|a| a.size).sum();
+            assert!(layout.total_size >= layout.peak_live_size);
+            assert!(layout.total_size <= sum);
+        }
+    }
+}

--- a/crates/cuda-common/src/static_alloc/tests.rs
+++ b/crates/cuda-common/src/static_alloc/tests.rs
@@ -1,0 +1,269 @@
+//! GPU tests for the static allocator: end-to-end acquire/copy/release,
+//! memory reuse, pointer stability, and lifetime-violation detection.
+
+use super::*;
+use crate::{copy::MemCopyD2H, stream::GpuDeviceCtx};
+
+fn test_ctx() -> GpuDeviceCtx {
+    GpuDeviceCtx::for_current_device().unwrap()
+}
+
+/// Two-phase plan where phase temps share space:
+///   phase 1: input (temp) -> output (long-lived)
+///   phase 2: scratch (temp, expected to reuse input's space)
+struct TwoPhasePlan {
+    input: AllocIdx<u32>,
+    output: AllocIdx<u32>,
+    scratch: AllocIdx<u32>,
+    alloc: StaticAllocator,
+    ctx: GpuDeviceCtx,
+}
+
+fn two_phase_plan(len: usize, policy: ViolationPolicy) -> TwoPhasePlan {
+    let builder = AllocBuilder::new();
+    let input_fake = builder.alloc_fake_labeled::<u32>(len, "input");
+    let output_fake = builder.alloc_fake_labeled::<u32>(len, "output");
+    let (input, output) = (input_fake.idx(), output_fake.idx());
+    drop(input_fake); // phase 1 ends: input's space becomes reusable
+    let scratch = builder.alloc_fake_labeled::<u32>(len, "scratch").idx();
+    // `output_fake` is still alive at build: output lives until the end.
+    let ctx = test_ctx();
+    let alloc = builder.build_with_policy_on(&ctx, policy).unwrap();
+    TwoPhasePlan {
+        input,
+        output,
+        scratch,
+        alloc,
+        ctx,
+    }
+}
+
+// ============================================================================
+// Roundtrip: planned buffers work with the MemCopy traits and kernels
+// ============================================================================
+#[test]
+fn test_roundtrip_through_planned_buffers() {
+    let len = 1 << 12;
+    let plan = two_phase_plan(len, ViolationPolicy::Error);
+
+    let host: Vec<u32> = (0..len as u32).collect();
+    let mut input = plan.alloc.get(&plan.input).unwrap();
+    input.copy_from(&host, &plan.ctx).unwrap();
+    assert_eq!(input.to_host_on(&plan.ctx).unwrap(), host);
+
+    let mut output = plan.alloc.get(&plan.output).unwrap();
+    output.copy_from(&host, &plan.ctx).unwrap();
+    drop(input);
+
+    // Phase 2: scratch may reuse input's space; output data must survive.
+    let scratch = plan.alloc.get(&plan.scratch).unwrap();
+    scratch.fill_zero_on(&plan.ctx).unwrap();
+    assert_eq!(scratch.to_host_on(&plan.ctx).unwrap(), vec![0u32; len]);
+    assert_eq!(output.to_host_on(&plan.ctx).unwrap(), host);
+}
+
+// ============================================================================
+// Packing: disjoint lifetimes share memory, workspace stays at peak-live
+// ============================================================================
+#[test]
+fn test_scratch_reuses_input_space() {
+    let len = 1 << 20;
+    let plan = two_phase_plan(len, ViolationPolicy::Error);
+
+    // input dies before scratch is born -> same planned offset; the
+    // workspace holds 2 buffers' worth, not 3.
+    assert_eq!(plan.alloc.workspace_size(), 2 * 4 * len);
+    assert_eq!(plan.alloc.workspace_size(), plan.alloc.peak_live_size());
+
+    let input_ptr = {
+        let input = plan.alloc.get(&plan.input).unwrap();
+        input.as_ptr() as usize
+    };
+    let scratch = plan.alloc.get(&plan.scratch).unwrap();
+    assert_eq!(
+        scratch.as_ptr() as usize,
+        input_ptr,
+        "scratch should reuse input's planned space"
+    );
+}
+
+// ============================================================================
+// Pointer stability across acquire/release rounds (cudaGraphs prerequisite)
+// ============================================================================
+#[test]
+fn test_stable_pointers_across_rounds() {
+    let len = 1 << 10;
+    let plan = two_phase_plan(len, ViolationPolicy::Error);
+
+    let mut ptrs = Vec::new();
+    for _round in 0..3 {
+        let input = plan.alloc.get(&plan.input).unwrap();
+        let output = plan.alloc.get(&plan.output).unwrap();
+        ptrs.push((input.as_ptr() as usize, output.as_ptr() as usize));
+    }
+    assert_eq!(ptrs[0], ptrs[1]);
+    assert_eq!(ptrs[1], ptrs[2]);
+}
+
+// ============================================================================
+// Lifetime violations: error policy
+// ============================================================================
+#[test]
+fn test_use_after_lifetime_errors_then_recovers() {
+    let len = 1 << 10;
+    let plan = two_phase_plan(len, ViolationPolicy::Error);
+
+    // Hold `input` beyond its declared lifetime.
+    let input = plan.alloc.get(&plan.input).unwrap();
+    let err = plan.alloc.get(&plan.scratch).unwrap_err();
+    match err {
+        StaticAllocError::LifetimeViolation { requested, holders } => {
+            assert_eq!(requested, "scratch");
+            assert_eq!(holders, vec!["input".to_string()]);
+        }
+        other => panic!("expected LifetimeViolation, got {other:?}"),
+    }
+
+    // Dropping the offender makes the space safe to use.
+    drop(input);
+    plan.alloc.get(&plan.scratch).unwrap();
+}
+
+#[test]
+fn test_double_acquire_errors() {
+    let len = 1 << 10;
+    let plan = two_phase_plan(len, ViolationPolicy::Error);
+
+    let _output = plan.alloc.get(&plan.output).unwrap();
+    assert!(matches!(
+        plan.alloc.get(&plan.output),
+        Err(StaticAllocError::AlreadyAcquired { .. })
+    ));
+}
+
+// ============================================================================
+// Lifetime violations: warn-and-allocate fallback policy
+// ============================================================================
+#[test]
+fn test_warn_and_allocate_fallback() {
+    let len = 1 << 10;
+    let plan = two_phase_plan(len, ViolationPolicy::WarnAndAllocate);
+
+    let input = plan.alloc.get(&plan.input).unwrap();
+    let planned_ptr = input.as_ptr() as usize;
+
+    // Conflict -> fresh dynamic allocation with a different pointer.
+    let scratch = plan.alloc.get(&plan.scratch).unwrap();
+    assert_ne!(scratch.as_ptr() as usize, planned_ptr);
+
+    // Fallback buffers still work end-to-end.
+    let host: Vec<u32> = (0..len as u32).collect();
+    let mut scratch = scratch;
+    scratch.copy_from(&host, &plan.ctx).unwrap();
+    assert_eq!(scratch.to_host_on(&plan.ctx).unwrap(), host);
+
+    // Once the offender and the fallback are gone, the planned space serves
+    // the same idx at its planned pointer again.
+    drop(input);
+    drop(scratch);
+    let scratch = plan.alloc.get(&plan.scratch).unwrap();
+    assert_eq!(scratch.as_ptr() as usize, planned_ptr);
+}
+
+// ============================================================================
+// Plan identity: indices are not interchangeable between allocators
+// ============================================================================
+#[test]
+fn test_plan_mismatch_detected() {
+    let plan_a = two_phase_plan(1 << 10, ViolationPolicy::Error);
+    let plan_b = two_phase_plan(1 << 10, ViolationPolicy::Error);
+
+    assert!(matches!(
+        plan_b.alloc.get(&plan_a.input),
+        Err(StaticAllocError::PlanMismatch { .. })
+    ));
+}
+
+// ============================================================================
+// Interfering buffers acquired together hold disjoint memory
+// ============================================================================
+#[test]
+fn test_concurrent_buffers_do_not_alias() {
+    let len = 1 << 12;
+    let builder = AllocBuilder::new();
+    let a = builder.alloc_fake_labeled::<u64>(len, "a");
+    let b = builder.alloc_fake_labeled::<u64>(len, "b");
+    let (a, b) = (a.idx(), b.idx());
+    let ctx = test_ctx();
+    let alloc = builder.build_on(&ctx).unwrap();
+
+    let mut buf_a = alloc.get(&a).unwrap();
+    let mut buf_b = alloc.get(&b).unwrap();
+    let host_a: Vec<u64> = (0..len as u64).collect();
+    let host_b: Vec<u64> = (0..len as u64).map(|x| x.wrapping_mul(31)).collect();
+    buf_a.copy_from(&host_a, &ctx).unwrap();
+    buf_b.copy_from(&host_b, &ctx).unwrap();
+    assert_eq!(buf_a.to_host_on(&ctx).unwrap(), host_a);
+    assert_eq!(buf_b.to_host_on(&ctx).unwrap(), host_b);
+}
+
+// ============================================================================
+// Data written to a planned buffer survives release + reacquire as long as
+// no overlapping allocation ran in between
+// ============================================================================
+// Under `touchemall` every planned acquisition is poisoned with 0xff, so
+// cross-acquisition persistence intentionally does not hold there.
+#[cfg(not(feature = "touchemall"))]
+#[test]
+fn test_data_survives_release_without_reuse() {
+    let len = 1 << 10;
+    let plan = two_phase_plan(len, ViolationPolicy::Error);
+
+    let host: Vec<u32> = (0..len as u32).rev().collect();
+    {
+        let mut output = plan.alloc.get(&plan.output).unwrap();
+        output.copy_from(&host, &plan.ctx).unwrap();
+    }
+    let output = plan.alloc.get(&plan.output).unwrap();
+    assert_eq!(output.to_host_on(&plan.ctx).unwrap(), host);
+}
+
+// ============================================================================
+// Cross-stream declarations never share memory
+// ============================================================================
+#[test]
+fn test_cross_stream_no_reuse() {
+    let len = 1 << 16;
+    let builder = AllocBuilder::new();
+    let a = builder
+        .alloc_fake_on_stream::<u32>(len, "stream1-temp", 1)
+        .idx();
+    // `a`'s fake is already dropped; a same-stream alloc would reuse its
+    // space, but a different-stream alloc must not.
+    let b = builder
+        .alloc_fake_on_stream::<u32>(len, "stream2-temp", 2)
+        .idx();
+    let alloc = builder.build_on(&test_ctx()).unwrap();
+
+    let buf_a = alloc.get(&a).unwrap();
+    let buf_b = alloc.get(&b).unwrap();
+    assert_ne!(buf_a.as_ptr() as usize, buf_b.as_ptr() as usize);
+    assert_eq!(alloc.workspace_size(), 2 * 4 * len);
+}
+
+// ============================================================================
+// Sanity: describe() renders and empty plans build
+// ============================================================================
+#[test]
+fn test_describe_and_empty_plan() {
+    let builder = AllocBuilder::new();
+    let alloc = builder.build_on(&test_ctx()).unwrap();
+    assert_eq!(alloc.workspace_size(), 0);
+    assert_eq!(alloc.num_allocs(), 0);
+
+    let plan = two_phase_plan(1 << 10, ViolationPolicy::Error);
+    let desc = plan.alloc.describe();
+    assert!(desc.contains("input"));
+    assert!(desc.contains("output"));
+    assert!(desc.contains("scratch"));
+}

--- a/docs/static_alloc_spec.md
+++ b/docs/static_alloc_spec.md
@@ -1,0 +1,188 @@
+# Static Memory Planner (`static_alloc`)
+
+## Motivation
+
+The GPU prover allocates buffers with heavily skewed sizes — from single-element sums to
+multi-gigabyte LDE matrices — through the dynamic memory manager ([VPMM](./vpmm_spec.md)). VPMM
+fights fragmentation at run time by remapping pages, which costs work, makes peak usage an emergent
+property of allocator state, and makes pointer values non-deterministic across runs. For workloads
+like OpenVM where, once the trace heights are known, **every** downstream allocation size and
+lifetime is a deterministic function of `(heights, widths, quotient degrees, FRI params)`, we can
+instead plan GPU memory statically:
+
+- declare all allocations of a proof (or of a phase) together with their lifetimes up front;
+- build an interference graph from those lifetimes and run a packing pass that assigns every
+  allocation a fixed byte offset inside one workspace, minimizing the total workspace size;
+- at run time, hand out buffers at the planned offsets — no allocator behavior at all, no
+  fragmentation, and stable pointers (a prerequisite for CUDA graph replay, where captured kernel
+  launches bake in device addresses).
+
+The design prefers **explicit over implicit**: the programmer declares each phase's buffers and
+lifetimes in code, and the plan is inspectable (`StaticAllocator::describe()`).
+
+## Two-stage usage
+
+### Stage 1: setup — declare allocations with RAII handles
+
+Each phase of the computation is represented by a struct that declares its allocations in a
+`setup`-style constructor taking an `&AllocBuilder`:
+
+```rust
+struct QuotientPhase {
+    accumulator: AllocIdx<F>, // temp, internal to the phase
+    selectors: AllocIdx<F>,   // temp, internal to the phase
+    chunks: AllocIdx<F>,      // output, used downstream
+}
+
+impl QuotientPhase {
+    fn setup(builder: &AllocBuilder, qsize: usize) -> (Self, DeviceBufFake<F>) {
+        let accumulator = builder.alloc_fake_labeled::<F>(4 * qsize, "q_acc");
+        let selectors = builder.alloc_fake_labeled::<F>(4 * qsize, "q_sel");
+        let chunks = builder.alloc_fake_labeled::<F>(4 * qsize, "q_chunks");
+        let this = Self {
+            accumulator: accumulator.idx(),
+            selectors: selectors.idx(),
+            chunks: chunks.idx(),
+        };
+        (this, chunks)
+        // accumulator + selectors fakes drop here: their space becomes
+        // reusable by later phases. chunks is returned; the caller decides
+        // when the output's lifetime ends by dropping the fake.
+    }
+}
+```
+
+`AllocBuilder::alloc_fake::<T>(len)` returns a `DeviceBufFake<T>`: an RAII handle that owns **no
+memory** — its Rust lifetime *is* the declared lifetime of the future allocation. The builder keeps
+a logical clock; each `alloc_fake` records a birth tick, each fake drop records a death tick. Two
+allocations *interfere* (may not share memory) iff their `[birth, death)` intervals overlap — plus
+the stream rule below. Rust's ordinary ownership rules therefore build the interference graph:
+return a fake from `setup` to extend a buffer's life into later phases, drop it (explicitly or by
+scope end) to end it.
+
+`DeviceBufFake::idx()` yields an `AllocIdx<T>` — a small `Copy` handle (think: a symbolic pointer)
+stored in the phase struct and redeemed for the real buffer in stage 2.
+
+**Footgun to know about**: `builder.alloc_fake::<F>(n).idx()` creates and immediately drops the
+fake (Rust drops the temporary at the end of the statement), declaring a buffer live for a single
+tick. Buffers used simultaneously in the run stage must be declared by fakes that are alive
+simultaneously in the setup stage — bind them to locals. Misdeclarations are caught at run time
+*while the guards involved are held simultaneously* (see below). What is not detectable: releasing
+a guard, letting an overlapping allocation use the space, then reacquiring the same index expecting
+its old contents — `get` succeeds at the same pointer and the prior contents are simply gone (the
+allocator cannot distinguish "reacquire to rewrite", which is the normal replay pattern, from
+"reacquire expecting persistence"). The `touchemall` feature closes this gap for testing: it
+poisons every planned region with `0xff` on each acquisition, so stale-read bugs surface
+immediately.
+
+### Stage 2: run — build once, then acquire at fixed offsets
+
+```rust
+let ctx = GpuDeviceCtx::for_current_device()?;
+let alloc: StaticAllocator = builder.build_on(&ctx)?; // packs + allocates workspace
+
+// in each phase:
+let mut acc = alloc.get(&self.accumulator)?;   // StaticDeviceBuffer<F>
+let mut chunks = alloc.get(&self.chunks)?;
+// ... launch kernels: both deref to &DeviceBuffer<F> ...
+drop(acc); // releases the planned region (the memory is not freed)
+```
+
+`build_on(&GpuDeviceCtx)` runs the packing pass, allocates one workspace buffer through the normal
+memory manager on the given stream, and returns a `StaticAllocator` bound to that stream. `get` returns a `StaticDeviceBuffer<T>` — an RAII
+view at the planned offset that derefs to `DeviceBuffer<T>` (shared access), so kernels and
+device-to-host copies work unchanged; host-to-device copies go through the inherent
+`copy_from(&mut self, &[T], &GpuDeviceCtx)` method. (The guard deliberately does not implement `DerefMut`:
+`&mut DeviceBuffer<T>` would let safe code `mem::replace` the non-owning view out of the guard and
+free workspace-interior memory on its drop.) Dropping the view releases the planned region;
+acquiring the same `AllocIdx` again returns the **same pointer** (stable across acquire/release
+cycles and proof rounds — the property CUDA graphs need).
+
+The whole schedule can be replayed every proof round with zero allocator work: `get` is pointer
+arithmetic plus a liveness check under a mutex.
+
+## Packing algorithm
+
+Offline interval placement (offline dynamic storage allocation) is NP-hard; the planner uses the
+classic *greedy-by-size* heuristic, which is near-optimal on skewed, phase-structured workloads:
+
+1. Sort allocations by decreasing size (ties: birth tick, then declaration order — the plan is
+   fully deterministic).
+2. For each allocation, collect the `[offset, offset + size)` ranges of already-placed allocations
+   that interfere with it, and place it at the lowest 256-byte-aligned offset that fits in a gap
+   (first fit).
+
+The workspace size is compared against the *peak-live* lower bound (max over time of the sum of
+live sizes — the weight of the heaviest clique of the interval graph); `build_on` logs both. On the
+prover-shaped benchmark schedule the greedy pass lands within a few percent of the lower bound.
+
+Alignment: every offset is at least 256-byte aligned (the `cudaMalloc` guarantee), raised to
+`align_of::<T>()` if larger; `build_on` verifies the workspace base pointer satisfies the largest
+requested alignment.
+
+## Streams
+
+Reusing memory between buffers used on *different* streams would require event synchronization that
+the planner does not insert, so allocations with different stream keys **always interfere** (never
+share memory). Within one stream key, reuse is safe when lifetime intervals are disjoint, because
+work on a single stream executes in issue order — the run stage must therefore issue work in the
+same order as the declared lifetimes. `alloc_fake` uses stream key 0; `alloc_fake_on_stream` declares work issued elsewhere.
+
+An allocator is bound to the `GpuDeviceCtx` it was built with: the workspace lives on that stream,
+fallback allocations use it, and planned reuse relies on work being issued in declared-lifetime
+order on it — the same discipline every explicitly-allocated `DeviceBuffer` already follows. Using
+a planned buffer on a foreign stream requires the caller to synchronize, exactly as with any other
+device buffer.
+
+## Use-after-lifetime detection
+
+The planner trusts the declared lifetimes for packing, but the allocator *checks* them at run time:
+it tracks which planned regions are currently acquired, and `get(b)` fails if any live buffer's
+planned region overlaps `b`'s. Since interfering allocations never overlap in the plan, any overlap
+among live buffers means some buffer outlived its declared lifetime.
+
+Two policies (chosen at `build_with_policy`):
+
+- `ViolationPolicy::Error` (default): `get(b)` returns `StaticAllocError::LifetimeViolation` naming
+  the holders. When the offending buffer is dropped, the space becomes acquirable again.
+- `ViolationPolicy::WarnAndAllocate`: `get(b)` logs a warning and serves `b` from a fresh dynamic
+  allocation (correct but off-plan: `b`'s pointer is not stable for that acquisition).
+
+Double-acquiring an index and redeeming an index against the wrong allocator are errors in both
+policies.
+
+## Interaction with the dynamic memory manager
+
+The workspace is a single ordinary `d_malloc` allocation, so a `StaticAllocator` coexists with
+dynamic allocation: code outside the plan keeps using `DeviceBuffer::with_capacity` and the VPMM
+pool. Because the workspace is page-backed and never freed until the allocator drops, VPMM will
+never remap (defragment) pages under it mid-use — pointer stability holds for the allocator's
+lifetime.
+
+## Limitations and future work
+
+- **Adoption in the prover.** The current GPU prover shares buffers via `Arc<DeviceBuffer<T>>`
+  (`DeviceMatrix`), with lifetimes ended by the last Arc drop. Migrating a phase to the planner
+  means expressing that phase's buffers as `AllocIdx` handles and threading a `StaticAllocator`
+  through; heights are only known at prove time, so the plan is built (or memoized per
+  height-shape) after trace generation.
+- The planner covers allocations declared through the builder; small incidental allocations can
+  stay dynamic (they bypass the VPMM pool below page size anyway).
+- Growing a plan after `build_on` is not supported — build a new plan instead.
+- The greedy packer does not currently exploit cross-stream event dependencies to allow safe
+  cross-stream reuse.
+
+## Record-and-replay integration (`VPMM_REPLAY`)
+
+The planner is integrated into the memory manager through a record-and-replay mode that requires no
+prover code changes. Record a workload once with `VPMM_TRACE=trace.csv`, then rerun it with
+`VPMM_REPLAY=trace.csv`: at startup the manager plans all traced allocations of at least
+`VPMM_REPLAY_MIN` bytes (default 16 MiB), lazily allocates one workspace through the pool, and
+serves matching allocations at their planned offsets — pointer arithmetic instead of pool work,
+with frees reduced to bookkeeping. Correctness does not depend on an exact replay: an allocation is
+served only when its size matches the next planned event and its planned range overlaps no live
+served allocation; anything else (including a second stream — replay is single-stream by design)
+falls back to the dynamic allocator, and divergence counters are logged.
+
+On the openvm reth workload this replays perfectly (all planned allocations served, zero
+fallbacks), making it a faithful way to run real proving on statically planned memory.


### PR DESCRIPTION
## Motivation

GPU proving allocates buffers with heavily skewed sizes — from single-element sums to multi-GiB RS-code matrices — through the dynamic memory manager (VPMM). VPMM fights fragmentation at run time by remapping pages, which makes peak usage an emergent property of allocator state and makes pointer values nondeterministic across runs. For workloads like OpenVM, once trace heights are known every downstream allocation size and lifetime is a deterministic function of the proving key and config, so GPU memory can instead be planned statically.

This PR adds a static memory planner to `openvm-cuda-common`, the allocation tracing/analysis tooling used to evaluate it on real workloads, and a record-and-replay integration that runs existing provers on statically planned memory with no prover code changes. Design doc: `docs/static_alloc_spec.md`.

## Design

Explicit planning happens in two stages:

1. **Setup** — each phase declares its allocations through an `AllocBuilder`. `alloc_fake::<T>(len)` returns a `DeviceBufFake<T>`, an RAII handle owning no memory whose Rust lifetime *is* the declared lifetime of the future buffer; the builder's logical clock records every handle's birth/death interval, so ordinary ownership rules build the interference graph. `idx()` yields a small `Copy` handle (`AllocIdx<T>`).
2. **Run** — `build_on(&GpuDeviceCtx)` packs all declarations into one workspace (greedy best-fit-decreasing over the interference graph: deterministic, 256-byte aligned, lowest-offset first fit), allocates it on the given stream, and returns a `StaticAllocator` bound to that stream. `get(&idx)` returns a `StaticDeviceBuffer<T>` — an RAII view at the planned offset that derefs to `DeviceBuffer<T>`, so kernels and D2H copies work unchanged (H2D goes through an inherent `copy_from`; exposing `DerefMut` would let safe code `mem::replace` the non-owning view out of the guard and free workspace-interior memory). Pointers are stable across acquire/release cycles and proof rounds — the prerequisite for CUDA graph capture.

Safety nets: use-after-lifetime detection while conflicting guards are held (error or warn-and-allocate policy); planned reuse relies on declared-lifetime issue order on the bound stream, the same discipline as any explicitly allocated `DeviceBuffer`; `touchemall` poisons planned regions on each acquisition.

## Tracing, analysis, and replay integration

- `VPMM_TRACE=<path>` records every `d_malloc_on`/`d_free` (requested size, stream, timestamp, measured call latency) plus `MemTracker` phase markers.
- `AllocBuilder::plan_stats()` runs the packing pass without allocating; `benches/trace_replay.rs` and `benches/trace_phases.rs` replay traces offline (whole-trace plan vs dynamic peak; per-phase and per-proof-window breakdowns).
- `VPMM_REPLAY=<trace>` integrates the planner into the memory manager itself: at startup it plans all traced allocations of at least `VPMM_REPLAY_MIN` bytes (default 16 MiB), lazily allocates one workspace through the pool, and serves matching allocations at their planned offsets; frees of served pointers are bookkeeping only. Correctness does not depend on an exact replay: an allocation is served only when its size matches the next planned event and its planned range overlaps no live served allocation; anything else (including a second stream — replay is single-stream by design) falls back to the dynamic allocator with counters logged. The workspace base is rejected in `d_free` so a double-free of the offset-0 served pointer cannot release the workspace to the pool.

## Measurements (RTX Pro 6000, openvm-eth mainnet block 23992138, this codebase / v2.0.0 lineage)

Packing — the planner hits the peak-live lower bound exactly (efficiency 1.000) on every recorded trace; planning takes seconds for 10k–60k allocations:

| workload | allocs planned | static workspace | dynamic tracked peak | ws/peak |
|---|---|---|---|---|
| prove-app (84 segments) | 9,815 (≥16 MiB) | 14.0 GiB | 14.1 GiB | 98.8% |
| prove-stark (full aggregation) | 11,622 (≥16 MiB) | 14.0 GiB | 14.2 GiB | 98.3% |

End-to-end A/B with `VPMM_REPLAY` (real proving on planned memory; 9,815/9,815 allocations served, zero fallbacks across 9 runs): the allocation-heavy zerocheck/logup phase improves consistently (27.28 s → 26.50 s summed per proof, ±0.36 s over 5 paired runs), matching the ~0.8 s of dynamic-pool CPU it removes; total `app_prove` time is unchanged within noise (±3–6 s on ~176 s). The dynamic allocator is not a throughput bottleneck on this workload — the planner's value is the deterministic pre-known memory budget, allocator-independent peak behavior, and stable pointers for future CUDA graph capture of the segment loop.

Older-generation (v1.4.0) traces show the same packing behavior (12.5 GiB / 38.3 GiB workspaces at 99.0–99.5% of the dynamic peak).

## Limitations / follow-ups

- Explicit adoption inside the prover (declaring phase buffers through `AllocBuilder` rather than replaying a trace) is future work; heights are only known at prove time, so plans would be built or memoized per height shape after trace generation.
- The packer does not exploit cross-stream event dependencies (different stream keys never share memory).
- CUDA graph capture of the segment-proving loop on top of the stable-pointer property is the natural next step.
