### PR TITLE
fix: pinned pool lifecycle

### DIFF
--- a/crates/cuda-common/src/pinned.rs
+++ b/crates/cuda-common/src/pinned.rs
@@ -24,6 +24,9 @@
 //! [PinnedBuffer::record_last_use]; the cleaner then waits on exactly those
 //! events. Without a recorded event it falls back to synchronizing the device
 //! that was current when the guard dropped.
+//!
+//! The pool retains at most [set_max_pooled_bytes] bytes (default 4 GiB);
+//! past that, returning a buffer evicts pooled ones, largest first.
 
 use std::{
     collections::BTreeMap,
@@ -193,11 +196,63 @@ struct Returned {
     device: i32,
 }
 
+/// Default value for [set_max_pooled_bytes].
+const DEFAULT_MAX_POOLED_BYTES: usize = 4 << 30; // 4 GiB
+
 /// Registered, all-zero buffers ready for reuse, keyed by allocation size.
-/// Invariant: every pooled buffer is page-locked and quiescent.
-fn pool() -> &'static Mutex<BTreeMap<usize, Vec<Vec<u8>>>> {
-    static POOL: OnceLock<Mutex<BTreeMap<usize, Vec<Vec<u8>>>>> = OnceLock::new();
-    POOL.get_or_init(|| Mutex::new(BTreeMap::new()))
+/// Invariants: every pooled buffer is page-locked and quiescent, empty size
+/// classes are removed, and `total_bytes` is the sum over all pooled buffers.
+struct Pool {
+    by_size: BTreeMap<usize, Vec<Vec<u8>>>,
+    total_bytes: usize,
+    max_bytes: usize,
+}
+
+fn pool() -> &'static Mutex<Pool> {
+    static POOL: OnceLock<Mutex<Pool>> = OnceLock::new();
+    POOL.get_or_init(|| {
+        Mutex::new(Pool {
+            by_size: BTreeMap::new(),
+            total_bytes: 0,
+            max_bytes: DEFAULT_MAX_POOLED_BYTES,
+        })
+    })
+}
+
+/// Caps the bytes of pinned memory the pool may retain (default 4 GiB).
+/// A returned buffer that would push the total over the cap evicts pooled
+/// buffers instead, largest size class first, and a buffer larger than the
+/// whole cap is never pooled. Lowering the cap evicts immediately.
+pub fn set_max_pooled_bytes(max_bytes: usize) {
+    let evicted = {
+        let mut pool = pool().lock().unwrap();
+        pool.max_bytes = max_bytes;
+        evict_to_fit(&mut pool, 0)
+    };
+    for mut buf in evicted {
+        unregister_region(buf.as_mut_ptr());
+    }
+}
+
+/// Pops pooled buffers, largest size class first, until a buffer of
+/// `incoming` bytes fits under the cap (no-op if it never can). The caller
+/// unregisters the evicted buffers, ideally outside the pool lock.
+fn evict_to_fit(pool: &mut Pool, incoming: usize) -> Vec<Vec<u8>> {
+    let mut evicted = Vec::new();
+    if incoming > pool.max_bytes {
+        return evicted;
+    }
+    while pool.total_bytes + incoming > pool.max_bytes {
+        let Some((&class, bufs)) = pool.by_size.iter_mut().next_back() else {
+            break;
+        };
+        evicted.push(bufs.pop().expect("empty size classes are removed"));
+        if bufs.is_empty() {
+            pool.by_size.remove(&class);
+        }
+        pool.total_bytes -= class;
+    }
+    evicted
 }
 
 /// A running cleaner thread and the channel feeding it.
@@ -312,31 +367,45 @@ fn recycle(mut returned: Returned) {
     }
     let dirty_len = returned.dirty_len.min(returned.data.len());
     returned.data[..dirty_len].fill(0);
