### PR TITLE
fix: improve memory metering accuracy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Non-default benchmark workspace members:
 - **`openvm-benchmarks-fields`** (`benchmarks/fields`): CUDA field-extension and Poseidon2 benchmarks and verification tests.
 - **`openvm-benchmark-synthetic`** (`benchmarks/synthetic`): Synthetic AIR benchmark suite, including the champ-vs-candidate profile replay workflow documented in its README.
 
-When changing CUDA fractional-GKR buffer layout, scheduling, or scratch allocations, update the interaction memory estimate in `crates/stark-backend/src/memory_metering.rs` and the accounting in `docs/cuda-backend/gkr-prover.md`.
+When changing GPU buffer layout, scheduling, scratch allocations, or memory estimates for any proving phase — fractional-GKR, batch-constraint/batch-MLE, stacking/RS encoding, or WHIR opening — update the proving memory model in `crates/stark-backend/src/memory_metering.rs`. For GKR changes, also keep the accounting in `docs/cuda-backend/gkr-prover.md` in sync.
 
 Plonky3 crates are exact-version crates.io dependencies pinned in the workspace `Cargo.toml`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - (CUDA common) `DeviceBuffer::mut_slice(range)` returning a `DeviceBufferMutSlice<'_, T>` with a `copy_from_host` method for overwriting a subrange of a device buffer from a host slice on a caller-supplied stream.
 
+### Changed
+- Reworked the proving memory model to estimate per-phase peaks.
+
 ## v2.0.0 (2026-07-06)
 
 ### Added

--- a/crates/cuda-backend/src/device.rs
+++ b/crates/cuda-backend/src/device.rs
@@ -37,7 +37,12 @@ impl GpuProverConfig {
         // Interaction memory is estimated from the CUDA fractional-GKR buffer model in
         // `openvm_stark_backend::memory_metering`. Update that estimate when changing GKR
         // input layout, work-buffer sizing, or scratch allocations.
-        ProvingMemoryConfig::from_protocol_config(config, self.cache_rs_code_matrix)
+        ProvingMemoryConfig::from_protocol_config(
+            config,
+            self.cache_stacked_matrix,
+            self.cache_rs_code_matrix,
+            self.zerocheck_save_memory,
+        )
     }
 }
 

--- a/crates/cuda-backend/src/gpu_backend.rs
+++ b/crates/cuda-backend/src/gpu_backend.rs
@@ -6,8 +6,8 @@ use openvm_stark_backend::{
     poly_common::Squarable,
     proof::*,
     prover::{
-        DeviceMultiStarkProvingKey, MultiRapProver, OpeningProver, ProverBackend, ProverDevice,
-        ProvingContext, TraceCommitter,
+        DeviceMultiStarkProvingKey, DeviceStarkProvingKey, MultiRapProver, OpeningProver,
+        ProverBackend, ProverDevice, ProvingContext, TraceCommitter,
     },
 };
 use tracing::instrument;
@@ -50,6 +50,10 @@ impl<HS: GpuHashScheme> ProverBackend for GenericGpuBackend<HS> {
     type Matrix = DeviceMatrix<F>;
     type PcsData = StackedPcsDataGpu<F, HS::Digest>;
     type OtherAirData = AirDataGpu;
+
+    fn constraint_eval_buffer_size(pk: &DeviceStarkProvingKey<Self>) -> usize {
+        pk.other_data.zerocheck_round0.inner.buffer_size as usize
+    }
 }
 
 impl<HS: GpuHashScheme> TraceCommitter<GenericGpuBackend<HS>> for GpuDevice

--- a/crates/stark-backend/src/engine.rs
+++ b/crates/stark-backend/src/engine.rs
@@ -66,7 +66,15 @@ where
     }
 
     fn proving_memory_config(&self) -> ProvingMemoryConfig {
-        ProvingMemoryConfig::from_protocol_config(self.config(), true)
+        let cache_stacked_matrix = false;
+        let cache_rs_code_matrix = true;
+        let zerocheck_save_memory = self.config().params().log_blowup == 1;
+        ProvingMemoryConfig::from_protocol_config(
+            self.config(),
+            cache_stacked_matrix,
+            cache_rs_code_matrix,
+            zerocheck_save_memory,
+        )
     }
 
     fn device(&self) -> &Self::PD;

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -5,13 +5,13 @@ use std::{cmp::max, mem::size_of};
 use crate::{StarkProtocolConfig, SystemParams};
 
 /// Fixed batch-constraint scratch on top of the modeled main-trace buffers.
-pub const BATCH_CONSTRAINT_MEMORY_OVERHEAD: usize = 192 << 20;
+pub const BATCH_CONSTRAINT_MEMORY_OVERHEAD: usize = 256 << 20;
 
 /// Minimum batch-MLE scratch budget when `zerocheck_save_memory` is off.
 pub const BATCH_MLE_MEMORY_FLOOR: usize = 6 << 30;
 
 /// Fixed fractional-GKR scratch not proportional to interaction cells.
-pub const GKR_MEMORY_OVERHEAD: usize = 64 << 20;
+pub const GKR_MEMORY_OVERHEAD: usize = 256 << 20;
 
 /// Minimum fractional-GKR work-buffer length in `Frac<EF>` entries.
 pub const GKR_MIN_WORK_BUFFER_LEN: usize = 1 << 22;

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -50,10 +50,10 @@ pub struct ProvingMemoryEstimate {
     pub main: usize,
     /// Reed-Solomon code matrix for main traces.
     pub rs_code_matrix: usize,
-    /// Secondary main-trace buffers after PCS opening.
-    pub main_secondary: usize,
-    /// Interaction GKR buffers plus fixed interaction overhead.
-    pub interaction: usize,
+    /// Batch-constraint main-trace buffers after PCS opening.
+    pub batch_constraint: usize,
+    /// Fractional-GKR buffers plus fixed GKR-phase overhead.
+    pub gkr: usize,
     /// Peak among secondary phases, excluding cached main trace data.
     pub secondary_peak: usize,
 }
@@ -98,118 +98,122 @@ impl ProvingMemoryConfig {
         }
     }
 
+    /// Resident main trace matrices.
     #[inline]
     pub fn main_memory_bytes(&self, main_cells: usize) -> usize {
         main_cells * self.base_field_size
     }
 
+    /// Reed-Solomon code matrix for the committed main trace data.
     #[inline]
     pub fn rs_code_matrix_memory_bytes(&self, main_cells: usize) -> usize {
         main_cells * (1usize << self.log_blowup) * self.base_field_size
     }
 
     #[inline]
