### PR TITLE
feat(scheduler POC): resource-aware DAG scheduling engine and release-stream buffer ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,13 +30,14 @@ cargo +nightly fmt -- --check  # check only
 
 ## Project Structure
 
-Rust workspace with 5 default-member crates:
+Rust workspace with 6 default-member crates:
 
 - **`openvm-stark-backend`** (`crates/stark-backend`): Core SWIRL proof system — prover, verifier, AIR builders, interactions, keygen, PCS. Re-exports Plonky3 crates.
 - **`openvm-codec-derive`** (`crates/stark-backend/codec-derive`): Proc macro for serialization codegen.
 - **`openvm-stark-sdk`** (`crates/stark-sdk`): Concrete configs (`BabyBearPoseidon2Config`, `BabyBearBn254Poseidon2Config`), tracing/metrics, benchmarks.
 - **`openvm-backend-tests`** (`crates/backend-tests`): Shared backend-generic test suite for the SWIRL proof system.
 - **`openvm-cpu-backend`** (`crates/cpu-backend`): Optimized row-major CPU prover backend.
+- **`openvm-scheduler`** (`crates/scheduler`): Resource-aware DAG scheduling engine. Admits abstract nodes against per-axis resource budgets; depends on nothing.
 
 Non-default CUDA support members (require GPU/CUDA toolchain — don't add to default-members):
 - **`openvm-cuda-builder`** (`crates/cuda-builder`): Build-time utility for compiling `.cu` files via `nvcc`/`cc`. Used as a `[build-dependency]` by CUDA crates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Unreleased
 
 ### Added
+- (Scheduler) `openvm-scheduler` crate: a resource-aware DAG scheduling engine that admits ready nodes whose declared resource profile fits a per-axis budget, GPU-first, and releases on completion.
 - (CUDA common) `DeviceBuffer::mut_slice(range)` returning a `DeviceBufferMutSlice<'_, T>` with a `copy_from_host` method for overwriting a subrange of a device buffer from a host slice on a caller-supplied stream.
 
 ## v2.0.0 (2026-07-06)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 
 [workspace]
 members = [
+    "crates/scheduler",
     "crates/stark-backend",
     "crates/stark-backend/codec-derive",
     "crates/stark-sdk",
@@ -22,6 +23,7 @@ members = [
 ]
 # Only these build by default
 default-members = [
+    "crates/scheduler",
     "crates/stark-backend",
     "crates/stark-backend/codec-derive",
     "crates/stark-sdk",

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The backend is designed to be modular and compatible with different proof system
 - [`openvm-cuda-common`](crates/cuda-common): Shared headers (`.cuh/.h` files) and CUDA utilities library.
 - [`openvm-cuda-backend`](crates/cuda-backend): CUDA implementation of a STARK prover backend using all of the previous crates.
 - [`openvm-backend-tests`](crates/backend-tests): Shared backend-generic test suite for the SWIRL proof system.
+- [`openvm-scheduler`](crates/scheduler): Resource-aware DAG scheduling engine that admits abstract units of work against per-axis resource budgets.
 
 Contributors should read [Development without CUDA](./docs/README.md#development-without-cuda) and [Development with CUDA](./docs/README.md#development-with-cuda) for instructions on how to set up their development environments.
 

--- a/crates/cuda-backend/src/base.rs
+++ b/crates/cuda-backend/src/base.rs
@@ -1,9 +1,30 @@
 use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 
 use openvm_cuda_common::{
-    copy::MemCopyD2H, d_buffer::DeviceBuffer, error::MemCopyError, stream::GpuDeviceCtx,
+    copy::MemCopyD2H,
+    d_buffer::DeviceBuffer,
+    error::{MemCopyError, MemoryError},
+    stream::GpuDeviceCtx,
 };
 use openvm_stark_backend::prover::MatrixDimensions;
+
+/// Why a [`DeviceMatrix::adopt_release_stream_after_sync`] handoff was refused.
+///
+/// Deliberately its own type rather than a new `MemoryError` variant: callers
+/// outside this crate match `MemoryError` exhaustively, and this failure is
+/// specific to matrix ownership rather than to the allocator.
+#[derive(Debug, thiserror::Error)]
+pub enum DeviceMatrixStreamHandoffError {
+    /// The buffer has other owners, so no single stream can order its release.
+    #[error(
+        "cannot hand off release ordering for an aliased device matrix          (Arc::strong_count = {strong_count}, expected 1)"
+    )]
+    Aliased { strong_count: usize },
+
+    /// The allocator rejected the handoff, e.g. the pointer is not live.
+    #[error(transparent)]
+    Memory(#[from] MemoryError),
+}
 
 pub struct DeviceMatrix<T> {
     buffer: Arc<DeviceBuffer<T>>,
@@ -74,6 +95,34 @@ impl<T> DeviceMatrix<T> {
 
     pub fn strong_count(&self) -> usize {
         Arc::strong_count(&self.buffer)
+    }
+
+    /// Hands release ordering for this matrix's buffer to `target`'s stream.
+    ///
+    /// See [`DeviceBuffer::adopt_release_stream_after_sync`]. A matrix produced
+    /// during trace generation on one stream and then proved on another must
+    /// move its release onto the proving stream, or a sibling stream can reuse
+    /// the allocation while the prove is still reading it.
+    ///
+    /// Fails rather than rebinding when the buffer is aliased. Release ordering
+    /// names exactly one stream, so an aliased buffer would leave every other
+    /// owner reading memory that some other stream is now free to reuse — the
+    /// bug this operation exists to prevent. The error carries the observed
+    /// `Arc::strong_count` so the caller can trace the alias.
+    ///
+    /// # Safety
+    /// The caller must uphold [`DeviceBuffer::adopt_release_stream_after_sync`]'s
+    /// contract: all work on the current release stream is complete, and this
+    /// matrix is the sole owner of the buffer for the rest of its life.
+    pub unsafe fn adopt_release_stream_after_sync(
+        &mut self,
+        target: &GpuDeviceCtx,
+    ) -> Result<(), DeviceMatrixStreamHandoffError> {
+        let strong_count = Arc::strong_count(&self.buffer);
+        let buffer = Arc::get_mut(&mut self.buffer)
+            .ok_or(DeviceMatrixStreamHandoffError::Aliased { strong_count })?;
+        buffer.adopt_release_stream_after_sync(target)?;
+        Ok(())
     }
 
     pub fn as_view(&self) -> DeviceMatrixView<'_, T> {
@@ -211,5 +260,36 @@ mod tests {
         let matrix = DeviceMatrix::<i32>::new(buffer, 3, 4);
         assert_eq!(matrix.height(), 3);
         assert_eq!(matrix.width(), 4);
+    }
+
+    #[test]
+    fn release_stream_handoff_accepts_a_solely_owned_matrix() {
+        let producer = GpuDeviceCtx::for_current_device().unwrap();
+        let consumer = GpuDeviceCtx::for_current_device().unwrap();
+        let buffer = Arc::new(DeviceBuffer::<i32>::with_capacity_on(12, &producer));
+        let mut matrix = DeviceMatrix::<i32>::new(buffer, 3, 4);
+        assert_eq!(matrix.strong_count(), 1);
+
+        unsafe { matrix.adopt_release_stream_after_sync(&consumer) }
+            .expect("a solely owned matrix may hand off its release stream");
+    }
+
+    #[test]
+    fn release_stream_handoff_refuses_an_aliased_matrix() {
+        let producer = GpuDeviceCtx::for_current_device().unwrap();
+        let consumer = GpuDeviceCtx::for_current_device().unwrap();
+        let buffer = Arc::new(DeviceBuffer::<i32>::with_capacity_on(12, &producer));
+        let mut matrix = DeviceMatrix::<i32>::new(buffer, 3, 4);
+        // The alias is what makes a single release stream wrong: this clone can
+        // go on reading on some third stream after the handoff.
+        let alias = matrix.clone();
+
+        let error = unsafe { matrix.adopt_release_stream_after_sync(&consumer) }
+            .expect_err("an aliased matrix must not silently rebind");
+        assert!(matches!(
+            error,
+            DeviceMatrixStreamHandoffError::Aliased { strong_count: 2 }
+        ));
+        drop(alias);
     }
 }

--- a/crates/cuda-common/src/d_buffer.rs
+++ b/crates/cuda-common/src/d_buffer.rs
@@ -7,8 +7,8 @@ use std::{
 
 use crate::{
     copy::cuda_memcpy_on,
-    error::{check, CudaError, MemCopyError},
-    memory_manager::{d_free, d_malloc_on},
+    error::{check, CudaError, MemCopyError, MemoryError},
+    memory_manager::{d_free, d_malloc_on, rebind_release_stream},
     stream::{cudaStream_t, GpuDeviceCtx},
 };
 
@@ -95,6 +95,44 @@ impl<T> DeviceBuffer<T> {
             #[cfg(feature = "debug-cuda-stream")]
             alloc_stream: device_ctx.stream.as_raw(),
         }
+    }
+
+    /// Hands release ordering for this buffer to `target`'s stream.
+    ///
+    /// Until this is called, the buffer's eventual free is enqueued on the
+    /// stream that allocated it. A buffer produced on one stream and then read
+    /// on another therefore becomes reusable by a *third* stream as soon as the
+    /// producer's queue drains — which says nothing about whether the consumer
+    /// has finished reading. Adopting the consumer's stream moves the free (and,
+    /// on the VPMM path, the free region's reuse event) behind the reads already
+    /// queued there, so reuse can only happen after them.
+    ///
+    /// This is host-side metadata only: nothing is enqueued on either stream and
+    /// no event is recorded, so it neither synchronizes nor orders the two
+    /// streams against each other. That ordering must already hold — hence
+    /// `after_sync`.
+    ///
+    /// # Safety
+    /// - All work on the buffer's current release stream must be **complete**, not merely enqueued.
+    /// - The caller must be the buffer's **sole owner**. Aliases that keep using it on other
+    ///   streams are not covered by the new release ordering.
+    /// - No alias may be handed to another stream afterwards.
+    /// - All subsequent use and the release itself are ordered on `target` until another explicit
+    ///   handoff moves them again.
+    pub unsafe fn adopt_release_stream_after_sync(
+        &mut self,
+        target: &GpuDeviceCtx,
+    ) -> Result<(), MemoryError> {
+        if self.ptr.is_null() {
+            // A null buffer owns no allocation, so there is no release to order.
+            return Ok(());
+        }
+        rebind_release_stream(self.ptr as *mut c_void, &target.stream)?;
+        #[cfg(feature = "debug-cuda-stream")]
+        {
+            self.alloc_stream = target.stream.as_raw();
+        }
+        Ok(())
     }
 
     /// Fills the buffer with zeros on an explicit stream.
@@ -308,10 +346,14 @@ impl<T> Drop for DeviceBuffer<T> {
                 self.len,
                 size_of::<T>()
             );
-            // d_free enqueues cudaFreeAsync on the stream that originally
-            // allocated this buffer (stored in the memory manager's record).
-            // This is correct even when Drop runs on a different thread —
-            // CUDA handles cross-thread stream operations safely.
+            // d_free enqueues the release on the buffer's recorded *release*
+            // stream — the allocating stream unless
+            // `adopt_release_stream_after_sync` moved it. Reuse by another
+            // stream is ordered after that release, so the record has to name
+            // the stream that last reads this buffer, not merely the one that
+            // allocated it. Which thread runs Drop is a separate question and
+            // not the one this ordering answers: CUDA handles cross-thread
+            // stream operations safely on its own.
             unsafe {
                 d_free(self.ptr as *mut c_void).expect("GPU free failed");
             }

--- a/crates/cuda-common/src/memory_manager/mod.rs
+++ b/crates/cuda-common/src/memory_manager/mod.rs
@@ -2,7 +2,10 @@ use std::{
     collections::HashMap,
     ffi::c_void,
     ptr::NonNull,
-    sync::{Mutex, OnceLock},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Mutex, OnceLock,
+    },
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -28,6 +31,20 @@ extern "C" {
 }
 
 static MEMORY_MANAGER: OnceLock<Mutex<MemoryManager>> = OnceLock::new();
+
+/// Number of release-stream handoffs performed since process start.
+///
+/// Observability only — nothing branches on it. It exists so a caller in another
+/// crate can assert that a code path it does not own actually performed the
+/// handoff. Without it, deleting the production call site is invisible to every
+/// test: the allocator's own tests call the operation directly and stay green.
+static RELEASE_STREAM_HANDOFFS: AtomicU64 = AtomicU64::new(0);
+
+/// Reads [`RELEASE_STREAM_HANDOFFS`]. Monotonic; compare two samples around the
+/// work under test rather than expecting an absolute value.
+pub fn release_stream_handoffs() -> u64 {
+    RELEASE_STREAM_HANDOFFS.load(Ordering::Relaxed)
+}
 
 pub fn device_memory_used() -> usize {
     let mut free = 0usize;
@@ -227,6 +244,8 @@ pub(crate) unsafe fn rebind_release_stream(
     let previous = manager.rebind_release_stream_under_lock(ptr, target)?;
     drop(manager);
     drop(previous);
+    // After the record is committed, so a failed handoff is never counted.
+    RELEASE_STREAM_HANDOFFS.fetch_add(1, Ordering::Relaxed);
     Ok(())
 }
 

--- a/crates/cuda-common/src/memory_manager/mod.rs
+++ b/crates/cuda-common/src/memory_manager/mod.rs
@@ -45,6 +45,14 @@ fn init() {
 /// Allocation record for the small-allocation path (`cudaMallocAsync`).
 struct AllocRecord {
     size: usize,
+    /// The stream that must order this allocation's **release**, which is the
+    /// allocating stream only until a handoff moves it.
+    ///
+    /// Release ordering is what makes reuse safe: `cudaFreeAsync` is enqueued on
+    /// this stream, so the allocation only becomes reusable after the work
+    /// already queued on it. When a buffer is produced on one stream and then
+    /// consumed on another, the consumer's stream is the one that must carry the
+    /// free — see [`rebind_release_stream`].
     stream: StreamGuard,
 }
 
@@ -132,6 +140,31 @@ impl MemoryManager {
             Ok(guard)
         }
     }
+
+    /// Two-stage release-stream handoff, mirroring [`Self::d_free_under_lock`]:
+    /// resolves the record under the lock and returns the previous
+    /// `StreamGuard`, which the caller must drop AFTER releasing the lock.
+    ///
+    /// No event is recorded here. The previous stream is already complete, and
+    /// the event that matters is the one the eventual free records on `target`.
+    ///
+    /// # Safety
+    /// - `ptr` must be a live device pointer previously returned by this manager.
+    /// - All work on the allocation's current release stream must be complete.
+    /// - The caller must hold the `MEMORY_MANAGER` lock before calling this method.
+    unsafe fn rebind_release_stream_under_lock(
+        &mut self,
+        ptr: *mut c_void,
+        target: &StreamGuard,
+    ) -> Result<StreamGuard, MemoryError> {
+        let nn = NonNull::new(ptr).ok_or(MemoryError::NullPointer)?;
+
+        if let Some(record) = self.allocated_ptrs.get_mut(&nn) {
+            Ok(std::mem::replace(&mut record.stream, target.clone()))
+        } else {
+            self.pool.rebind_release_stream(ptr, target)
+        }
+    }
 }
 
 impl Drop for MemoryManager {
@@ -169,6 +202,46 @@ pub unsafe fn d_free(ptr: *mut c_void) -> Result<(), MemoryError> {
     drop(manager);
     drop(guard);
     Ok(())
+}
+
+/// Moves the stream that must order `ptr`'s release onto `target`.
+///
+/// This is metadata only: nothing is enqueued and no event is recorded. The
+/// effect appears at the eventual free, which then enqueues `cudaFreeAsync` (or
+/// records the VPMM free-region event) on `target` — behind whatever `target`
+/// has already queued against the allocation. Another stream may therefore only
+/// reuse the memory once that work has completed.
+///
+/// # Safety
+/// - `ptr` must be a live device pointer previously returned by this manager.
+/// - All work on the allocation's current release stream must already be complete, because nothing
+///   here orders the two streams against each other.
+/// - The caller must be the allocation's sole owner: any alias that goes on using it from a third
+///   stream is no longer covered by the release ordering.
+pub(crate) unsafe fn rebind_release_stream(
+    ptr: *mut c_void,
+    target: &StreamGuard,
+) -> Result<(), MemoryError> {
+    let manager = MEMORY_MANAGER.get().unwrap();
+    let mut manager = manager.lock().map_err(|_| MemoryError::LockError)?;
+    let previous = manager.rebind_release_stream_under_lock(ptr, target)?;
+    drop(manager);
+    drop(previous);
+    Ok(())
+}
+
+/// The release stream recorded for a small (`cudaMallocAsync`) allocation.
+///
+/// Test-only: the same assertion for the VPMM path lives on the pool itself.
+#[cfg(test)]
+pub(super) fn small_alloc_release_stream(ptr: *mut c_void) -> Option<StreamGuard> {
+    let manager = MEMORY_MANAGER.get().unwrap();
+    let manager = manager.lock().unwrap();
+    let nn = NonNull::new(ptr)?;
+    manager
+        .allocated_ptrs
+        .get(&nn)
+        .map(|record| record.stream.clone())
 }
 
 #[derive(Debug, Clone)]

--- a/crates/cuda-common/src/memory_manager/tests.rs
+++ b/crates/cuda-common/src/memory_manager/tests.rs
@@ -708,3 +708,384 @@ fn test_defrag_various_scenarios() {
     pool.free_internal(ptr_b).unwrap();
     pool.free_internal(ptr_7).unwrap();
 }
+
+// ============================================================================
+// Release-stream handoff
+//
+// A buffer produced on one stream and consumed on another is released according
+// to the stream recorded against it. While that record names the *producer*, the
+// release is enqueued on a stream that has already drained, so the allocation
+// becomes reusable by any sibling stream immediately — including while the
+// consumer is still reading it. These tests pin down both the metadata change
+// and the reuse it prevents.
+// ============================================================================
+
+use std::{
+    ffi::c_void,
+    sync::{Arc, Condvar, Mutex},
+};
+
+use super::small_alloc_release_stream;
+use crate::{copy::cudaMemcpyKind, stream::cudaStream_t};
+
+#[link(name = "cudart")]
+extern "C" {
+    fn cudaMemsetAsync(dst: *mut c_void, value: i32, count: usize, stream: cudaStream_t) -> i32;
+    fn cudaMemcpyAsync(
+        dst: *mut c_void,
+        src: *const c_void,
+        count: usize,
+        kind: cudaMemcpyKind,
+        stream: cudaStream_t,
+    ) -> i32;
+    fn cudaLaunchHostFunc(
+        stream: cudaStream_t,
+        func: extern "C" fn(*mut c_void),
+        user_data: *mut c_void,
+    ) -> i32;
+}
+
+/// What A writes into the trace, and what B must still see when it reads.
+const PRODUCED_BYTE: u8 = 0xAB;
+/// What the sibling stream writes if it is allowed to reuse the allocation.
+const OVERWRITE_BYTE: u8 = 0x5C;
+
+fn cuda_ok(code: i32, what: &str) {
+    assert_eq!(code, 0, "{what} failed with CUDA error {code}");
+}
+
+/// Holds a CUDA stream at a chosen point until the host lets it go.
+///
+/// `cudaLaunchHostFunc` runs in stream order, so everything queued behind it
+/// waits for it to return. Blocking inside it is what makes the schedules below
+/// exact: no sleeps, no polling, and no dependence on how long any copy happens
+/// to take. Nothing this callback waits on is itself CUDA work, so it cannot
+/// deadlock against the device.
+struct StreamGate {
+    open: Mutex<bool>,
+    changed: Condvar,
+}
+
+impl StreamGate {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            open: Mutex::new(false),
+            changed: Condvar::new(),
+        })
+    }
+
+    /// Queues the gate on `stream`. The returned `Arc` must outlive the stream's
+    /// work; every caller here synchronizes the stream before dropping it.
+    fn hold(self: &Arc<Self>, stream: &StreamGuard) {
+        extern "C" fn wait_for_gate(data: *mut c_void) {
+            // SAFETY: `hold`'s caller keeps the `Arc` alive until the stream has
+            // been synchronized, so this pointer is valid whenever CUDA runs it.
+            let gate = unsafe { &*(data as *const StreamGate) };
+            let mut open = gate.open.lock().unwrap();
+            while !*open {
+                open = gate.changed.wait(open).unwrap();
+            }
+        }
+        cuda_ok(
+            unsafe {
+                cudaLaunchHostFunc(
+                    stream.as_raw(),
+                    wait_for_gate,
+                    Arc::as_ptr(self) as *mut c_void,
+                )
+            },
+            "cudaLaunchHostFunc",
+        );
+    }
+
+    fn release(&self) {
+        *self.open.lock().unwrap() = true;
+        self.changed.notify_all();
+    }
+}
+
+/// What one run of the cross-stream schedule observed.
+#[derive(Debug)]
+struct CrossStreamOutcome {
+    /// The sibling was handed the very address the consumer is still reading.
+    reused_the_live_address: bool,
+    /// The freed region's reuse event had already completed while the consumer's
+    /// read was still queued behind the gate — i.e. reuse was unguarded.
+    reusable_while_consumer_reads: bool,
+    /// The freed region's release is ordered on the consumer's stream.
+    released_on_consumer_stream: bool,
+    /// The consumer read back exactly what the producer wrote.
+    consumer_read_intact: bool,
+    /// The sibling was served out of the same physical pages, with none added.
+    physical_pages_reused: bool,
+}
+
+/// Runs the scheduler's shape end to end on a pool sized so that the trace's own
+/// pages are the *only* thing that can satisfy the sibling's request.
+///
+/// `adopt` is a test-local switch for skipping the handoff, which is exactly the
+/// pre-fix behaviour. It exists only here — there is no production feature,
+/// environment variable or configuration field that turns the handoff off.
+fn run_cross_stream_reuse(adopt: bool) -> CrossStreamOutcome {
+    const PAGES: usize = 2;
+
+    // A produces, B consumes, C is the sibling slot proving alongside B.
+    let producer_ctx = test_ctx();
+    let consumer_ctx = test_ctx();
+    let sibling_ctx = test_ctx();
+    let producer = producer_ctx.stream.clone();
+    let consumer = consumer_ctx.stream.clone();
+    let sibling = sibling_ctx.stream.clone();
+
+    let mut pool = create_test_pool(PAGES);
+    let size = PAGES * pool.page_size;
+
+    // Produce the trace on A, then synchronize A. This is the tracegen fence:
+    // by the time the context is handed on, nothing is outstanding on A.
+    let trace = pool.malloc_internal(size, &producer).unwrap();
+    cuda_ok(
+        unsafe { cudaMemsetAsync(trace, PRODUCED_BYTE as i32, size, producer.as_raw()) },
+        "cudaMemsetAsync(produce)",
+    );
+    producer.synchronize().unwrap();
+
+    // B's landing buffer comes from the global manager, so it never competes for
+    // this pool's pages and cannot perturb the reuse decision under test.
+    let landing = DeviceBuffer::<u8>::with_capacity_on(size, &consumer_ctx);
+
+    if adopt {
+        let previous = pool.rebind_release_stream(trace, &consumer).unwrap();
+        assert_eq!(
+            previous, producer,
+            "the handoff must report the producer as the previous release stream"
+        );
+        assert_eq!(
+            pool.release_stream_of(trace).unwrap(),
+            consumer,
+            "the live allocation's record must now name the consumer's stream"
+        );
+    }
+
+    // B reads the trace, held at the gate so the read is provably still pending
+    // for the rest of the schedule.
+    let gate = StreamGate::new();
+    gate.hold(&consumer);
+    cuda_ok(
+        unsafe {
+            cudaMemcpyAsync(
+                landing.as_mut_ptr() as *mut c_void,
+                trace,
+                size,
+                cudaMemcpyKind::cudaMemcpyDeviceToDevice,
+                consumer.as_raw(),
+            )
+        },
+        "cudaMemcpyAsync(consume)",
+    );
+
+    // The sole owner drops. The release is enqueued on the recorded stream.
+    pool.free_internal(trace).unwrap();
+    // A is idle in both arms and never depends on B, so this is free here. It
+    // makes the freed region's event state a settled fact rather than a query
+    // racing the driver's own processing of the record.
+    producer.synchronize().unwrap();
+
+    let (region_stream, region_event) = pool
+        .free_region_release(trace)
+        .expect("the freed trace must leave exactly one free region at its address");
+    let released_on_consumer_stream = region_stream == consumer;
+    let reusable_while_consumer_reads = region_event.completed();
+
+    // The sibling asks for memory. This pool holds exactly the trace's pages, so
+    // the region B is reading is the only thing that can satisfy the request.
+    let mapped_before = pool.memory_usage();
+    let sibling_ptr = pool.malloc_internal(size, &sibling).unwrap();
+    let physical_pages_reused = pool.memory_usage() == mapped_before;
+    let reused_the_live_address = sibling_ptr == trace;
+    cuda_ok(
+        unsafe { cudaMemsetAsync(sibling_ptr, OVERWRITE_BYTE as i32, size, sibling.as_raw()) },
+        "cudaMemsetAsync(overwrite)",
+    );
+
+    if reused_the_live_address {
+        // The sibling holds the address B is still reading. Drain it before
+        // opening the gate so the overwrite is a fact on the memory rather than
+        // a race this run happened to win.
+        sibling.synchronize().unwrap();
+    }
+    gate.release();
+    consumer.synchronize().unwrap();
+    sibling.synchronize().unwrap();
+
+    let mut host = vec![0u8; size];
+    cuda_ok(
+        unsafe {
+            cudaMemcpyAsync(
+                host.as_mut_ptr() as *mut c_void,
+                landing.as_ptr() as *const c_void,
+                size,
+                cudaMemcpyKind::cudaMemcpyDeviceToHost,
+                consumer.as_raw(),
+            )
+        },
+        "cudaMemcpyAsync(readback)",
+    );
+    consumer.synchronize().unwrap();
+    let consumer_read_intact = host.iter().all(|&byte| byte == PRODUCED_BYTE);
+
+    pool.free_internal(sibling_ptr).unwrap();
+
+    CrossStreamOutcome {
+        reused_the_live_address,
+        reusable_while_consumer_reads,
+        released_on_consumer_stream,
+        consumer_read_intact,
+        physical_pages_reused,
+    }
+}
+
+// ============================================================================
+// Test: adopting the consumer's stream defers reuse until its reads are done
+// ============================================================================
+#[test]
+fn handoff_defers_sibling_reuse_until_the_consumer_has_read() {
+    let outcome = run_cross_stream_reuse(true);
+
+    assert!(
+        outcome.physical_pages_reused,
+        "the fixture is vacuous unless the sibling is served from the trace's own \
+         pages: {outcome:?}"
+    );
+    assert!(
+        outcome.released_on_consumer_stream,
+        "the freed region's release must be ordered on the consumer's stream: {outcome:?}"
+    );
+    assert!(
+        !outcome.reusable_while_consumer_reads,
+        "the freed region must not look reusable while the consumer's read is \
+         still queued: {outcome:?}"
+    );
+    assert!(
+        !outcome.reused_the_live_address,
+        "the sibling must not be handed the address the consumer is reading: {outcome:?}"
+    );
+    assert!(
+        outcome.consumer_read_intact,
+        "the consumer must read what the producer wrote: {outcome:?}"
+    );
+}
+
+// ============================================================================
+// Test (negative control): the same schedule without the handoff corrupts the
+// consumer's read. Skipping the handoff is what the code did before the fix, so
+// this is the shape of the defect itself, not a synthetic hazard.
+// ============================================================================
+#[test]
+fn without_the_handoff_a_sibling_overwrites_a_live_trace() {
+    let outcome = run_cross_stream_reuse(false);
+
+    assert!(
+        outcome.physical_pages_reused,
+        "the fixture is vacuous unless the sibling is served from the trace's own \
+         pages: {outcome:?}"
+    );
+    assert!(
+        !outcome.released_on_consumer_stream,
+        "without the handoff the release stays on the producer's stream: {outcome:?}"
+    );
+    assert!(
+        outcome.reusable_while_consumer_reads,
+        "without the handoff the region looks reusable the moment the producer \
+         drains, which is the defect: {outcome:?}"
+    );
+    assert!(
+        outcome.reused_the_live_address,
+        "without the handoff the sibling is handed the consumer's live address: {outcome:?}"
+    );
+    assert!(
+        !outcome.consumer_read_intact,
+        "NEGATIVE CONTROL FAILED: the sibling overwrote the trace the consumer was \
+         still reading, so the consumer must not read back the produced bytes. If \
+         this passes, the schedule above is not reproducing the race and the \
+         positive test proves nothing: {outcome:?}"
+    );
+}
+
+// ============================================================================
+// Test: the VPMM record follows the handoff, and the free lands on it
+// ============================================================================
+#[test]
+fn vpmm_record_and_free_region_follow_the_handoff() {
+    let producer = test_stream();
+    let consumer = test_stream();
+
+    let mut pool = create_test_pool(1);
+    let size = pool.page_size;
+
+    let ptr = pool.malloc_internal(size, &producer).unwrap();
+    assert_eq!(pool.release_stream_of(ptr).unwrap(), producer);
+
+    let previous = pool.rebind_release_stream(ptr, &consumer).unwrap();
+    assert_eq!(previous, producer);
+    assert_eq!(pool.release_stream_of(ptr).unwrap(), consumer);
+
+    // The allocation is still live, so nothing describes it in `free_regions`
+    // yet; the handoff must not have invented an entry there.
+    assert!(pool.free_region_release(ptr).is_none());
+
+    let (_, guard) = pool.free_internal(ptr).unwrap();
+    assert_eq!(guard, consumer, "the free must be ordered on the consumer");
+    let (region_stream, _) = pool.free_region_release(ptr).unwrap();
+    assert_eq!(
+        region_stream, consumer,
+        "the freed region's reuse event must be recorded on the consumer"
+    );
+
+    // Rebinding a pointer the pool does not hold is rejected rather than silently
+    // creating a record.
+    assert!(matches!(
+        pool.rebind_release_stream(ptr, &producer),
+        Err(MemoryError::InvalidPointer)
+    ));
+}
+
+// ============================================================================
+// Test: the small (`cudaMallocAsync`) record follows the handoff too
+// ============================================================================
+#[test]
+fn small_allocation_record_follows_the_handoff() {
+    let producer = test_ctx();
+    let consumer = test_ctx();
+
+    // Far below any plausible pool page size, so this takes the small path.
+    let mut buffer = DeviceBuffer::<u8>::with_capacity_on(256, &producer);
+    let ptr = buffer.as_raw_ptr() as *mut c_void;
+    assert_eq!(
+        small_alloc_release_stream(ptr).expect("256 bytes must take the small path"),
+        producer.stream,
+        "a fresh allocation is released on the stream that made it"
+    );
+
+    unsafe { buffer.adopt_release_stream_after_sync(&consumer) }.unwrap();
+    assert_eq!(
+        small_alloc_release_stream(ptr).unwrap(),
+        consumer.stream,
+        "the small-path record must name the adopted stream"
+    );
+
+    drop(buffer);
+    assert!(
+        small_alloc_release_stream(ptr).is_none(),
+        "the record is removed by the free"
+    );
+}
+
+// ============================================================================
+// Test: a null buffer has no allocation to hand off
+// ============================================================================
+#[test]
+fn adopting_a_release_stream_on_an_empty_buffer_is_a_no_op() {
+    let consumer = test_ctx();
+    let mut buffer = DeviceBuffer::<u8>::new();
+    unsafe { buffer.adopt_release_stream_after_sync(&consumer) }.unwrap();
+}

--- a/crates/cuda-common/src/memory_manager/vm_pool.rs
+++ b/crates/cuda-common/src/memory_manager/vm_pool.rs
@@ -91,6 +91,10 @@ impl VpmmConfig {
 /// Allocation record for the VPMM path.
 pub(super) struct VpmmRecord {
     size: usize,
+    /// The stream that must order this allocation's **release**, which is the
+    /// allocating stream only until a handoff moves it. `free_internal` hands
+    /// this stream to `free_region_insert`, so it is the stream the freed
+    /// region's reuse event is recorded on.
     stream: StreamGuard,
 }
 
@@ -366,6 +370,30 @@ impl VirtualMemoryPool {
         self.free_region_insert(ptr, size, &record.stream);
 
         Ok((size, record.stream))
+    }
+
+    /// Changes the stream that must order a **live** allocation's release.
+    ///
+    /// Returns the previous `StreamGuard`, which the caller must drop AFTER
+    /// releasing the memory manager lock.
+    ///
+    /// `free_regions` is deliberately left alone: the allocation is still live,
+    /// so no free region describes it yet. The handoff takes effect at
+    /// `free_internal`, which passes this stream to `free_region_insert` and so
+    /// records the region's reuse event on it. `find_best_fit` phase 1b and the
+    /// defragmentation path both gate cross-stream reuse on that event.
+    pub(super) fn rebind_release_stream(
+        &mut self,
+        ptr: *mut c_void,
+        target: &StreamGuard,
+    ) -> Result<StreamGuard, MemoryError> {
+        let ptr = ptr as CUdeviceptr;
+        let record = self
+            .malloc_regions
+            .get_mut(&ptr)
+            .ok_or(MemoryError::InvalidPointer)?;
+
+        Ok(std::mem::replace(&mut record.stream, target.clone()))
     }
 
     // ========================================================================
@@ -764,6 +792,27 @@ impl VirtualMemoryPool {
     /// Returns the total physical memory currently mapped in this pool (in bytes).
     pub(super) fn memory_usage(&self) -> usize {
         self.active_pages.len() * self.page_size
+    }
+
+    /// The release stream recorded for a live allocation, for tests that assert
+    /// a handoff actually changed the record rather than trusting that it did.
+    #[cfg(test)]
+    pub(super) fn release_stream_of(&self, ptr: *mut c_void) -> Option<StreamGuard> {
+        self.malloc_regions
+            .get(&(ptr as CUdeviceptr))
+            .map(|record| record.stream.clone())
+    }
+
+    /// The release stream and reuse event recorded for a free region. Cross-stream
+    /// reuse is gated on that event, so tests assert on it directly.
+    #[cfg(test)]
+    pub(super) fn free_region_release(
+        &self,
+        ptr: *mut c_void,
+    ) -> Option<(StreamGuard, Arc<CudaEvent>)> {
+        self.free_regions
+            .get(&(ptr as CUdeviceptr))
+            .map(|region| (region.stream.clone(), region.event.clone()))
     }
 }
 

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "openvm-scheduler"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+description = "Resource-aware DAG scheduling engine"
+
+# Intentionally empty: the engine schedules abstract nodes and depends on
+# nothing, which is what keeps it reusable outside this workspace.
+[dependencies]

--- a/crates/scheduler/src/engine.rs
+++ b/crates/scheduler/src/engine.rs
@@ -30,8 +30,10 @@ pub enum Admission<I> {
     /// A node is ready but does not fit what is left of the budget. Progress
     /// needs an in-flight node to complete first.
     Backpressure,
-    /// Nothing is ready: every unfinished node waits on a predecessor that is
-    /// still in flight.
+    /// No pending node is ready while registered work remains. A pending node may
+    /// be waiting on an unfinished predecessor, and an already-admitted node is
+    /// excluded from later passes until it completes — so a single running root
+    /// with no dependents also reports this.
     Blocked,
     /// Every registered node has completed. A caller that may still register
     /// more work reads this as idle rather than final.
@@ -171,6 +173,12 @@ impl<I: Clone + Eq + Hash> Engine<I> {
     }
 
     /// Admit every ready node that still fits, GPU-first.
+    ///
+    /// A ready node that does not fit is skipped rather than reserved, so a
+    /// smaller node behind it can still be admitted. Over a finite graph whose
+    /// admitted nodes are all eventually completed, every node is therefore
+    /// admitted in the end; a caller that keeps registering new work can starve a
+    /// large node indefinitely, and this admits no fairness rule against that.
     pub fn admit(&mut self) -> Admission<I> {
         let mut ready: Vec<usize> = (0..self.nodes.len())
             .filter(|&idx| self.nodes[idx].is_ready())

--- a/crates/scheduler/src/engine.rs
+++ b/crates/scheduler/src/engine.rs
@@ -1,0 +1,230 @@
+use std::{cmp::Reverse, collections::HashMap, fmt, hash::Hash, mem};
+
+use crate::{Budget, ResourceProfile};
+
+/// A unit of schedulable work: an id of the caller's choosing, the ids it must
+/// wait for, and what it occupies while it runs.
+#[derive(Clone, Debug)]
+pub struct Node<I> {
+    pub id: I,
+    pub dependencies: Vec<I>,
+    pub profile: ResourceProfile,
+}
+
+impl<I> Node<I> {
+    pub fn new(id: I, dependencies: Vec<I>, profile: ResourceProfile) -> Self {
+        Self {
+            id,
+            dependencies,
+            profile,
+        }
+    }
+}
+
+/// The outcome of one call to [`Engine::admit`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Admission<I> {
+    /// These nodes now hold their profiles. The caller runs them and reports
+    /// each one back through [`Engine::complete`].
+    Admitted(Vec<I>),
+    /// A node is ready but does not fit what is left of the budget. Progress
+    /// needs an in-flight node to complete first.
+    Backpressure,
+    /// Nothing is ready: every unfinished node waits on a predecessor that is
+    /// still in flight.
+    Blocked,
+    /// Every registered node has completed. A caller that may still register
+    /// more work reads this as idle rather than final.
+    AllComplete,
+}
+
+/// Why a graph edit or a completion was refused.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SchedulerError<I> {
+    /// The id is already registered.
+    DuplicateNode(I),
+    /// `node` names a dependency that is not registered yet.
+    UnknownDependency { node: I, dependency: I },
+    /// The profile exceeds the budget on some axis, so the node could never be
+    /// admitted.
+    ExceedsBudget(I),
+    /// The node is not currently admitted, so there is nothing to release.
+    NotRunning(I),
+}
+
+impl<I: fmt::Debug> fmt::Display for SchedulerError<I> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DuplicateNode(id) => write!(f, "node {id:?} is already registered"),
+            Self::UnknownDependency { node, dependency } => {
+                write!(f, "node {node:?} depends on unregistered {dependency:?}")
+            }
+            Self::ExceedsBudget(id) => write!(f, "node {id:?} does not fit the budget"),
+            Self::NotRunning(id) => write!(f, "node {id:?} is not running"),
+        }
+    }
+}
+
+impl<I: fmt::Debug> std::error::Error for SchedulerError<I> {}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum State {
+    Pending,
+    Running,
+    Complete,
+}
+
+struct NodeState<I> {
+    id: I,
+    profile: ResourceProfile,
+    /// Predecessors that have not completed yet.
+    pending_deps: usize,
+    /// Dependents still counting this node in their `pending_deps`.
+    successors: Vec<usize>,
+    state: State,
+}
+
+impl<I> NodeState<I> {
+    fn is_ready(&self) -> bool {
+        self.state == State::Pending && self.pending_deps == 0
+    }
+}
+
+/// Admits graph nodes against a [`Budget`].
+///
+/// The engine never runs anything and never blocks: [`Engine::admit`] and
+/// [`Engine::complete`] are bookkeeping, so the caller keeps full control over
+/// threads, streams, and ordering.
+pub struct Engine<I> {
+    budget: Budget,
+    /// Sum of the profiles of every running node, and so never over `budget` on
+    /// any axis.
+    in_use: ResourceProfile,
+    nodes: Vec<NodeState<I>>,
+    index: HashMap<I, usize>,
+    completed: usize,
+}
+
+impl<I: Clone + Eq + Hash> Engine<I> {
+    pub fn new(budget: Budget) -> Self {
+        Self {
+            budget,
+            in_use: ResourceProfile::ZERO,
+            nodes: Vec::new(),
+            index: HashMap::new(),
+            completed: 0,
+        }
+    }
+
+    /// Register a node. Every dependency must already be registered, which makes
+    /// the graph acyclic by construction — there is no cycle check because a
+    /// cycle cannot be expressed.
+    ///
+    /// Nodes may be added while others run, so a caller that discovers work as
+    /// it goes can keep extending the graph.
+    pub fn add_node(&mut self, node: Node<I>) -> Result<(), SchedulerError<I>> {
+        if self.index.contains_key(&node.id) {
+            return Err(SchedulerError::DuplicateNode(node.id));
+        }
+        if !self
+            .budget
+            .has_room_for(&ResourceProfile::ZERO, &node.profile)
+        {
+            return Err(SchedulerError::ExceedsBudget(node.id));
+        }
+
+        // Resolve every dependency before touching the graph, so a rejected node
+        // leaves no partial edges behind.
+        let mut dependencies = Vec::with_capacity(node.dependencies.len());
+        for dependency in &node.dependencies {
+            match self.index.get(dependency) {
+                Some(&idx) => dependencies.push(idx),
+                None => {
+                    return Err(SchedulerError::UnknownDependency {
+                        node: node.id,
+                        dependency: dependency.clone(),
+                    })
+                }
+            }
+        }
+
+        let idx = self.nodes.len();
+        let mut pending_deps = 0;
+        for dependency in dependencies {
+            // Only an unfinished predecessor needs an edge, so each counted
+            // dependency has exactly one successor entry to release later.
+            if self.nodes[dependency].state != State::Complete {
+                pending_deps += 1;
+                self.nodes[dependency].successors.push(idx);
+            }
+        }
+
+        self.index.insert(node.id.clone(), idx);
+        self.nodes.push(NodeState {
+            id: node.id,
+            profile: node.profile,
+            pending_deps,
+            successors: Vec::new(),
+            state: State::Pending,
+        });
+        Ok(())
+    }
+
+    /// Admit every ready node that still fits, GPU-first.
+    pub fn admit(&mut self) -> Admission<I> {
+        let mut ready: Vec<usize> = (0..self.nodes.len())
+            .filter(|&idx| self.nodes[idx].is_ready())
+            .collect();
+        // The GPU is the scarce axis, so the heaviest GPU consumer claims
+        // contended capacity ahead of any lighter or CPU-only node. The sort is
+        // stable, so registration order breaks ties.
+        ready.sort_by_key(|&idx| Reverse(self.nodes[idx].profile.gpu_bytes));
+
+        let mut admitted = Vec::new();
+        for &idx in &ready {
+            let profile = self.nodes[idx].profile;
+            if !self.budget.has_room_for(&self.in_use, &profile) {
+                continue;
+            }
+            // `has_room_for` just proved these sums stay within the budget.
+            self.in_use.gpu_bytes += profile.gpu_bytes;
+            self.in_use.host_bytes += profile.host_bytes;
+            self.in_use.cpu_threads += profile.cpu_threads;
+            self.nodes[idx].state = State::Running;
+            admitted.push(self.nodes[idx].id.clone());
+        }
+
+        if !admitted.is_empty() {
+            Admission::Admitted(admitted)
+        } else if !ready.is_empty() {
+            Admission::Backpressure
+        } else if self.completed == self.nodes.len() {
+            Admission::AllComplete
+        } else {
+            Admission::Blocked
+        }
+    }
+
+    /// Release a running node's resources and unblock its dependents.
+    pub fn complete(&mut self, id: &I) -> Result<(), SchedulerError<I>> {
+        let idx = match self.index.get(id) {
+            Some(&idx) if self.nodes[idx].state == State::Running => idx,
+            _ => return Err(SchedulerError::NotRunning(id.clone())),
+        };
+
+        let profile = self.nodes[idx].profile;
+        // Mirrors the admission that reserved this profile, so it cannot
+        // underflow.
+        self.in_use.gpu_bytes -= profile.gpu_bytes;
+        self.in_use.host_bytes -= profile.host_bytes;
+        self.in_use.cpu_threads -= profile.cpu_threads;
+        self.nodes[idx].state = State::Complete;
+        self.completed += 1;
+
+        // A node completes once, so its edges are consumed for good.
+        for successor in mem::take(&mut self.nodes[idx].successors) {
+            self.nodes[successor].pending_deps -= 1;
+        }
+        Ok(())
+    }
+}