-    pool()
-        .lock()
-        .unwrap()
-        .entry(returned.data.len())
-        .or_default()
-        .push(returned.data);
+    let size = returned.data.len();
+    let mut evicted;
+    {
+        let mut pool = pool().lock().unwrap();
+        evicted = evict_to_fit(&mut pool, size);
+        if pool.total_bytes + size <= pool.max_bytes {
+            pool.total_bytes += size;
+            pool.by_size.entry(size).or_default().push(returned.data);
+        } else {
+            // Larger than the whole cap: never pooled.
+            evicted.push(returned.data);
+        }
+    }
+    for mut buf in evicted {
+        // Pooled buffers are quiescent, so unregistering evictees is safe.
+        unregister_region(buf.as_mut_ptr());
+    }
 }
 
 /// Returns an all-zero buffer of at least `min_size` bytes (rounded up to the
 /// next power of two), page-locked if it came from the pool.
 pub fn take(min_size: usize) -> PinnedBuffer {
     let size = min_size.next_power_of_two();
-    if let Some(data) = pool()
-        .lock()
-        .unwrap()
-        .get_mut(&size)
-        .and_then(|bufs| bufs.pop())
     {
-        debug_assert_eq!(data.len(), size);
-        return PinnedBuffer {
-            data,
-            dirty_len: size,
-            registered: true,
-            last_use: Vec::new(),
-        };
+        let mut pool = pool().lock().unwrap();
+        if let Some(bufs) = pool.by_size.get_mut(&size) {
+            let data = bufs.pop().expect("empty size classes are removed");
+            if bufs.is_empty() {
+                pool.by_size.remove(&size);
+            }
+            pool.total_bytes -= size;
+            debug_assert_eq!(data.len(), size);
+            return PinnedBuffer {
+                data,
+                dirty_len: size,
+                registered: true,
+                last_use: Vec::new(),
+            };
+        }
     }
     // Pool miss: when no recycled buffer of that size is available,
     // take returns a plain, unpinned allocation instead of pinning one on the spot.
@@ -352,12 +421,13 @@ pub fn take(min_size: usize) -> PinnedBuffer {
 /// queued for the cleaner; [shutdown] drains those first.
 pub fn clear() {
     let mut pool = pool().lock().unwrap();
-    for (_, bufs) in pool.iter_mut() {
+    for (_, bufs) in pool.by_size.iter_mut() {
         for mut buf in bufs.drain(..) {
             unregister_region(buf.as_mut_ptr());
         }
     }
-    pool.clear();
+    pool.by_size.clear();
+    pool.total_bytes = 0;
 }
 
 #[cfg(test)]
@@ -381,6 +451,7 @@ mod tests {
         while pool()
             .lock()
             .unwrap()
+            .by_size
             .get(&size)
             .is_none_or(|bufs| bufs.is_empty())
         {
@@ -434,7 +505,7 @@ mod tests {
         drop(buf); // queued to the cleaner
         shutdown();
         assert!(
-            pool().lock().unwrap().is_empty(),
+            pool().lock().unwrap().by_size.is_empty(),
             "shutdown left buffers pooled"
         );
         // The pool keeps working afterwards: the next drop respawns the cleaner.
@@ -443,6 +514,32 @@ mod tests {
         drop(buf);
         wait_for_pooled(SIZE);
         assert!(take(SIZE).is_pinned());
+    }
+
+    #[test]
+    fn byte_cap_evicts_largest_first() {
+        let _lock = lock_tests();
+        const SIZE: usize = 1 << 16;
+        const MARKER: usize = 1 << 10;
+        // Start from a drained, empty pool so the accounting is deterministic.
+        shutdown();
+        set_max_pooled_bytes(2 * SIZE + MARKER);
+        let bufs: Vec<_> = (0..3).map(|_| take(SIZE)).collect();
+        drop(bufs);
+        // The channel is FIFO, so once this later-returned marker is pooled,
+        // all three SIZE buffers have been processed.
+        drop(take(MARKER));
+        wait_for_pooled(MARKER);
+        {
+            let pool = pool().lock().unwrap();
+            assert_eq!(
+                pool.by_size.get(&SIZE).map(|bufs| bufs.len()),
+                Some(2),
+                "third buffer should have evicted one of the first two"
+            );
+            assert_eq!(pool.total_bytes, 2 * SIZE + MARKER);
+        }
+        set_max_pooled_bytes(DEFAULT_MAX_POOLED_BYTES);
     }
 
     #[test]

--- a/crates/cuda-common/src/pinned.rs
+++ b/crates/cuda-common/src/pinned.rs
@@ -115,8 +115,29 @@ impl Drop for PinnedBuffer {
             registered: self.registered,
         };
         // The cleaner owning the receiver never exits, so send only fails if
-        // the buffer raced process teardown; dropping it then is fine.
-        let _ = cleaner().lock().unwrap().send(returned);
+        // the buffer raced process teardown; clean up inline then.
+        if let Err(mpsc::SendError(returned)) = cleaner().lock().unwrap().send(returned) {
+            wait_and_release(returned);
+        }
+    }
+}
+
+/// Best-effort drain of the copies still reading `returned`, then [release].
+/// For use outside the cleaner (whose batch loop amortizes the waiting).
+fn wait_and_release(returned: Returned) {
+    if let Err(e) = device_synchronize() {
+        tracing::debug!("cudaDeviceSynchronize failed: {e}");
+    }
+    release(returned);
+}
+
+/// Frees `returned` without pooling it, unregistering first so the allocator
+/// never gets back memory that is still page-locked. Called on failure paths
+/// where in-flight copies could not be drained; a broken context is not
+/// making DMA progress, so unregistering is the lesser evil there.
+fn release(mut returned: Returned) {
+    if returned.registered {
+        unregister_region(returned.data.as_mut_ptr());
     }
 }
 
@@ -160,6 +181,9 @@ fn cleaner() -> &'static Mutex<mpsc::Sender<Returned>> {
                             "cudaDeviceSynchronize failed: {e}; dropping {} pooled buffers",
                             batch.len()
                         );
+                        for returned in batch {
+                            release(returned);
+                        }
                         continue;
                     }
                     for returned in batch {

--- a/crates/cuda-common/src/pinned.rs
+++ b/crates/cuda-common/src/pinned.rs
@@ -150,11 +150,7 @@ impl Drop for PinnedBuffer {
             // issued from the dropping thread, on its current device.
             device: get_device().unwrap_or(0),
         };
-        // The cleaner owning the receiver never exits, so send only fails if
-        // the buffer raced process teardown; clean up inline then.
-        if let Err(mpsc::SendError(returned)) = cleaner().lock().unwrap().send(returned) {
-            wait_and_release(returned);
-        }
+        send_to_cleaner(returned);
     }
 }
 
@@ -204,68 +200,105 @@ fn pool() -> &'static Mutex<BTreeMap<usize, Vec<Vec<u8>>>> {
     POOL.get_or_init(|| Mutex::new(BTreeMap::new()))
 }
 