-    pub fn main_cell_secondary_weight(&self) -> f64 {
-        default_main_cell_secondary_weight(
+    pub fn batch_constraint_main_cell_weight(&self) -> f64 {
+        default_batch_constraint_main_cell_weight(
             self.extension_degree,
             self.l_skip,
             self.max_constraint_degree,
         )
     }
 
-    /// Secondary memory for `main_cells = Σ(padded_height * width)`.
+    /// Batch-constraint main-trace buffers for `main_cells = Σ(padded_height * width)`.
     ///
     /// ```text
     /// mat_eval_bytes = (padded_height / 2^l_skip) * ((1 + need_rot) * width) * sizeof(EF)
     ///                = (1 + need_rot) * main_cells * D_EF / 2^l_skip * sizeof(F)
     ///
-    /// interp_bytes      = (constraint_degree / 2) * mat_eval_bytes
-    /// secondary_bytes   = (1 + constraint_degree / 2) * mat_eval_bytes
-    /// secondary_weight  = (1 + constraint_degree / 2) * D_EF / 2^l_skip
+    /// interp_bytes = (constraint_degree / 2) * mat_eval_bytes
+    /// weight       = (1 + constraint_degree / 2) * D_EF / 2^l_skip
     /// ```
     ///
     /// AIRs with `need_rot = true` open two PCS cells per column.
     #[inline]
-    pub fn main_secondary_memory_bytes_for_rot(&self, main_cells: usize, need_rot: bool) -> usize {
-        let main_cell_secondary_weight = self.main_cell_secondary_weight();
+    pub fn batch_constraint_memory_bytes_for_rot(
+        &self,
+        main_cells: usize,
+        need_rot: bool,
+    ) -> usize {
+        let main_cell_weight = self.batch_constraint_main_cell_weight();
         let weight = if need_rot {
-            2.0 * main_cell_secondary_weight
+            2.0 * main_cell_weight
         } else {
-            main_cell_secondary_weight
+            main_cell_weight
         };
         ceil_weighted_bytes(main_cells, self.base_field_size, weight)
     }
 
+    /// Batch-constraint main-trace buffers across rotation classes.
     #[inline]
-    pub fn main_secondary_memory_bytes(&self, counts: ProvingMemoryCounts) -> usize {
-        self.main_secondary_memory_bytes_for_rot(counts.main_cells_with_rot, true)
-            + self.main_secondary_memory_bytes_for_rot(counts.main_cells_without_rot, false)
+    pub fn batch_constraint_memory_bytes(&self, counts: ProvingMemoryCounts) -> usize {
+        self.batch_constraint_memory_bytes_for_rot(counts.main_cells_with_rot, true)
+            + self.batch_constraint_memory_bytes_for_rot(counts.main_cells_without_rot, false)
     }
 
+    /// Fractional-GKR interaction buffers before fixed interaction-phase overhead.
     #[inline]
-    pub fn interaction_memory_bytes_without_overhead(&self, interaction_cells: usize) -> usize {
+    pub fn gkr_memory_bytes_without_overhead(&self, interaction_cells: usize) -> usize {
         ceil_weighted_bytes(
             interaction_cells,
             self.base_field_size,
-            default_interaction_cell_weight(self.extension_degree),
+            default_gkr_cell_weight(self.extension_degree),
         )
     }
 
+    /// Fractional-GKR interaction phase, including fixed non-cell-proportional overhead.
     #[inline]
-    pub fn interaction_memory_bytes(&self, interaction_cells: usize) -> usize {
-        self.interaction_memory_bytes_without_overhead(interaction_cells)
-            + INTERACTION_MEMORY_OVERHEAD
+    pub fn gkr_memory_bytes(&self, interaction_cells: usize) -> usize {
+        self.gkr_memory_bytes_without_overhead(interaction_cells) + INTERACTION_MEMORY_OVERHEAD
     }
 
-    /// Convert main trace cells and interaction cells to memory bytes.
+    /// Convert main trace cells and interaction cells to proving memory bytes.
     ///
     /// ```text
     /// main_cells       = main_cells_with_rot + main_cells_without_rot
-    /// main             = main_cells * sizeof(F)
-    /// rs_code_matrix   = main_cells * 2^log_blowup * sizeof(F)
-    /// main_secondary   = sizeof(F) *
-    ///                    (2 * main_cell_secondary_weight() * main_cells_with_rot
-    ///                     + main_cell_secondary_weight() * main_cells_without_rot)
-    /// interaction      = sizeof(F) * interaction_cell_weight * interaction_cells
-    ///                    + INTERACTION_MEMORY_OVERHEAD
+    /// main             = main_memory_bytes(main_cells)
+    /// rs_code_matrix   = rs_code_matrix_memory_bytes(main_cells)
+    /// batch_constraint = batch_constraint_memory_bytes(counts)
+    /// gkr              = gkr_memory_bytes(interaction_cells)
     /// ```
     ///
     /// Cached RS code matrix:
     ///
     /// ```text
-    /// total = main + rs_code_matrix + max(main_secondary, interaction)
+    /// total = main + rs_code_matrix + max(batch_constraint, gkr)
     /// ```
     ///
     /// Dropped RS code matrix:
     ///
     /// ```text
-    /// total = main + max(rs_code_matrix, main_secondary, interaction)
+    /// total = main + max(rs_code_matrix, batch_constraint, gkr)
     /// ```
     #[inline]
     pub fn estimate(&self, counts: ProvingMemoryCounts) -> ProvingMemoryEstimate {
         let main_cells = counts.main_cells();
         let main = self.main_memory_bytes(main_cells);
         let rs_code_matrix = self.rs_code_matrix_memory_bytes(main_cells);
-        let main_secondary = self.main_secondary_memory_bytes(counts);
-        let interaction = self.interaction_memory_bytes(counts.interaction_cells);
+        let batch_constraint = self.batch_constraint_memory_bytes(counts);
+        let gkr = self.gkr_memory_bytes(counts.interaction_cells);
         let secondary_peak = if self.cache_rs_code_matrix {
-            rs_code_matrix + max(main_secondary, interaction)
+            rs_code_matrix + max(batch_constraint, gkr)
         } else {
-            max(rs_code_matrix, max(main_secondary, interaction))
+            max(rs_code_matrix, max(batch_constraint, gkr))
         };
 
         ProvingMemoryEstimate {
             total: main + secondary_peak,
             main,
             rs_code_matrix,
-            main_secondary,
-            interaction,
+            batch_constraint,
+            gkr,
             secondary_peak,
         }
     }
 }
 
-fn default_main_cell_secondary_weight(
+fn default_batch_constraint_main_cell_weight(
     extension_degree: usize,
     l_skip: usize,
     max_constraint_degree: usize,
@@ -226,7 +230,7 @@ fn default_main_cell_secondary_weight(
 ///
 /// interaction_weight = leaf_weight * (1 + 2 * (1 / 16 + 1 / 256))
 /// ```
-fn default_interaction_cell_weight(extension_degree: usize) -> f64 {
+fn default_gkr_cell_weight(extension_degree: usize) -> f64 {
     (2 * extension_degree) as f64 * (1.0 + 2.0 * (1.0 / 16.0 + 1.0 / 256.0))
 }
 
@@ -260,7 +264,7 @@ mod tests {
             estimate.secondary_peak,
             max(
                 estimate.rs_code_matrix,
-                max(estimate.main_secondary, estimate.interaction)
+                max(estimate.batch_constraint, estimate.gkr)
             )
         );
     }
@@ -274,7 +278,7 @@ mod tests {
 
         assert_eq!(
             estimate.secondary_peak,
-            estimate.rs_code_matrix + max(estimate.main_secondary, estimate.interaction)
+            estimate.rs_code_matrix + max(estimate.batch_constraint, estimate.gkr)
         );
     }
 }

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -73,22 +73,36 @@ pub struct ProvingMemoryConfig {
     pub log_stacked_height: usize,
     /// Maximum constraint degree across AIR and interaction constraints.
     pub max_constraint_degree: usize,
+    /// Whether the prover keeps the stacked matrix cached after `stacked_commit`.
+    pub cache_stacked_matrix: bool,
     /// Whether the prover keeps the Reed-Solomon code matrix cached after `stacked_commit`.
     pub cache_rs_code_matrix: bool,
+    /// Whether the batch-MLE scratch budget is reduced by the resident `mat_eval` buffers.
+    pub zerocheck_save_memory: bool,
 }
 
 impl ProvingMemoryConfig {
     pub fn from_protocol_config<SC: StarkProtocolConfig>(
         config: &SC,
+        cache_stacked_matrix: bool,
         cache_rs_code_matrix: bool,
+        zerocheck_save_memory: bool,
     ) -> Self {
-        Self::from_params::<SC::F>(config.params(), SC::D_EF, cache_rs_code_matrix)
+        Self::from_params::<SC::F>(
+            config.params(),
+            SC::D_EF,
+            cache_stacked_matrix,
+            cache_rs_code_matrix,
+            zerocheck_save_memory,
+        )
     }
 
     fn from_params<F>(
         params: &SystemParams,
         extension_degree: usize,
+        cache_stacked_matrix: bool,
         cache_rs_code_matrix: bool,
+        zerocheck_save_memory: bool,
     ) -> Self {
         Self {
             base_field_size: size_of::<F>(),
@@ -97,7 +111,9 @@ impl ProvingMemoryConfig {
             l_skip: params.l_skip,
             log_stacked_height: params.log_stacked_height(),
             max_constraint_degree: params.max_constraint_degree,
+            cache_stacked_matrix,
             cache_rs_code_matrix,
+            zerocheck_save_memory,
         }
     }
 
@@ -252,13 +268,13 @@ mod tests {
 
     fn test_memory_config() -> ProvingMemoryConfig {
         let params = default_test_params_small();
-        ProvingMemoryConfig::from_params::<u32>(&params, 4, true)
+        ProvingMemoryConfig::from_params::<u32>(&params, 4, false, true, true)
     }
 
     #[test]
     fn dropped_rs_code_matrix_is_phase_disjoint() {
         let params = default_test_params_small();
-        let config = ProvingMemoryConfig::from_params::<u32>(&params, 4, false);
+        let config = ProvingMemoryConfig::from_params::<u32>(&params, 4, false, false, true);
         let counts = ProvingMemoryCounts::new(10, 20, 5);
 
         let estimate = config.estimate(counts);

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -57,6 +57,8 @@ pub struct ProvingMemoryEstimate {
     pub total: usize,
     /// Cached main trace data.
     pub main: usize,
+    /// Cached stacked PCS matrix, if retained after commitment.
+    pub stacked_matrix: usize,
     /// Reed-Solomon code matrix for main traces.
     pub rs_code_matrix: usize,
     /// Batch-constraint phase peak.
@@ -130,6 +132,13 @@ impl ProvingMemoryConfig {
     #[inline]
     pub fn main_memory_bytes(&self, main_cells: usize) -> usize {
         main_cells * self.base_field_size
+    }
+
+    /// Stacked PCS matrix for the committed main trace data.
+    #[inline]
+    pub fn stacked_matrix_memory_bytes(&self, main_cells: usize) -> usize {
+        let stacked_height = 1usize << self.log_stacked_height;
+        main_cells.next_multiple_of(stacked_height) * self.base_field_size
     }
 
     /// Reed-Solomon code matrix for the committed main trace data.
@@ -211,6 +220,7 @@ impl ProvingMemoryConfig {
     /// ```text
     /// main_cells       = main_cells_with_rot + main_cells_without_rot
     /// main             = main_memory_bytes(main_cells)
+    /// stacked_matrix   = stacked_matrix_memory_bytes(main_cells), if cached
     /// rs_code_matrix   = rs_code_matrix_memory_bytes(main_cells)
     /// batch_constraint = batch-constraint phase peak
     /// gkr              = GKR phase peak
@@ -219,18 +229,23 @@ impl ProvingMemoryConfig {
     /// Cached RS code matrix:
     ///
     /// ```text
-    /// total = main + rs_code_matrix + max(batch_constraint, gkr)
+    /// total = main + stacked_matrix + rs_code_matrix + max(batch_constraint, gkr)
     /// ```
     ///
     /// Dropped RS code matrix:
     ///
     /// ```text
-    /// total = main + max(rs_code_matrix, batch_constraint, gkr)
+    /// total = main + stacked_matrix + max(rs_code_matrix, batch_constraint, gkr)
     /// ```
     #[inline]
     pub fn estimate(&self, counts: ProvingMemoryCounts) -> ProvingMemoryEstimate {
         let main_cells = counts.main_cells();
         let main = self.main_memory_bytes(main_cells);
+        let stacked_matrix = if self.cache_stacked_matrix {
+            self.stacked_matrix_memory_bytes(main_cells)
+        } else {
+            0
+        };
         let rs_code_matrix = self.rs_code_matrix_memory_bytes(main_cells);
 
         let gkr_buffers = self.gkr_buffer_memory_bytes(counts.interaction_cells);
@@ -254,8 +269,9 @@ impl ProvingMemoryConfig {
         };
 
         ProvingMemoryEstimate {
-            total: main + secondary_peak,
+            total: main + stacked_matrix + secondary_peak,
             main,
+            stacked_matrix,
             rs_code_matrix,
             batch_constraint,
             gkr,

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -383,7 +383,8 @@ mod tests {
         let unsaved = config.estimate(counts);
         assert_eq!(
             unsaved.batch_constraint,
-            batch_main + max(gkr_buffers, BATCH_MLE_MEMORY_FLOOR)
+            batch_main
+                + max(gkr_buffers, BATCH_MLE_MEMORY_FLOOR)
                 + BATCH_CONSTRAINT_MEMORY_OVERHEAD
         );
         assert!(unsaved.total > saved.total);

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -145,9 +145,12 @@ impl ProvingMemoryConfig {
         main_cells * self.base_field_size
     }
 
-    /// Stacked PCS matrix for the committed main trace data.
+    /// Cached stacked PCS matrix for the committed main trace data.
     #[inline]
     pub fn stacked_matrix_memory_bytes(&self, main_cells: usize) -> usize {
+        if !self.cache_stacked_matrix {
+            return 0;
+        }
         let stacked_height = 1usize << self.log_stacked_height;
         main_cells.next_multiple_of(stacked_height) * self.base_field_size
     }
@@ -161,34 +164,66 @@ impl ProvingMemoryConfig {
             * self.base_field_size
     }
 
-    /// Batch-constraint main-trace buffers across rotation classes.
+    /// Batch-constraint phase peak.
     ///
-    /// The per-opening weight is `(1 + constraint_degree / 2) * D_EF / 2^l_skip`;
-    /// equivalently, `1 + constraint_degree / 2 = (constraint_degree + 2) / 2`.
+    /// The main-trace buffer's per-opening weight is
+    /// `(1 + constraint_degree / 2) * D_EF / 2^l_skip`; equivalently,
+    /// `1 + constraint_degree / 2 = (constraint_degree + 2) / 2`. AIRs with rotations have
+    /// `num_openings = 2`; AIRs without rotations have `num_openings = 1`.
     ///
     /// ```text
-    /// bytes = ceil(
+    /// main = ceil(
     ///   main_cells * num_openings * D_EF * sizeof(F) * (constraint_degree + 2)
     ///   / 2^(l_skip + 1)
     /// )
     /// ```
     ///
-    /// AIRs with rotations have `num_openings = 2`; AIRs without rotations have
-    /// `num_openings = 1`.
+    /// Round0 uses `gkr_mem_contribution`: GKR leaves plus the largest strategy
+    /// workspace (typically `/4`), without GKR-only `tmp_block_sums`. The GKR
+    /// estimate instead uses default precompute-M (`/16` plus `tmp_block_sums`).
+    ///
+    /// ```text
+    /// round0_max_temp_bytes = gkr_mem_contribution(interaction_cells)
+    /// working_set (save memory) = max(main, round0_max_temp_bytes)
+    /// working_set (no save memory) = main + max(round0_max_temp_bytes, 6 GiB)
+    /// batch_constraint = working_set + 192 MiB
+    /// ```
     #[inline]
-    pub fn batch_constraint_main_memory_bytes(&self, counts: ProvingMemoryCounts) -> usize {
-        let bytes_per_opening_numerator =
-            self.extension_degree * self.base_field_size * (self.max_constraint_degree + 2);
-        let denominator = 1usize << (self.l_skip + 1);
+    pub fn batch_constraint_memory_bytes(&self, counts: ProvingMemoryCounts) -> usize {
+        let main_bytes = {
+            let bytes_per_opening_numerator =
+                self.extension_degree * self.base_field_size * (self.max_constraint_degree + 2);
+            let denominator = 1usize << (self.l_skip + 1);
 
-        let bytes_for = |main_cells: usize, num_openings: usize| {
-            (main_cells * num_openings * bytes_per_opening_numerator).div_ceil(denominator)
+            let bytes_for = |main_cells: usize, num_openings: usize| {
+                (main_cells * num_openings * bytes_per_opening_numerator).div_ceil(denominator)
+            };
+
+            let bytes_with_rot = bytes_for(counts.main_cells_with_rot, 2);
+            let bytes_without_rot = bytes_for(counts.main_cells_without_rot, 1);
+
+            bytes_with_rot + bytes_without_rot
         };
 
-        bytes_for(counts.main_cells_with_rot, 2) + bytes_for(counts.main_cells_without_rot, 1)
+        let round0_max_temp_bytes = if counts.interaction_cells == 0 {
+            0
+        } else {
+            let leaf_bytes = 2 * self.extension_degree * self.base_field_size;
+            let logical_len = (counts.interaction_cells + 1).next_power_of_two();
+            let leaves = counts.interaction_cells * leaf_bytes;
+            let work_buffer = max(logical_len / 4, GKR_MIN_WORK_BUFFER_LEN) * leaf_bytes;
+            leaves + work_buffer
+        };
+
+        let batch_constraint_working_set_bytes = if self.zerocheck_save_memory {
+            max(main_bytes, round0_max_temp_bytes)
+        } else {
+            main_bytes + max(round0_max_temp_bytes, BATCH_MLE_MEMORY_FLOOR)
+        };
+        batch_constraint_working_set_bytes + BATCH_CONSTRAINT_MEMORY_OVERHEAD
     }
 
-    /// Fractional-GKR scalable buffers, excluding fixed GKR-phase overhead.
+    /// Fractional-GKR phase peak, including fixed overhead.
     ///
     /// ```text
     /// leaf_bytes     = 2 * extension_degree * sizeof(F)
@@ -197,9 +232,10 @@ impl ProvingMemoryConfig {
     /// leaves         = real_len * leaf_bytes
     /// work_buffer    = max(logical_len / 16, 2^22) * leaf_bytes
     /// tmp_block_sums = logical_len / 256 * leaf_bytes
+    /// gkr             = leaves + work_buffer + tmp_block_sums + 64 MiB
     /// ```
     #[inline]
-    pub fn gkr_buffer_memory_bytes(&self, interaction_cells: usize) -> usize {
+    pub fn gkr_memory_bytes(&self, interaction_cells: usize) -> usize {
         if interaction_cells == 0 {
             return 0;
         }
@@ -208,7 +244,7 @@ impl ProvingMemoryConfig {
         let leaves = interaction_cells * leaf_bytes;
         let work_buffer = max(logical_len / 16, GKR_MIN_WORK_BUFFER_LEN) * leaf_bytes;
         let tmp_block_sums = logical_len / 256 * leaf_bytes;
-        leaves + work_buffer + tmp_block_sums
+        leaves + work_buffer + tmp_block_sums + GKR_MEMORY_OVERHEAD
     }
 
     /// WHIR opening working set that coexists with the RS code matrix.
@@ -233,7 +269,7 @@ impl ProvingMemoryConfig {
     /// ```text
     /// main_cells       = main_cells_with_rot + main_cells_without_rot
     /// main             = main_memory_bytes(main_cells)
-    /// stacked_matrix   = stacked_matrix_memory_bytes(main_cells), if cached
+    /// stacked_matrix   = stacked_matrix_memory_bytes(main_cells)
     /// rs_code_matrix   = rs_code_matrix_memory_bytes(main_cells)
     /// batch_constraint = batch-constraint phase peak
     /// gkr              = GKR phase peak
@@ -255,27 +291,11 @@ impl ProvingMemoryConfig {
     pub fn estimate(&self, counts: ProvingMemoryCounts) -> ProvingMemoryEstimate {
         let main_cells = counts.main_cells();
         let main = self.main_memory_bytes(main_cells);
-        let stacked_matrix = if self.cache_stacked_matrix {
-            self.stacked_matrix_memory_bytes(main_cells)
-        } else {
-            0
-        };
+        let stacked_matrix = self.stacked_matrix_memory_bytes(main_cells);
         let rs_code_matrix = self.rs_code_matrix_memory_bytes(main_cells);
 
-        let gkr_buffers = self.gkr_buffer_memory_bytes(counts.interaction_cells);
-        let gkr = if gkr_buffers == 0 {
-            0
-        } else {
-            gkr_buffers + GKR_MEMORY_OVERHEAD
-        };
-
-        let batch_constraint_main = self.batch_constraint_main_memory_bytes(counts);
-        let batch_constraint = if self.zerocheck_save_memory {
-            max(batch_constraint_main, gkr_buffers)
-        } else {
-            batch_constraint_main + max(gkr_buffers, BATCH_MLE_MEMORY_FLOOR)
-        } + BATCH_CONSTRAINT_MEMORY_OVERHEAD;
-
+        let batch_constraint = self.batch_constraint_memory_bytes(counts);
+        let gkr = self.gkr_memory_bytes(counts.interaction_cells);
         let whir = self.whir_memory_bytes();
 
         let batch_or_gkr = max(batch_constraint, gkr);
@@ -348,7 +368,7 @@ mod tests {
     }
 
     #[test]
-    fn batch_constraint_main_memory_uses_integer_formula() {
+    fn batch_constraint_memory_uses_integer_formula() {
         let config = test_memory_config();
         let counts = ProvingMemoryCounts::new(7, 11, 0);
         let weighted_bytes = |main_cells: usize, need_rot: bool| {
@@ -360,34 +380,27 @@ mod tests {
         };
 
         assert_eq!(
-            config.batch_constraint_main_memory_bytes(counts),
+            config.batch_constraint_memory_bytes(counts),
             weighted_bytes(counts.main_cells_with_rot, true)
                 + weighted_bytes(counts.main_cells_without_rot, false)
+                + BATCH_CONSTRAINT_MEMORY_OVERHEAD
         );
     }
 
     #[test]
     fn no_save_memory_batch_scratch_is_additive() {
         let mut config = test_memory_config();
-        let counts = ProvingMemoryCounts::new(10, 20, 5);
-        let batch_main = config.batch_constraint_main_memory_bytes(counts);
-        let gkr_buffers = config.gkr_buffer_memory_bytes(counts.interaction_cells);
+        let counts = ProvingMemoryCounts::default();
 
         let saved = config.estimate(counts);
-        assert_eq!(
-            saved.batch_constraint,
-            max(batch_main, gkr_buffers) + BATCH_CONSTRAINT_MEMORY_OVERHEAD
-        );
+        assert_eq!(saved.batch_constraint, BATCH_CONSTRAINT_MEMORY_OVERHEAD);
 
         config.zerocheck_save_memory = false;
         let unsaved = config.estimate(counts);
         assert_eq!(
             unsaved.batch_constraint,
-            batch_main
-                + max(gkr_buffers, BATCH_MLE_MEMORY_FLOOR)
-                + BATCH_CONSTRAINT_MEMORY_OVERHEAD
+            BATCH_MLE_MEMORY_FLOOR + BATCH_CONSTRAINT_MEMORY_OVERHEAD
         );
-        assert!(unsaved.total > saved.total);
     }
 
     #[test]
@@ -399,9 +412,14 @@ mod tests {
             counts.main_cells().next_multiple_of(stacked_height) * config.base_field_size;
 
         let without_stacked = config.estimate(counts);
+        assert_eq!(config.stacked_matrix_memory_bytes(counts.main_cells()), 0);
         config.cache_stacked_matrix = true;
         let with_stacked = config.estimate(counts);
 
+        assert_eq!(
+            config.stacked_matrix_memory_bytes(counts.main_cells()),
+            expected_stacked
+        );
         assert_eq!(without_stacked.stacked_matrix, 0);
         assert_eq!(with_stacked.stacked_matrix, expected_stacked);
         assert_eq!(with_stacked.total - without_stacked.total, expected_stacked);

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -32,6 +32,10 @@ pub struct ProvingMemoryCounts {
     pub main_cells_without_rot: usize,
     /// Metered row-interaction slots after power-of-two padding.
     pub interaction_cells: usize,
+    /// Height-weighted round0 intermediate slots:
+    /// `Σ_AIR padded_height · zerocheck_round0_buffer_size`. `0` means unavailable, so the
+    /// estimate falls back to the full round0 temporary-memory limit.
+    pub constraint_eval_cells: usize,
 }
 
 impl ProvingMemoryCounts {
@@ -39,11 +43,13 @@ impl ProvingMemoryCounts {
         main_cells_with_rot: usize,
         main_cells_without_rot: usize,
         interaction_cells: usize,
+        constraint_eval_cells: usize,
     ) -> Self {
         Self {
             main_cells_with_rot,
             main_cells_without_rot,
             interaction_cells,
+            constraint_eval_cells,
         }
     }
 
@@ -181,11 +187,15 @@ impl ProvingMemoryConfig {
     /// Round0 uses `gkr_mem_contribution`: GKR leaves plus the largest strategy
     /// workspace (typically `/4`), without GKR-only `tmp_block_sums`. The GKR
     /// estimate instead uses default precompute-M (`/16` plus `tmp_block_sums`).
+    /// Missing `constraint_eval_cells` (`0`) makes `round0_spill` use the full limit.
     ///
     /// ```text
     /// round0_max_temp_bytes = gkr_mem_contribution(interaction_cells)
-    /// working_set (save memory) = max(main, round0_max_temp_bytes)
-    /// working_set (no save memory) = main + max(round0_max_temp_bytes, 6 GiB)
+    /// num_cosets = max(max_constraint_degree - 1, 1)
+    /// full_constraint_eval_buffer = constraint_eval_cells * num_cosets * sizeof(F)
+    /// round0_spill = min(full_constraint_eval_buffer, round0_max_temp_bytes)
+    /// working_set (save memory) = max(main, round0_spill)
+    /// working_set (no save memory) = main + max(round0_spill, 6 GiB)
     /// batch_constraint = working_set + 192 MiB
     /// ```
     #[inline]
@@ -205,20 +215,33 @@ impl ProvingMemoryConfig {
             bytes_with_rot + bytes_without_rot
         };
 
-        let round0_max_temp_bytes = if counts.interaction_cells == 0 {
-            0
-        } else {
-            let leaf_bytes = 2 * self.extension_degree * self.base_field_size;
-            let logical_len = (counts.interaction_cells + 1).next_power_of_two();
-            let leaves = counts.interaction_cells * leaf_bytes;
-            let work_buffer = max(logical_len / 4, GKR_MIN_WORK_BUFFER_LEN) * leaf_bytes;
-            leaves + work_buffer
+        let round0_spill = {
+            let round0_max_temp_bytes = if counts.interaction_cells == 0 {
+                0
+            } else {
+                let leaf_bytes = 2 * self.extension_degree * self.base_field_size;
+                let logical_len = (counts.interaction_cells + 1).next_power_of_two();
+                let leaves = counts.interaction_cells * leaf_bytes;
+                let work_buffer = max(logical_len / 4, GKR_MIN_WORK_BUFFER_LEN) * leaf_bytes;
+                leaves + work_buffer
+            };
+
+            if counts.constraint_eval_cells == 0 {
+                round0_max_temp_bytes
+            } else {
+                let num_cosets = self.max_constraint_degree.saturating_sub(1).max(1);
+                let full_constraint_eval_buffer_bytes = counts
+                    .constraint_eval_cells
+                    .saturating_mul(num_cosets)
+                    .saturating_mul(self.base_field_size);
+                full_constraint_eval_buffer_bytes.min(round0_max_temp_bytes)
+            }
         };
 
         let batch_constraint_working_set_bytes = if self.zerocheck_save_memory {
-            max(main_bytes, round0_max_temp_bytes)
+            max(main_bytes, round0_spill)
         } else {
-            main_bytes + max(round0_max_temp_bytes, BATCH_MLE_MEMORY_FLOOR)
+            main_bytes + max(round0_spill, BATCH_MLE_MEMORY_FLOOR)
         };
         batch_constraint_working_set_bytes + BATCH_CONSTRAINT_MEMORY_OVERHEAD
     }
@@ -333,7 +356,7 @@ mod tests {
         let params = default_test_params_small();
         let config =
             ProvingMemoryConfig::from_params::<u32, [u32; 8]>(&params, 4, false, false, true);
-        let counts = ProvingMemoryCounts::new(10, 20, 5);
+        let counts = ProvingMemoryCounts::new(10, 20, 5, 0);
 
         let estimate = config.estimate(counts);
 
@@ -356,7 +379,7 @@ mod tests {
     #[test]
     fn cached_rs_code_matrix_is_additive() {
         let config = test_memory_config();
-        let counts = ProvingMemoryCounts::new(10, 20, 5);
+        let counts = ProvingMemoryCounts::new(10, 20, 5, 0);
 
         let estimate = config.estimate(counts);
 
@@ -370,7 +393,7 @@ mod tests {
     #[test]
     fn batch_constraint_memory_uses_integer_formula() {
         let config = test_memory_config();
-        let counts = ProvingMemoryCounts::new(7, 11, 0);
+        let counts = ProvingMemoryCounts::new(7, 11, 0, 0);
         let weighted_bytes = |main_cells: usize, need_rot: bool| {
             let weight = (1.0 + config.max_constraint_degree as f64 / 2.0)
                 * config.extension_degree as f64
@@ -406,7 +429,7 @@ mod tests {
     #[test]
     fn stacked_matrix_and_whir_components_are_counted_separately() {
         let mut config = test_memory_config();
-        let counts = ProvingMemoryCounts::new(10, 20, 5);
+        let counts = ProvingMemoryCounts::new(10, 20, 5, 0);
         let stacked_height = 1usize << config.log_stacked_height;
         let expected_stacked =
             counts.main_cells().next_multiple_of(stacked_height) * config.base_field_size;

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -346,4 +346,71 @@ mod tests {
                 + max(estimate.whir, max(estimate.batch_constraint, estimate.gkr))
         );
     }
+
+    #[test]
+    fn batch_constraint_main_memory_uses_integer_formula() {
+        let config = test_memory_config();
+        let counts = ProvingMemoryCounts::new(7, 11, 0);
+        let weighted_bytes = |main_cells: usize, need_rot: bool| {
+            let weight = (1.0 + config.max_constraint_degree as f64 / 2.0)
+                * config.extension_degree as f64
+                / (1usize << config.l_skip) as f64;
+            let weight = if need_rot { 2.0 * weight } else { weight };
+            ((main_cells * config.base_field_size) as f64 * weight).ceil() as usize
+        };
+
+        assert_eq!(
+            config.batch_constraint_main_memory_bytes(counts),
+            weighted_bytes(counts.main_cells_with_rot, true)
+                + weighted_bytes(counts.main_cells_without_rot, false)
+        );
+    }
+
+    #[test]
+    fn no_save_memory_batch_scratch_is_additive() {
+        let mut config = test_memory_config();
+        let counts = ProvingMemoryCounts::new(10, 20, 5);
+        let batch_main = config.batch_constraint_main_memory_bytes(counts);
+        let gkr_buffers = config.gkr_buffer_memory_bytes(counts.interaction_cells);
+
+        let saved = config.estimate(counts);
+        assert_eq!(
+            saved.batch_constraint,
+            max(batch_main, gkr_buffers) + BATCH_CONSTRAINT_MEMORY_OVERHEAD
+        );
+
+        config.zerocheck_save_memory = false;
+        let unsaved = config.estimate(counts);
+        assert_eq!(
+            unsaved.batch_constraint,
+            batch_main + max(gkr_buffers, BATCH_MLE_MEMORY_FLOOR)
+                + BATCH_CONSTRAINT_MEMORY_OVERHEAD
+        );
+        assert!(unsaved.total > saved.total);
+    }
+
+    #[test]
+    fn stacked_matrix_and_whir_components_are_counted_separately() {
+        let mut config = test_memory_config();
+        let counts = ProvingMemoryCounts::new(10, 20, 5);
+        let stacked_height = 1usize << config.log_stacked_height;
+        let expected_stacked =
+            counts.main_cells().next_multiple_of(stacked_height) * config.base_field_size;
+
+        let without_stacked = config.estimate(counts);
+        config.cache_stacked_matrix = true;
+        let with_stacked = config.estimate(counts);
+
+        assert_eq!(without_stacked.stacked_matrix, 0);
+        assert_eq!(with_stacked.stacked_matrix, expected_stacked);
+        assert_eq!(with_stacked.total - without_stacked.total, expected_stacked);
+
+        let codeword_height = stacked_height << config.log_blowup;
+        let expected_whir = 2 * config.digest_size * (codeword_height >> config.k_whir)
+            + config.extension_degree * config.base_field_size * (codeword_height >> 1)
+            + 2 * config.digest_size * (codeword_height >> (config.k_whir + 1))
+            + WHIR_MEMORY_OVERHEAD;
+        assert_eq!(config.whir_memory_bytes(), expected_whir);
+        assert_eq!(with_stacked.whir, expected_whir);
+    }
 }

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -4,17 +4,20 @@ use std::{cmp::max, mem::size_of};
 
 use crate::{StarkProtocolConfig, SystemParams};
 
+/// Fixed batch-constraint scratch on top of the modeled main-trace buffers.
+pub const BATCH_CONSTRAINT_MEMORY_OVERHEAD: usize = 192 << 20;
+
+/// Minimum batch-MLE scratch budget when `zerocheck_save_memory` is off.
+pub const BATCH_MLE_MEMORY_FLOOR: usize = 6 << 30;
+
 /// Fixed fractional-GKR scratch not proportional to interaction cells.
 pub const GKR_MEMORY_OVERHEAD: usize = 64 << 20;
 
 /// Minimum fractional-GKR work-buffer length in `Frac<EF>` entries.
 pub const GKR_MIN_WORK_BUFFER_LEN: usize = 1 << 22;
 
-/// Fixed batch-constraint scratch on top of the modeled main-trace buffers.
-pub const BATCH_CONSTRAINT_MEMORY_OVERHEAD: usize = 192 << 20;
-
-/// Minimum batch-MLE scratch budget when `zerocheck_save_memory` is off.
-pub const BATCH_MLE_MEMORY_FLOOR: usize = 6 << 30;
+/// Fixed WHIR opening scratch not proportional to the stacked height.
+pub const WHIR_MEMORY_OVERHEAD: usize = 64 << 20;
 
 /// Cell counts for a proving memory estimate.
 ///
@@ -65,6 +68,8 @@ pub struct ProvingMemoryEstimate {
     pub batch_constraint: usize,
     /// Fractional-GKR buffers plus fixed GKR-phase overhead.
     pub gkr: usize,
+    /// WHIR opening working set that coexists with the RS code matrix.
+    pub whir: usize,
     /// Peak among secondary phases, excluding cached main trace data.
     pub secondary_peak: usize,
 }
@@ -76,12 +81,16 @@ pub struct ProvingMemoryConfig {
     pub base_field_size: usize,
     /// Degree of the extension field over the base field.
     pub extension_degree: usize,
+    /// Size of one commitment digest in bytes.
+    pub digest_size: usize,
     /// `-log_2` of the rate for the initial Reed-Solomon code.
     pub log_blowup: usize,
     /// `log_2` of the univariate skip domain.
     pub l_skip: usize,
     /// `log_2` of the stacked matrix height (`l_skip + n_stack`).
     pub log_stacked_height: usize,
+    /// `log_2` of the number of codeword rows per WHIR Merkle-tree leaf.
+    pub k_whir: usize,
     /// Maximum constraint degree across AIR and interaction constraints.
     pub max_constraint_degree: usize,
     /// Whether the prover keeps the stacked matrix cached after `stacked_commit`.
@@ -99,7 +108,7 @@ impl ProvingMemoryConfig {
         cache_rs_code_matrix: bool,
         zerocheck_save_memory: bool,
     ) -> Self {
-        Self::from_params::<SC::F>(
+        Self::from_params::<SC::F, SC::Digest>(
             config.params(),
             SC::D_EF,
             cache_stacked_matrix,
@@ -108,7 +117,7 @@ impl ProvingMemoryConfig {
         )
     }
 
-    fn from_params<F>(
+    fn from_params<F, Digest>(
         params: &SystemParams,
         extension_degree: usize,
         cache_stacked_matrix: bool,
@@ -118,9 +127,11 @@ impl ProvingMemoryConfig {
         Self {
             base_field_size: size_of::<F>(),
             extension_degree,
+            digest_size: size_of::<Digest>(),
             log_blowup: params.log_blowup,
             l_skip: params.l_skip,
             log_stacked_height: params.log_stacked_height(),
+            k_whir: params.k_whir(),
             max_constraint_degree: params.max_constraint_degree,
             cache_stacked_matrix,
             cache_rs_code_matrix,
@@ -215,6 +226,23 @@ impl ProvingMemoryConfig {
         leaves + work_buffer + tmp_block_sums
     }
 
+    /// WHIR opening working set that coexists with the RS code matrix.
+    ///
+    /// ```text
+    /// codeword_height = 2^(log_stacked_height + log_blowup)
+    /// commit_tree     = 2 * digest_size * codeword_height / 2^k_whir
+    /// g_codeword      = D_EF * sizeof(F) * codeword_height / 2
+    /// g_tree          = 2 * digest_size * codeword_height / 2^(k_whir + 1)
+    /// ```
+    #[inline]
+    pub fn whir_memory_bytes(&self) -> usize {
+        let codeword_height = 1usize << (self.log_stacked_height + self.log_blowup);
+        let commit_tree = 2 * self.digest_size * (codeword_height >> self.k_whir);
+        let g_codeword = self.extension_degree * self.base_field_size * (codeword_height >> 1);
+        let g_tree = 2 * self.digest_size * (codeword_height >> (self.k_whir + 1));
+        commit_tree + g_codeword + g_tree + WHIR_MEMORY_OVERHEAD
+    }
+
     /// Convert main trace cells and interaction cells to proving memory bytes.
     ///
     /// ```text
@@ -224,18 +252,19 @@ impl ProvingMemoryConfig {
     /// rs_code_matrix   = rs_code_matrix_memory_bytes(main_cells)
     /// batch_constraint = batch-constraint phase peak
     /// gkr              = GKR phase peak
+    /// whir             = WHIR working set that coexists with rs_code_matrix
     /// ```
     ///
     /// Cached RS code matrix:
     ///
     /// ```text
-    /// total = main + stacked_matrix + rs_code_matrix + max(batch_constraint, gkr)
+    /// total = main + stacked_matrix + rs_code_matrix + max(whir, batch_constraint, gkr)
     /// ```
     ///
     /// Dropped RS code matrix:
     ///
     /// ```text
-    /// total = main + stacked_matrix + max(rs_code_matrix, batch_constraint, gkr)
+    /// total = main + stacked_matrix + max(rs_code_matrix + whir, batch_constraint, gkr)
     /// ```
     #[inline]
     pub fn estimate(&self, counts: ProvingMemoryCounts) -> ProvingMemoryEstimate {
@@ -262,10 +291,13 @@ impl ProvingMemoryConfig {
             batch_constraint_main + max(gkr_buffers, BATCH_MLE_MEMORY_FLOOR)
         } + BATCH_CONSTRAINT_MEMORY_OVERHEAD;
 
+        let whir = self.whir_memory_bytes();
+
+        let batch_or_gkr = max(batch_constraint, gkr);
         let secondary_peak = if self.cache_rs_code_matrix {
-            rs_code_matrix + max(batch_constraint, gkr)
+            rs_code_matrix + max(whir, batch_or_gkr)
         } else {
-            max(rs_code_matrix, max(batch_constraint, gkr))
+            max(rs_code_matrix + whir, batch_or_gkr)
         };
 
         ProvingMemoryEstimate {
@@ -275,6 +307,7 @@ impl ProvingMemoryConfig {
             rs_code_matrix,
             batch_constraint,
             gkr,
+            whir,
             secondary_peak,
         }
     }
@@ -300,13 +333,14 @@ mod tests {
 
     fn test_memory_config() -> ProvingMemoryConfig {
         let params = default_test_params_small();
-        ProvingMemoryConfig::from_params::<u32>(&params, 4, false, true, true)
+        ProvingMemoryConfig::from_params::<u32, [u32; 8]>(&params, 4, false, true, true)
     }
 
     #[test]
     fn dropped_rs_code_matrix_is_phase_disjoint() {
         let params = default_test_params_small();
-        let config = ProvingMemoryConfig::from_params::<u32>(&params, 4, false, false, true);
+        let config =
+            ProvingMemoryConfig::from_params::<u32, [u32; 8]>(&params, 4, false, false, true);
         let counts = ProvingMemoryCounts::new(10, 20, 5);
 
         let estimate = config.estimate(counts);
@@ -321,7 +355,7 @@ mod tests {
         assert_eq!(
             estimate.secondary_peak,
             max(
-                estimate.rs_code_matrix,
+                estimate.rs_code_matrix + estimate.whir,
                 max(estimate.batch_constraint, estimate.gkr)
             )
         );
@@ -336,7 +370,8 @@ mod tests {
 
         assert_eq!(
             estimate.secondary_peak,
-            estimate.rs_code_matrix + max(estimate.batch_constraint, estimate.gkr)
+            estimate.rs_code_matrix
+                + max(estimate.whir, max(estimate.batch_constraint, estimate.gkr))
         );
     }
 }

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -4,8 +4,17 @@ use std::{cmp::max, mem::size_of};
 
 use crate::{StarkProtocolConfig, SystemParams};
 
-/// Fixed interaction scratch not proportional to interaction cells.
-pub const INTERACTION_MEMORY_OVERHEAD: usize = 2 << 20;
+/// Fixed fractional-GKR scratch not proportional to interaction cells.
+pub const GKR_MEMORY_OVERHEAD: usize = 64 << 20;
+
+/// Minimum fractional-GKR work-buffer length in `Frac<EF>` entries.
+pub const GKR_MIN_WORK_BUFFER_LEN: usize = 1 << 22;
+
+/// Fixed batch-constraint scratch on top of the modeled main-trace buffers.
+pub const BATCH_CONSTRAINT_MEMORY_OVERHEAD: usize = 192 << 20;
+
+/// Minimum batch-MLE scratch budget when `zerocheck_save_memory` is off.
+pub const BATCH_MLE_MEMORY_FLOOR: usize = 6 << 30;
 
 /// Cell counts for a proving memory estimate.
 ///
@@ -50,7 +59,7 @@ pub struct ProvingMemoryEstimate {
     pub main: usize,
     /// Reed-Solomon code matrix for main traces.
     pub rs_code_matrix: usize,
-    /// Batch-constraint main-trace buffers after PCS opening.
+    /// Batch-constraint phase peak.
     pub batch_constraint: usize,
     /// Fractional-GKR buffers plus fixed GKR-phase overhead.
     pub gkr: usize,
@@ -153,7 +162,7 @@ impl ProvingMemoryConfig {
     ///
     /// AIRs with `need_rot = true` open two PCS cells per column.
     #[inline]
-    pub fn batch_constraint_memory_bytes_for_rot(
+    pub fn batch_constraint_main_memory_bytes_for_rot(
         &self,
         main_cells: usize,
         need_rot: bool,
@@ -169,25 +178,32 @@ impl ProvingMemoryConfig {
 
     /// Batch-constraint main-trace buffers across rotation classes.
     #[inline]
-    pub fn batch_constraint_memory_bytes(&self, counts: ProvingMemoryCounts) -> usize {
-        self.batch_constraint_memory_bytes_for_rot(counts.main_cells_with_rot, true)
-            + self.batch_constraint_memory_bytes_for_rot(counts.main_cells_without_rot, false)
+    pub fn batch_constraint_main_memory_bytes(&self, counts: ProvingMemoryCounts) -> usize {
+        self.batch_constraint_main_memory_bytes_for_rot(counts.main_cells_with_rot, true)
+            + self.batch_constraint_main_memory_bytes_for_rot(counts.main_cells_without_rot, false)
     }
 
-    /// Fractional-GKR interaction buffers before fixed interaction-phase overhead.
+    /// Fractional-GKR scalable buffers, excluding fixed GKR-phase overhead.
+    ///
+    /// ```text
+    /// leaf_bytes     = 2 * extension_degree * sizeof(F)
+    /// real_len       = interaction_cells
+    /// logical_len    = 2^ceil_log2(real_len + 1)
+    /// leaves         = real_len * leaf_bytes
+    /// work_buffer    = max(logical_len / 16, 2^22) * leaf_bytes
+    /// tmp_block_sums = logical_len / 256 * leaf_bytes
+    /// ```
     #[inline]
-    pub fn gkr_memory_bytes_without_overhead(&self, interaction_cells: usize) -> usize {
-        ceil_weighted_bytes(
-            interaction_cells,
-            self.base_field_size,
-            default_gkr_cell_weight(self.extension_degree),
-        )
-    }
-
-    /// Fractional-GKR interaction phase, including fixed non-cell-proportional overhead.
-    #[inline]
-    pub fn gkr_memory_bytes(&self, interaction_cells: usize) -> usize {
-        self.gkr_memory_bytes_without_overhead(interaction_cells) + INTERACTION_MEMORY_OVERHEAD
+    pub fn gkr_buffer_memory_bytes(&self, interaction_cells: usize) -> usize {
+        if interaction_cells == 0 {
+            return 0;
+        }
+        let leaf_bytes = 2 * self.extension_degree * self.base_field_size;
+        let logical_len = (interaction_cells + 1).next_power_of_two();
+        let leaves = interaction_cells * leaf_bytes;
+        let work_buffer = max(logical_len / 16, GKR_MIN_WORK_BUFFER_LEN) * leaf_bytes;
+        let tmp_block_sums = logical_len / 256 * leaf_bytes;
+        leaves + work_buffer + tmp_block_sums
     }
 
     /// Convert main trace cells and interaction cells to proving memory bytes.
@@ -196,8 +212,8 @@ impl ProvingMemoryConfig {
     /// main_cells       = main_cells_with_rot + main_cells_without_rot
     /// main             = main_memory_bytes(main_cells)
     /// rs_code_matrix   = rs_code_matrix_memory_bytes(main_cells)
-    /// batch_constraint = batch_constraint_memory_bytes(counts)
-    /// gkr              = gkr_memory_bytes(interaction_cells)
+    /// batch_constraint = batch-constraint phase peak
+    /// gkr              = GKR phase peak
     /// ```
     ///
     /// Cached RS code matrix:
@@ -216,8 +232,21 @@ impl ProvingMemoryConfig {
         let main_cells = counts.main_cells();
         let main = self.main_memory_bytes(main_cells);
         let rs_code_matrix = self.rs_code_matrix_memory_bytes(main_cells);
-        let batch_constraint = self.batch_constraint_memory_bytes(counts);
-        let gkr = self.gkr_memory_bytes(counts.interaction_cells);
+
+        let gkr_buffers = self.gkr_buffer_memory_bytes(counts.interaction_cells);
+        let gkr = if gkr_buffers == 0 {
+            0
+        } else {
+            gkr_buffers + GKR_MEMORY_OVERHEAD
+        };
+
+        let batch_constraint_main = self.batch_constraint_main_memory_bytes(counts);
+        let batch_constraint = if self.zerocheck_save_memory {
+            max(batch_constraint_main, gkr_buffers)
+        } else {
+            batch_constraint_main + max(gkr_buffers, BATCH_MLE_MEMORY_FLOOR)
+        } + BATCH_CONSTRAINT_MEMORY_OVERHEAD;
+
         let secondary_peak = if self.cache_rs_code_matrix {
             rs_code_matrix + max(batch_constraint, gkr)
         } else {
@@ -241,19 +270,6 @@ fn default_batch_constraint_main_cell_weight(
     max_constraint_degree: usize,
 ) -> f64 {
     (1.0 + max_constraint_degree as f64 / 2.0) * extension_degree as f64 / (1usize << l_skip) as f64
-}
-
-/// ```
-/// leaf_weight = 2 * extension_degree
-///
-/// work_buffer    <= logical_len / 16
-/// tmp_block_sums ~= logical_len / 256
-/// logical_len    <= 2 * real_len
-///
-/// interaction_weight = leaf_weight * (1 + 2 * (1 / 16 + 1 / 256))
-/// ```
-fn default_gkr_cell_weight(extension_degree: usize) -> f64 {
-    (2 * extension_degree) as f64 * (1.0 + 2.0 * (1.0 / 16.0 + 1.0 / 256.0))
 }
 
 /// `ceil(cell_count * base_field_size * weight)`

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -161,46 +161,31 @@ impl ProvingMemoryConfig {
             * self.base_field_size
     }
 
-    #[inline]
-    pub fn batch_constraint_main_cell_weight(&self) -> f64 {
-        default_batch_constraint_main_cell_weight(
-            self.extension_degree,
-            self.l_skip,
-            self.max_constraint_degree,
-        )
-    }
-
-    /// Batch-constraint main-trace buffers for `main_cells = Σ(padded_height * width)`.
+    /// Batch-constraint main-trace buffers across rotation classes.
+    ///
+    /// The per-opening weight is `(1 + constraint_degree / 2) * D_EF / 2^l_skip`;
+    /// equivalently, `1 + constraint_degree / 2 = (constraint_degree + 2) / 2`.
     ///
     /// ```text
-    /// mat_eval_bytes = (padded_height / 2^l_skip) * ((1 + need_rot) * width) * sizeof(EF)
-    ///                = (1 + need_rot) * main_cells * D_EF / 2^l_skip * sizeof(F)
-    ///
-    /// interp_bytes = (constraint_degree / 2) * mat_eval_bytes
-    /// weight       = (1 + constraint_degree / 2) * D_EF / 2^l_skip
+    /// bytes = ceil(
+    ///   main_cells * num_openings * D_EF * sizeof(F) * (constraint_degree + 2)
+    ///   / 2^(l_skip + 1)
+    /// )
     /// ```
     ///
-    /// AIRs with `need_rot = true` open two PCS cells per column.
-    #[inline]
-    pub fn batch_constraint_main_memory_bytes_for_rot(
-        &self,
-        main_cells: usize,
-        need_rot: bool,
-    ) -> usize {
-        let main_cell_weight = self.batch_constraint_main_cell_weight();
-        let weight = if need_rot {
-            2.0 * main_cell_weight
-        } else {
-            main_cell_weight
-        };
-        ceil_weighted_bytes(main_cells, self.base_field_size, weight)
-    }
-
-    /// Batch-constraint main-trace buffers across rotation classes.
+    /// AIRs with rotations have `num_openings = 2`; AIRs without rotations have
+    /// `num_openings = 1`.
     #[inline]
     pub fn batch_constraint_main_memory_bytes(&self, counts: ProvingMemoryCounts) -> usize {
-        self.batch_constraint_main_memory_bytes_for_rot(counts.main_cells_with_rot, true)
-            + self.batch_constraint_main_memory_bytes_for_rot(counts.main_cells_without_rot, false)
+        let bytes_per_opening_numerator =
+            self.extension_degree * self.base_field_size * (self.max_constraint_degree + 2);
+        let denominator = 1usize << (self.l_skip + 1);
+
+        let bytes_for = |main_cells: usize, num_openings: usize| {
+            (main_cells * num_openings * bytes_per_opening_numerator).div_ceil(denominator)
+        };
+
+        bytes_for(counts.main_cells_with_rot, 2) + bytes_for(counts.main_cells_without_rot, 1)
     }
 
     /// Fractional-GKR scalable buffers, excluding fixed GKR-phase overhead.
@@ -311,19 +296,6 @@ impl ProvingMemoryConfig {
             secondary_peak,
         }
     }
-}
-
-fn default_batch_constraint_main_cell_weight(
-    extension_degree: usize,
-    l_skip: usize,
-    max_constraint_degree: usize,
-) -> f64 {
-    (1.0 + max_constraint_degree as f64 / 2.0) * extension_degree as f64 / (1usize << l_skip) as f64
-}
-
-/// `ceil(cell_count * base_field_size * weight)`
-fn ceil_weighted_bytes(cell_count: usize, base_field_size: usize, weight: f64) -> usize {
-    ((cell_count * base_field_size) as f64 * weight).ceil() as usize
 }
 
 #[cfg(test)]

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -69,6 +69,8 @@ pub struct ProvingMemoryConfig {
     pub log_blowup: usize,
     /// `log_2` of the univariate skip domain.
     pub l_skip: usize,
+    /// `log_2` of the stacked matrix height (`l_skip + n_stack`).
+    pub log_stacked_height: usize,
     /// Maximum constraint degree across AIR and interaction constraints.
     pub max_constraint_degree: usize,
     /// Whether the prover keeps the Reed-Solomon code matrix cached after `stacked_commit`.
@@ -93,6 +95,7 @@ impl ProvingMemoryConfig {
             extension_degree,
             log_blowup: params.log_blowup,
             l_skip: params.l_skip,
+            log_stacked_height: params.log_stacked_height(),
             max_constraint_degree: params.max_constraint_degree,
             cache_rs_code_matrix,
         }
@@ -107,7 +110,10 @@ impl ProvingMemoryConfig {
     /// Reed-Solomon code matrix for the committed main trace data.
     #[inline]
     pub fn rs_code_matrix_memory_bytes(&self, main_cells: usize) -> usize {
-        main_cells * (1usize << self.log_blowup) * self.base_field_size
+        let stacked_height = 1usize << self.log_stacked_height;
+        main_cells.next_multiple_of(stacked_height)
+            * (1usize << self.log_blowup)
+            * self.base_field_size
     }
 
     #[inline]
@@ -258,7 +264,11 @@ mod tests {
         let estimate = config.estimate(counts);
 
         assert_eq!(estimate.main, 30 * 4);
-        assert_eq!(estimate.rs_code_matrix, 30 * 2 * 4);
+        let stacked_height = 1usize << config.log_stacked_height;
+        assert_eq!(
+            estimate.rs_code_matrix,
+            30usize.next_multiple_of(stacked_height) * 2 * 4
+        );
         assert_eq!(estimate.total, estimate.main + estimate.secondary_peak);
         assert_eq!(
             estimate.secondary_peak,

--- a/crates/stark-backend/src/memory_metering.rs
+++ b/crates/stark-backend/src/memory_metering.rs
@@ -1,4 +1,8 @@
 //! Memory estimates for proving.
+//!
+//! These estimates model the memory used by the prove call itself. They may not include
+//! buffers that are already resident before proving starts (e.g. proving-key or
+//! preprocessed-trace device data).
 
 use std::{cmp::max, mem::size_of};
 
@@ -196,7 +200,7 @@ impl ProvingMemoryConfig {
     /// round0_spill = min(full_constraint_eval_buffer, round0_max_temp_bytes)
     /// working_set (save memory) = max(main, round0_spill)
     /// working_set (no save memory) = main + max(round0_spill, 6 GiB)
-    /// batch_constraint = working_set + 192 MiB
+    /// batch_constraint = working_set + BATCH_CONSTRAINT_MEMORY_OVERHEAD (256 MiB)
     /// ```
     #[inline]
     pub fn batch_constraint_memory_bytes(&self, counts: ProvingMemoryCounts) -> usize {
@@ -255,7 +259,7 @@ impl ProvingMemoryConfig {
     /// leaves         = real_len * leaf_bytes
     /// work_buffer    = max(logical_len / 16, 2^22) * leaf_bytes
     /// tmp_block_sums = logical_len / 256 * leaf_bytes
-    /// gkr             = leaves + work_buffer + tmp_block_sums + 64 MiB
+    /// gkr            = leaves + work_buffer + tmp_block_sums + GKR_MEMORY_OVERHEAD (256 MiB)
     /// ```
     #[inline]
     pub fn gkr_memory_bytes(&self, interaction_cells: usize) -> usize {

--- a/crates/stark-backend/src/prover/hal.rs
+++ b/crates/stark-backend/src/prover/hal.rs
@@ -6,7 +6,7 @@ use crate::{
     keygen::types::MultiStarkProvingKey,
     prover::{
         stacked_pcs::StackedPcsData, AirProvingContext, ColMajorMatrix, CommittedTraceData,
-        CpuColMajorBackend, DeviceMultiStarkProvingKey, ProvingContext,
+        CpuColMajorBackend, DeviceMultiStarkProvingKey, DeviceStarkProvingKey, ProvingContext,
     },
     StarkProtocolConfig,
 };
@@ -48,6 +48,18 @@ pub trait ProverBackend {
     /// For example, multiple buffers for LDE matrices, their trace domain sizes, and pointer to
     /// mixed merkle tree.
     type PcsData: Send + Sync;
+
+    // ==== Metering Functions ====
+    /// Per-row intermediate buffer size required to evaluate this AIR's constraints during
+    /// batch constraints zerocheck round 0. Constant `0` (the default) means the backend does
+    /// not track this; if all AIRs report `0`, memory metering falls back to the full round-0
+    /// temporary-memory limit.
+    fn constraint_eval_buffer_size(_pk: &DeviceStarkProvingKey<Self>) -> usize
+    where
+        Self: Sized,
+    {
+        0
+    }
 }
 
 pub trait ProverDevice<PB: ProverBackend, TS>:

--- a/docs/cuda-backend/gkr-prover.md
+++ b/docs/cuda-backend/gkr-prover.md
@@ -322,7 +322,7 @@ Let:
 - Assume precompute-M is active
 
 Buffers used at peak (workspace only; excludes input `layer`/leaves):
-- `work_buffer`: `2^(n-w-2) * |Frac|` (precompute-M defers `w+1` folds before first write)
+- `work_buffer`: `max(2^(n-w-1), 2^22) * |Frac|` (precompute-M defers `w+1` folds before first write; `2^(n-2) * |Frac|` if fold-eval only)
 - `copy_scratch`: `1 * |Frac|`
 - `d_sum_evals`: `2 * |EF|`
 - `tmp_block_sums`: `< 2^(n-7) * |EF|`
@@ -332,15 +332,21 @@ Buffers used at peak (workspace only; excludes input `layer`/leaves):
 - `eq_r_prefix_buffer` + `eq_suffix_buffer`: `2^(w+1) * |EF|` (default `w=3` gives `16 * |EF|`)
 
 Workspace upper bound (sum of the buffers above), using `|Frac| = 2 * |EF|`:
-- `W < (2^(n-w-1) + 2^(n-7) + 2^(n+w-10) + 2^floor(n/2) + 2^ceil(n/2) + 4^w + 2^(w+1) + 2) * |EF|`
+- `W < (2^(n-w) + 2^(n-7) + 2^(n+w-10) + 2^floor(n/2) + 2^ceil(n/2) + 4^w + 2^(w+1) + 2) * |EF|`
 
 Total GPU memory required (workspace + input leaves `2^n * |Frac| = 2^(n+1) * |EF|`):
-- `M_total < (2^(n+1) + 2^(n-w-1) + 2^(n-7) + 2^(n+w-10) + 2^floor(n/2) + 2^ceil(n/2) + 4^w + 2^(w+1) + 2) * |EF|`
+- `M_total < (2^(n+1) + 2^(n-w) + 2^(n-7) + 2^(n+w-10) + 2^floor(n/2) + 2^ceil(n/2) + 4^w + 2^(w+1) + 2) * |EF|`
 - With default `w = 3` and `|EF| = 16` bytes:
-  - `M_total < (2^(n+1) + 2^(n-4) + 2^(n-6) + 2^floor(n/2) + 2^ceil(n/2) + 82) / 2^26 GiB`
-  - `n = 27`: `M_total < 4.16 GiB`
-  - `n = 28`: `M_total < 8.31 GiB`
-  - `n = 29`: `M_total < 16.63 GiB`
-  - `n = 30`: `M_total < 33.25 GiB`
+  - `M_total < (2^(n+1) + 2^(n-3) + 2^(n-6) + 2^floor(n/2) + 2^ceil(n/2) + 82) / 2^26 GiB`
+  - `n = 27`: `M_total < 4.29 GiB`
+  - `n = 28`: `M_total < 8.57 GiB`
+  - `n = 29`: `M_total < 17.13 GiB`
+  - `n = 30`: `M_total < 34.26 GiB`
 
-Dominant term is the input leaves (`2^(n+1) * |EF|`). Workspace overhead is ~4%.
+Dominant term is the input leaves (`2^(n+1) * |EF|`). Workspace overhead is ~7%.
+
+`ProvingMemoryConfig::gkr_memory_bytes` (`memory_metering.rs`) mirrors this as
+`leaves + max(logical_len/16, 2^22) * |Frac| + logical_len/256 * |Frac| + 256 MiB`, with
+`logical_len = 2^ceil_log2(interaction_cells + 1)`. The batch-constraint round0 budget
+instead uses the fold-eval work buffer (`logical_len/4`), matching
+`FractionalInputSize::peak_work_buffer_bytes`. Keep both in sync with this section.


### PR DESCRIPTION
Resolves INT-8600. 

# Overview

## `openvm-stark-backend`: phase-aware memory model

`memory_metering.rs` is the core of the change. Previously, the estimator applied aggregate weights to main and interaction cells, then compared broad `main_secondary` and `interaction` buckets. That omitted some large allocations and did not distinguish buffers that coexist from buffers used in disjoint phases. The new model exposes each major component independently and combines them according to its lifetime.

### Model inputs and outputs

- `ProvingMemoryConfig` now carries the digest size, stacked height, WHIR leaf packing, stacked/RS cache flags, and `zerocheck_save_memory`. This lets the estimate use the same protocol dimensions and retention choices as the prover.
- `ProvingMemoryCounts` adds `constraint_eval_cells`, the sum of each active AIR's padded height multiplied by its zerocheck round-0 intermediate-buffer width. A zero value means the backend cannot provide this detail, so metering falls back to the full round-0 temporary-memory limit.
- `ProvingMemoryEstimate` reports `stacked_matrix`, `rs_code_matrix`, `batch_constraint`, `gkr`, and `whir` separately. These replace the former `main_secondary` and `interaction` buckets and make the selected peak inspectable by callers.

### Per-phase accounting

- **Main, stacked, and RS matrices:** resident main traces remain proportional to their base-field cell count. Stacked and RS allocations first round the main-cell count up to a whole stacked-height row; the RS allocation then applies the configured blowup. The stacked matrix contributes only when it is retained after commitment.
- **Batch constraints:** the trace working set is computed with integer arithmetic from the extension degree, constraint degree, and `l_skip`. AIRs needing next-row rotations count two openings; other AIRs count one. Round 0 additionally accounts for the interaction leaves and its larger `/4` work buffer, capped by the exact constraint-evaluation allocation when that size is available. Save-memory mode takes the maximum of the trace and round-0 buffers; normal mode treats them as co-resident and enforces a 6 GiB batch-MLE scratch floor. The phase includes 256 MiB of fixed overhead.
- **Fractional GKR:** the estimate uses `next_power_of_two(interaction_cells + 1)` for the logical length, then adds real interaction leaves, a `/16` precompute work buffer with a `2^22`-entry minimum, `/256` block-sum scratch, and 256 MiB of fixed overhead.
- **WHIR opening:** the estimate derives the codeword height from the stacked height and RS blowup, then accounts for the existing commitment tree plus the first folded extension-field codeword and its Merkle tree. This phase includes 64 MiB of fixed overhead.

### Peak composition

Resident main traces are always included, and a cached stacked matrix is added independently. The remaining peak depends on RS retention:

- With a cached RS matrix: `main + stacked + RS + max(WHIR, batch constraints, GKR)`.
- Without a cached RS matrix: `main + stacked + max(RS + WHIR, batch constraints, GKR)`.

This captures that WHIR opens the RS commitment and therefore overlaps the RS matrix, while batch constraints and GKR occur after a non-cached RS matrix can be released.

The default `StarkEngine` configuration now declares its cache assumptions explicitly and derives `zerocheck_save_memory` from `log_blowup == 1`.

## Backend interface and CUDA integration

- Adds an optional `ProverBackend::constraint_eval_buffer_size` hook. Backends that do not provide round-0 sizing return zero and use the conservative fallback.
- The CUDA backend reports each AIR's generated zerocheck round-0 buffer size from its device proving key.
- `GpuProverConfig` now forwards `cache_stacked_matrix`, `cache_rs_code_matrix`, and `zerocheck_save_memory` into the shared estimator, keeping metering aligned with the selected CUDA execution mode.
