### PR TITLE
perf(cuda): use warp shuffles for fractional bit reversal

### DIFF
--- a/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
+++ b/crates/cuda-backend/cuda/src/logup_zerocheck/gkr.cu
@@ -1738,31 +1738,33 @@ T bit_rev(T i, unsigned int nbits)
 //
 // DERIVED FROM: bit_rev_permutation_z<T, Z_COUNT> in supra/ntt_bitrev.cu.
 // Diff vs the original template kernel:
-//   - Z_COUNT = 8 hardcoded (not a template param)
+//   - Z_COUNT is restricted to 4 or 8
 //   - In-place: single `inout` pointer (original has separate `out`/`in`)
 //   - No poly_count / no 2-D grid: operates on one poly only
 //   - Extra `alpha` parameter: adds alpha to every denominator after bit-reversing
 //   - Two GKR tree layers (K=2) are computed inside shmem before writing to global mem,
 //     eliminating two separate kernel passes
-//   - Masked __syncwarp(subgroup_mask) is used for each 8-lane Z-tile (matching
+//   - Masked __syncwarp(subgroup_mask) is used for each Z-tile (matching
 //     the original Z_COUNT <= WARP_SIZE path)
 //
-// Output layout for each Z-tile written at base_rev (i*step + base_rev, i=0..7):
-//   [0,1]  : layer-1 results  (tree level 2)
-//   [2,3]  : layer-0 results preserved (tree level 1 right half, for revert of layer 1)
-//   [4..7] : original+alpha preserved (leaves, for revert of layer 0)
+// Output layout for each Z-tile written at base_rev (i*step + base_rev, i=0..Z_COUNT-1):
+//   [0 .. Z/4)   : layer-1 results  (tree level 2)
+//   [Z/4 .. Z/2) : layer-0 results preserved (tree level 1 right half)
+//   [Z/2 .. Z)   : original+alpha preserved (leaves, for revert of layer 0)
 //