-/// Cleaner thread: registers (first cycle) and re-zeroes buffers off the
-/// critical path, then makes them available to [`take`].
-fn cleaner() -> &'static Mutex<mpsc::Sender<Returned>> {
-    static TX: OnceLock<Mutex<mpsc::Sender<Returned>>> = OnceLock::new();
-    TX.get_or_init(|| {
-        let (tx, rx) = mpsc::channel::<Returned>();
-        std::thread::Builder::new()
-            .name("pinned-cleaner".into())
-            .spawn(move || {
-                while let Ok(first) = rx.recv() {
-                    // Coalesce the burst of buffer returns behind one device sync.
-                    let mut batch = vec![first];
-                    while batch.len() < 64 {
-                        match rx.recv_timeout(std::time::Duration::from_millis(100)) {
-                            Ok(next) => batch.push(next),
-                            Err(_) => break,
-                        }
-                    }
-                    // The H2D copies reading each buffer were enqueued before
-                    // its owner gave it back; wait for them before touching
-                    // contents:
-                    //  - recorded last-use events cover exactly those copies;
-                    //  - a registered buffer without events falls back to a whole-device sync of
-                    //    the device recorded at drop (memoized per batch);
-                    //  - a never-registered buffer was pageable during use, and a pageable
-                    //    cudaMemcpyAsync returns only after the source is staged, so it is already
-                    //    quiescent.
-                    let mut synced_devices = BTreeMap::new();
-                    for returned in batch {
-                        let drained = if !returned.last_use.is_empty() {
-                            returned
-                                .last_use
-                                .iter()
-                                .try_for_each(CudaEvent::synchronize)
-                                .map_err(|e| tracing::debug!("cudaEventSynchronize failed: {e}"))
-                                .is_ok()
-                        } else if !returned.registered {
-                            true
-                        } else {
-                            *synced_devices.entry(returned.device).or_insert_with(|| {
-                                set_device_by_id(returned.device)
-                                    .and_then(|_| device_synchronize())
-                                    .map_err(|e| {
-                                        tracing::debug!(
-                                            "synchronizing device {} failed: {e}",
-                                            returned.device
-                                        )
-                                    })
-                                    .is_ok()
-                            })
-                        };
-                        if drained {
-                            recycle(returned);
-                        } else {
-                            release(returned);
-                        }
+/// A running cleaner thread and the channel feeding it.
+struct Cleaner {
+    tx: mpsc::Sender<Returned>,
+    thread: std::thread::JoinHandle<()>,
+}
+
+/// Slot holding the live cleaner; empty until first use and after [shutdown].
+fn cleaner_slot() -> &'static Mutex<Option<Cleaner>> {
+    static SLOT: OnceLock<Mutex<Option<Cleaner>>> = OnceLock::new();
+    SLOT.get_or_init(|| Mutex::new(None))
+}
+
+/// Queues `returned` for the cleaner, spawning it if none is running.
+fn send_to_cleaner(returned: Returned) {
+    let mut slot = cleaner_slot().lock().unwrap();
+    let cleaner = slot.get_or_insert_with(spawn_cleaner);
+    if let Err(mpsc::SendError(returned)) = cleaner.tx.send(returned) {
+        // Only reachable if the cleaner thread died; clean up inline.
+        tracing::debug!("pinned-cleaner thread is gone; releasing buffer inline");
+        wait_and_release(returned);
+    }
+}
+
+/// Spawns the cleaner thread: it drains in-flight copies, registers buffers
+/// on their first cycle, and re-zeroes them off the critical path, then makes
+/// them available to [`take`]. It exits once the feeding channel closes and
+/// its queue is empty.
+fn spawn_cleaner() -> Cleaner {
+    let (tx, rx) = mpsc::channel::<Returned>();
+    let thread = std::thread::Builder::new()
+        .name("pinned-cleaner".into())
+        .spawn(move || {
+            while let Ok(first) = rx.recv() {
+                // Coalesce the burst of buffer returns behind one device sync.
+                let mut batch = vec![first];
+                while batch.len() < 64 {
+                    match rx.recv_timeout(std::time::Duration::from_millis(100)) {
+                        Ok(next) => batch.push(next),
+                        Err(_) => break,
                     }
                 }
-            })
-            .expect("failed to spawn pinned-cleaner thread");
-        Mutex::new(tx)
-    })
+                // The H2D copies reading each buffer were enqueued before
+                // its owner gave it back; wait for them before touching
+                // contents:
+                //  - recorded last-use events cover exactly those copies;
+                //  - a registered buffer without events falls back to a whole-device sync of the
+                //    device recorded at drop (memoized per batch);
+                //  - a never-registered buffer was pageable during use, and a pageable
+                //    cudaMemcpyAsync returns only after the source is staged, so it is already
+                //    quiescent.
+                let mut synced_devices = BTreeMap::new();
+                for returned in batch {
+                    let drained = if !returned.last_use.is_empty() {
+                        returned
+                            .last_use
+                            .iter()
+                            .try_for_each(CudaEvent::synchronize)
+                            .map_err(|e| tracing::debug!("cudaEventSynchronize failed: {e}"))
+                            .is_ok()
+                    } else if !returned.registered {
+                        true
+                    } else {
+                        *synced_devices.entry(returned.device).or_insert_with(|| {
+                            set_device_by_id(returned.device)
+                                .and_then(|_| device_synchronize())
+                                .map_err(|e| {
+                                    tracing::debug!(
+                                        "synchronizing device {} failed: {e}",
+                                        returned.device
+                                    )
+                                })
+                                .is_ok()
+                        })
+                    };
+                    if drained {
+                        recycle(returned);
+                    } else {
+                        release(returned);
+                    }
+                }
+            }
+        })
+        .expect("failed to spawn pinned-cleaner thread");
+    Cleaner { tx, thread }
+}
+
+/// Drains and joins the cleaner thread, then unregisters and frees every
+/// pooled buffer. Call once outstanding buffers have been handed back, e.g.
+/// before tearing down CUDA contexts or between tests. Not final: a
+/// [PinnedBuffer] dropped afterwards respawns the cleaner (and may repopulate
+/// the pool).
+pub fn shutdown() {
+    let cleaner = cleaner_slot().lock().unwrap().take();
+    if let Some(Cleaner { tx, thread }) = cleaner {
+        // Closing the channel lets the cleaner drain its queue, then exit.
+        drop(tx);
+        let _ = thread.join();
+    }
+    clear();
 }
 
 /// Registers `returned` if this is its first cycle, re-zeroes its dirty
@@ -315,7 +348,8 @@ pub fn take(min_size: usize) -> PinnedBuffer {
     }
 }
 