--- a/crates/scheduler/src/engine.rs
+++ b/crates/scheduler/src/engine.rs
@@ -175,10 +175,13 @@ impl<I: Clone + Eq + Hash> Engine<I> {
     /// Admit every ready node that still fits, GPU-first.
     ///
     /// A ready node that does not fit is skipped rather than reserved, so a
-    /// smaller node behind it can still be admitted. Over a finite graph whose
-    /// admitted nodes are all eventually completed, every node is therefore
-    /// admitted in the end; a caller that keeps registering new work can starve a
-    /// large node indefinitely, and this admits no fairness rule against that.
+    /// smaller node behind it can still be admitted. Over a finite graph, a
+    /// caller that completes what it admits *and* keeps calling this after each
+    /// completion admits every node in the end — the engine is passive and makes
+    /// no progress on its own, so a caller that stops asking leaves ready work
+    /// unadmitted forever. A caller that keeps registering new work can also
+    /// starve a large node indefinitely; this admits no fairness rule against
+    /// that.
     pub fn admit(&mut self) -> Admission<I> {
         let mut ready: Vec<usize> = (0..self.nodes.len())
             .filter(|&idx| self.nodes[idx].is_ready())

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -1,0 +1,17 @@
+//! Resource-aware scheduling of an abstract task graph.
+//!
+//! An [`Engine`] holds a [`Budget`] — one ceiling per resource axis — and a
+//! graph of [`Node`]s, each declaring the [`ResourceProfile`] it occupies while
+//! it runs. [`Engine::admit`] hands back the nodes that are both dependency-free
+//! and small enough to fit what is left of the budget; the caller runs them
+//! however it likes and reports each one back through [`Engine::complete`],
+//! which releases its resources.
+//!
+//! The engine names no domain concept. What a node *is*, what "GPU bytes" cost,
+//! and how work actually runs are all the caller's business.
+
+mod engine;
+mod resource;
+
+pub use engine::{Admission, Engine, Node, SchedulerError};
+pub use resource::{Budget, ResourceProfile};

--- a/crates/scheduler/src/resource.rs
+++ b/crates/scheduler/src/resource.rs
@@ -1,0 +1,62 @@
+/// What one node occupies while it is resident.
+///
+/// Profiles are `const`-constructible so a caller can declare them as constants
+/// next to the code that consumes the resource.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ResourceProfile {
+    pub gpu_bytes: u64,
+    pub host_bytes: u64,
+    pub cpu_threads: u32,
+}
+
+impl ResourceProfile {
+    pub const ZERO: Self = Self::new(0, 0, 0);
+
+    pub const fn new(gpu_bytes: u64, host_bytes: u64, cpu_threads: u32) -> Self {
+        Self {
+            gpu_bytes,
+            host_bytes,
+            cpu_threads,
+        }
+    }
+}
+
+/// The ceilings admission never exceeds, one per axis of a [`ResourceProfile`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Budget {
+    pub gpu_bytes: u64,
+    pub host_bytes: u64,
+    pub cpu_threads: u32,
+}
+
+impl Budget {
+    pub const fn new(gpu_bytes: u64, host_bytes: u64, cpu_threads: u32) -> Self {
+        Self {
+            gpu_bytes,
+            host_bytes,
+            cpu_threads,
+        }
+    }
+
+    /// Whether `want` still fits once `in_use` is already resident.
+    ///
+    /// Every admission passes through here, which is what keeps the sum of the
+    /// admitted profiles inside the budget on every axis.
+    pub(crate) fn has_room_for(&self, in_use: &ResourceProfile, want: &ResourceProfile) -> bool {
+        fits(in_use.gpu_bytes, want.gpu_bytes, self.gpu_bytes)
+            && fits(in_use.host_bytes, want.host_bytes, self.host_bytes)
+            && fits(
+                u64::from(in_use.cpu_threads),
+                u64::from(want.cpu_threads),
+                u64::from(self.cpu_threads),
+            )
+    }
+}
+
+/// Checked, so a profile near `u64::MAX` answers "no room" instead of wrapping
+/// into a fit.
+fn fits(in_use: u64, want: u64, ceiling: u64) -> bool {
+    in_use
+        .checked_add(want)
+        .is_some_and(|total| total <= ceiling)
+}