-// Sync is per 8-lane Z-tile using subgroup masks because branch predicates are
-// uniform per tile, not per whole warp. The launcher uses bsize=256, chosen after
-// benchmarking: 2x faster than bsize=32 in isolation (1525 vs 754 GB/s at lg=24
-// on RTX 5090). It requires 64KB dynamic shmem per block, so cudaFuncSetAttribute
-// is used in the launcher, paid once on the first call.
+// Sync is per Z-tile using subgroup masks because branch predicates are uniform per tile,
+// not per whole warp. The Z=8 launcher uses bsize=256, chosen after benchmarking: 2x faster
+// than bsize=32 in isolation (1525 vs 754 GB/s at lg=24 on RTX 5090). Z=4 is an alternate
+// geometry with half the per-thread FracExt register fan-out and half the dynamic shared
+// memory. It launches twice as many blocks to cover the same domain. cudaFuncSetAttribute
+// raises the dynamic-shmem limit for Z=8 and is paid once on the first call.
+template<uint32_t Z_COUNT>
 __global__
 void bit_rev_frac_build_k2_kernel(
     FracExt* inout, uint32_t real_len, uint32_t lg_domain_size, FpExt alpha)
 {
-    constexpr uint32_t Z_COUNT = 8;
-    constexpr uint32_t LG_Z_COUNT = 3;
+    static_assert(Z_COUNT == 4 || Z_COUNT == 8, "K=2 bitrev supports Z_COUNT 4 or 8");
+    constexpr uint32_t LG_Z_COUNT = Z_COUNT == 4 ? 2 : 3;
 
     extern __shared__ unsigned char xchg_raw[];
     FracExt (*xchg)[Z_COUNT][Z_COUNT] =
@@ -1814,19 +1816,22 @@ void bit_rev_frac_build_k2_kernel(
             for (uint32_t i = 0; i < Z_COUNT; i++)
                 row[i].q += alpha;
             #pragma unroll
-            for (uint32_t i = 0; i < 4; i++)  // tree layer 0: pairs (0,4),(1,5),(2,6),(3,7)
-                frac_add_inplace(row[i], row[i + 4]);
+            for (uint32_t i = 0; i < Z_COUNT / 2; i++)
+                frac_add_inplace(row[i], row[i + Z_COUNT / 2]);
             #pragma unroll
-            for (uint32_t i = 0; i < 2; i++)  // tree layer 1: pairs (0,2),(1,3)
-                frac_add_inplace(row[i], row[i + 2]);
+            for (uint32_t i = 0; i < Z_COUNT / 4; i++)
+                frac_add_inplace(row[i], row[i + Z_COUNT / 4]);
         }
         #pragma unroll
         for (uint32_t i = 0; i < Z_COUNT; i++) {
             index_t out_idx = i * step + base_rev;
             if (virtual_mode) {
                 uint32_t active_size =
-                    i < 2 ? (uint32_t)(domain_size >> 2)
-                          : (i < 4 ? (uint32_t)(domain_size >> 1) : (uint32_t)domain_size);
+                    i < Z_COUNT / 4
+                        ? (uint32_t)(domain_size >> 2)
+                        : (i < Z_COUNT / 2
+                               ? (uint32_t)(domain_size >> 1)
+                               : (uint32_t)domain_size);
                 virtual_node_store(
                     inout,
                     (uint32_t)out_idx,
@@ -1858,19 +1863,22 @@ void bit_rev_frac_build_k2_kernel(
             for (uint32_t i = 0; i < Z_COUNT; i++)
                 row[i].q += alpha;
             #pragma unroll
-            for (uint32_t i = 0; i < 4; i++)
-                frac_add_inplace(row[i], row[i + 4]);
+            for (uint32_t i = 0; i < Z_COUNT / 2; i++)
+                frac_add_inplace(row[i], row[i + Z_COUNT / 2]);
             #pragma unroll
-            for (uint32_t i = 0; i < 2; i++)
-                frac_add_inplace(row[i], row[i + 2]);
+            for (uint32_t i = 0; i < Z_COUNT / 4; i++)
+                frac_add_inplace(row[i], row[i + Z_COUNT / 4]);
         }
         #pragma unroll
         for (uint32_t i = 0; i < Z_COUNT; i++) {
             index_t out_idx = i * step + base_idx;
             if (virtual_mode) {
                 uint32_t active_size =
-                    i < 2 ? (uint32_t)(domain_size >> 2)
-                          : (i < 4 ? (uint32_t)(domain_size >> 1) : (uint32_t)domain_size);
+                    i < Z_COUNT / 4
+                        ? (uint32_t)(domain_size >> 2)
+                        : (i < Z_COUNT / 2
+                               ? (uint32_t)(domain_size >> 1)
+                               : (uint32_t)domain_size);
                 virtual_node_store(
                     inout,
                     (uint32_t)out_idx,
@@ -1886,21 +1894,196 @@ void bit_rev_frac_build_k2_kernel(
 
     } while ((tid += blockDim.x*gridDim.x) < step);
     // Note: the original bit_rev_permutation_z guards this with "Z_COUNT <= WARP_SIZE &&"
-    // to prevent register spills when Z_COUNT > WARP_SIZE. Z_COUNT=8 is always <= 32.
+    // to prevent register spills when Z_COUNT > WARP_SIZE. Both variants are <= 32.
+}
+
+__device__ __forceinline__ FpExt shfl_xor_fpext(
+    unsigned subgroup_mask, FpExt value, uint32_t lane_mask)
+{
+    FpExt result;
+    #pragma unroll
+    for (uint32_t limb = 0; limb < 4; ++limb) {
+        result.elems[limb] = Fp::fromRaw(
+            __shfl_xor_sync(subgroup_mask, value.elems[limb].asRaw(), lane_mask));
+    }
+    return result;
+}
+
+__device__ __forceinline__ FracExt shfl_xor_fracext(
+    unsigned subgroup_mask, FracExt value, uint32_t lane_mask)
+{
+    return {
+        shfl_xor_fpext(subgroup_mask, value.p, lane_mask),
+        shfl_xor_fpext(subgroup_mask, value.q, lane_mask),
+    };
+}
+
+// Transpose a 4x4 register tile across a four-lane subgroup. Before the transpose,
+// lane l owns values[l][j]. Afterwards lane l owns values[j][l]. Each stage swaps
+// one coordinate bit between the physical lane and register index. Every lane named
+// in subgroup_mask executes every shuffle.
+__device__ __forceinline__ void transpose_fracext_z4(
+    FracExt values[4], uint32_t lane_in_group, unsigned subgroup_mask)
+{
+    #pragma unroll
+    for (uint32_t lane_mask = 1; lane_mask < 4; lane_mask <<= 1) {
+        #pragma unroll
+        for (uint32_t base = 0; base < 4; base += 2 * lane_mask) {
+            #pragma unroll
+            for (uint32_t offset = 0; offset < lane_mask; ++offset) {
+                uint32_t lo_idx = base + offset;
+                uint32_t hi_idx = lo_idx + lane_mask;
+                FracExt lo_from_hi_lane =
+                    shfl_xor_fracext(subgroup_mask, values[hi_idx], lane_mask);
+                FracExt hi_from_lo_lane =
+                    shfl_xor_fracext(subgroup_mask, values[lo_idx], lane_mask);
+                if ((lane_in_group & lane_mask) != 0) {
+                    values[lo_idx] = lo_from_hi_lane;
+                } else {
+                    values[hi_idx] = hi_from_lo_lane;
+                }
+            }
+        }
+    }
+}
+
+__device__ __forceinline__ void build_k2_z4_in_registers(FracExt values[4], FpExt alpha)
+{
+    #pragma unroll
+    for (uint32_t i = 0; i < 4; ++i)
+        values[i].q += alpha;
+
+    // Logical row slots are values[bit_rev(i, 2)]. Thus the K=2 tree operations
+    // (row[0] += row[2], row[1] += row[3], row[0] += row[1]) become:
+    frac_add_inplace(values[0], values[1]);
+    frac_add_inplace(values[2], values[3]);
+    frac_add_inplace(values[0], values[2]);
+}
+
+__device__ __forceinline__ void store_k2_z4_register_tile(
+    FracExt* inout,
+    FracExt values[4],
+    index_t step,
+    index_t target_base,
+    uint32_t output_suffix,
+    bool virtual_mode,
+    uint32_t real_len,
+    uint32_t domain_size)
+{
+    #pragma unroll
+    for (uint32_t i = 0; i < 4; ++i) {
+        index_t out_idx = i * step + target_base + output_suffix;
+        FracExt value = values[bit_rev(i, 2)];
+        if (virtual_mode) {
+            uint32_t active_size =
+                i < 1 ? (domain_size >> 2)
+                      : (i < 2 ? (domain_size >> 1) : domain_size);
+            virtual_node_store(
+                inout,
+                (uint32_t)out_idx,
+                active_size,
+                real_len,
+                domain_size,
+                value
+            );
+        } else {
+            inout[out_idx] = value;
+        }
+    }
+}
+
+// Z=4 alternative that replaces the 32 KiB shared-memory transpose with two
+// four-lane butterfly shuffle stages. The output suffix is bit-reversed so the
+// transposed register row lands at exactly the same dense indices as the shared
+// kernel. For an off-diagonal group pair both source tiles must remain live until
+// the first output is written, because either output overwrites the other tile's
+// source addresses.
+__global__ void bit_rev_frac_build_k2_z4_shuffle_kernel(
+    FracExt* inout, uint32_t real_len, uint32_t lg_domain_size, FpExt alpha)
+{
+    constexpr uint32_t Z_COUNT = 4;
+    constexpr uint32_t LG_Z_COUNT = 2;
+
+    uint32_t idx = threadIdx.x % Z_COUNT;
+    uint32_t rev = bit_rev(idx, LG_Z_COUNT);
+    uint32_t lane = threadIdx.x & (WARP_SIZE - 1);
+    uint32_t subgroup_base = lane - idx;
+    unsigned subgroup_mask = ((1u << Z_COUNT) - 1u) << subgroup_base;
+
+    index_t domain_size = (index_t)1 << lg_domain_size;
+    index_t step = (index_t)1 << (lg_domain_size - LG_Z_COUNT);
+    index_t tid = threadIdx.x + blockDim.x * (index_t)blockIdx.x;
+    bool virtual_mode = real_len < domain_size;
+    FracExt zero_frac = FracExt::zero();
+
+    #pragma unroll 1
+    do {
+        index_t group_idx = tid >> LG_Z_COUNT;
+        index_t group_rev = bit_rev(group_idx, lg_domain_size - 2 * LG_Z_COUNT);
+
+        if (group_idx > group_rev)
+            continue;
+
+        index_t base_idx = group_idx * Z_COUNT;
+        index_t base_rev = group_rev * Z_COUNT;
+        bool paired_group = group_idx != group_rev;
+
+        FracExt first[Z_COUNT];
+        FracExt second[Z_COUNT];
+        #pragma unroll
+        for (uint32_t i = 0; i < Z_COUNT; ++i) {
+            index_t first_src = i * step + base_idx + idx;
+            first[i] = first_src < real_len ? inout[first_src] : zero_frac;
+            if (paired_group) {
+                index_t second_src = i * step + base_rev + idx;
+                second[i] = second_src < real_len ? inout[second_src] : zero_frac;
+            }
+        }
+
+        transpose_fracext_z4(first, idx, subgroup_mask);
+        build_k2_z4_in_registers(first, alpha);
+        store_k2_z4_register_tile(
+            inout,
+            first,
+            step,
+            base_rev,
+            rev,
+            virtual_mode,
+            real_len,
+            (uint32_t)domain_size
+        );
+
+        if (!paired_group)
+            continue;
+
+        transpose_fracext_z4(second, idx, subgroup_mask);
+        build_k2_z4_in_registers(second, alpha);
+        store_k2_z4_register_tile(
+            inout,
+            second,
+            step,
+            base_idx,
+            rev,
+            virtual_mode,
+            real_len,
+            (uint32_t)domain_size
+        );
+    } while ((tid += blockDim.x * gridDim.x) < step);
 }
 
 // Fused bitrev + K=2 tree build for a single FracExt buffer.
 // Requires domain_size >= 256 (uses Z-tile shmem kernel).
 // Applies alpha to denominators and fuses tree layers 0 and 1 in shmem.
-extern "C" int _bit_rev_frac_ext_build_k2(
+template<uint32_t Z_COUNT>
+int launch_bit_rev_frac_ext_build_k2(
     FracExt* inout, size_t real_len, uint32_t lg_domain_size, FpExt alpha, cudaStream_t stream)
 {
-    constexpr uint32_t Z_COUNT = 8;
+    static_assert(Z_COUNT == 4 || Z_COUNT == 8, "K=2 bitrev supports Z_COUNT 4 or 8");
     constexpr uint32_t bsize = 256;
-    constexpr size_t shmem_bytes = (size_t)bsize * Z_COUNT * sizeof(FracExt);  // 64 KB
+    constexpr size_t shmem_bytes = (size_t)bsize * Z_COUNT * sizeof(FracExt);
     // Raise the per-block dynamic shmem limit once (static → paid on first call only).
     static const cudaError_t shmem_err = cudaFuncSetAttribute(
-        bit_rev_frac_build_k2_kernel,
+        bit_rev_frac_build_k2_kernel<Z_COUNT>,
         cudaFuncAttributeMaxDynamicSharedMemorySize,
         (int)shmem_bytes);
     if (shmem_err != cudaSuccess) return shmem_err;
@@ -1908,7 +2091,33 @@ extern "C" int _bit_rev_frac_ext_build_k2(
     if (domain_size < (size_t)(bsize * Z_COUNT))
         return cudaErrorInvalidValue;
     uint32_t grid_x = (uint32_t)(domain_size / Z_COUNT / bsize);
-    bit_rev_frac_build_k2_kernel<<<dim3(grid_x), bsize, shmem_bytes, stream>>>(
+    bit_rev_frac_build_k2_kernel<Z_COUNT><<<dim3(grid_x), bsize, shmem_bytes, stream>>>(
+        inout, (uint32_t)real_len, lg_domain_size, alpha);
+    return CHECK_KERNEL();
+}
+
+extern "C" int _bit_rev_frac_ext_build_k2(
+    FracExt* inout, size_t real_len, uint32_t lg_domain_size, FpExt alpha, cudaStream_t stream)
+{
+    return launch_bit_rev_frac_ext_build_k2<8>(inout, real_len, lg_domain_size, alpha, stream);
+}
+
+extern "C" int _bit_rev_frac_ext_build_k2_z4(
+    FracExt* inout, size_t real_len, uint32_t lg_domain_size, FpExt alpha, cudaStream_t stream)
+{
+    return launch_bit_rev_frac_ext_build_k2<4>(inout, real_len, lg_domain_size, alpha, stream);
+}
+
+extern "C" int _bit_rev_frac_ext_build_k2_z4_shuffle(
+    FracExt* inout, size_t real_len, uint32_t lg_domain_size, FpExt alpha, cudaStream_t stream)
+{
+    constexpr uint32_t Z_COUNT = 4;
+    constexpr uint32_t bsize = 256;
+    size_t domain_size = (size_t)1 << lg_domain_size;
+    if (domain_size < (size_t)(bsize * Z_COUNT))
+        return cudaErrorInvalidValue;
+    uint32_t grid_x = (uint32_t)(domain_size / Z_COUNT / bsize);
+    bit_rev_frac_build_k2_z4_shuffle_kernel<<<dim3(grid_x), bsize, 0, stream>>>(
         inout, (uint32_t)real_len, lg_domain_size, alpha);
     return CHECK_KERNEL();
 }

--- a/crates/cuda-backend/src/cuda/ntt.rs
+++ b/crates/cuda-backend/src/cuda/ntt.rs
@@ -84,6 +84,24 @@ extern "C" {
         alpha: EF,
         stream: cudaStream_t,
     ) -> i32;
+
+    /// Z=4 shared-memory variant of the fused bitrev + K=2 tree build.
+    fn _bit_rev_frac_ext_build_k2_z4(
+        inout: *mut std::ffi::c_void,
+        real_len: usize,
+        lg_domain_size: u32,
+        alpha: EF,
+        stream: cudaStream_t,
+    ) -> i32;
+
+    /// Z=4 warp-shuffle variant of the fused bitrev + K=2 tree build.
+    fn _bit_rev_frac_ext_build_k2_z4_shuffle(
+        inout: *mut std::ffi::c_void,
+        real_len: usize,
+        lg_domain_size: u32,
+        alpha: EF,
+        stream: cudaStream_t,
+    ) -> i32;
 }
 
 pub unsafe fn bit_rev(
@@ -148,6 +166,38 @@ pub unsafe fn bit_rev_frac_ext_build_k2(
     stream: cudaStream_t,
 ) -> Result<(), CudaError> {
     CudaError::from_result(_bit_rev_frac_ext_build_k2(
+        inout.as_mut_raw_ptr(),
+        real_len,
+        lg_domain_size,
+        alpha,
+        stream,
+    ))
+}
+
+pub unsafe fn bit_rev_frac_ext_build_k2_z4(
+    inout: &DeviceBuffer<(EF, EF)>,
+    real_len: usize,
+    lg_domain_size: u32,
+    alpha: EF,
+    stream: cudaStream_t,
+) -> Result<(), CudaError> {
+    CudaError::from_result(_bit_rev_frac_ext_build_k2_z4(
+        inout.as_mut_raw_ptr(),
+        real_len,
+        lg_domain_size,
+        alpha,
+        stream,
+    ))
+}
+
+pub unsafe fn bit_rev_frac_ext_build_k2_z4_shuffle(
+    inout: &DeviceBuffer<(EF, EF)>,
+    real_len: usize,
+    lg_domain_size: u32,
+    alpha: EF,
+    stream: cudaStream_t,
+) -> Result<(), CudaError> {
+    CudaError::from_result(_bit_rev_frac_ext_build_k2_z4_shuffle(
         inout.as_mut_raw_ptr(),
         real_len,
         lg_domain_size,

--- a/crates/cuda-backend/src/logup_zerocheck/fractional.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/fractional.rs
@@ -26,7 +26,10 @@ use crate::{
             frac_compute_round_and_revert, frac_multifold_raw, frac_precompute_m_build_raw,
             frac_precompute_m_eval_round_raw,
         },
-        ntt::{bit_rev_frac_ext, bit_rev_frac_ext_build_k2},
+        ntt::{
+            bit_rev_frac_ext, bit_rev_frac_ext_build_k2, bit_rev_frac_ext_build_k2_z4,
+            bit_rev_frac_ext_build_k2_z4_shuffle,
+        },
     },
     poly::SqrtEqLayers,
     prelude::EF,
@@ -132,6 +135,20 @@ const PRECOMPUTE_M_TAIL_TILE: usize = 4096;
 const PRECOMPUTE_M_MIN_TAIL_TILE: usize = 256;
 const PRECOMPUTE_M_DEFAULT_MIN_BLOCKS: usize = 64;
 const PRECOMPUTE_M_DEFAULT_TARGET_BLOCKS: usize = 1024;
+
+fn bitrev_build_z4_enabled() -> bool {
+    !matches!(
+        env::var("SWIRL_CUDA_GKR_BITREV_Z_COUNT").as_deref(),
+        Ok("8")
+    )
+}
+
+fn bitrev_z4_shuffle_enabled() -> bool {
+    !matches!(
+        env::var("SWIRL_CUDA_GKR_BITREV_Z4_SHUFFLE").as_deref(),
+        Ok("0")
+    )
+}
 
 impl BufferScheduler {
     /// Creates a new scheduler with data initially in layer buffer.
@@ -707,8 +724,22 @@ where
         unsafe {
             // SAFETY: Frac<EF> has exact same memory layout and alignment as (EF, EF).
             let buf = transmute::<&DeviceBuffer<Frac<EF>>, &DeviceBuffer<(EF, EF)>>(&layer);
-            bit_rev_frac_ext_build_k2(buf, real_len, total_rounds as u32, alpha, stream)
-                .map_err(FractionalSumcheckError::BitReversal)?;
+            let bitrev_result = if bitrev_build_z4_enabled() {
+                if bitrev_z4_shuffle_enabled() {
+                    bit_rev_frac_ext_build_k2_z4_shuffle(
+                        buf,
+                        real_len,
+                        total_rounds as u32,
+                        alpha,
+                        stream,
+                    )
+                } else {
+                    bit_rev_frac_ext_build_k2_z4(buf, real_len, total_rounds as u32, alpha, stream)
+                }
+            } else {
+                bit_rev_frac_ext_build_k2(buf, real_len, total_rounds as u32, alpha, stream)
+            };
+            bitrev_result.map_err(FractionalSumcheckError::BitReversal)?;
         }
         2 // layers 0+1 already done
     } else {
@@ -1597,6 +1628,11 @@ pub fn make_synthetic_leaves(
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        ffi::OsString,
+        sync::{Mutex, MutexGuard},
+    };
+
     use openvm_cuda_common::{
         common::get_device,
         copy::MemCopyH2D,
@@ -1612,6 +1648,59 @@ mod tests {
     };
     use crate::{prelude::SC, sponge::DuplexSpongeGpu};
 
+    static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
+    const TEST_ENV_VARS: &[&str] = &[
+        "SWIRL_CUDA_GKR_PRECOMPUTE_M",
+        "SWIRL_CUDA_GKR_PRECOMPUTE_M_MIN_BLOCKS",
+        "SWIRL_CUDA_GKR_PRECOMPUTE_M_MIN_N",
+        "SWIRL_CUDA_GKR_BITREV_Z_COUNT",
+        "SWIRL_CUDA_GKR_BITREV_Z4_SHUFFLE",
+    ];
+
+    struct TestEnvGuard(Vec<(&'static str, Option<OsString>)>);
+
+    struct LockedTestEnv {
+        // Fields drop in declaration order, restoring the environment before unlocking.
+        _guard: TestEnvGuard,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl TestEnvGuard {
+        fn capture() -> Self {
+            Self(
+                TEST_ENV_VARS
+                    .iter()
+                    .map(|&name| (name, std::env::var_os(name)))
+                    .collect(),
+            )
+        }
+    }
+
+    impl Drop for TestEnvGuard {
+        fn drop(&mut self) {
+            for (name, value) in self.0.drain(..) {
+                unsafe {
+                    if let Some(value) = value {
+                        std::env::set_var(name, value);
+                    } else {
+                        std::env::remove_var(name);
+                    }
+                }
+            }
+        }
+    }
+
+    fn lock_test_env() -> LockedTestEnv {
+        let lock = TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let guard = TestEnvGuard::capture();
+        LockedTestEnv {
+            _guard: guard,
+            _lock: lock,
+        }
+    }
+
     fn test_ctx() -> GpuDeviceCtx {
         GpuDeviceCtx {
             device_id: get_device().unwrap() as u32,
@@ -1624,7 +1713,7 @@ mod tests {
         n: usize,
         strategy: GkrRoundStrategy,
     ) -> Result<(super::FracSumcheckProof<SC>, Vec<EF>), FractionalSumcheckError> {
-        // SAFETY: test sets process env; run with --test-threads=1.
+        // SAFETY: callers hold TEST_ENV_LOCK while this helper mutates process-global state.
         let enable_precompute_m = matches!(strategy, GkrRoundStrategy::PrecomputeM);
         unsafe {
             std::env::set_var(
@@ -1715,7 +1804,7 @@ mod tests {
         alpha: EF,
         strategy: GkrRoundStrategy,
     ) -> Result<(super::FracSumcheckProof<SC>, Vec<EF>), FractionalSumcheckError> {
-        // SAFETY: test sets process env; run with --test-threads=1.
+        // SAFETY: callers hold TEST_ENV_LOCK while this helper mutates process-global state.
         let enable_precompute_m = matches!(strategy, GkrRoundStrategy::PrecomputeM);
         unsafe {
             std::env::set_var(
@@ -1749,6 +1838,7 @@ mod tests {
 
     #[test]
     fn test_virtual_input_padding_matches_dense_padding() -> Result<(), FractionalSumcheckError> {
+        let _env = lock_test_env();
         let small_cases = [4, 8, 16, 32].into_iter().flat_map(|logical_len| {
             (logical_len / 2..logical_len).map(move |real_len| (real_len, logical_len))
         });
@@ -1768,6 +1858,7 @@ mod tests {
     #[test]
     fn test_virtual_input_padding_matches_dense_padding_precompute_m(
     ) -> Result<(), FractionalSumcheckError> {
+        let _env = lock_test_env();
         for (real_len, logical_len) in [
             (33, 64),
             (47, 64),
@@ -1800,6 +1891,7 @@ mod tests {
     /// n=26: top layer rem_n=24 (one window, even more tail).
     #[test]
     fn test_precompute_m_matches_fused() -> Result<(), FractionalSumcheckError> {
+        let _env = lock_test_env();
         for n in [24, 25, 26] {
             eprintln!("--- testing n={n} ---");
             let fused = run_with_strategy(n, GkrRoundStrategy::FoldEval)?;
@@ -1814,6 +1906,7 @@ mod tests {
     /// window 2 at base=4 (rem_n=11), then fold-eval tail for the remaining round.
     #[test]
     fn test_precompute_m_multi_window_matches_fused() -> Result<(), FractionalSumcheckError> {
+        let _env = lock_test_env();
         unsafe {
             std::env::set_var("SWIRL_CUDA_GKR_PRECOMPUTE_M_MIN_N", "8");
             std::env::set_var("SWIRL_CUDA_GKR_PRECOMPUTE_M_MIN_BLOCKS", "1");
@@ -1824,6 +1917,59 @@ mod tests {
         unsafe {
             std::env::remove_var("SWIRL_CUDA_GKR_PRECOMPUTE_M_MIN_N");
             std::env::remove_var("SWIRL_CUDA_GKR_PRECOMPUTE_M_MIN_BLOCKS");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_bitrev_z4_shuffle_matches_shared_and_z8() -> Result<(), FractionalSumcheckError> {
+        let _env = lock_test_env();
+        for (real_len, logical_len) in [(2048, 2048), (1500, 2048)] {
+            let host = make_host_leaves(real_len);
+            unsafe {
+                std::env::set_var("SWIRL_CUDA_GKR_BITREV_Z_COUNT", "8");
+                std::env::remove_var("SWIRL_CUDA_GKR_BITREV_Z4_SHUFFLE");
+            }
+            let z8 = run_from_host(
+                &host,
+                real_len,
+                logical_len,
+                virtual_padding_test_alpha(),
+                GkrRoundStrategy::FoldEval,
+            )?;
+
+            unsafe {
+                std::env::set_var("SWIRL_CUDA_GKR_BITREV_Z_COUNT", "4");
+                std::env::set_var("SWIRL_CUDA_GKR_BITREV_Z4_SHUFFLE", "0");
+            }
+            let shared_z4 = run_from_host(
+                &host,
+                real_len,
+                logical_len,
+                virtual_padding_test_alpha(),
+                GkrRoundStrategy::FoldEval,
+            )?;
+            assert_proofs_equal_with_context(
+                &shared_z4,
+                &z8,
+                &format!("shared Z=4, real_len={real_len}, logical_len={logical_len}"),
+            );
+
+            unsafe {
+                std::env::set_var("SWIRL_CUDA_GKR_BITREV_Z4_SHUFFLE", "1");
+            }
+            let shuffle_z4 = run_from_host(
+                &host,
+                real_len,
+                logical_len,
+                virtual_padding_test_alpha(),
+                GkrRoundStrategy::FoldEval,
+            )?;
+            assert_proofs_equal_with_context(
+                &shuffle_z4,
+                &shared_z4,
+                &format!("shuffle Z=4, real_len={real_len}, logical_len={logical_len}"),
+            );
         }
         Ok(())
     }

--- a/docs/cuda-backend/gkr-prover.md
+++ b/docs/cuda-backend/gkr-prover.md
@@ -106,6 +106,8 @@ In the natural (big-endian) ordering, leaf at index `i` corresponds to hypercube
 
 Before building the tree, the leaves are permuted into bit-reversed order. This changes the tree wiring so that each layer's children are at stride `half` (a power of 2) apart in memory, which gives coalesced warp accesses since adjacent threads read adjacent positions.
 
+For domains larger than 1024, `bit_rev_frac_build_k2_kernel<Z_COUNT>` fuses this permutation with the first two tree layers. The default path uses a Z=4 two-stage register-shuffle transpose with no dynamic shared memory. The shuffle kernel bit-reverses its output suffix so its register-transposed rows land at exactly the same dense indices as the original Z=8 kernel. Set `SWIRL_CUDA_GKR_BITREV_Z_COUNT=8` to restore the original 64 KiB shared-memory geometry, or set `SWIRL_CUDA_GKR_BITREV_Z4_SHUFFLE=0` to use the 32 KiB shared-memory Z=4 transpose. The shuffle path retains both four-element source tiles during off-diagonal in-place swaps, so it uses more registers even though it eliminates shared-memory allocation and barriers.
+
 The tree kernel pairs `layer[idx]` with `layer[idx + half]` where `half` is halved each layer. In bit-reversed order, this means the tree sums variables from last to first (x_n, x_{n-1}, ..., x_1).
 
 Concrete example with `n = 3` (8 leaves):


### PR DESCRIPTION
## Summary

- generalize the fused fractional bit-reversal and K=2 tree-build kernel to support Z=4 tiles
- replace the Z=4 shared-memory transpose with a two-stage four-lane register-shuffle butterfly
- make the shuffle path the default while retaining the original Z=8 and shared-memory Z=4 paths as rollback options
- add dense and virtual-padding proof-equivalence coverage and document the launch modes

Addresses INT-7891.

## Motivation

Profiling showed that the fused bit-reversal/tree-build kernel was the largest fractional-sumcheck component. Its Z=8 transpose used 64 KiB of dynamic shared memory per block and synchronized through shared memory while sustaining low warps in flight.

The Z=4 shuffle path removes dynamic shared memory and transpose barriers. It uses more registers than shared-memory Z=4, but produced no local-memory spills and was substantially faster on the target Blackwell GPU.

## Performance

Standard block 23992138, 78 cached segments, RTX Pro 6000, sequential main-to-candidate runs in the same sandbox:

| Metric | main | candidate | Change |
| --- | ---: | ---: | ---: |
| Fractional sumcheck | 10,369 ms | 8,575 ms | **-17.30%** |
| LogUp GKR | 10,458 ms | 8,669 ms | -17.11% |
| Zerocheck + LogUp GPU | 24,414 ms | 22,698 ms | -7.03% |
| Wall time | 421.9 s | 413.8 s | -1.92% |
| Peak VRAM | 16,157 MiB | 16,157 MiB | unchanged |

The candidate used the new default path without optimization environment variables.

Isolated shared-Z4 to shuffle-Z4 fractional-sumcheck results:

| Size | Shared Z4 | Shuffle Z4 | Change |
| --- | ---: | ---: | ---: |
| n=24 | 16.362 ms | 15.353 ms | -6.16% |
| n=26 | 32.335 ms | 29.198 ms | -9.70% |
| n=28 | 90.323 ms | 76.680 ms | -15.10% |

## Validation

- `cargo +nightly fmt --all -- --check`
- `CXX=g++-12 CUDA_ARCH=89 cargo check -p openvm-cuda-backend --tests`
- `CXX=g++-12 CUDA_ARCH=89 cargo clippy -p openvm-cuda-backend --tests -- -D warnings`
- GPU proof equivalence across Z8, shared Z4, and shuffle Z4 for dense and virtually padded inputs
- clean release build and end-to-end standard-block prove

## Rollback controls

- `SWIRL_CUDA_GKR_BITREV_Z_COUNT=8` restores the original Z=8 shared-memory kernel
- `SWIRL_CUDA_GKR_BITREV_Z4_SHUFFLE=0` selects the shared-memory Z=4 transpose