-/// Unregisters and frees all pooled buffers (test hygiene; optional).
+/// Unregisters and frees all pooled buffers. Does not touch buffers still
+/// queued for the cleaner; [shutdown] drains those first.
 pub fn clear() {
     let mut pool = pool().lock().unwrap();
     for (_, bufs) in pool.iter_mut() {
@@ -389,6 +423,26 @@ mod tests {
             "pool hit should reuse the allocation"
         );
         assert!(buf.iter().all(|&b| b == 0), "recycled buffer not re-zeroed");
+    }
+
+    #[test]
+    fn shutdown_drains_joins_and_respawns_on_demand() {
+        let _lock = lock_tests();
+        const SIZE: usize = 1 << 15;
+        let mut buf = take(SIZE);
+        buf.fill(0xEF);
+        drop(buf); // queued to the cleaner
+        shutdown();
+        assert!(
+            pool().lock().unwrap().is_empty(),
+            "shutdown left buffers pooled"
+        );
+        // The pool keeps working afterwards: the next drop respawns the cleaner.
+        let buf = take(SIZE);
+        assert!(!buf.is_pinned(), "pool should be empty after shutdown");
+        drop(buf);
+        wait_for_pooled(SIZE);
+        assert!(take(SIZE).is_pinned());
     }
 
     #[test]

--- a/crates/cuda-common/src/pinned.rs
+++ b/crates/cuda-common/src/pinned.rs
@@ -9,11 +9,11 @@
 //! are often provisioned at full capacity while only partially written,
 //! so neither registration nor re-zeroing may sit on the caller's critical path.
 //!
-//! Dropped buffers are therefore handed via [give_back] to a background cleaner
-//! thread which registers them once (cudaHostRegister), zeroes the prefix the
-//! previous owner wrote, and only then returns them to the pool.
-//! [take] hands out ready (registered, all-zero) buffers on a pool hit;
-//! on a miss it falls back to a fresh pageable allocation.
+//! [take] hands out [PinnedBuffer] guards: ready (registered, all-zero)
+//! buffers on a pool hit; on a miss it falls back to a fresh pageable
+//! allocation. Dropping the guard hands the buffer to a background cleaner
+//! thread which registers it once (cudaHostRegister), zeroes the prefix the
+//! previous owner wrote, and only then returns it to the pool.
 //!
 //! Lifetime hazard: `cudaMemcpyAsync` from *pageable* memory returns only
 //! after the source has been staged, so code not using the pool may free a
@@ -24,8 +24,9 @@
 //! every buffer waiting in its queue) before touching buffer contents.
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::BTreeMap,
     ffi::c_void,
+    ops::{Deref, DerefMut},
     sync::{mpsc, Mutex, OnceLock},
 };
 
@@ -36,9 +37,6 @@ extern "C" {
     fn cudaHostRegister(ptr: *mut c_void, size: usize, flags: u32) -> i32;
     fn cudaHostUnregister(ptr: *mut c_void) -> i32;
 }
-
-/// A returned buffer together with its dirty-prefix length.
-type ReturnedBuffer = (Vec<u8>, usize);
 
 /// Page-locks `len` bytes at `ptr` in a single `cudaHostRegister` call.
 /// Returns `false` (leaving the buffer pageable) if registration fails.
@@ -62,24 +60,86 @@ pub fn unregister_region(ptr: *mut u8) {
     unsafe { cudaHostUnregister(ptr as *mut c_void) };
 }
 
