### PR TITLE
perf(cuda-backend): fuse zeta and zero-extend passes into the NTT bit-reversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - (CUDA common) `DeviceBuffer::mut_slice(range)` returning a `DeviceBufferMutSlice<'_, T>` with a `copy_from_host` method for overwriting a subrange of a device buffer from a host slice on a caller-supplied stream.
 
 ### Changed
+- GPU prover: fused the subset-zeta and zero-extend passes of RS encoding into the bit-reversal permutation, removing the standalone bit-reversal sweeps before large NTTs (~2.5% lower proving time on the reth benchmark on RTX Pro 6000; committed codeword order and proofs unchanged).
 - GPU prover: batched the per-round parameter uploads, kernel launches, and result readbacks of the batch-constraint, stacked-reduction, and round-0 sumcheck phases, and moved per-round transcript readbacks to pinned memory; the interactions round-0 DAG is now cached in the proving key instead of rebuilt per proof. Measured ~2.4% lower proving time on the reth benchmark on RTX Pro 6000.
 
 ## v2.0.0 (2026-07-06)

--- a/crates/cuda-backend/cuda/supra/ntt_bitrev.cu
+++ b/crates/cuda-backend/cuda/supra/ntt_bitrev.cu
@@ -7,6 +7,8 @@
  * - 2025-08-13: Support multiple rows in bit_rev_permutation & bit_rev_permutation_z
  * - 2025-09-10: Add extern "C" launcher from sppark/ntt/ntt.cuh
  * - 2025-12-24: Template field type to support fr_t and bb31_4_t
+ * - 2026-07-10: Add fused subset-zeta + bit-reversal and expand-pad + bit-reversal
+ *               kernels (prover-side fusions; output identical to the two-pass forms)
  */
 
 #include <cstdint>
@@ -158,6 +160,198 @@ void bit_rev_permutation_z(T* out, const T* in, uint32_t lg_domain_size,
     // without "Z_COUNT <= WARP_SIZE" compiler spills 128 bytes to stack
 }
 
