### PR TITLE
perf(cuda-backend): prefetch the WHIR round-0 RS codeword on a low-priority stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - (CUDA common) `DeviceBuffer::mut_slice(range)` returning a `DeviceBufferMutSlice<'_, T>` with a `copy_from_host` method for overwriting a subrange of a device buffer from a host slice on a caller-supplied stream.
 
 ### Changed
+- GPU prover: when the RS codeword is not cached, the WHIR initial-round re-encode is now launched ahead of time on a low-priority auxiliary CUDA stream (right after the GKR fractional sumcheck), overlapping the batch-constraint and stacked-reduction sumcheck phases instead of running serially inside WHIR (~2.4% lower proving time on the reth benchmark on RTX Pro 6000). Controlled by `GpuProverConfig::prefetch_rs_code_matrix` (default on); proofs unchanged.
 - GPU prover: fused the subset-zeta and zero-extend passes of RS encoding into the bit-reversal permutation, removing the standalone bit-reversal sweeps before large NTTs (~2.5% lower proving time on the reth benchmark on RTX Pro 6000; committed codeword order and proofs unchanged).
 - GPU prover: batched the per-round parameter uploads, kernel launches, and result readbacks of the batch-constraint, stacked-reduction, and round-0 sumcheck phases, and moved per-round transcript readbacks to pinned memory; the interactions round-0 DAG is now cached in the proving key instead of rebuilt per proof. Measured ~2.4% lower proving time on the reth benchmark on RTX Pro 6000.
 

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -1,12 +1,20 @@
+use std::sync::{Arc, Mutex};
+
 use getset::{CopyGetters, Getters, MutGetters};
-use openvm_cuda_common::{common::get_device, stream::GpuDeviceCtx};
+use openvm_cuda_common::{
+    common::get_device,
+    stream::{CudaStream, GpuDeviceCtx, StreamGuard},
+};
 use openvm_stark_backend::{
     memory_metering::ProvingMemoryConfig, StarkProtocolConfig, SystemParams,
 };
 