+/// A host staging buffer owned by the pool, handed out by [take].
+///
+/// Dereferences to `[u8]`. The allocation can never grow or move, so the base
+/// pointer a registration was made for stays valid for the buffer's whole
+/// life, and dropping the guard is the only way to release the allocation —
+/// it goes back through the pool's cleaner, never straight to the allocator
+/// while page-locked.
+pub struct PinnedBuffer {
+    data: Vec<u8>,
+    /// Upper bound on the prefix of `data` written since [take].
+    dirty_len: usize,
+    /// Whether `data` is currently page-locked.
+    registered: bool,
+}
+
+impl PinnedBuffer {
+    /// Whether the buffer is page-locked. False for pool-miss buffers, which
+    /// stay pageable until their first trip through the cleaner.
+    pub fn is_pinned(&self) -> bool {
+        self.registered
+    }
+
+    /// Narrows the prefix the cleaner re-zeroes before pooling the buffer
+    /// (by default the whole buffer). The caller asserts that bytes at
+    /// `len..` have not been written since [take].
+    pub fn set_dirty_len(&mut self, len: usize) {
+        self.dirty_len = len;
+    }
+}
+
+impl Deref for PinnedBuffer {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+impl DerefMut for PinnedBuffer {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        &mut self.data
+    }
+}
+
+impl Drop for PinnedBuffer {
+    fn drop(&mut self) {
+        let data = std::mem::take(&mut self.data);
+        if data.is_empty() {
+            return;
+        }
+        let returned = Returned {
+            data,
+            dirty_len: self.dirty_len,
+            registered: self.registered,
+        };
+        // The cleaner owning the receiver never exits, so send only fails if
+        // the buffer raced process teardown; dropping it then is fine.
+        let _ = cleaner().lock().unwrap().send(returned);
+    }
+}
+
+/// A buffer on its way back to the pool.
+struct Returned {
+    data: Vec<u8>,
+    dirty_len: usize,
+    registered: bool,
+}
+
 /// Registered, all-zero buffers ready for reuse, keyed by allocation size.
+/// Invariant: every pooled buffer is page-locked and quiescent.
 fn pool() -> &'static Mutex<BTreeMap<usize, Vec<Vec<u8>>>> {
     static POOL: OnceLock<Mutex<BTreeMap<usize, Vec<Vec<u8>>>>> = OnceLock::new();
     POOL.get_or_init(|| Mutex::new(BTreeMap::new()))
 }
 
-/// Base pointers of buffers whose `cudaHostRegister` succeeded.
-fn registered() -> &'static Mutex<HashSet<usize>> {
-    static REGISTERED: OnceLock<Mutex<HashSet<usize>>> = OnceLock::new();
-    REGISTERED.get_or_init(|| Mutex::new(HashSet::new()))
-}
-
 /// Cleaner thread: registers (first cycle) and re-zeroes buffers off the
 /// critical path, then makes them available to [`take`].
-fn cleaner() -> &'static Mutex<mpsc::Sender<ReturnedBuffer>> {
-    static TX: OnceLock<Mutex<mpsc::Sender<ReturnedBuffer>>> = OnceLock::new();
+fn cleaner() -> &'static Mutex<mpsc::Sender<Returned>> {
+    static TX: OnceLock<Mutex<mpsc::Sender<Returned>>> = OnceLock::new();
     TX.get_or_init(|| {
-        let (tx, rx) = mpsc::channel::<ReturnedBuffer>();
+        let (tx, rx) = mpsc::channel::<Returned>();
         std::thread::Builder::new()
             .name("pinned-cleaner".into())
             .spawn(move || {
@@ -102,23 +162,8 @@ fn cleaner() -> &'static Mutex<mpsc::Sender<ReturnedBuffer>> {
                         );
                         continue;
                     }
-                    for (mut buffer, dirty_len) in batch {
-                        let ptr = buffer.as_mut_ptr();
-                        let is_new = !registered().lock().unwrap().contains(&(ptr as usize));
-                        if is_new {
-                            if !register_region(ptr, buffer.len()) {
-                                continue;
-                            }
-                            registered().lock().unwrap().insert(ptr as usize);
-                        }
-                        let dirty_len = dirty_len.min(buffer.len());
-                        buffer[..dirty_len].fill(0);
-                        pool()
-                            .lock()
-                            .unwrap()
-                            .entry(buffer.len())
-                            .or_default()
-                            .push(buffer);
+                    for returned in batch {
+                        recycle(returned);
                     }
                 }
             })
@@ -127,44 +172,57 @@ fn cleaner() -> &'static Mutex<mpsc::Sender<ReturnedBuffer>> {
     })
 }
 
+/// Registers `returned` if this is its first cycle, re-zeroes its dirty
+/// prefix, and pools it. The buffer must be quiescent (no copies in flight).
+fn recycle(mut returned: Returned) {
+    if !returned.registered {
+        if !register_region(returned.data.as_mut_ptr(), returned.data.len()) {
+            return; // stays pageable; drop normally
+        }
+        returned.registered = true;
+    }
+    let dirty_len = returned.dirty_len.min(returned.data.len());
+    returned.data[..dirty_len].fill(0);
+    pool()
+        .lock()
+        .unwrap()
+        .entry(returned.data.len())
+        .or_default()
+        .push(returned.data);
+}
+
 /// Returns an all-zero buffer of at least `min_size` bytes (rounded up to the
 /// next power of two), page-locked if it came from the pool.