--- a/crates/scheduler/tests/common/mod.rs
+++ b/crates/scheduler/tests/common/mod.rs
@@ -22,8 +22,6 @@ pub struct Run {
     pub rounds: Vec<Vec<Id>>,
     /// Passes that reported [`Admission::Backpressure`].
     pub backpressure: usize,
-    /// Passes that reported [`Admission::Blocked`].
-    pub blocked: usize,
     /// Largest simultaneous occupancy the driver itself summed.
     pub peak: ResourceProfile,
 }
@@ -67,7 +65,6 @@ pub fn drive(budget: Budget, nodes: Vec<Node<Id>>) -> Run {
     let mut run = Run {
         rounds: Vec::new(),
         backpressure: 0,
-        blocked: 0,
         peak: ResourceProfile::ZERO,
     };
     let mut resident = ResourceProfile::ZERO;
@@ -79,7 +76,7 @@ pub fn drive(budget: Budget, nodes: Vec<Node<Id>>) -> Run {
         match &admission {
             Admission::AllComplete => return run,
             Admission::Backpressure => run.backpressure += 1,
-            Admission::Blocked => run.blocked += 1,
+            Admission::Blocked => {}
             Admission::Admitted(ids) => {
                 for id in ids {
                     for dep in &deps[id] {

--- a/crates/scheduler/tests/common/mod.rs
+++ b/crates/scheduler/tests/common/mod.rs
@@ -1,0 +1,121 @@
+//! Shared driver for the scheduler tests.
+//!
+//! The driver keeps its own occupancy and completion bookkeeping, so budget and
+//! dependency safety are checked against the declared graph rather than against
+//! the engine's own accounting.
+//!
+//! Each test binary compiles this module separately, so not every binary uses
+//! every helper.
+#![allow(dead_code)]
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use openvm_scheduler::{Admission, Budget, Engine, Node, ResourceProfile};
+
+pub type Id = &'static str;
+
+pub const GB: u64 = 1 << 30;
+
+/// What one drive to completion observed.
+pub struct Run {
+    /// Ids admitted per admission pass, in admission order.
+    pub rounds: Vec<Vec<Id>>,
+    /// Passes that reported [`Admission::Backpressure`].
+    pub backpressure: usize,
+    /// Passes that reported [`Admission::Blocked`].
+    pub blocked: usize,
+    /// Largest simultaneous occupancy the driver itself summed.
+    pub peak: ResourceProfile,
+}
+
+impl Run {
+    /// Widest admission pass — how much concurrency the budget allowed.
+    pub fn widest_round(&self) -> usize {
+        self.rounds.iter().map(Vec::len).max().unwrap_or(0)
+    }
+
+    pub fn admitted_count(&self) -> usize {
+        self.rounds.iter().map(Vec::len).sum()
+    }
+
+    /// Index of the pass that admitted `id`.
+    pub fn round_of(&self, id: Id) -> usize {
+        self.rounds
+            .iter()
+            .position(|round| round.contains(&id))
+            .unwrap_or_else(|| panic!("{id} was never admitted"))
+    }
+}
+
+/// Drive `nodes` to completion under `budget`, completing the oldest in-flight
+/// node whenever no further admission is possible.
+///
+/// Panics if the engine puts occupancy over budget on any axis, admits a node
+/// whose predecessors have not completed, or stalls with nothing in flight.
+pub fn drive(budget: Budget, nodes: Vec<Node<Id>>) -> Run {
+    let profiles: HashMap<Id, ResourceProfile> = nodes.iter().map(|n| (n.id, n.profile)).collect();
+    let deps: HashMap<Id, Vec<Id>> = nodes
+        .iter()
+        .map(|n| (n.id, n.dependencies.clone()))
+        .collect();
+
+    let mut engine = Engine::new(budget);
+    for node in nodes {
+        engine.add_node(node).expect("graph is well formed");
+    }
+
+    let mut run = Run {
+        rounds: Vec::new(),
+        backpressure: 0,
+        blocked: 0,
+        peak: ResourceProfile::ZERO,
+    };
+    let mut resident = ResourceProfile::ZERO;
+    let mut in_flight: VecDeque<Id> = VecDeque::new();
+    let mut completed: HashSet<Id> = HashSet::new();
+
+    loop {
+        let admission = engine.admit();
+        match &admission {
+            Admission::AllComplete => return run,
+            Admission::Backpressure => run.backpressure += 1,
+            Admission::Blocked => run.blocked += 1,
+            Admission::Admitted(ids) => {
+                for id in ids {
+                    for dep in &deps[id] {
+                        assert!(
+                            completed.contains(dep),
+                            "dependency safety: {id} admitted while {dep} was unfinished"
+                        );
+                    }
+                    let profile = profiles[id];
+                    resident.gpu_bytes += profile.gpu_bytes;
+                    resident.host_bytes += profile.host_bytes;
+                    resident.cpu_threads += profile.cpu_threads;
+                    in_flight.push_back(*id);
+                }
+                assert!(
+                    resident.gpu_bytes <= budget.gpu_bytes
+                        && resident.host_bytes <= budget.host_bytes
+                        && resident.cpu_threads <= budget.cpu_threads,
+                    "budget safety: resident {resident:?} exceeds {budget:?}"
+                );
+                run.peak.gpu_bytes = run.peak.gpu_bytes.max(resident.gpu_bytes);
+                run.peak.host_bytes = run.peak.host_bytes.max(resident.host_bytes);
+                run.peak.cpu_threads = run.peak.cpu_threads.max(resident.cpu_threads);
+                run.rounds.push(ids.clone());
+                continue;
+            }
+        }
+
+        let id = in_flight
+            .pop_front()
+            .expect("engine stalled with nothing in flight");
+        let profile = profiles[id];
+        resident.gpu_bytes -= profile.gpu_bytes;
+        resident.host_bytes -= profile.host_bytes;
+        resident.cpu_threads -= profile.cpu_threads;
+        completed.insert(id);
+        engine.complete(&id).expect("node was admitted");
+    }
+}

--- a/crates/scheduler/tests/generality.rs
+++ b/crates/scheduler/tests/generality.rs
@@ -1,9 +1,10 @@
 //! The subdivision test.
 //!
-//! The next increment replaces one coarse GPU node with several finer nodes that
-//! carry their own profiles and their own edges. Both graphs below are built
-//! from the same `Node` type and driven by the same unchanged `common::drive`:
-//! subdividing a node is a change to the node list, never to an interface.
+//! The next increment replaces one coarse GPU node with a sub-graph of finer
+//! nodes carrying their own profiles and edges, while the work on either side of
+//! it stays put. Both graphs below hold the same producer and the same consumer
+//! fixed and are driven by the same unchanged `common::drive`: subdividing a node
+//! is a change to graph data, never to an interface.
 
 use common::{drive, Id, GB};
 use openvm_scheduler::{Budget, Node, ResourceProfile};
@@ -13,64 +14,96 @@ mod common;
 const CPU_BOUND: ResourceProfile = ResourceProfile::new(0, 4 * GB, 8);
 const GPU_BOUND: ResourceProfile = ResourceProfile::new(16 * GB, 8 * GB, 2);
 
-fn coarse() -> Vec<Node<Id>> {
-    vec![
-        Node::new("c0", vec![], CPU_BOUND),
-        Node::new("g0", vec!["c0"], GPU_BOUND),
-        Node::new("c1", vec!["c0"], CPU_BOUND),
-        Node::new("g1", vec!["c1"], GPU_BOUND),
-    ]
+/// The producer upstream of the node being subdivided.
+const UP: Id = "up";
+/// The node that gets replaced.
+const MID: Id = "mid";
+/// The consumer downstream of it.
+const DOWN: Id = "down";
+/// The sub-graph that replaces [`MID`], ending in a join.
+const MID_A: Id = "mid.a";
+const MID_B: Id = "mid.b";
+const MID_JOIN: Id = "mid.join";
+
+/// The two nodes that must survive subdivision untouched. `produces` is the id
+/// the consumer waits for — the only thing that differs between the two graphs,
+/// and it is a dependency id: graph data the caller already owns, not part of any
+/// interface.
+fn boundary(produces: Id) -> (Node<Id>, Node<Id>) {
+    (
+        Node::new(UP, vec![], CPU_BOUND),
+        Node::new(DOWN, vec![produces], CPU_BOUND),
+    )
 }
 
-/// Each GPU node split into two heterogeneous stages and a join. Their GPU peaks
-/// sum to the coarse node's, so the same budget describes the same machine.
+/// `UP -> MID -> DOWN`, one coarse GPU node in the middle.
+fn coarse() -> Vec<Node<Id>> {
+    let (up, down) = boundary(MID);
+    vec![up, Node::new(MID, vec![UP], GPU_BOUND), down]
+}
+
+/// [`MID`] replaced by two heterogeneous stages and a join. Nothing else moves,
+/// and the stages' GPU peaks sum to [`MID`]'s, so the same budget describes the
+/// same machine.
 fn subdivided() -> Vec<Node<Id>> {
-    let stage_a = ResourceProfile::new(4 * GB, 2 * GB, 1);
-    let stage_b = ResourceProfile::new(6 * GB, 3 * GB, 1);
-    let join = ResourceProfile::new(6 * GB, 3 * GB, 2);
+    let (up, down) = boundary(MID_JOIN);
     vec![
-        Node::new("c0", vec![], CPU_BOUND),
-        Node::new("g0.a", vec!["c0"], stage_a),
-        Node::new("g0.b", vec!["c0"], stage_b),
-        Node::new("g0.join", vec!["g0.a", "g0.b"], join),
-        Node::new("c1", vec!["c0"], CPU_BOUND),
-        Node::new("g1.a", vec!["c1"], stage_a),
-        Node::new("g1.b", vec!["c1"], stage_b),
-        Node::new("g1.join", vec!["g1.a", "g1.b"], join),
+        up,
+        Node::new(MID_A, vec![UP], ResourceProfile::new(4 * GB, 2 * GB, 1)),
+        Node::new(MID_B, vec![UP], ResourceProfile::new(6 * GB, 3 * GB, 1)),
+        Node::new(
+            MID_JOIN,
+            vec![MID_A, MID_B],
+            ResourceProfile::new(6 * GB, 3 * GB, 2),
+        ),
+        down,
     ]
 }
 
 #[test]
-fn subdividing_a_node_needs_no_interface_change() {
+fn subdividing_one_node_keeps_the_boundary_around_it_intact() {
     let budget = Budget::new(16 * GB, 32 * GB, 16);
+    let coarse_graph = coarse();
+    let fine_graph = subdivided();
 
-    let coarse_run = drive(budget, coarse());
-    let fine_run = drive(budget, subdivided());
+    // The surviving nodes are the same declarations on both sides: the producer
+    // is identical down to its edges, and the consumer keeps its id and profile
+    // while naming a different producer.
+    let (coarse_up, fine_up) = (&coarse_graph[0], &fine_graph[0]);
+    assert_eq!(coarse_up.id, fine_up.id);
+    assert_eq!(coarse_up.profile, fine_up.profile);
+    assert_eq!(coarse_up.dependencies, fine_up.dependencies);
 
-    assert_eq!(
-        coarse_run.rounds,
-        vec![vec!["c0"], vec!["g0", "c1"], vec!["g1"]]
-    );
+    let coarse_down = coarse_graph.last().unwrap();
+    let fine_down = fine_graph.last().unwrap();
+    assert_eq!(coarse_down.id, fine_down.id);
+    assert_eq!(coarse_down.profile, fine_down.profile);
+    assert_eq!(coarse_down.dependencies, vec![MID]);
+    assert_eq!(fine_down.dependencies, vec![MID_JOIN]);
+
+    let coarse_run = drive(budget, coarse_graph);
+    let fine_run = drive(budget, fine_graph);
+
+    assert_eq!(coarse_run.rounds, vec![vec![UP], vec![MID], vec![DOWN]]);
     assert_eq!(
         fine_run.rounds,
-        vec![
-            vec!["c0"],
-            vec!["g0.b", "g0.a", "c1"],
-            vec!["g0.join"],
-            vec!["g1.b", "g1.a"],
-            vec!["g1.join"],
-        ]
+        vec![vec![UP], vec![MID_B, MID_A], vec![MID_JOIN], vec![DOWN],]
     );
 
-    assert_eq!(coarse_run.admitted_count(), 4);
-    assert_eq!(fine_run.admitted_count(), 8);
+    // The external boundary still holds. The consumer waits for the whole
+    // replacement sub-graph, not just the join it names, and the producer still
+    // precedes every one of the finer nodes.
+    assert!(fine_run.round_of(DOWN) > fine_run.round_of(MID_JOIN));
+    assert!(fine_run.round_of(MID_JOIN) > fine_run.round_of(MID_A));
+    assert!(fine_run.round_of(MID_JOIN) > fine_run.round_of(MID_B));
+    assert!(fine_run.round_of(MID_A) > fine_run.round_of(UP));
+    assert!(fine_run.round_of(MID_B) > fine_run.round_of(UP));
+    assert_eq!(fine_run.rounds.first().unwrap(), &vec![UP]);
+    assert_eq!(fine_run.rounds.last().unwrap(), &vec![DOWN]);
 
-    // One coarse node saturates the GPU axis alone; the finer nodes share it, so
-    // subdivision buys concurrency the budget could not express before.
-    assert!(fine_run.widest_round() > coarse_run.widest_round());
+    // Subdivision buys concurrency the coarse node could not express, without
+    // moving the boundary or exceeding the same budget.
+    assert_eq!(coarse_run.widest_round(), 1);
+    assert_eq!(fine_run.widest_round(), 2);
     assert!(fine_run.peak.gpu_bytes <= budget.gpu_bytes);
-
-    // The sub-graph's own edges are scheduled like any other.
-    assert!(fine_run.round_of("g0.join") > fine_run.round_of("g0.a"));
-    assert!(fine_run.round_of("g1.join") > fine_run.round_of("g1.b"));
 }

--- a/crates/scheduler/tests/generality.rs
+++ b/crates/scheduler/tests/generality.rs
@@ -1,0 +1,76 @@
+//! The subdivision test.
+//!
+//! The next increment replaces one coarse GPU node with several finer nodes that
+//! carry their own profiles and their own edges. Both graphs below are built
+//! from the same `Node` type and driven by the same unchanged `common::drive`:
+//! subdividing a node is a change to the node list, never to an interface.
+
+use common::{drive, Id, GB};
+use openvm_scheduler::{Budget, Node, ResourceProfile};
+
+mod common;
+
+const CPU_BOUND: ResourceProfile = ResourceProfile::new(0, 4 * GB, 8);
+const GPU_BOUND: ResourceProfile = ResourceProfile::new(16 * GB, 8 * GB, 2);
+
+fn coarse() -> Vec<Node<Id>> {
+    vec![
+        Node::new("c0", vec![], CPU_BOUND),
+        Node::new("g0", vec!["c0"], GPU_BOUND),
+        Node::new("c1", vec!["c0"], CPU_BOUND),
+        Node::new("g1", vec!["c1"], GPU_BOUND),
+    ]
+}
+
+/// Each GPU node split into two heterogeneous stages and a join. Their GPU peaks
+/// sum to the coarse node's, so the same budget describes the same machine.
+fn subdivided() -> Vec<Node<Id>> {
+    let stage_a = ResourceProfile::new(4 * GB, 2 * GB, 1);
+    let stage_b = ResourceProfile::new(6 * GB, 3 * GB, 1);
+    let join = ResourceProfile::new(6 * GB, 3 * GB, 2);
+    vec![
+        Node::new("c0", vec![], CPU_BOUND),
+        Node::new("g0.a", vec!["c0"], stage_a),
+        Node::new("g0.b", vec!["c0"], stage_b),
+        Node::new("g0.join", vec!["g0.a", "g0.b"], join),
+        Node::new("c1", vec!["c0"], CPU_BOUND),
+        Node::new("g1.a", vec!["c1"], stage_a),
+        Node::new("g1.b", vec!["c1"], stage_b),
+        Node::new("g1.join", vec!["g1.a", "g1.b"], join),
+    ]
+}
+
+#[test]
+fn subdividing_a_node_needs_no_interface_change() {
+    let budget = Budget::new(16 * GB, 32 * GB, 16);
+
+    let coarse_run = drive(budget, coarse());
+    let fine_run = drive(budget, subdivided());
+
+    assert_eq!(
+        coarse_run.rounds,
+        vec![vec!["c0"], vec!["g0", "c1"], vec!["g1"]]
+    );
+    assert_eq!(
+        fine_run.rounds,
+        vec![
+            vec!["c0"],
+            vec!["g0.b", "g0.a", "c1"],
+            vec!["g0.join"],
+            vec!["g1.b", "g1.a"],
+            vec!["g1.join"],
+        ]
+    );
+
+    assert_eq!(coarse_run.admitted_count(), 4);
+    assert_eq!(fine_run.admitted_count(), 8);
+
+    // One coarse node saturates the GPU axis alone; the finer nodes share it, so
+    // subdivision buys concurrency the budget could not express before.
+    assert!(fine_run.widest_round() > coarse_run.widest_round());
+    assert!(fine_run.peak.gpu_bytes <= budget.gpu_bytes);
+
+    // The sub-graph's own edges are scheduled like any other.
+    assert!(fine_run.round_of("g0.join") > fine_run.round_of("g0.a"));
+    assert!(fine_run.round_of("g1.join") > fine_run.round_of("g1.b"));
+}

--- a/crates/scheduler/tests/generality.rs
+++ b/crates/scheduler/tests/generality.rs
@@ -26,7 +26,7 @@ const MID_B: Id = "mid.b";
 const MID_JOIN: Id = "mid.join";
 
 /// The two nodes that must survive subdivision untouched. `produces` is the id
-/// the consumer waits for — the only thing that differs between the two graphs,
+/// the consumer waits for — the only thing that differs between the graphs below,
 /// and it is a dependency id: graph data the caller already owns, not part of any
 /// interface.
 fn boundary(produces: Id) -> (Node<Id>, Node<Id>) {
@@ -36,19 +36,10 @@ fn boundary(produces: Id) -> (Node<Id>, Node<Id>) {
     )
 }
 
-/// `UP -> MID -> DOWN`, one coarse GPU node in the middle.
-fn coarse() -> Vec<Node<Id>> {
-    let (up, down) = boundary(MID);
-    vec![up, Node::new(MID, vec![UP], GPU_BOUND), down]
-}
-
-/// [`MID`] replaced by two heterogeneous stages and a join. Nothing else moves,
-/// and the stages' GPU peaks sum to [`MID`]'s, so the same budget describes the
-/// same machine.
-fn subdivided() -> Vec<Node<Id>> {
-    let (up, down) = boundary(MID_JOIN);
+/// The heterogeneous sub-graph that replaces [`MID`]. Its GPU peaks sum to
+/// [`MID`]'s, so the same budget describes the same machine.
+fn replacement() -> Vec<Node<Id>> {
     vec![
-        up,
         Node::new(MID_A, vec![UP], ResourceProfile::new(4 * GB, 2 * GB, 1)),
         Node::new(MID_B, vec![UP], ResourceProfile::new(6 * GB, 3 * GB, 1)),
         Node::new(
@@ -56,8 +47,32 @@ fn subdivided() -> Vec<Node<Id>> {
             vec![MID_A, MID_B],
             ResourceProfile::new(6 * GB, 3 * GB, 2),
         ),
-        down,
     ]
+}
+
+/// `UP -> MID -> DOWN`, one coarse GPU node in the middle.
+fn coarse() -> Vec<Node<Id>> {
+    let (up, down) = boundary(MID);
+    vec![up, Node::new(MID, vec![UP], GPU_BOUND), down]
+}
+
+/// [`MID`] replaced by [`replacement`], with the consumer waiting on the join.
+fn subdivided() -> Vec<Node<Id>> {
+    let (up, down) = boundary(MID_JOIN);
+    let mut graph = vec![up];
+    graph.extend(replacement());
+    graph.push(down);
+    graph
+}
+
+/// The same replacement, with the consumer wired to an interior node instead of
+/// the join. Used as the control below.
+fn subdivided_past_the_join() -> Vec<Node<Id>> {
+    let (up, down) = boundary(MID_A);
+    let mut graph = vec![up];
+    graph.extend(replacement());
+    graph.push(down);
+    graph
 }
 
 #[test]
@@ -84,16 +99,14 @@ fn subdividing_one_node_keeps_the_boundary_around_it_intact() {
     let coarse_run = drive(budget, coarse_graph);
     let fine_run = drive(budget, fine_graph);
 
-    assert_eq!(coarse_run.rounds, vec![vec![UP], vec![MID], vec![DOWN]]);
-    assert_eq!(
-        fine_run.rounds,
-        vec![vec![UP], vec![MID_B, MID_A], vec![MID_JOIN], vec![DOWN],]
-    );
-
     // The external boundary still holds. The consumer waits for the whole
     // replacement sub-graph, not just the join it names, and the producer still
-    // precedes every one of the finer nodes.
-    assert!(fine_run.round_of(DOWN) > fine_run.round_of(MID_JOIN));
+    // precedes every one of the finer nodes. Asserted before the exact schedule
+    // below so that a wiring change fails here, where the claim lives.
+    assert!(
+        fine_run.round_of(DOWN) > fine_run.round_of(MID_JOIN),
+        "the consumer must wait for the join that closes the sub-graph"
+    );
     assert!(fine_run.round_of(MID_JOIN) > fine_run.round_of(MID_A));
     assert!(fine_run.round_of(MID_JOIN) > fine_run.round_of(MID_B));
     assert!(fine_run.round_of(MID_A) > fine_run.round_of(UP));
@@ -101,9 +114,37 @@ fn subdividing_one_node_keeps_the_boundary_around_it_intact() {
     assert_eq!(fine_run.rounds.first().unwrap(), &vec![UP]);
     assert_eq!(fine_run.rounds.last().unwrap(), &vec![DOWN]);
 
+    assert_eq!(coarse_run.rounds, vec![vec![UP], vec![MID], vec![DOWN]]);
+    assert_eq!(
+        fine_run.rounds,
+        vec![vec![UP], vec![MID_B, MID_A], vec![MID_JOIN], vec![DOWN]]
+    );
+
     // Subdivision buys concurrency the coarse node could not express, without
     // moving the boundary or exceeding the same budget.
     assert_eq!(coarse_run.widest_round(), 1);
     assert_eq!(fine_run.widest_round(), 2);
     assert!(fine_run.peak.gpu_bytes <= budget.gpu_bytes);
+}
+
+/// Control for the boundary assertions above. Wiring the consumer to an interior
+/// node of the sub-graph instead of its join stops it waiting for the whole
+/// replacement: it is admitted in the *same* pass as the join. So
+/// `round_of(DOWN) > round_of(MID_JOIN)` is exactly what separates a preserved
+/// boundary from a broken one, rather than holding for any wiring at all.
+#[test]
+fn a_consumer_wired_past_the_join_stops_waiting_for_the_sub_graph() {
+    let budget = Budget::new(16 * GB, 32 * GB, 16);
+
+    let run = drive(budget, subdivided_past_the_join());
+
+    assert_eq!(
+        run.rounds,
+        vec![vec![UP], vec![MID_B, MID_A], vec![MID_JOIN, DOWN]]
+    );
+    assert_eq!(
+        run.round_of(DOWN),
+        run.round_of(MID_JOIN),
+        "the consumer no longer waits for the join"
+    );
 }

--- a/crates/scheduler/tests/invariants.rs
+++ b/crates/scheduler/tests/invariants.rs
@@ -32,7 +32,7 @@ fn budget_safety_defers_a_node_that_does_not_fit() {
 
 /// A serial CPU chain with a fan-out of independent GPU nodes. Under a budget
 /// wide enough to hold the whole graph at once, admission order is decided purely
-/// by dependencies — and a predecessor that is merely *in flight* still blocks.
+/// by dependencies.
 #[test]
 fn dependency_safety_holds_under_an_unconstrained_budget() {
     let budget = Budget::new(1024 * GB, 1024 * GB, 1024);
@@ -52,10 +52,45 @@ fn dependency_safety_holds_under_an_unconstrained_budget() {
         vec![vec!["c0"], vec!["g0", "c1"], vec!["g1", "c2"], vec!["g2"]]
     );
     assert_eq!(run.admitted_count(), 6);
-    assert!(
-        run.blocked > 0,
-        "successors stayed unadmitted while a predecessor was in flight"
-    );
+}
+
+/// A predecessor that is merely *in flight* still blocks. The budget is wide
+/// enough that backpressure is impossible, so the only thing keeping the
+/// dependent out is its unfinished predecessor — and it is admitted on the very
+/// next pass after that predecessor completes.
+#[test]
+fn a_dependent_waits_while_its_predecessor_is_in_flight() {
+    let mut engine: Engine<Id> = Engine::new(Budget::new(1024 * GB, 1024 * GB, 1024));
+    engine.add_node(Node::new("c", vec![], CPU_BOUND)).unwrap();
+    engine
+        .add_node(Node::new("g", vec!["c"], GPU_BOUND))
+        .unwrap();
+
+    assert_eq!(engine.admit(), Admission::Admitted(vec!["c"]));
+    assert_eq!(engine.admit(), Admission::Blocked);
+
+    engine.complete(&"c").unwrap();
+
+    assert_eq!(engine.admit(), Admission::Admitted(vec!["g"]));
+}
+
+/// Repeating a pass over an already-admitted root reports `Blocked` and reserves
+/// nothing further. The root is unfinished but waits on no predecessor, so
+/// `Blocked` cannot be read as "some predecessor is in flight".
+#[test]
+fn a_second_admit_pass_over_a_running_root_reports_blocked() {
+    let mut engine: Engine<Id> = Engine::new(Budget::new(32 * GB, 64 * GB, 16));
+    engine
+        .add_node(Node::new("root", vec![], CPU_BOUND))
+        .unwrap();
+
+    assert_eq!(engine.admit(), Admission::Admitted(vec!["root"]));
+    assert_eq!(engine.admit(), Admission::Blocked);
+    assert_eq!(engine.admit(), Admission::Blocked);
+
+    engine.complete(&"root").unwrap();
+
+    assert_eq!(engine.admit(), Admission::AllComplete);
 }
 
 /// GPU-first: when a contended axis admits only one of two ready nodes, the GPU

--- a/crates/scheduler/tests/invariants.rs
+++ b/crates/scheduler/tests/invariants.rs
@@ -1,0 +1,194 @@
+//! The engine's load-bearing invariants: budget safety, dependency safety,
+//! GPU-first admission order, and the crate's ignorance of its callers.
+
+use common::{drive, Id, GB};
+use openvm_scheduler::{Admission, Budget, Engine, Node, ResourceProfile, SchedulerError};
+
+mod common;
+
+/// A CPU-bound node: no GPU residency.
+const CPU_BOUND: ResourceProfile = ResourceProfile::new(0, 4 * GB, 8);
+/// A GPU-bound node.
+const GPU_BOUND: ResourceProfile = ResourceProfile::new(16 * GB, 8 * GB, 2);
+
+/// Occupancy never passes the budget on any axis, and a node too large for what
+/// remains waits for a release rather than overrunning it.
+#[test]
+fn budget_safety_defers_a_node_that_does_not_fit() {
+    let budget = Budget::new(32 * GB, 64 * GB, 16);
+    let nodes = vec![
+        Node::new("A", vec![], ResourceProfile::new(16 * GB, 8 * GB, 1)),
+        Node::new("B", vec![], ResourceProfile::new(16 * GB, 8 * GB, 1)),
+        // Ready only once A completes, and then too large to join B.
+        Node::new("C", vec!["A"], ResourceProfile::new(24 * GB, 8 * GB, 1)),
+    ];
+
+    let run = drive(budget, nodes);
+
+    assert_eq!(run.rounds, vec![vec!["A", "B"], vec!["C"]]);
+    assert_eq!(run.peak.gpu_bytes, 32 * GB);
+    assert_eq!(run.backpressure, 1, "C waits for B to release the GPU axis");
+}
+
+/// A serial CPU chain with a fan-out of independent GPU nodes. Under a budget
+/// wide enough to hold the whole graph at once, admission order is decided purely
+/// by dependencies — and a predecessor that is merely *in flight* still blocks.
+#[test]
+fn dependency_safety_holds_under_an_unconstrained_budget() {
+    let budget = Budget::new(1024 * GB, 1024 * GB, 1024);
+    let nodes = vec![
+        Node::new("c0", vec![], CPU_BOUND),
+        Node::new("g0", vec!["c0"], GPU_BOUND),
+        Node::new("c1", vec!["c0"], CPU_BOUND),
+        Node::new("g1", vec!["c1"], GPU_BOUND),
+        Node::new("c2", vec!["c1"], CPU_BOUND),
+        Node::new("g2", vec!["c2"], GPU_BOUND),
+    ];
+
+    let run = drive(budget, nodes);
+
+    assert_eq!(
+        run.rounds,
+        vec![vec!["c0"], vec!["g0", "c1"], vec!["g1", "c2"], vec!["g2"]]
+    );
+    assert_eq!(run.admitted_count(), 6);
+    assert!(
+        run.blocked > 0,
+        "successors stayed unadmitted while a predecessor was in flight"
+    );
+}
+
+/// GPU-first: when a contended axis admits only one of two ready nodes, the GPU
+/// consumer goes first even though the CPU-only node was registered earlier.
+/// The control case pins that the GPU axis is what flips the order: with GPU
+/// demand equal, registration order decides.
+#[test]
+fn gpu_demand_wins_a_contended_axis() {
+    let budget = Budget::new(32 * GB, 10 * GB, 16);
+    let cpu_only = ResourceProfile::new(0, 10 * GB, 8);
+    let gpu_bound = ResourceProfile::new(16 * GB, 10 * GB, 8);
+
+    let run = drive(
+        budget,
+        vec![
+            Node::new("cpu", vec![], cpu_only),
+            Node::new("gpu", vec![], gpu_bound),
+        ],
+    );
+    assert_eq!(run.rounds, vec![vec!["gpu"], vec!["cpu"]]);
+
+    let control = drive(
+        budget,
+        vec![
+            Node::new("cpu", vec![], cpu_only),
+            Node::new("also-cpu", vec![], cpu_only),
+        ],
+    );
+    assert_eq!(control.rounds, vec![vec!["cpu"], vec!["also-cpu"]]);
+}
+
+/// A node that cannot fit an empty machine would stall the graph forever, so it
+/// is refused at registration instead.
+#[test]
+fn a_node_larger_than_the_budget_is_rejected() {
+    let mut engine: Engine<Id> = Engine::new(Budget::new(32 * GB, 64 * GB, 16));
+
+    let err = engine
+        .add_node(Node::new(
+            "huge",
+            vec![],
+            ResourceProfile::new(33 * GB, 0, 0),
+        ))
+        .unwrap_err();
+
+    assert_eq!(err, SchedulerError::ExceedsBudget("huge"));
+}
+
+/// Dependencies must be registered before their dependents. That is what makes
+/// the graph acyclic by construction.
+#[test]
+fn a_dependency_must_be_registered_first() {
+    let mut engine: Engine<Id> = Engine::new(Budget::new(32 * GB, 64 * GB, 16));
+
+    let err = engine
+        .add_node(Node::new("g0", vec!["c0"], GPU_BOUND))
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        SchedulerError::UnknownDependency {
+            node: "g0",
+            dependency: "c0",
+        }
+    );
+}
+
+#[test]
+fn a_duplicate_id_is_rejected() {
+    let mut engine: Engine<Id> = Engine::new(Budget::new(32 * GB, 64 * GB, 16));
+    engine.add_node(Node::new("c0", vec![], CPU_BOUND)).unwrap();
+
+    let err = engine
+        .add_node(Node::new("c0", vec![], CPU_BOUND))
+        .unwrap_err();
+
+    assert_eq!(err, SchedulerError::DuplicateNode("c0"));
+}
+
+#[test]
+fn completing_a_node_that_was_not_admitted_is_rejected() {
+    let mut engine: Engine<Id> = Engine::new(Budget::new(32 * GB, 64 * GB, 16));
+
+    assert_eq!(
+        engine.complete(&"absent").unwrap_err(),
+        SchedulerError::NotRunning("absent")
+    );
+
+    engine.add_node(Node::new("c0", vec![], CPU_BOUND)).unwrap();
+    assert_eq!(
+        engine.complete(&"c0").unwrap_err(),
+        SchedulerError::NotRunning("c0")
+    );
+}
+
+/// The graph may grow while work is in flight, which is what lets a caller
+/// register work it only discovers as it goes.
+#[test]
+fn a_node_added_after_its_predecessor_completed_is_ready_at_once() {
+    let mut engine: Engine<Id> = Engine::new(Budget::new(32 * GB, 64 * GB, 16));
+    engine.add_node(Node::new("c0", vec![], CPU_BOUND)).unwrap();
+
+    assert_eq!(engine.admit(), Admission::Admitted(vec!["c0"]));
+    engine.complete(&"c0").unwrap();
+    assert_eq!(engine.admit(), Admission::AllComplete);
+
+    engine
+        .add_node(Node::new("g0", vec!["c0"], GPU_BOUND))
+        .unwrap();
+
+    assert_eq!(engine.admit(), Admission::Admitted(vec!["g0"]));
+}
+
+/// The engine stays ignorant of its callers. A dependency edge is the only way
+/// that could change, so pin it here rather than leave it to review.
+#[test]
+fn the_manifest_declares_no_dependencies() {
+    let manifest = include_str!("../Cargo.toml");
+    let mut section = "";
+    let declared: Vec<&str> = manifest
+        .lines()
+        .map(str::trim)
+        .filter(|line| {
+            if line.starts_with('[') {
+                section = line;
+                return false;
+            }
+            section.contains("dependencies") && !line.is_empty() && !line.starts_with('#')
+        })
+        .collect();
+
+    assert!(
+        declared.is_empty(),
+        "the engine crate must depend on nothing, found {declared:?}"
+    );
+}


### PR DESCRIPTION
Adds `openvm-scheduler`, a dependency-free engine that runs independent nodes of an execution graph concurrently under an explicit resource budget, and fixes a stream-ordering defect in the CUDA allocator that concurrent proving exposes.

  ### `openvm-scheduler` (new crate)

  A ready-queue scheduler over a DAG of nodes, each declaring a resource profile, admitted against a budget. Additive: no existing crate changes behaviour, and nothing depends on it unless it opts in. The first consumer models execution and proving as a two-node graph so both a CPU stage and a GPU stage stay busy, with proving prioritised.  Node granularity is deliberately not fixed by the engine — a node can later be split into finer sub-nodes with their own dependencies and memory profiles without touching the engine.

  ### Release-stream buffer ownership

  With two proves resident on distinct streams, a buffer was freed via `cudaFreeAsync` on the stream that **allocated** it rather than the stream that last **read** it. A trace buffer could therefore be recycled while another stream was still reading it, producing well-formed but unverifiable proofs — the failure surfaces downstream as `LogupZerocheck: Fractional sumcheck: nonzero root sum`, at a rate around one run in three under concurrency, and never under serial proving.

  The allocation record now tracks the stream that must order release, with an explicit handoff at the ownership-transfer boundary. Rebind and free are serialised by the manager mutex, with sole ownership enforced rather than assumed. No device-wide barrier and no cross-prove synchronisation are introduced; measured overlap between two concurrent proves is unchanged.

  ### Scope

  This is a targeted ownership handoff for scheduler-owned trace buffers, **not** general reader tracking. Allocations read on a stream other than their allocator's, without an explicit handoff, still release on the allocating stream; the serial path is untouched and unaffected.