-use crate::cuda::{
-    batch_ntt_small::{ensure_device_ntt_twiddles_initialized, validate_gpu_l_skip},
-    device_info::get_sm_count,
+use crate::{
+    cuda::{
+        batch_ntt_small::{ensure_device_ntt_twiddles_initialized, validate_gpu_l_skip},
+        device_info::get_sm_count,
+    },
+    stacked_pcs::RsCodewordPrefetch,
 };
 
 /// Pure device configuration — no stream, no CUDA runtime state.
@@ -26,6 +34,12 @@ pub struct GpuDeviceConfig {
 pub struct GpuProverConfig {
     pub cache_stacked_matrix: bool,
     pub cache_rs_code_matrix: bool,
+    /// When the RS codeword is not cached on device, re-encode it for the
+    /// WHIR initial round ahead of time on a low-priority auxiliary stream
+    /// (launched after the GKR fractional sumcheck), so the encode overlaps
+    /// the sumcheck phases instead of running serially inside WHIR. Has no
+    /// effect if `cache_rs_code_matrix` is set.
+    pub prefetch_rs_code_matrix: bool,
     pub zerocheck_save_memory: bool,
 }
 
@@ -47,6 +61,13 @@ impl GpuProverConfig {
 pub struct GpuDevice {
     pub config: GpuDeviceConfig,
     pub device_ctx: GpuDeviceCtx,
+    /// Low-priority stream for `prefetch_rs_code_matrix`: its kernels yield
+    /// to the main proving stream and only soak idle bubbles.
+    pub(crate) aux_ctx: GpuDeviceCtx,
+    /// Handoff slot from the prefetch launch (during RAP constraints) to the
+    /// WHIR opening prover. Assumes proofs on one `GpuDevice` do not run
+    /// concurrently, matching the single main-stream design.
+    pub(crate) rs_prefetch: Arc<Mutex<Option<RsCodewordPrefetch>>>,
 }
 
 impl GpuDevice {
@@ -62,6 +83,10 @@ impl GpuDevice {
         };
         let id = get_device().unwrap() as u32;
         let device_ctx = GpuDeviceCtx::for_device(id)?;
+        let aux_ctx = GpuDeviceCtx {
+            device_id: id,
+            stream: StreamGuard::new(CudaStream::new_low_priority()?),
+        };
         let sm_count = get_sm_count(id).expect("failed to get SM count");
         let config = GpuDeviceConfig {
             params,
@@ -70,7 +95,12 @@ impl GpuDevice {
             sm_count,
         };
 
-        Ok(Self { config, device_ctx })
+        Ok(Self {
+            config,
+            device_ctx,
+            aux_ctx,
+            rs_prefetch: Arc::new(Mutex::new(None)),
+        })
     }
 
     // Delegate accessors to inner config
@@ -102,6 +132,15 @@ impl GpuDevice {
     pub fn set_cache_rs_code_matrix(&mut self, cache_rs_code_matrix: bool) {
         self.config.prover_config.cache_rs_code_matrix = cache_rs_code_matrix;
     }
+
+    pub fn with_prefetch_rs_code_matrix(mut self, prefetch_rs_code_matrix: bool) -> Self {
+        self.config.prover_config.prefetch_rs_code_matrix = prefetch_rs_code_matrix;
+        self
+    }
+
+    pub fn set_prefetch_rs_code_matrix(&mut self, prefetch_rs_code_matrix: bool) {
+        self.config.prover_config.prefetch_rs_code_matrix = prefetch_rs_code_matrix;
+    }
 }
 
 /// Default GPU prover cache settings.
@@ -110,6 +149,7 @@ impl Default for GpuProverConfig {
         Self {
             cache_stacked_matrix: false,
             cache_rs_code_matrix: false,
+            prefetch_rs_code_matrix: true,
             zerocheck_save_memory: true,
         }
     }

--- a/crates/cuda-backend/src/error.rs
+++ b/crates/cuda-backend/src/error.rs
@@ -92,6 +92,8 @@ pub enum LogupZerocheckError {
     BatchFoldMle(CudaError),
     #[error("fill_zero: {0}")]
     FillZero(CudaError),
+    #[error("rs codeword prefetch: {0}")]
+    RsPrefetch(#[from] RsPrefetchError),
 }
 
 #[derive(Error, Debug)]
@@ -149,6 +151,8 @@ pub enum StackTracesError {
 pub enum RsCodeMatrixError {
     #[error(transparent)]
     MemCopy(#[from] MemCopyError),
+    #[error("event: {0}")]
+    Event(CudaError),
     #[error("stack_traces_into_expanded error: {0}")]
     StackTraces(StackTracesError),
     #[error("batch_expand_pad error: {0}")]
@@ -161,6 +165,16 @@ pub enum RsCodeMatrixError {
     BitRev(CudaError),
 }
 
+/// Errors from launching the WHIR round-0 codeword prefetch on the auxiliary
+/// stream.
+#[derive(Error, Debug)]
+pub enum RsPrefetchError {
+    #[error("event: {0}")]
+    Event(CudaError),
+    #[error(transparent)]
+    RsCodeMatrix(#[from] RsCodeMatrixError),
+}
+
 #[derive(Error, Debug)]
 pub enum WhirProverError {
     #[error(transparent)]
@@ -169,6 +183,8 @@ pub enum WhirProverError {
     MerkleTree(MerkleTreeError),
     #[error("rs_code_matrix: {0}")]
     RsCodeMatrix(RsCodeMatrixError),
+    #[error("rs prefetch wait: {0}")]
+    RsPrefetchWait(CudaError),
     #[error("whir_algebraic_batch_traces: {0}")]
     AlgebraicBatch(CudaError),
     #[error("transpose_fp_to_fpext_vec: {0}")]

--- a/crates/cuda-backend/src/gpu_backend.rs
+++ b/crates/cuda-backend/src/gpu_backend.rs
@@ -19,7 +19,7 @@ use crate::{
     merkle_tree::{MerkleProofQueryDigest, MerkleTreeConstructor},
     prelude::{D_EF, EF, F},
     sponge::GpuFiatShamirTranscript,
-    stacked_pcs::{stacked_commit, StackedPcsDataGpu},
+    stacked_pcs::{stacked_commit, RsPrefetchRequest, StackedPcsDataGpu},
     stacked_reduction::prove_stacked_opening_reduction_gpu,
     whir::prove_whir_opening_gpu,
     AirDataGpu, GpuDevice, ProverError,
@@ -107,9 +107,29 @@ impl<HS: GpuHashScheme, TS: GpuFiatShamirTranscript<HS::SC>>
         transcript: &mut TS,
         mpk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
         ctx: &ProvingContext<GenericGpuBackend<HS>>,
-        _common_main_pcs_data: &StackedPcsDataGpu<F, HS::Digest>,
+        common_main_pcs_data: &StackedPcsDataGpu<F, HS::Digest>,
     ) -> Result<((GkrProof<HS::SC>, BatchConstraintProof<HS::SC>), Vec<EF>), Self::Error> {
         let mem = MemTracker::start_and_reset_peak("prover.rap_constraints");
+        // Drop any prefetch left over from an aborted proof; its codeword
+        // does not belong to this proof's traces.
+        self.rs_prefetch
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take();
+        let rs_prefetch = (self.prover_config().prefetch_rs_code_matrix
+            && !self.prover_config().cache_rs_code_matrix)
+            .then(|| RsPrefetchRequest {
+                layout: common_main_pcs_data.layout(),
+                traces: ctx
+                    .per_trace
+                    .iter()
+                    .map(|(_, air_ctx)| &air_ctx.common_main)
+                    .collect(),
+                stacked_matrix: common_main_pcs_data.matrix(),
+                log_blowup: self.params().log_blowup,
+                aux_ctx: &self.aux_ctx,
+                slot: &self.rs_prefetch,
+            });
         let save_memory = self.prover_config().zerocheck_save_memory;
         // Threshold for monomial evaluation path based on proof type:
         // - App proofs (log_blowup=1): higher threshold (512)
@@ -126,6 +146,7 @@ impl<HS: GpuHashScheme, TS: GpuFiatShamirTranscript<HS::SC>>
             save_memory,
             monomial_num_y_threshold,
             self.sm_count(),
+            rs_prefetch,
             &self.device_ctx,
         )?;
         mem.emit_metrics();
@@ -194,11 +215,17 @@ where
             .chain(u_rest.iter().copied())
             .collect_vec();
 
+        let prefetched_rs = self
+            .rs_prefetch
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take();
         let whir_proof = prove_whir_opening_gpu::<HS, TS>(
             params,
             transcript,
             stacked_per_commit,
             &u_cube,
+            prefetched_rs,
             &self.device_ctx,
         )?;
         mem.emit_metrics();

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -249,13 +249,15 @@ where
 
     // The fractional GKR peak has passed: start re-encoding the WHIR round-0
     // RS codeword on the low-priority auxiliary stream, soaking the idle
-    // bubbles of the sumcheck phases below. The batch-MLE phases size their
-    // working buffers up to the GKR peak; shrink that budget by the resident
-    // codeword so total demand stays inside the same memory envelope.
+    // bubbles of the sumcheck phases below. Do NOT shrink `memory_limit_bytes`
+    // to "reserve" for the resident codeword: that budget is the batch-MLE
+    // working-buffer hint, and driving it below the value keygen picked pushes
+    // the round-0 batch-MLE onto a degenerate path whose D2H readback
+    // deadlocks. The codeword is a separate pool allocation already accounted
+    // by the allocator, which returns a recoverable OOM rather than corrupting
+    // the batch budget.
     if let Some(request) = rs_prefetch {
-        let codeword_bytes = request.codeword_bytes();
         request.launch(device_ctx)?;
-        prover.memory_limit_bytes = prover.memory_limit_bytes.saturating_sub(codeword_bytes);
     }
 
     // Note: this span includes ple_fold, but that function has no cuda synchronization so it does

--- a/crates/cuda-backend/src/logup_zerocheck/mod.rs
+++ b/crates/cuda-backend/src/logup_zerocheck/mod.rs
@@ -59,6 +59,7 @@ use crate::{
     poly::EqEvalLayers,
     prelude::{EF, F},
     sponge::GpuFiatShamirTranscript,
+    stacked_pcs::RsPrefetchRequest,
     utils::compute_barycentric_inv_lagrange_denoms,
 };
 
@@ -119,6 +120,7 @@ pub(crate) fn air_width_for_mat(need_rot: bool, mat_width: usize) -> u32 {
 
 #[allow(clippy::type_complexity)]
 #[instrument(level = "info", skip_all)]
+#[allow(clippy::too_many_arguments)]
 pub fn prove_zerocheck_and_logup_gpu<HS, TS>(
     transcript: &mut TS,
     mpk: &DeviceMultiStarkProvingKey<GenericGpuBackend<HS>>,
@@ -126,6 +128,7 @@ pub fn prove_zerocheck_and_logup_gpu<HS, TS>(
     save_memory: bool,
     monomial_num_y_threshold: u32,
     sm_count: u32,
+    rs_prefetch: Option<RsPrefetchRequest<'_>>,
     device_ctx: &GpuDeviceCtx,
 ) -> Result<(GkrProof<HS::SC>, BatchConstraintProof<HS::SC>, Vec<EF>), LogupZerocheckError>
 where
@@ -243,6 +246,17 @@ where
     prover.xi = xi;
 
     logup_gkr_span.exit();
+
+    // The fractional GKR peak has passed: start re-encoding the WHIR round-0
+    // RS codeword on the low-priority auxiliary stream, soaking the idle
+    // bubbles of the sumcheck phases below. The batch-MLE phases size their
+    // working buffers up to the GKR peak; shrink that budget by the resident
+    // codeword so total demand stays inside the same memory envelope.
+    if let Some(request) = rs_prefetch {
+        let codeword_bytes = request.codeword_bytes();
+        request.launch(device_ctx)?;
+        prover.memory_limit_bytes = prover.memory_limit_bytes.saturating_sub(codeword_bytes);
+    }
 
     // Note: this span includes ple_fold, but that function has no cuda synchronization so it does
     // not include the kernel times for the actual folding

--- a/crates/cuda-backend/src/stacked_pcs.rs
+++ b/crates/cuda-backend/src/stacked_pcs.rs
@@ -56,13 +56,6 @@ pub struct RsPrefetchRequest<'a> {
 }
 
 impl RsPrefetchRequest<'_> {
-    /// Device bytes the prefetched codeword will occupy while it is resident
-    /// (from launch until the WHIR initial round). Callers subtract this from
-    /// concurrent phases' memory budgets so peak usage does not grow.
-    pub(crate) fn codeword_bytes(&self) -> usize {
-        (self.layout.height() << self.log_blowup) * self.layout.width() * std::mem::size_of::<F>()
-    }
-
     /// Enqueues the RS re-encode on the auxiliary stream, ordered after all
     /// work currently queued on `main_ctx`'s stream (the traces it reads are
     /// settled long before). Does not block the host; the codeword is handed

--- a/crates/cuda-backend/src/stacked_pcs.rs
+++ b/crates/cuda-backend/src/stacked_pcs.rs
@@ -1,9 +1,15 @@
-use std::{ffi::c_void, sync::Arc};
+use std::{
+    ffi::c_void,
+    sync::{Arc, Mutex},
+};
 
 use getset::Getters;
 use itertools::Itertools;
 use openvm_cuda_common::{
-    copy::cuda_memcpy_on, d_buffer::DeviceBuffer, memory_manager::MemTracker, stream::GpuDeviceCtx,
+    copy::cuda_memcpy_on,
+    d_buffer::DeviceBuffer,
+    memory_manager::MemTracker,
+    stream::{CudaEvent, GpuDeviceCtx},
 };
 use openvm_stark_backend::{
     p3_util::log2_strict_usize,
@@ -23,8 +29,61 @@ use crate::{
     ntt::batch_ntt,
     poly::{mle_interpolate_stages, PleMatrix},
     prelude::F,
-    GpuProverConfig, ProverError, RsCodeMatrixError, StackTracesError,
+    GpuProverConfig, ProverError, RsCodeMatrixError, RsPrefetchError, StackTracesError,
 };
+
+/// The WHIR round-0 RS codeword, re-encoded ahead of time on a low-priority
+/// auxiliary stream so the encode overlaps the sumcheck phases between the
+/// trace commit and WHIR instead of running serially inside the WHIR round.
+pub struct RsCodewordPrefetch {
+    pub(crate) matrix: DeviceMatrix<F>,
+    /// Recorded on the auxiliary stream after the encode; the main stream
+    /// waits on this before gathering opened rows.
+    pub(crate) done: CudaEvent,
+}
+
+/// Inputs for launching the round-0 codeword prefetch once the GKR
+/// fractional sumcheck — the phase with the largest transient device-memory
+/// footprint — has completed.
+pub struct RsPrefetchRequest<'a> {
+    pub(crate) layout: &'a StackedLayout,
+    /// Common-main traces in the same (height-sorted) order used at commit.
+    pub(crate) traces: Vec<&'a DeviceMatrix<F>>,
+    pub(crate) stacked_matrix: &'a Option<PleMatrix<F>>,
+    pub(crate) log_blowup: usize,
+    pub(crate) aux_ctx: &'a GpuDeviceCtx,
+    pub(crate) slot: &'a Mutex<Option<RsCodewordPrefetch>>,
+}
+
+impl RsPrefetchRequest<'_> {
+    /// Device bytes the prefetched codeword will occupy while it is resident
+    /// (from launch until the WHIR initial round). Callers subtract this from
+    /// concurrent phases' memory budgets so peak usage does not grow.
+    pub(crate) fn codeword_bytes(&self) -> usize {
+        (self.layout.height() << self.log_blowup) * self.layout.width() * std::mem::size_of::<F>()
+    }
+
+    /// Enqueues the RS re-encode on the auxiliary stream, ordered after all
+    /// work currently queued on `main_ctx`'s stream (the traces it reads are
+    /// settled long before). Does not block the host; the codeword is handed
+    /// to the WHIR prover through `slot`.
+    pub(crate) fn launch(self, main_ctx: &GpuDeviceCtx) -> Result<(), RsPrefetchError> {
+        let matrix = rs_code_matrix_with_exec(
+            self.log_blowup,
+            self.layout,
+            &self.traces,
+            self.stacked_matrix,
+            main_ctx,
+            self.aux_ctx,
+        )?;
+        let done = CudaEvent::new().map_err(RsPrefetchError::Event)?;
+        done.record_on(&self.aux_ctx.stream)
+            .map_err(RsPrefetchError::Event)?;
+        *self.slot.lock().unwrap_or_else(|e| e.into_inner()) =
+            Some(RsCodewordPrefetch { matrix, done });
+        Ok(())
+    }
+}
 
 #[derive(Getters)]
 pub struct StackedPcsDataGpu<F, Digest> {
@@ -233,13 +292,52 @@ pub fn rs_code_matrix(
     stacked_matrix: &Option<PleMatrix<F>>,
     device_ctx: &GpuDeviceCtx,
 ) -> Result<DeviceMatrix<F>, RsCodeMatrixError> {
+    rs_code_matrix_with_exec(
+        log_blowup,
+        layout,
+        traces,
+        stacked_matrix,
+        device_ctx,
+        device_ctx,
+    )
+}
+
+/// Same as [`rs_code_matrix`], but allocates the codeword on `alloc_ctx`'s
+/// stream while enqueueing all kernels and copies on `exec_ctx`'s stream.
+///
+/// Used by the round-0 prefetch: keeping the multi-GB codeword allocation on
+/// the main stream keeps the VPMM pool single-stream — same-stream free
+/// regions are reusable without event gating, and regions of different
+/// streams never coalesce — while execution overlaps on the low-priority
+/// auxiliary stream. When the streams differ, the exec stream is ordered
+/// after all work currently enqueued on the alloc stream (which covers both
+/// earlier users of any recycled pages and the production of `traces`).
+pub(crate) fn rs_code_matrix_with_exec(
+    log_blowup: usize,
+    layout: &StackedLayout,
+    traces: &[&DeviceMatrix<F>],
+    stacked_matrix: &Option<PleMatrix<F>>,
+    alloc_ctx: &GpuDeviceCtx,
+    exec_ctx: &GpuDeviceCtx,
+) -> Result<DeviceMatrix<F>, RsCodeMatrixError> {
     let mem = MemTracker::start_and_reset_peak("prover.rs_code_matrix");
     let l_skip = layout.l_skip();
     let height = layout.height();
     let width = layout.width();
     debug_assert!(height >= (1 << l_skip));
     let codeword_height = height.checked_shl(log_blowup as u32).unwrap();
-    let mut codewords = DeviceBuffer::<F>::with_capacity_on(codeword_height * width, device_ctx);
+    let mut codewords = DeviceBuffer::<F>::with_capacity_on(codeword_height * width, alloc_ctx);
+    if alloc_ctx.stream.as_raw() != exec_ctx.stream.as_raw() {
+        let ready = CudaEvent::new().map_err(RsCodeMatrixError::Event)?;
+        ready
+            .record_on(&alloc_ctx.stream)
+            .map_err(RsCodeMatrixError::Event)?;
+        exec_ctx
+            .stream
+            .wait(&ready)
+            .map_err(RsCodeMatrixError::Event)?;
+    }
+    let device_ctx = exec_ctx;
     // The following kernels together perform MLE interpolation followed by coset NTT for
     // `width` polys from `height -> codeword_height` size domains.
     if let Some(stacked_matrix) = stacked_matrix.as_ref() {

--- a/crates/cuda-backend/src/tests.rs
+++ b/crates/cuda-backend/src/tests.rs
@@ -1056,3 +1056,46 @@ fn test_monomial_vs_dag_equivalence() {
         );
     }
 }
+
+// ===========================================================================
+// RS codeword prefetch
+// ===========================================================================
+
+/// The prefetched round-0 codeword must yield byte-identical proofs to the
+/// in-round recompute it replaces: both run the same `rs_code_matrix` kernels
+/// on the same inputs, only earlier and on the auxiliary stream.
+#[test]
+fn test_rs_codeword_prefetch_proof_unchanged() {
+    use openvm_stark_backend::{codec::Encode, proof::Proof};
+
+    setup_tracing_with_log_level(Level::WARN);
+    let params = default_test_params_small();
+    let fib = FibFixture::new(0, 1, 1 << 10);
+
+    let mut prefetch_engine = BabyBearPoseidon2GpuEngine::new(params.clone());
+    prefetch_engine
+        .device_mut()
+        .set_prefetch_rs_code_matrix(true);
+    let (pk, vk) = fib.keygen(&prefetch_engine);
+    let prefetch_proof = fib.prove(&prefetch_engine, &pk);
+    prefetch_engine
+        .verify(&vk, &prefetch_proof)
+        .expect("verification with prefetch_rs_code_matrix failed");
+
+    let mut recompute_engine = BabyBearPoseidon2GpuEngine::new(params);
+    recompute_engine
+        .device_mut()
+        .set_prefetch_rs_code_matrix(false);
+    let recompute_proof = fib.prove(&recompute_engine, &pk);
+
+    let encode = |proof: &Proof<SC>| {
+        let mut bytes = Vec::new();
+        proof.encode(&mut bytes).unwrap();
+        bytes
+    };
+    assert_eq!(
+        encode(&prefetch_proof),
+        encode(&recompute_proof),
+        "prefetch and recompute proofs must be byte-identical"
+    );
+}

--- a/crates/cuda-backend/src/whir.rs
+++ b/crates/cuda-backend/src/whir.rs
@@ -38,7 +38,7 @@ use crate::{
     poly::evals_eq_hypercube,
     prelude::{D_EF, EF, F},
     sponge::GpuFiatShamirTranscript,
-    stacked_pcs::rs_code_matrix,
+    stacked_pcs::{rs_code_matrix, RsCodewordPrefetch},
     stacked_reduction::StackedPcsData2,
     WhirProverError,
 };
@@ -68,6 +68,7 @@ pub fn prove_whir_opening_gpu<HS, TS>(
     transcript: &mut TS,
     mut stacked_per_commit: Vec<StackedPcsData2<HS::Digest>>,
     u: &[EF],
+    mut prefetched_rs: Option<RsCodewordPrefetch>,
     device_ctx: &GpuDeviceCtx,
 ) -> Result<WhirProof<HS::SC>, WhirProverError>
 where
@@ -428,6 +429,16 @@ where
             // Vector to hold owned copies of backing matrices that are regenerated in the case they
             // were not cached
             let mut backing_mats_owned = vec![None; stacked_per_commit.len()];
+            // The common-main (first) commit's codeword may have been
+            // re-encoded ahead of time on the auxiliary stream: order the
+            // main stream after it and use it in place of the recompute.
+            if let Some(prefetch) = prefetched_rs.take() {
+                device_ctx
+                    .stream
+                    .wait(&prefetch.done)
+                    .map_err(WhirProverError::RsPrefetchWait)?;
+                backing_mats_owned[0] = Some(prefetch.matrix);
+            }
             let mut backing_matrices = Vec::with_capacity(stacked_per_commit.len());
             let mut trees = Vec::with_capacity(stacked_per_commit.len());
             for (d, backing_mat_owned) in zip(&mut stacked_per_commit, &mut backing_mats_owned) {
@@ -435,14 +446,21 @@ where
                 if let Some(matrix) = d.inner.tree.backing_matrix.as_ref() {
                     backing_matrices.push(matrix);
                 } else {
-                    let layout = d.layout();
-                    let traces = d.traces.iter().collect_vec();
-                    debug_assert!(!traces.is_empty());
-                    let backing_matrix =
-                        rs_code_matrix(log_blowup, layout, &traces, &d.inner.matrix, device_ctx)
-                            .map_err(WhirProverError::RsCodeMatrix)?;
-                    d.traces.clear();
-                    *backing_mat_owned = Some(backing_matrix);
+                    if backing_mat_owned.is_none() {
+                        let layout = d.layout();
+                        let traces = d.traces.iter().collect_vec();
+                        debug_assert!(!traces.is_empty());
+                        let backing_matrix = rs_code_matrix(
+                            log_blowup,
+                            layout,
+                            &traces,
+                            &d.inner.matrix,
+                            device_ctx,
+                        )
+                        .map_err(WhirProverError::RsCodeMatrix)?;
+                        d.traces.clear();
+                        *backing_mat_owned = Some(backing_matrix);
+                    }
                     backing_matrices.push(backing_mat_owned.as_ref().unwrap());
                 }
             }
@@ -706,6 +724,7 @@ mod tests {
             &mut prover_sponge,
             stacked_per_commit,
             &z_cube,
+            None,
             &device.device_ctx,
         )
         .unwrap();

--- a/crates/cuda-common/src/stream.rs
+++ b/crates/cuda-common/src/stream.rs
@@ -11,6 +11,11 @@ use crate::error::{check, CudaError};
 extern "C" {
     fn cudaDeviceSynchronize() -> i32;
     fn cudaStreamCreateWithFlags(stream: *mut cudaStream_t, flags: u32) -> i32;
+    fn cudaStreamCreateWithPriority(stream: *mut cudaStream_t, flags: u32, priority: i32) -> i32;
+    fn cudaDeviceGetStreamPriorityRange(
+        least_priority: *mut i32,
+        greatest_priority: *mut i32,
+    ) -> i32;
     fn cudaStreamDestroy(stream: cudaStream_t) -> i32;
     fn cudaStreamSynchronize(stream: cudaStream_t) -> i32;
     fn cudaStreamWaitEvent(stream: cudaStream_t, event: cudaEvent_t, flags: u32) -> i32;
@@ -56,6 +61,21 @@ impl CudaStream {
     pub fn new_non_blocking() -> Result<Self, CudaError> {
         let mut stream: cudaStream_t = std::ptr::null_mut();
         check(unsafe { cudaStreamCreateWithFlags(&mut stream, CUDA_STREAM_NON_BLOCKING) })?;
+        let host_event = Mutex::new(CudaEvent::new()?);
+        Ok(Self { stream, host_event })
+    }
+
+    /// Creates a non-blocking stream at the device's lowest scheduling
+    /// priority. Kernels on such a stream yield SMs to work queued on
+    /// default-priority streams, so background work only soaks idle bubbles.
+    pub fn new_low_priority() -> Result<Self, CudaError> {
+        let mut least = 0i32;
+        let mut greatest = 0i32;
+        check(unsafe { cudaDeviceGetStreamPriorityRange(&mut least, &mut greatest) })?;
+        let mut stream: cudaStream_t = std::ptr::null_mut();
+        check(unsafe {
+            cudaStreamCreateWithPriority(&mut stream, CUDA_STREAM_NON_BLOCKING, least)
+        })?;
         let host_event = Mutex::new(CudaEvent::new()?);
         Ok(Self { stream, host_event })
     }


### PR DESCRIPTION
## Summary

Stacked on #381. With `cache_rs_code_matrix = false` (the default), the WHIR initial round re-encodes the stacked matrix into the full RS codeword — trace stacking, per-chunk iNTT, subset-zeta/bit-reversal, and a full-size forward NTT — solely to gather the `num_queries * 2^k_whir` opened rows for the proof. This runs serially on the main stream inside the WHIR round. Caching the commit-time codeword instead (`cache_rs_code_matrix = true`) avoids the re-encode but keeps a full codeword resident from commit to WHIR, which is unacceptable on memory-constrained GPUs.

This PR launches the same re-encode ahead of time on a dedicated lowest-priority CUDA stream, right after the GKR fractional sumcheck (the phase with the largest transient memory) completes. The encode kernels yield to the main stream and soak the idle bubbles of the round-0 / batch-MLE / stacked-reduction phases, so when WHIR reaches the query openings the codeword is already (mostly) available: the main stream waits on the prefetch event and gathers. Proof bytes are identical — same kernels, same inputs, exact field arithmetic — and a new test asserts byte-equality of proofs with the prefetch on vs off.

Controlled by `GpuProverConfig::prefetch_rs_code_matrix` (default on); commits without a prefetched codeword (preprocessed/cached commits, or the flag off) fall back to the existing in-round recompute.

## Memory

Peak device memory is kept within the existing envelope:
- The codeword is resident only from post-GKR to the WHIR initial round, not for the whole proof as with `cache_rs_code_matrix`.
- The batch-MLE working buffers keep the `memory_limit_bytes` budget that keygen sized them to; the prefetched codeword is a separate pool allocation the allocator already tracks. (An earlier revision shrank this budget by the codeword size to "reserve" for it — that drove the round-0 batch-MLE below its working floor and deadlocked on the real e2e prover; see **Correctness**.)
- The codeword is **allocated on the main stream** while only the encode kernels run on the auxiliary stream. This matters for the VPMM: free regions are reusable same-stream without event gating, but cross-stream reuse requires completed free events and regions of different streams never coalesce — allocating multi-GB buffers on a second stream fragments the pool and triggers page-allocation/defrag churn (measured as a 28% regression before this fix). The auxiliary stream is ordered after the allocation point by an event, which also orders it after trace production.

## Correctness

The initial prefetch revision subtracted the resident codeword's size from the batch-MLE `memory_limit_bytes` after launching the re-encode, to keep peak demand flat. On the real end-to-end reth prover (`prove-stark`, whose app proofs run with `zerocheck_save_memory = true`) this drives the round-0 batch-MLE onto a degenerate low-memory path whose device-to-host readback **deadlocks** — the proof hangs indefinitely, busy-spinning in `cuMemcpyDtoHAsync` inside `sumcheck_uni_round0_polys`. `memory_limit_bytes` is the batch-MLE working-buffer hint sized by keygen, not a whole-proof accounting knob; the codeword is a separate pool allocation the allocator already tracks (and which returns a recoverable OOM rather than corrupting the batch budget). The subtraction (and the now-unused `codeword_bytes` helper) is removed, so the budget stays at the keygen value, matching the non-prefetch path. Proof output is byte-identical and verifies.

## Benchmark

### Synthetic (app-proof segments)

Modal RTX Pro 6000 (Blackwell, 96 GB), `synthetic_runner` replaying app-proof segments of the captured reth block 23992138 profile (per-AIR `max_constraint_degree <= 3`, `--seed 42 --max-log-height 22`), shared Cargo.lock, VPMM pool 16 GiB, interleaved champ (#381 tip) vs candidate:

| tier | #381 (ms prove) | this PR (ms prove) | delta |
|---|---|---|---|
| `--sample-frac 0.5` (75 segments, 6 reps interleaved) | 20614 / 20501 / 20462 / 20611 / 20595 / 20485 (mean 20545) | 20371 / 20018 / 19955 / 20027 / 20033 / 19972 (mean 20063) | −2.35% |
| `--sample-frac 0.1` (15 segments, 3 reps interleaved) | 4244 / 4077 / 4074 | 3988 / 3970 / 3989 | −3.5% |

### End-to-end (openvm-eth, reth block 23992138)

The synthetic gain **does not reproduce on the full recursive proof**. Modal RTX Pro 6000 (Blackwell, 96 GB), `openvm-reth-benchmark --mode prove-stark` on the standard block (app + leaf + internal + root, 224 proofs), interleaved base (`perf/ntt-bitrev-fusion` tip = this PR's base) vs this PR HEAD, 2 warmups + 8 measured runs in balanced ABBA|BAAB order, shared Cargo.lock, VPMM pool 16 GiB. Metric is summed `stark_prove_excluding_trace_time_ms` over all proofs.

| metric | base (#381 tip) | this PR | delta |
|---|---|---|---|
| prove (excl. trace) | 67.22 / 65.61 / 65.76 / 65.69 (mean 66.07 s) | 66.53 / 66.06 / 66.30 / 65.67 (mean 66.14 s) | **+0.11%** |
| total proof time | mean 117.48 s | mean 118.69 s | +1.03% |
| WHIR openings | mean 11.48 s | mean 5.13 s | −55.3% |

The WHIR-openings span halves — the round-0 re-encode leaves WHIR's critical path as intended — but that does not turn into an end-to-end saving here: on the full recursive workload the sumcheck phases the encode overlaps are already GPU-saturated, so it competes for the same SMs rather than filling idle bubbles, and prove-excluding-trace time is flat (within run-to-run noise). Proof output is byte-identical (315287 bytes) and verifies in every run.

## Test plan

- `cargo nextest run -p openvm-cuda-backend -p openvm-cuda-common --test-threads=4` on RTX Pro 6000: 132 passed (including the new `test_rs_codeword_prefetch_proof_unchanged` byte-equality test), 2 skipped
- End-to-end `prove-stark` of reth block 23992138 with the prefetch active: completes without hang and the proof verifies (10/10 runs, byte-identical 315287-byte proof)
- `uniform_runner` end-to-end prove+verify at stacked heights 2^22 and 2^20 with the prefetch active: verifies
- `cargo clippy --all-targets -- -D warnings` clean, `cargo +nightly fmt -- --check` clean