-pub fn take(min_size: usize) -> Vec<u8> {
+pub fn take(min_size: usize) -> PinnedBuffer {
     let size = min_size.next_power_of_two();
-    if let Some(buffer) = pool()
+    if let Some(data) = pool()
         .lock()
         .unwrap()
         .get_mut(&size)
         .and_then(|bufs| bufs.pop())
     {
-        debug_assert_eq!(buffer.len(), size);
-        return buffer;
+        debug_assert_eq!(data.len(), size);
+        return PinnedBuffer {
+            data,
+            dirty_len: size,
+            registered: true,
+        };
     }
     // Pool miss: when no recycled buffer of that size is available,
     // take returns a plain, unpinned allocation instead of pinning one on the spot.
-    vec![0u8; size]
-}
-
-/// Hands `buffer` to the cleaner for registration, re-zeroing, and reuse.
-/// `dirty_len` is an upper bound on the prefix of `buffer` that may have
-/// been written since it left [`take`]; the rest must still be zero.
-pub fn give_back(buffer: Vec<u8>, dirty_len: usize) {
-    if buffer.is_empty() || !buffer.len().is_power_of_two() {
-        return; // not a pool-shaped buffer; drop normally
+    PinnedBuffer {
+        data: vec![0u8; size],
+        dirty_len: size,
+        registered: false,
     }
-    // The cleaner owning the receiver never exits, so send only fails if
-    // the buffer raced process teardown; dropping it then is fine.
-    let _ = cleaner().lock().unwrap().send((buffer, dirty_len));
 }
 
 /// Unregisters and frees all pooled buffers (test hygiene; optional).
 pub fn clear() {
     let mut pool = pool().lock().unwrap();
-    let mut reg = registered().lock().unwrap();
     for (_, bufs) in pool.iter_mut() {
         for mut buf in bufs.drain(..) {
-            reg.remove(&(buf.as_ptr() as usize));
-            unsafe { cudaHostUnregister(buf.as_mut_ptr() as *mut c_void) };
+            unregister_region(buf.as_mut_ptr());
         }
     }
     pool.clear();
@@ -175,6 +233,14 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use super::*;
+
+    /// Serializes tests: they share the process-global pool and cleaner, so
+    /// distinct buffer sizes alone don't isolate them.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn lock_tests() -> std::sync::MutexGuard<'static, ()> {
+        TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
 
     /// Waits until the cleaner (batching window + device sync) has returned a
     /// buffer of exactly `size` bytes to the pool.
@@ -196,6 +262,7 @@ mod tests {
 
     #[test]
     fn take_rounds_up_to_next_power_of_two_and_zero_fills() {
+        let _lock = lock_tests();
         for (min_size, expected) in [(1, 1), (3, 4), (1024, 1024), (1025, 2048)] {
             let buf = take(min_size);
             assert_eq!(buf.len(), expected, "take({min_size})");
@@ -207,18 +274,17 @@ mod tests {
     // pool entries are never shared.
     #[test]
     fn round_trip_recycles_registered_rezeroed_buffer() {
+        let _lock = lock_tests();
         const SIZE: usize = 1 << 13;
         let mut buf = take(SIZE);
         let ptr = buf.as_ptr() as usize;
         buf.fill(0xAB);
         // Oversized dirty_len must be clamped, not panic.
-        give_back(buf, usize::MAX);
+        buf.set_dirty_len(usize::MAX);
+        drop(buf);
         wait_for_pooled(SIZE);
-        assert!(
-            registered().lock().unwrap().contains(&ptr),
-            "pooled buffer was not page-locked"
-        );
         let buf = take(SIZE);
+        assert!(buf.is_pinned(), "pool hit should be page-locked");
         assert_eq!(
             buf.as_ptr() as usize,
             ptr,

--- a/crates/cuda-common/src/pinned.rs
+++ b/crates/cuda-common/src/pinned.rs
@@ -19,9 +19,11 @@
 //! after the source has been staged, so code not using the pool may free a
 //! source buffer right after enqueueing its copy. From *pinned* memory the
 //! call returns immediately with the DMA still in flight, so a returned
-//! buffer must not be zeroed or reused until previously enqueued work has
-//! drained. The cleaner therefore calls `cudaDeviceSynchronize` (batched over
-//! every buffer waiting in its queue) before touching buffer contents.
+//! buffer must not be zeroed or reused until the copies reading it have
+//! drained. Callers should mark the last copy out of a buffer with
+//! [PinnedBuffer::record_last_use]; the cleaner then waits on exactly those
+//! events. Without a recorded event it falls back to synchronizing the device
+//! that was current when the guard dropped.
 
 use std::{
     collections::BTreeMap,
@@ -30,7 +32,11 @@ use std::{
     sync::{mpsc, Mutex, OnceLock},
 };
 
-use crate::{error::CudaError, stream::device_synchronize};
+use crate::{
+    common::{get_device, set_device_by_id},
+    error::CudaError,
+    stream::{device_synchronize, CudaEvent, CudaStream},
+};
 
 #[link(name = "cudart")]
 extern "C" {
@@ -38,11 +44,17 @@ extern "C" {
     fn cudaHostUnregister(ptr: *mut c_void) -> i32;
 }
 
-/// Page-locks `len` bytes at `ptr` in a single `cudaHostRegister` call.
-/// Returns `false` (leaving the buffer pageable) if registration fails.
+/// Registered memory is pinned for all CUDA contexts, so copies issued from
+/// any device get the fast path; without this flag, contexts other than the
+/// registering one (the cleaner's) would treat the buffer as pageable.
+const CUDA_HOST_REGISTER_PORTABLE: u32 = 0x1;
+
+/// Page-locks `len` bytes at `ptr` in a single `cudaHostRegister` call, for
+/// all CUDA contexts. Returns `false` (leaving the buffer pageable) if
+/// registration fails.
 pub fn register_region(ptr: *mut u8, len: usize) -> bool {
     // SAFETY: [ptr, ptr+len) is a live allocation owned by the caller.
-    let rc = unsafe { cudaHostRegister(ptr as *mut c_void, len, 0) };
+    let rc = unsafe { cudaHostRegister(ptr as *mut c_void, len, CUDA_HOST_REGISTER_PORTABLE) };
     if rc != 0 {
         tracing::debug!(
             "cudaHostRegister failed: {}; buffer stays pageable",
@@ -73,6 +85,9 @@ pub struct PinnedBuffer {
     dirty_len: usize,
     /// Whether `data` is currently page-locked.
     registered: bool,
+    /// Events recorded after the last copies reading `data`; the cleaner
+    /// waits on these before re-zeroing and reusing it.
+    last_use: Vec<CudaEvent>,
 }
 
 impl PinnedBuffer {
@@ -87,6 +102,22 @@ impl PinnedBuffer {
     /// `len..` have not been written since [take].
     pub fn set_dirty_len(&mut self, len: usize) {
         self.dirty_len = len;
+    }
+
+    /// Records the point on `stream` after which the buffer is no longer
+    /// read, i.e. right after enqueueing the last copy out of it there. The
+    /// cleaner then waits on exactly the recorded events — instead of a
+    /// whole-device synchronize — before reusing the buffer, which is also
+    /// what makes reuse safe when several devices are active.
+    ///
+    /// Call from the thread that enqueued the copies, with the same device
+    /// current (CUDA requires the event and stream to share a context). If
+    /// several streams consume the buffer, record on each of them.
+    pub fn record_last_use(&mut self, stream: &CudaStream) -> Result<(), CudaError> {
+        let event = CudaEvent::new()?;
+        event.record_on(stream)?;
+        self.last_use.push(event);
+        Ok(())
     }
 }
 
@@ -113,6 +144,11 @@ impl Drop for PinnedBuffer {
             data,
             dirty_len: self.dirty_len,
             registered: self.registered,
+            last_use: std::mem::take(&mut self.last_use),
+            // Fallback sync target when no event was recorded: per this
+            // crate's convention (GpuDeviceCtx::for_device) the copies were
+            // issued from the dropping thread, on its current device.
+            device: get_device().unwrap_or(0),
         };
         // The cleaner owning the receiver never exits, so send only fails if
         // the buffer raced process teardown; clean up inline then.
@@ -125,8 +161,16 @@ impl Drop for PinnedBuffer {
 /// Best-effort drain of the copies still reading `returned`, then [release].
 /// For use outside the cleaner (whose batch loop amortizes the waiting).
 fn wait_and_release(returned: Returned) {
-    if let Err(e) = device_synchronize() {
-        tracing::debug!("cudaDeviceSynchronize failed: {e}");
+    let result = if returned.last_use.is_empty() {
+        set_device_by_id(returned.device).and_then(|_| device_synchronize())
+    } else {
+        returned
+            .last_use
+            .iter()
+            .try_for_each(CudaEvent::synchronize)
+    };
+    if let Err(e) = result {
+        tracing::debug!("draining copies from returned buffer failed: {e}");
     }
     release(returned);
 }
@@ -146,6 +190,11 @@ struct Returned {
     data: Vec<u8>,
     dirty_len: usize,
     registered: bool,
+    /// Events recorded after the last copies reading `data`.
+    last_use: Vec<CudaEvent>,
+    /// Device current when the guard dropped; whole-device sync fallback
+    /// target when `last_use` is empty.
+    device: i32,
 }
 
 /// Registered, all-zero buffers ready for reuse, keyed by allocation size.
@@ -173,21 +222,44 @@ fn cleaner() -> &'static Mutex<mpsc::Sender<Returned>> {
                             Err(_) => break,
                         }
                     }
-                    // The H2D copies reading these buffers were enqueued
-                    // before the owners gave them back; wait for them (and
-                    // anything else in flight) before touching contents.
-                    if let Err(e) = device_synchronize() {
-                        tracing::debug!(
-                            "cudaDeviceSynchronize failed: {e}; dropping {} pooled buffers",
-                            batch.len()
-                        );
-                        for returned in batch {
+                    // The H2D copies reading each buffer were enqueued before
+                    // its owner gave it back; wait for them before touching
+                    // contents:
+                    //  - recorded last-use events cover exactly those copies;
+                    //  - a registered buffer without events falls back to a whole-device sync of
+                    //    the device recorded at drop (memoized per batch);
+                    //  - a never-registered buffer was pageable during use, and a pageable
+                    //    cudaMemcpyAsync returns only after the source is staged, so it is already
+                    //    quiescent.
+                    let mut synced_devices = BTreeMap::new();
+                    for returned in batch {
+                        let drained = if !returned.last_use.is_empty() {
+                            returned
+                                .last_use
+                                .iter()
+                                .try_for_each(CudaEvent::synchronize)
+                                .map_err(|e| tracing::debug!("cudaEventSynchronize failed: {e}"))
+                                .is_ok()
+                        } else if !returned.registered {
+                            true
+                        } else {
+                            *synced_devices.entry(returned.device).or_insert_with(|| {
+                                set_device_by_id(returned.device)
+                                    .and_then(|_| device_synchronize())
+                                    .map_err(|e| {
+                                        tracing::debug!(
+                                            "synchronizing device {} failed: {e}",
+                                            returned.device
+                                        )
+                                    })
+                                    .is_ok()
+                            })
+                        };
+                        if drained {
+                            recycle(returned);
+                        } else {
                             release(returned);
                         }
-                        continue;
-                    }
-                    for returned in batch {
-                        recycle(returned);
                     }
                 }
             })
@@ -230,6 +302,7 @@ pub fn take(min_size: usize) -> PinnedBuffer {
             data,
             dirty_len: size,
             registered: true,
+            last_use: Vec::new(),
         };
     }
     // Pool miss: when no recycled buffer of that size is available,
@@ -238,6 +311,7 @@ pub fn take(min_size: usize) -> PinnedBuffer {
         data: vec![0u8; size],
         dirty_len: size,
         registered: false,
+        last_use: Vec::new(),
     }
 }
 
@@ -305,6 +379,27 @@ mod tests {
         buf.fill(0xAB);
         // Oversized dirty_len must be clamped, not panic.
         buf.set_dirty_len(usize::MAX);
+        drop(buf);
+        wait_for_pooled(SIZE);
+        let buf = take(SIZE);
+        assert!(buf.is_pinned(), "pool hit should be page-locked");
+        assert_eq!(
+            buf.as_ptr() as usize,
+            ptr,
+            "pool hit should reuse the allocation"
+        );
+        assert!(buf.iter().all(|&b| b == 0), "recycled buffer not re-zeroed");
+    }
+
+    #[test]
+    fn recorded_last_use_event_gates_reuse() {
+        let _lock = lock_tests();
+        const SIZE: usize = 1 << 14;
+        let stream = crate::stream::CudaStream::new_non_blocking().unwrap();
+        let mut buf = take(SIZE);
+        let ptr = buf.as_ptr() as usize;
+        buf.fill(0xCD);
+        buf.record_last_use(&stream).unwrap();
         drop(buf);
         wait_for_pooled(SIZE);
         let buf = take(SIZE);

--- a/crates/cuda-common/src/pinned.rs
+++ b/crates/cuda-common/src/pinned.rs
@@ -23,7 +23,8 @@
 //! drained. Callers should mark the last copy out of a buffer with
 //! [PinnedBuffer::record_last_use]; the cleaner then waits on exactly those
 //! events. Without a recorded event it falls back to synchronizing the device
-//! that was current when the guard dropped.
+//! that was current when the guard dropped, which is sound only if the guard
+//! drops on the thread and device that issued the copies.
 //!
 //! The pool retains at most [set_max_pooled_bytes] bytes (default 4 GiB);
 //! past that, returning a buffer evicts pooled ones, largest first.
@@ -116,6 +117,11 @@ impl PinnedBuffer {
     /// Call from the thread that enqueued the copies, with the same device
     /// current (CUDA requires the event and stream to share a context). If
     /// several streams consume the buffer, record on each of them.
+    ///
+    /// Record after the last copy but before dropping the guard: drop hands
+    /// the events recorded so far to the cleaner, and copies never recorded
+    /// are covered only by the no-events-at-all fallback, a whole-device
+    /// synchronize of the device current on the *dropping* thread.
     pub fn record_last_use(&mut self, stream: &CudaStream) -> Result<(), CudaError> {
         let event = CudaEvent::new()?;
         event.record_on(stream)?;


### PR DESCRIPTION
Fixes the following issues: 

The current locked cuda-common pool still has several problems.
- It is process-global, but returned buffers do not carry their originating CUDA device or completion event.
- The cleaner is a new thread and calls cudaDeviceSynchronize() without selecting the originating device.
- In a process using GPU 0 and GPU 1, it could synchronize GPU 0 and then reuse a buffer still being read by GPU 1.
- The cleaner never shuts down or joins cleanly.
- If device synchronization fails, an already-registered pooled buffer can be dropped without cudaHostUnregister, while its pointer remains in the registered-pointer set.
- The pool retains an unlimited number of pinned buffers at every size class.

The robust design is for every returned buffer to carry its device and a CUDA event recorded after the last consuming copy. The cleaner waits for that exact event before zeroing or reusing it. Add an explicit shutdown/drain path and a global/per-size pinned-byte cap with eviction.

I tested on the PoC in `gunadi/pinned-module-poc` branch and it passed the PoC tests now. 