+
+// [DIFF 2026-07-10]: Fused subset-zeta + bit-reversal. Applies `l_skip` coeff-to-eval
+// zeta stages (x[j + 2^s] += x[j] for s = 0..l_skip-1, acting on the low l_skip bits of
+// the natural index) to each column while performing the bit-reversal permutation,
+// saving a full read+write pass over the buffer. In the Z-tile's bit-reversed column
+// storage, natural-index bit s maps to tile-column bit (LG_Z_COUNT-1-s), so the stages
+// become column butterflies at strides Z_COUNT >> (s+1), applied in the same order.
+// Requires l_skip <= LG_Z_COUNT so every zeta chunk lies within one tile row, and a
+// single Z-subgroup per block (blockDim.x == Z_COUNT) so __syncthreads() is uniform.
+template<typename T, unsigned int Z_COUNT>
+__launch_bounds__(192, 2) __global__
+void bit_rev_zeta_fused_kernel(T* out, const T* in, uint32_t lg_domain_size,
+                               uint32_t padded_poly_size, uint32_t poly_count,
+                               uint32_t l_skip)
+{
+    const uint32_t poly_idx = blockIdx.y + blockIdx.z * gridDim.y;
+    if (poly_idx >= poly_count)
+        return;
+    out += static_cast<size_t>(poly_idx) * padded_poly_size;
+    in += static_cast<size_t>(poly_idx) * padded_poly_size;
+
+    const uint32_t LG_Z_COUNT = 31 - __clz(Z_COUNT);
+
+    extern __shared__ unsigned char xchg_raw[];
+    T (*xchg)[Z_COUNT][Z_COUNT] = reinterpret_cast<T (*)[Z_COUNT][Z_COUNT]>(xchg_raw);
+
+    uint32_t gid = threadIdx.x / Z_COUNT;
+    uint32_t idx = threadIdx.x % Z_COUNT;
+    uint32_t rev = bit_rev(idx, LG_Z_COUNT);
+
+    index_t step = (index_t)1 << (lg_domain_size - LG_Z_COUNT);
+    index_t tid = threadIdx.x + blockDim.x * (index_t)blockIdx.x;
+
+    index_t group_idx = tid >> LG_Z_COUNT;
+    index_t group_rev = bit_rev(group_idx, lg_domain_size - 2*LG_Z_COUNT);
+
+    // Uniform per block: blockDim.x == Z_COUNT means group_idx == blockIdx.x.
+    if (group_idx > group_rev)
+        return;
+
+    index_t base_idx = group_idx * Z_COUNT + idx;
+    index_t base_rev = group_rev * Z_COUNT + idx;
+
+    T regs[Z_COUNT];
+
+    #pragma unroll
+    for (uint32_t i = 0; i < Z_COUNT; i++) {
+        xchg[gid][i][rev] = (regs[i] = in[i * step + base_idx]);
+        if (group_idx != group_rev)
+            regs[i] = in[i * step + base_rev];
+    }
+
+    __syncthreads();
+
+    #pragma unroll 1
+    for (uint32_t s = 0; s < l_skip; s++) {
+        uint32_t rs = Z_COUNT >> (s + 1);
+        if (idx & rs) {
+            #pragma unroll
+            for (uint32_t i = 0; i < Z_COUNT; i++)
+                xchg[gid][i][idx] = xchg[gid][i][idx] + xchg[gid][i][idx ^ rs];
+        }
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (uint32_t i = 0; i < Z_COUNT; i++)
+        out[i * step + base_rev] = xchg[gid][rev][i];
+
+    if (group_idx == group_rev)
+        return;
+
+    __syncthreads();
+
+    #pragma unroll
+    for (uint32_t i = 0; i < Z_COUNT; i++)
+        xchg[gid][i][rev] = regs[i];
+
+    __syncthreads();
+
+    #pragma unroll 1
+    for (uint32_t s = 0; s < l_skip; s++) {
+        uint32_t rs = Z_COUNT >> (s + 1);
+        if (idx & rs) {
+            #pragma unroll
+            for (uint32_t i = 0; i < Z_COUNT; i++)
+                xchg[gid][i][idx] = xchg[gid][i][idx] + xchg[gid][i][idx ^ rs];
+        }
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (uint32_t i = 0; i < Z_COUNT; i++)
+        out[i * step + base_idx] = xchg[gid][rev][i];
+}
+
+// [DIFF 2026-07-10]: Fused zero-extend + bit-reversal: out[bit_rev(i)] = i < src_len ?
+// in[i] : 0, per column. Replaces a batch_expand_pad pass followed by a standalone
+// bit-reversal pass. `in` and `out` must not alias (unlike the in-place permutation,
+// the source is shorter than the domain).
+template<typename T, unsigned int Z_COUNT>
+__launch_bounds__(192, 2) __global__
+void bit_rev_expand_pad_kernel(T* out, const T* in, uint32_t lg_domain_size,
+                               uint32_t out_stride, uint32_t in_stride,
+                               uint32_t poly_count, uint32_t src_len)
+{
+    const uint32_t poly_idx = blockIdx.y + blockIdx.z * gridDim.y;
+    if (poly_idx >= poly_count)
+        return;
+    out += static_cast<size_t>(poly_idx) * out_stride;
+    in += static_cast<size_t>(poly_idx) * in_stride;
+
+    const uint32_t LG_Z_COUNT = 31 - __clz(Z_COUNT);
+
+    extern __shared__ unsigned char xchg_raw[];
+    T (*xchg)[Z_COUNT][Z_COUNT] = reinterpret_cast<T (*)[Z_COUNT][Z_COUNT]>(xchg_raw);
+
+    uint32_t gid = threadIdx.x / Z_COUNT;
+    uint32_t idx = threadIdx.x % Z_COUNT;
+    uint32_t rev = bit_rev(idx, LG_Z_COUNT);
+
+    index_t step = (index_t)1 << (lg_domain_size - LG_Z_COUNT);
+    index_t tid = threadIdx.x + blockDim.x * (index_t)blockIdx.x;
+
+    index_t group_idx = tid >> LG_Z_COUNT;
+    index_t group_rev = bit_rev(group_idx, lg_domain_size - 2*LG_Z_COUNT);
+
+    index_t base_idx = group_idx * Z_COUNT + idx;
+    index_t base_rev = group_rev * Z_COUNT + idx;
+
+    #pragma unroll
+    for (uint32_t i = 0; i < Z_COUNT; i++) {
+        index_t src_idx = i * step + base_idx;
+        xchg[gid][i][rev] = src_idx < src_len ? in[src_idx] : T(0u);
+    }
+
+    __syncthreads();
+
+    #pragma unroll
+    for (uint32_t i = 0; i < Z_COUNT; i++)
+        out[i * step + base_rev] = xchg[gid][rev][i];
+}
+
+extern "C" int _bit_rev_zeta_fused(fr_t* d_inout,
+    uint32_t lg_domain_size, uint32_t padded_poly_size, uint32_t poly_count,
+    uint32_t l_skip, cudaStream_t stream)
+{
+    const uint32_t Z_COUNT = 256 / sizeof(fr_t);
+    const uint32_t LG_Z_COUNT = 31 - __builtin_clz(Z_COUNT);
+    size_t domain_size = (size_t)1 << lg_domain_size;
+
+    if (poly_count == 0)
+        return cudaSuccess;
+    // One Z-subgroup per block so the in-tile __syncthreads() is block-uniform.
+    if (l_skip > LG_Z_COUNT || domain_size < (size_t)(Z_COUNT * Z_COUNT))
+        return cudaErrorInvalidValue;
+
+    const uint32_t MAX_Y = 65535;
+    uint32_t grid_y = poly_count < MAX_Y ? poly_count : MAX_Y;
+    uint32_t grid_z = (poly_count + grid_y - 1) / grid_y;
+    uint32_t grid_x = (uint32_t)(domain_size / Z_COUNT / Z_COUNT);
+
+    bit_rev_zeta_fused_kernel<fr_t, Z_COUNT>
+        <<<dim3(grid_x, grid_y, grid_z), Z_COUNT, Z_COUNT * Z_COUNT * sizeof(fr_t), stream>>>
+        (d_inout, d_inout, lg_domain_size, padded_poly_size, poly_count, l_skip);
+
+    return CHECK_KERNEL();
+}
+
+extern "C" int _bit_rev_expand_pad(fr_t* d_out, const fr_t* d_inp,
+    uint32_t lg_domain_size, uint32_t out_stride, uint32_t in_stride,
+    uint32_t poly_count, uint32_t src_len, cudaStream_t stream)
+{
+    const uint32_t Z_COUNT = 256 / sizeof(fr_t);
+    size_t domain_size = (size_t)1 << lg_domain_size;
+
+    if (poly_count == 0)
+        return cudaSuccess;
+    if (domain_size < (size_t)(Z_COUNT * Z_COUNT))
+        return cudaErrorInvalidValue;
+
+    const uint32_t MAX_Y = 65535;
+    uint32_t grid_y = poly_count < MAX_Y ? poly_count : MAX_Y;
+    uint32_t grid_z = (poly_count + grid_y - 1) / grid_y;
+    uint32_t grid_x = (uint32_t)(domain_size / Z_COUNT / Z_COUNT);
+
+    bit_rev_expand_pad_kernel<fr_t, Z_COUNT>
+        <<<dim3(grid_x, grid_y, grid_z), Z_COUNT, Z_COUNT * Z_COUNT * sizeof(fr_t), stream>>>
+        (d_out, d_inp, lg_domain_size, out_stride, in_stride, poly_count, src_len);
+
+    return CHECK_KERNEL();
+}
 
 template<typename T>
 static int bit_rev_impl(T* d_out, const T* d_inp,

--- a/crates/cuda-backend/src/cuda/ntt.rs
+++ b/crates/cuda-backend/src/cuda/ntt.rs
@@ -84,6 +84,86 @@ extern "C" {
         alpha: EF,
         stream: cudaStream_t,
     ) -> i32;
+
+    fn _bit_rev_zeta_fused(
+        d_inout: *mut std::ffi::c_void,
+        lg_domain_size: u32,
+        padded_poly_size: u32,
+        poly_count: u32,
+        l_skip: u32,
+        stream: cudaStream_t,
+    ) -> i32;
+
+    fn _bit_rev_expand_pad(
+        d_out: *mut std::ffi::c_void,
+        d_inp: *const std::ffi::c_void,
+        lg_domain_size: u32,
+        out_stride: u32,
+        in_stride: u32,
+        poly_count: u32,
+        src_len: u32,
+        stream: cudaStream_t,
+    ) -> i32;
+}
+
+/// Fused subset-zeta transform (coeff-to-eval stages over the low `l_skip` index bits)
+/// plus in-place bit-reversal permutation, per column. Produces the identical buffer
+/// contents as `mle_interpolate_stages(0..l_skip-1)` followed by [`bit_rev`], in one
+/// read+write pass.
+///
+/// # Safety
+/// - `d_inout` must be a device buffer of `poly_count` columns with stride `padded_poly_size >=
+///   2^lg_domain_size`.
+/// - Requires `l_skip <= 6` and `2^lg_domain_size >= 4096` (Z-tile kernel bounds); the launcher
+///   returns an error otherwise.
+pub unsafe fn bit_rev_zeta_fused(
+    d_inout: &DeviceBuffer<F>,
+    lg_domain_size: u32,
+    padded_poly_size: u32,
+    poly_count: u32,
+    l_skip: u32,
+    stream: cudaStream_t,
+) -> Result<(), CudaError> {
+    CudaError::from_result(_bit_rev_zeta_fused(
+        d_inout.as_mut_raw_ptr(),
+        lg_domain_size,
+        padded_poly_size,
+        poly_count,
+        l_skip,
+        stream,
+    ))
+}
+
+/// Fused zero-extend + bit-reversal: `out[bit_rev(i)] = if i < src_len { in[i] } else { 0 }`
+/// per column. Produces the identical buffer contents as `batch_expand_pad` followed by
+/// [`bit_rev`], in one pass. `d_out` and `d_inp` must not alias.
+///
+/// # Safety
+/// - `d_out` must have `poly_count` columns of stride `out_stride >= 2^lg_domain_size`; `d_inp`
+///   must have `poly_count` columns of stride `in_stride >= src_len`.
+/// - Requires `2^lg_domain_size >= 4096` (Z-tile kernel bounds); the launcher returns an error
+///   otherwise.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn bit_rev_expand_pad(
+    d_out: &DeviceBuffer<F>,
+    d_inp: &DeviceBuffer<F>,
+    lg_domain_size: u32,
+    out_stride: u32,
+    in_stride: u32,
+    poly_count: u32,
+    src_len: u32,
+    stream: cudaStream_t,
+) -> Result<(), CudaError> {
+    CudaError::from_result(_bit_rev_expand_pad(
+        d_out.as_mut_raw_ptr(),
+        d_inp.as_raw_ptr(),
+        lg_domain_size,
+        out_stride,
+        in_stride,
+        poly_count,
+        src_len,
+        stream,
+    ))
 }
 
 pub unsafe fn bit_rev(

--- a/crates/cuda-backend/src/stacked_pcs.rs
+++ b/crates/cuda-backend/src/stacked_pcs.rs
@@ -16,7 +16,7 @@ use crate::{
     cuda::{
         batch_ntt_small::batch_ntt_small,
         matrix::{batch_expand_pad, batch_expand_pad_wide},
-        ntt::bit_rev,
+        ntt::{bit_rev, bit_rev_zeta_fused},
     },
     hash_scheme::GpuMerkleHash,
     merkle_tree::{MerkleTreeConstructor, MerkleTreeGpu},
@@ -285,39 +285,54 @@ pub fn rs_code_matrix(
     // e.g. for log_height=17, l_skip=2: 2 stages instead of 15.
     let log_codeword_height = log2_strict_usize(codeword_height);
 
-    // Apply l_skip stages of coeffs_to_evals within each 2^l_skip chunk.
-    // After iNTT, each chunk holds Z-monomial coefficients. We apply the subset-zeta
-    // transform to convert to hypercube evaluations over the Z-bit variables.
-    if l_skip > 0 {
-        // SAFETY: `codewords` is properly initialized and parameters are valid.
-        // Steps 2^0, 2^1, ..., 2^(l_skip-1) stay within chunk boundaries.
+    // Apply l_skip stages of coeffs_to_evals within each 2^l_skip chunk, then
+    // bit-reverse the entire buffer in-place (required for NTT). The common case
+    // fuses both into one read+write pass: the zeta stages act on the low l_skip
+    // index bits, which fit inside a bit-reversal Z-tile row.
+    if l_skip > 0 && l_skip <= 6 && codeword_height >= 4096 {
+        // SAFETY: `codewords` is properly initialized; kernel bounds checked above.
         unsafe {
-            mle_interpolate_stages(
-                codewords.as_mut_ptr(),
-                width,
+            bit_rev_zeta_fused(
+                &codewords,
+                log_codeword_height as u32,
                 codeword_height as u32,
-                log_blowup as u32,
-                0,                 // start_log_step
-                l_skip as u32 - 1, // end_log_step (inclusive)
-                false,             // coeffs to evals (NOT eval to coeff)
-                false,             // natural order
+                width as u32,
+                l_skip as u32,
                 device_ctx.stream.as_raw(),
             )
-            .map_err(|error| RsCodeMatrixError::MleInterpolateStage2d { error, step: 1 })?;
+            .map_err(RsCodeMatrixError::BitRev)?;
         }
-    }
-
-    // Bit-reverse the entire buffer in-place (required for NTT)
-    unsafe {
-        bit_rev(
-            &codewords,
-            &codewords,
-            log_codeword_height as u32,
-            codeword_height as u32,
-            width as u32,
-            device_ctx.stream.as_raw(),
-        )
-        .map_err(RsCodeMatrixError::BitRev)?;
+    } else {
+        if l_skip > 0 {
+            // SAFETY: `codewords` is properly initialized and parameters are valid.
+            // Steps 2^0, 2^1, ..., 2^(l_skip-1) stay within chunk boundaries.
+            unsafe {
+                mle_interpolate_stages(
+                    codewords.as_mut_ptr(),
+                    width,
+                    codeword_height as u32,
+                    log_blowup as u32,
+                    0,                 // start_log_step
+                    l_skip as u32 - 1, // end_log_step (inclusive)
+                    false,             // coeffs to evals (NOT eval to coeff)
+                    false,             // natural order
+                    device_ctx.stream.as_raw(),
+                )
+                .map_err(|error| RsCodeMatrixError::MleInterpolateStage2d { error, step: 1 })?;
+            }
+        }
+        // SAFETY: `codewords` is properly initialized.
+        unsafe {
+            bit_rev(
+                &codewords,
+                &codewords,
+                log_codeword_height as u32,
+                codeword_height as u32,
+                width as u32,
+                device_ctx.stream.as_raw(),
+            )
+            .map_err(RsCodeMatrixError::BitRev)?;
+        }
     }
 
     // Compute RS codeword via DFT on the smoothly-embedded domain.

--- a/crates/cuda-backend/src/whir.rs
+++ b/crates/cuda-backend/src/whir.rs
@@ -24,6 +24,7 @@ use crate::{
         batch_ntt_small::batch_ntt_small,
         matrix::{batch_expand_pad, split_ext_to_base_col_major_matrix},
         mle_interpolate::mle_interpolate_stage_ext,
+        ntt::bit_rev_expand_pad,
         poly::{eval_poly_ext_at_point_from_base, transpose_fp_to_fpext_vec},
         whir::{
             _whir_sumcheck_coeff_moments_required_temp_buffer_size, w_moments_accumulate,
@@ -317,26 +318,52 @@ where
             //   2^{m-k_whir}
             // - We resize each F-poly to RS domain size 2^{log_rs_domain_size - 1}, which is
             //   equivalent to resizing the EF-polynomial
+            // The zero-extension is fused with the bit-reversal the NTT needs, saving a
+            // full pass; small domains fall back to the two-pass form.
             unsafe {
-                batch_expand_pad(
-                    g_rs.as_mut_ptr(),
-                    g_coeffs.as_ptr(),
-                    D_EF as u32,
-                    codeword_height as u32,
-                    f_height as u32,
-                    device_ctx.stream.as_raw(),
-                )
-                .map_err(|error| WhirProverError::BatchExpandPad { error, whir_round })?;
+                if codeword_height >= 4096 {
+                    bit_rev_expand_pad(
+                        &g_rs,
+                        &g_coeffs,
+                        (log_rs_domain_size - 1) as u32,
+                        codeword_height as u32,
+                        f_height as u32,
+                        D_EF as u32,
+                        f_height as u32,
+                        device_ctx.stream.as_raw(),
+                    )
+                    .map_err(|error| WhirProverError::BatchExpandPad { error, whir_round })?;
 
-                batch_ntt(
-                    &g_rs,
-                    (log_rs_domain_size - 1) as u32,
-                    0u32,
-                    D_EF as u32,
-                    true,
-                    false,
-                    device_ctx,
-                );
+                    batch_ntt(
+                        &g_rs,
+                        (log_rs_domain_size - 1) as u32,
+                        0u32,
+                        D_EF as u32,
+                        false,
+                        false,
+                        device_ctx,
+                    );
+                } else {
+                    batch_expand_pad(
+                        g_rs.as_mut_ptr(),
+                        g_coeffs.as_ptr(),
+                        D_EF as u32,
+                        codeword_height as u32,
+                        f_height as u32,
+                        device_ctx.stream.as_raw(),
+                    )
+                    .map_err(|error| WhirProverError::BatchExpandPad { error, whir_round })?;
+
+                    batch_ntt(
+                        &g_rs,
+                        (log_rs_domain_size - 1) as u32,
+                        0u32,
+                        D_EF as u32,
+                        true,
+                        false,
+                        device_ctx,
+                    );
+                }
             }
 
             let g_tree = MerkleTreeGpu::<F, HS::Digest>::new_with_hash::<HS::MerkleHash>(


### PR DESCRIPTION
## Summary

Stacked on #380. Kernel profiling of the reth workload showed the standalone bit-reversal permutation (`bit_rev_permutation_z`) accounting for ~12% of prover kernel time: it runs as its own full read+write pass over the codeword buffer before every large NTT, in both the stacked commit and the WHIR rounds.

This PR removes the standalone passes by fusing the reordering into the adjacent passes, **without changing the committed codeword order, the proof, or the verifier**:

- **`bit_rev_zeta_fused`**: the RS encoding pipeline previously ran the subset-zeta stages (`x[j + 2^s] += x[j]` on the low `l_skip` index bits) and then the bit-reversal as two sweeps. The zeta chunks fit inside one row of the bit-reversal Z-tile, and under the tile's bit-reversed column storage, natural-index bit `s` maps to tile-column bit `LG_Z−1−s` — so the stages become in-tile column butterflies at strides `Z >> (s+1)`, applied while the tile is staged in shared memory. One pass instead of two; used by `rs_code_matrix` (commit and WHIR initial-round recompute).
- **`bit_rev_expand_pad`**: WHIR's per-round codeword previously did `batch_expand_pad` (zero-extend) and then a bit-reversal inside `batch_ntt`. The fused kernel writes `out[bit_rev(i)] = i < src_len ? in[i] : 0` directly through the Z-tile, again one pass instead of two.

Both kernels produce buffers bit-identical to the two-pass forms (the small-domain cases fall back to the original path). Verified end-to-end at production-like sizes (`uniform_runner` with stacked height 2^22 and 2^20, which exercises both fused kernels): proofs verify against the unchanged verifier.

## Benchmark

### End-to-end (full reth `prove-stark`)

Measured on the real openvm-eth proof of block 23992138 (full recursive proof: app + leaf + internal + root, 224 proofs; openvm `develop-v2.1.0-rv64`), RTX Pro 6000. Steady-state (2 warmups), then main / #380 / this PR interleaved 3× in a Latin square (each config in each run-position once, so warmup drift and run-order bias cancel), mean of 3 reps; per-rep spread <0.3%. Metric is summed `stark_prove_excluding_trace_time_ms` over all 224 proofs. Incremental over #380 (this PR's base):

| metric | #380 | this PR | delta |
|---|---|---|---|
| prove (excl. trace) | 66.39 s | 65.10 s | **−1.9%** |
| total proof time | 117.11 s | 115.59 s | −1.3% |
| commit | 12.73 s | 12.25 s | −3.8% |
| openings (incl. WHIR) | 15.67 s | 15.04 s | −4.0% |

The gain shows up across the phases that RS-encode (commit and openings/WHIR), as expected. Cumulative #380 + this PR vs stark-backend main: **−5.5%** prove (excl. trace) / −3.5% total.

### Synthetic segment replay

`synthetic_runner` replaying app-proof segments of the captured block-23992138 profile (per-AIR `max_constraint_degree <= 3`; `--seed 42 --max-log-height 22`), shared Cargo.lock, interleaved champ (#380 tip) vs candidate:

| tier | #380 (ms prove) | this PR (ms prove) | delta |
|---|---|---|---|
| `--sample-frac 0.5` (75 segments, 2 reps interleaved) | 20249 / 20282 | 19792 / 19742 | **−2.46%** |
| `--sample-frac 0.1` (15 segments, 3 reps interleaved) | 4074 / 4035 / 4009 | 3960 / 3932 / 3936 | −2.39% |

## Test plan

- `uniform_runner` end-to-end prove+verify at stacked heights 2^22 and 2^20 (fused-kernel path): verifies
- `cargo nextest run -p openvm-cuda-backend -p openvm-cuda-common` on RTX Pro 6000: 131 passed, 2 skipped
- `cargo clippy --all-targets` clean
